### PR TITLE
test: close zero-coverage gaps in optics, c_api, sim_data + fix doc errors

### DIFF
--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -546,9 +546,8 @@ End-to-end tests verify the complete CLI simulation pipeline, from configuration
 
 ```
 test/e2e/
-├── conftest.py              # pytest fixtures (binary path, temp dirs)
 ├── test_smoke.py            # Smoke tests with PSNR image verification
-├── test_error_handling.py   # Error scenario tests (exit code verification)
+├── test_errors.py           # Error scenario tests (exit code verification)
 ├── configs/                 # Test configuration JSON files
 └── references/              # Reference output images (*.jpg)
 ```

--- a/doc/developer-guide_zh.md
+++ b/doc/developer-guide_zh.md
@@ -546,9 +546,8 @@ t->TestFunc = [](ImGuiTestContext* ctx) {
 
 ```
 test/e2e/
-├── conftest.py              # pytest fixtures（二进制路径、临时目录）
 ├── test_smoke.py            # 冒烟测试（PSNR 图像验证）
-├── test_error_handling.py   # 错误场景测试（退出码验证）
+├── test_errors.py           # 错误场景测试（退出码验证）
 ├── configs/                 # 测试配置 JSON 文件
 └── references/              # 参考输出图片（*.jpg）
 ```

--- a/doc/windows-remote-testing.md
+++ b/doc/windows-remote-testing.md
@@ -47,7 +47,7 @@ From your development machine (macOS/Linux):
 
 ```bash
 # Download CI artifact
-gh run download <RUN_ID> --name LumiceGUITests-windows --dir /tmp/ci-win
+gh run download <RUN_ID> --name LumiceGUITests-windows-msvc --dir /tmp/ci-win
 
 # Run perf test with VSync (real display)
 ./scripts/win_remote_test.sh /tmp/ci-win/bin/LumiceGUITests.exe \

--- a/doc/windows-remote-testing_zh.md
+++ b/doc/windows-remote-testing_zh.md
@@ -43,7 +43,7 @@ watcher 监控 `C:\lumice-test` 中的触发文件，并在交互会话中执行
 
 ```bash
 # 下载 CI 产物
-gh run download <RUN_ID> --name LumiceGUITests-windows --dir /tmp/ci-win
+gh run download <RUN_ID> --name LumiceGUITests-windows-msvc --dir /tmp/ci-win
 
 # 运行 VSync 下的性能测试（真实显示器）
 ./scripts/win_remote_test.sh /tmp/ci-win/bin/LumiceGUITests.exe \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(unit_test
   "${PROJ_TEST_DIR}/test_rng.cpp"
   "${PROJ_TEST_DIR}/test_filter.cpp"
   "${PROJ_TEST_DIR}/test_optics.cpp"
+  "${PROJ_TEST_DIR}/test_sim_data.cpp"
   "${PROJ_TEST_DIR}/test_simulator.cpp"
   "${PROJ_TEST_DIR}/test_main.cpp")
 target_include_directories(unit_test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(unit_test
   "${PROJ_TEST_DIR}/test_projection.cpp"
   "${PROJ_TEST_DIR}/test_rng.cpp"
   "${PROJ_TEST_DIR}/test_filter.cpp"
+  "${PROJ_TEST_DIR}/test_optics.cpp"
   "${PROJ_TEST_DIR}/test_simulator.cpp"
   "${PROJ_TEST_DIR}/test_main.cpp")
 target_include_directories(unit_test

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <thread>
 
 #include "include/lumice.h"
 
@@ -370,4 +372,247 @@ TEST(ParseConfigApi, SpectrumEnumerations) {
 
   LUMICE_Config config{};
   EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_ERR_INVALID_VALUE);
+}
+
+
+// =============== Server Lifecycle / Results API Tests ===============
+
+// Helper: build a small finite-ray-count config with non-empty scattering.
+// - Based on MakeMinimalConfigJson() (parse-modify-dump pattern, like SpectrumEnumerations)
+// - ray_num set to 1000 for fast completion
+// - scattering layer added with prob=0.0 (single-pass: rays exit after one crystal interaction).
+//   Without a non-empty scattering, the simulator processes no crystals, leaving crystal_num == 0.
+static std::string MakeSmallSimConfigJson() {
+  auto base = nlohmann::json::parse(MakeMinimalConfigJson());
+  base["scene"]["ray_num"] = 1000ul;
+
+  // crystal id 1 matches the single crystal in MakeMinimalConfigJson()
+  nlohmann::json entry;
+  entry["crystal"] = 1;
+  entry["proportion"] = 1.0f;
+  nlohmann::json layer;
+  layer["prob"] = 0.0f;  // single-pass: rays terminate after this scattering layer
+  layer["entries"] = nlohmann::json::array({ entry });
+  base["scene"]["scattering"] = nlohmann::json::array({ layer });
+  return base.dump();
+}
+
+// Helper: poll the server until it transitions to LUMICE_SERVER_IDLE or timeout.
+// Returns true if idle was reached within timeout_ms; false on timeout.
+static bool WaitForIdle(LUMICE_Server* server, int timeout_ms) {
+  using clock = std::chrono::steady_clock;
+  auto deadline = clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (clock::now() < deadline) {
+    LUMICE_ServerState state{};
+    if (LUMICE_QueryServerState(server, &state) == LUMICE_OK && state == LUMICE_SERVER_IDLE) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return false;
+}
+
+// Lightweight fixture: only creates and destroys a server with num_workers=1.
+// Tests explicitly call CommitAndWaitForIdle() to advance the lifecycle as needed,
+// keeping each test self-documenting and avoiding hidden coupling on simulator success.
+class ServerLifecycleApi : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    LUMICE_ServerConfig server_config{};
+    server_config.num_workers = 1;  // Predictable single-worker behavior on CI
+    server_ = LUMICE_CreateServerEx(&server_config);
+    ASSERT_NE(server_, nullptr);
+  }
+
+  void TearDown() override {
+    if (server_ != nullptr) {
+      LUMICE_StopServer(server_);
+      LUMICE_DestroyServer(server_);
+      server_ = nullptr;
+    }
+  }
+
+  // Commit a small finite simulation and wait for it to complete.
+  // After this returns, the server is in IDLE with stats/render results available.
+  void CommitAndWaitForIdle() {
+    auto json = MakeSmallSimConfigJson();
+    ASSERT_EQ(LUMICE_CommitConfig(server_, json.c_str()), LUMICE_OK);
+    ASSERT_TRUE(WaitForIdle(server_, 10000)) << "Server did not reach IDLE within 10 seconds";
+  }
+
+  LUMICE_Server* server_ = nullptr;
+};
+
+
+TEST_F(ServerLifecycleApi, FullLifecycle) {
+  // Initial state after creation: IDLE.
+  // Note: only IDLE and RUNNING are observable; LUMICE_SERVER_NOT_READY is unreachable
+  // through the public API in the current implementation (intentional — covered in
+  // GetBeforeCommit test below).
+  LUMICE_ServerState state{};
+  ASSERT_EQ(LUMICE_QueryServerState(server_, &state), LUMICE_OK);
+  EXPECT_EQ(state, LUMICE_SERVER_IDLE);
+
+  // Commit config and wait for completion.
+  auto json = MakeSmallSimConfigJson();
+  ASSERT_EQ(LUMICE_CommitConfig(server_, json.c_str()), LUMICE_OK);
+  ASSERT_TRUE(WaitForIdle(server_, 10000)) << "Server did not reach IDLE within 10 seconds";
+
+  // Final state: IDLE.
+  ASSERT_EQ(LUMICE_QueryServerState(server_, &state), LUMICE_OK);
+  EXPECT_EQ(state, LUMICE_SERVER_IDLE);
+}
+
+
+TEST_F(ServerLifecycleApi, GetRenderResults) {
+  CommitAndWaitForIdle();
+
+  // out array size = LUMICE_MAX_RENDER_RESULTS + 1 (sentinel slot)
+  LUMICE_RenderResult out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  ASSERT_EQ(LUMICE_GetRenderResults(server_, out, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
+
+  // First (and only) renderer matches MakeMinimalConfigJson() resolution 800x400, id=1
+  EXPECT_EQ(out[0].renderer_id, 1);
+  EXPECT_EQ(out[0].img_width, 800);
+  EXPECT_EQ(out[0].img_height, 400);
+  EXPECT_NE(out[0].img_buffer, nullptr);
+
+  // Sentinel: img_buffer == NULL marks end of array
+  EXPECT_EQ(out[1].img_buffer, nullptr);
+}
+
+
+TEST_F(ServerLifecycleApi, GetRawXyzResults) {
+  CommitAndWaitForIdle();
+
+  LUMICE_RawXyzResult out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  ASSERT_EQ(LUMICE_GetRawXyzResults(server_, out, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
+
+  EXPECT_EQ(out[0].renderer_id, 1);
+  EXPECT_EQ(out[0].img_width, 800);
+  EXPECT_EQ(out[0].img_height, 400);
+
+  // Sentinel: xyz_buffer == NULL marks end of array
+  EXPECT_EQ(out[1].xyz_buffer, nullptr);
+}
+
+
+TEST_F(ServerLifecycleApi, GetStatsResults) {
+  CommitAndWaitForIdle();
+
+  LUMICE_StatsResult out[LUMICE_MAX_STATS_RESULTS + 1]{};
+  ASSERT_EQ(LUMICE_GetStatsResults(server_, out, LUMICE_MAX_STATS_RESULTS), LUMICE_OK);
+
+  // After running 1000 rays through one crystal with single-pass scattering:
+  EXPECT_GT(out[0].sim_ray_num, 0u);
+  EXPECT_GT(out[0].crystal_num, 0u);
+
+  // Sentinel: sim_ray_num == 0 marks end of array
+  EXPECT_EQ(out[1].sim_ray_num, 0u);
+}
+
+
+TEST_F(ServerLifecycleApi, GetCachedStatsConsistency) {
+  CommitAndWaitForIdle();
+  // Precondition: simulation has completed; no new data is being produced.
+  // This guarantees DoSnapshot results are stable across calls.
+
+  // Trigger DoSnapshot (which updates cached_stats_result_) by calling GetStatsResults.
+  // Note: any Get function that triggers DoSnapshot updates the cache, not just GetStatsResults.
+  LUMICE_StatsResult fresh[LUMICE_MAX_STATS_RESULTS + 1]{};
+  ASSERT_EQ(LUMICE_GetStatsResults(server_, fresh, LUMICE_MAX_STATS_RESULTS), LUMICE_OK);
+  ASSERT_GT(fresh[0].sim_ray_num, 0u);
+
+  // Cached stats should now match the fresh ones.
+  LUMICE_StatsResult cached{};
+  ASSERT_EQ(LUMICE_GetCachedStats(server_, &cached), LUMICE_OK);
+  EXPECT_EQ(cached.sim_ray_num, fresh[0].sim_ray_num);
+  EXPECT_EQ(cached.crystal_num, fresh[0].crystal_num);
+  EXPECT_EQ(cached.ray_seg_num, fresh[0].ray_seg_num);
+
+  // Cache stability: a second GetCachedStats call without any intervening Get*Results
+  // call must return the same values (no new snapshot).
+  LUMICE_StatsResult cached_again{};
+  ASSERT_EQ(LUMICE_GetCachedStats(server_, &cached_again), LUMICE_OK);
+  EXPECT_EQ(cached_again.sim_ray_num, cached.sim_ray_num);
+  EXPECT_EQ(cached_again.crystal_num, cached.crystal_num);
+}
+
+
+// NULL-arg checks for the four Get* result functions.
+TEST(ResultsApi, NullArgsGetters) {
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+
+  LUMICE_RenderResult render_out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetRenderResults(nullptr, render_out, LUMICE_MAX_RENDER_RESULTS), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_GetRenderResults(server, nullptr, LUMICE_MAX_RENDER_RESULTS), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_RawXyzResult xyz_out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetRawXyzResults(nullptr, xyz_out, LUMICE_MAX_RENDER_RESULTS), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_GetRawXyzResults(server, nullptr, LUMICE_MAX_RENDER_RESULTS), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_StatsResult stats_out[LUMICE_MAX_STATS_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetStatsResults(nullptr, stats_out, LUMICE_MAX_STATS_RESULTS), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_GetStatsResults(server, nullptr, LUMICE_MAX_STATS_RESULTS), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_StatsResult cached{};
+  EXPECT_EQ(LUMICE_GetCachedStats(nullptr, &cached), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_GetCachedStats(server, nullptr), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
+
+TEST(ResultsApi, NullArgsQueryState) {
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+
+  LUMICE_ServerState state{};
+  EXPECT_EQ(LUMICE_QueryServerState(nullptr, &state), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_QueryServerState(server, nullptr), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
+
+// "No-data" path: a freshly created server with no committed config should return
+// LUMICE_OK + sentinel/empty results from all Get functions, not error codes.
+// This is intentional — there is no public API path that returns LUMICE_SERVER_NOT_READY,
+// because callers are expected to treat "no data yet" as a normal state.
+TEST(ResultsApi, GetBeforeCommit) {
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+
+  // Render results: empty count, sentinel at index 0
+  LUMICE_RenderResult render_out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetRenderResults(server, render_out, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
+  EXPECT_EQ(render_out[0].img_buffer, nullptr);
+
+  // Raw XYZ results: empty count, sentinel at index 0
+  LUMICE_RawXyzResult xyz_out[LUMICE_MAX_RENDER_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetRawXyzResults(server, xyz_out, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
+  EXPECT_EQ(xyz_out[0].xyz_buffer, nullptr);
+
+  // Stats results: empty count, sentinel at index 0
+  LUMICE_StatsResult stats_out[LUMICE_MAX_STATS_RESULTS + 1]{};
+  EXPECT_EQ(LUMICE_GetStatsResults(server, stats_out, LUMICE_MAX_STATS_RESULTS), LUMICE_OK);
+  EXPECT_EQ(stats_out[0].sim_ray_num, 0u);
+
+  // Cached stats: all-zero struct
+  LUMICE_StatsResult cached{};
+  EXPECT_EQ(LUMICE_GetCachedStats(server, &cached), LUMICE_OK);
+  EXPECT_EQ(cached.sim_ray_num, 0u);
+  EXPECT_EQ(cached.crystal_num, 0u);
+  EXPECT_EQ(cached.ray_seg_num, 0u);
+
+  // Server state: IDLE (no commit, no work running)
+  LUMICE_ServerState state = LUMICE_SERVER_RUNNING;  // Initialize to non-IDLE to detect change
+  EXPECT_EQ(LUMICE_QueryServerState(server, &state), LUMICE_OK);
+  EXPECT_EQ(state, LUMICE_SERVER_IDLE);
+
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
 }

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -448,7 +448,9 @@ TEST_F(ServerLifecycleApi, FullLifecycle) {
   // Initial state after creation: IDLE.
   // Note: only IDLE and RUNNING are observable; LUMICE_SERVER_NOT_READY is unreachable
   // through the public API in the current implementation (intentional — covered in
-  // GetBeforeCommit test below).
+  // GetBeforeCommit test below). RUNNING is also racy to observe at this scale
+  // (1000 rays + 1 worker complete in <20ms), so this test asserts only the
+  // before/after IDLE states, not the intermediate RUNNING state.
   LUMICE_ServerState state{};
   ASSERT_EQ(LUMICE_QueryServerState(server_, &state), LUMICE_OK);
   EXPECT_EQ(state, LUMICE_SERVER_IDLE);
@@ -491,6 +493,8 @@ TEST_F(ServerLifecycleApi, GetRawXyzResults) {
   EXPECT_EQ(out[0].renderer_id, 1);
   EXPECT_EQ(out[0].img_width, 800);
   EXPECT_EQ(out[0].img_height, 400);
+  EXPECT_NE(out[0].xyz_buffer, nullptr);
+  EXPECT_NE(out[0].has_valid_data, 0);
 
   // Sentinel: xyz_buffer == NULL marks end of array
   EXPECT_EQ(out[1].xyz_buffer, nullptr);

--- a/test/test_optics.cpp
+++ b/test/test_optics.cpp
@@ -1,0 +1,541 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "core/buffer.hpp"
+#include "core/crystal.hpp"
+#include "core/math.hpp"
+#include "core/optics.hpp"
+
+using namespace lumice;
+
+// GetReflectRatio has external linkage (not static, not in anonymous namespace)
+namespace lumice {
+float GetReflectRatio(float delta, float rr);
+}  // namespace lumice
+
+
+// ============================================================================
+// IceRefractiveIndex::Get() tests
+// Reference values computed from code's Sellmeier formula with kCoefAvr coefficients.
+// Cross-checked against refractiveindex.info (ice Ih, ordinary ray).
+// ============================================================================
+
+TEST(IceRefractiveIndexTest, KnownWavelength589nm) {
+  // 589nm (sodium D-line): n ≈ 1.3097 (refractiveindex.info: ~1.3098)
+  double n = IceRefractiveIndex::Get(589.0);
+  EXPECT_NEAR(n, 1.3097193039, 1e-6);
+}
+
+TEST(IceRefractiveIndexTest, KnownWavelength550nm) {
+  // 550nm (green): n ≈ 1.3110
+  double n = IceRefractiveIndex::Get(550.0);
+  EXPECT_NEAR(n, 1.3110129171, 1e-6);
+}
+
+TEST(IceRefractiveIndexTest, BoundaryMin350nm) {
+  double n = IceRefractiveIndex::Get(350.0);
+  EXPECT_NEAR(n, 1.3246528270, 1e-6);
+  EXPECT_GT(n, 1.0);
+}
+
+TEST(IceRefractiveIndexTest, BoundaryMax900nm) {
+  double n = IceRefractiveIndex::Get(900.0);
+  EXPECT_NEAR(n, 1.3031960565, 1e-6);
+  EXPECT_GT(n, 1.0);
+}
+
+TEST(IceRefractiveIndexTest, OutOfRangeReturns1) {
+  EXPECT_DOUBLE_EQ(IceRefractiveIndex::Get(349.0), 1.0);
+  EXPECT_DOUBLE_EQ(IceRefractiveIndex::Get(901.0), 1.0);
+  EXPECT_DOUBLE_EQ(IceRefractiveIndex::Get(0.0), 1.0);
+  EXPECT_DOUBLE_EQ(IceRefractiveIndex::Get(-100.0), 1.0);
+}
+
+
+// ============================================================================
+// GetReflectRatio() tests — Fresnel reflection coefficient
+// ============================================================================
+
+TEST(GetReflectRatioTest, NormalIncidence) {
+  // At normal incidence: delta = 1, d_sqrt = 1
+  // Rs = ((rr - 1)/(rr + 1))^2, Rp = ((1 - rr)/(1 + rr))^2 = Rs
+  // Result = Rs (since Rs == Rp)
+  float n = 1.3097f;
+  float r = GetReflectRatio(1.0f, n);  // NOLINT(readability-identifier-naming) Fresnel notation
+  float expected = ((n - 1.0f) / (n + 1.0f)) * ((n - 1.0f) / (n + 1.0f));
+  EXPECT_NEAR(r, expected, 1e-5f);
+  EXPECT_NEAR(r, 0.01798f, 1e-4f);
+}
+
+TEST(GetReflectRatioTest, KnownValues) {
+  // delta = 0.5, rr = 1.5 -> d_sqrt = sqrt(0.5)
+  // Rs = (1.5 - 0.7071)/(1.5 + 0.7071) = 0.7929/2.2071 = 0.35929, Rs^2 = 0.12909
+  // Rp = (1 - 1.5*0.7071)/(1 + 1.5*0.7071) = (1 - 1.06066)/(1 + 1.06066) = -0.06066/2.06066
+  //    = -0.02944, Rp^2 = 0.000867
+  // R = (0.12909 + 0.000867) / 2 = 0.06498
+  float d_sqrt = std::sqrt(0.5f);
+  float rs = (1.5f - d_sqrt) / (1.5f + d_sqrt);  // NOLINT(readability-identifier-naming) Fresnel notation
+  rs *= rs;
+  float rp = (1.0f - 1.5f * d_sqrt) / (1.0f + 1.5f * d_sqrt);  // NOLINT(readability-identifier-naming) Fresnel notation
+  rp *= rp;
+  float expected = (rs + rp) / 2.0f;
+
+  float r = GetReflectRatio(0.5f, 1.5f);  // NOLINT(readability-identifier-naming) Fresnel notation
+  EXPECT_NEAR(r, expected, 1e-5f);
+}
+
+
+// ============================================================================
+// HitSurface() tests
+// ============================================================================
+
+class HitSurfaceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    crystal_ = Crystal::CreatePrism(1.0f);
+    n_ = static_cast<float>(IceRefractiveIndex::Get(589.0));
+  }
+
+  // Helper to call HitSurface for a single ray
+  struct HitResult {
+    float reflect_dir[3];
+    float refract_dir[3];
+    float reflect_weight;
+    float refract_weight;
+  };
+
+  HitResult HitSingle(const float* dir, float weight, int fid) {
+    float dir_in[3] = { dir[0], dir[1], dir[2] };
+    float w_in[1] = { weight };
+    int fid_in[1] = { fid };
+    float dir_out[6] = {};
+    float w_out[2] = {};
+
+    float_bf_t d_in(dir_in, 3 * sizeof(float));
+    float_bf_t wt_in(w_in, sizeof(float));
+    int_bf_t fi_in(fid_in, sizeof(int));
+    float_bf_t d_out(dir_out, 3 * sizeof(float));
+    float_bf_t wt_out(w_out, sizeof(float));
+
+    HitSurface(crystal_, n_, 1, d_in, wt_in, fi_in, d_out, wt_out);
+
+    HitResult r{};
+    std::memcpy(r.reflect_dir, dir_out, 3 * sizeof(float));
+    std::memcpy(r.refract_dir, dir_out + 3, 3 * sizeof(float));
+    r.reflect_weight = w_out[0];
+    r.refract_weight = w_out[1];
+    return r;
+  }
+
+  Crystal crystal_;
+  float n_ = 0;
+};
+
+TEST_F(HitSurfaceTest, AirToIceNormalIncidence) {
+  // Find a face normal and shoot a ray along -normal (air -> ice, cos_theta < 0)
+  const float* norms = crystal_.GetTriangleNormal();
+  int fid = 0;
+  float norm[3] = { norms[0], norms[1], norms[2] };
+
+  // Ray direction = -normal (shooting into the crystal)
+  float dir[3] = { -norm[0], -norm[1], -norm[2] };
+
+  auto result = HitSingle(dir, 1.0f, fid);
+
+  // Reflection should be along +normal
+  for (int j = 0; j < 3; j++) {
+    EXPECT_NEAR(result.reflect_dir[j], norm[j], 1e-4f);
+  }
+
+  // Refraction at normal incidence: direction barely changes (d_refract ≈ d_in for small n-1)
+  // More precisely: refract = rr * d_in - (rr - sqrt(d)) * cos * norm
+  // At normal incidence with cos=-1, rr=1/n: refract = (1/n)*(-norm) - (1/n - 1)*(-1)*norm
+  //   = -norm/n + (1 - 1/n)*norm = -norm/n + norm - norm/n = norm*(1 - 2/n)
+  // Actually just check it's roughly in the same direction as input
+  float dot = 0;
+  for (int j = 0; j < 3; j++) {
+    dot += result.refract_dir[j] * dir[j];
+  }
+  EXPECT_GT(dot, 0.0f);  // Refracted ray goes in same general direction as incident
+
+  // Fresnel at normal incidence: R = ((n-1)/(n+1))^2 ≈ 0.018
+  EXPECT_NEAR(result.reflect_weight, 0.018f, 0.002f);
+  EXPECT_GT(result.refract_weight, 0.0f);
+}
+
+TEST_F(HitSurfaceTest, SnellsLaw30Degrees) {
+  // Construct a ray at 30° to a face normal (air -> ice)
+  const float* norms = crystal_.GetTriangleNormal();
+  int fid = 0;
+  float norm[3] = { norms[0], norms[1], norms[2] };
+
+  // Build a tangent vector perpendicular to norm
+  float tangent[3];
+  if (std::abs(norm[0]) < 0.9f) {
+    float tmp[3] = { 1, 0, 0 };
+    // tangent = tmp - (tmp.norm)*norm
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  } else {
+    float tmp[3] = { 0, 1, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  }
+  float t_len = Norm3(tangent);
+  for (float& v : tangent) {
+    v /= t_len;
+  }
+
+  // Ray direction: 30° from -normal toward tangent (air -> ice, cos_theta < 0)
+  float theta_i = 30.0f * math::kDegreeToRad;
+  float dir[3];
+  for (int j = 0; j < 3; j++) {
+    dir[j] = -std::cos(theta_i) * norm[j] + std::sin(theta_i) * tangent[j];
+  }
+
+  auto result = HitSingle(dir, 1.0f, fid);
+
+  // Verify Snell's law: sin(theta_r) = sin(theta_i) / n
+  // Compute refracted angle from dot product with -normal
+  float cos_refract = 0;
+  for (int j = 0; j < 3; j++) {
+    cos_refract += result.refract_dir[j] * (-norm[j]);
+  }
+  cos_refract = std::abs(cos_refract);
+  float sin_refract = std::sqrt(1.0f - cos_refract * cos_refract);
+
+  float expected_sin_refract = std::sin(theta_i) / n_;
+  EXPECT_NEAR(sin_refract, expected_sin_refract, 1e-4f);
+}
+
+TEST_F(HitSurfaceTest, TotalInternalReflection) {
+  // Ice -> air (cos_theta > 0), angle > critical angle (~49.8°)
+  const float* norms = crystal_.GetTriangleNormal();
+  int fid = 0;
+  float norm[3] = { norms[0], norms[1], norms[2] };
+
+  // Build tangent
+  float tangent[3];
+  if (std::abs(norm[0]) < 0.9f) {
+    float tmp[3] = { 1, 0, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  } else {
+    float tmp[3] = { 0, 1, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  }
+  float t_len = Norm3(tangent);
+  for (float& v : tangent) {
+    v /= t_len;
+  }
+
+  // 60° from +normal (ice -> air, cos_theta > 0), well above critical angle ~49.8°
+  float theta = 60.0f * math::kDegreeToRad;
+  float dir[3];
+  for (int j = 0; j < 3; j++) {
+    dir[j] = std::cos(theta) * norm[j] + std::sin(theta) * tangent[j];
+  }
+
+  auto result = HitSingle(dir, 1.0f, fid);
+
+  // Total reflection: refract weight should be -1
+  EXPECT_FLOAT_EQ(result.refract_weight, -1.0f);
+  // Reflection weight should be positive
+  EXPECT_GT(result.reflect_weight, 0.0f);
+}
+
+TEST_F(HitSurfaceTest, EnergyConservation) {
+  // Non-total-reflection case: reflect_weight + refract_weight ≈ input_weight
+  const float* norms = crystal_.GetTriangleNormal();
+  int fid = 0;
+  float norm[3] = { norms[0], norms[1], norms[2] };
+
+  // Air -> ice, 20° incidence
+  float tangent[3];
+  if (std::abs(norm[0]) < 0.9f) {
+    float tmp[3] = { 1, 0, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  } else {
+    float tmp[3] = { 0, 1, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  }
+  float t_len = Norm3(tangent);
+  for (float& v : tangent) {
+    v /= t_len;
+  }
+
+  float theta = 20.0f * math::kDegreeToRad;
+  float dir[3];
+  for (int j = 0; j < 3; j++) {
+    dir[j] = -std::cos(theta) * norm[j] + std::sin(theta) * tangent[j];
+  }
+
+  float input_weight = 1.0f;
+  auto result = HitSingle(dir, input_weight, fid);
+
+  EXPECT_GT(result.refract_weight, 0.0f);
+  EXPECT_NEAR(result.reflect_weight + result.refract_weight, input_weight, 1e-5f);
+}
+
+TEST_F(HitSurfaceTest, DirectionSwitchAirVsIce) {
+  // Same face, same angle, but from air side (cos < 0) vs ice side (cos > 0)
+  const float* norms = crystal_.GetTriangleNormal();
+  int fid = 0;
+  float norm[3] = { norms[0], norms[1], norms[2] };
+
+  float tangent[3];
+  if (std::abs(norm[0]) < 0.9f) {
+    float tmp[3] = { 1, 0, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  } else {
+    float tmp[3] = { 0, 1, 0 };
+    float d = tmp[0] * norm[0] + tmp[1] * norm[1] + tmp[2] * norm[2];
+    tangent[0] = tmp[0] - d * norm[0];
+    tangent[1] = tmp[1] - d * norm[1];
+    tangent[2] = tmp[2] - d * norm[2];
+  }
+  float t_len = Norm3(tangent);
+  for (float& v : tangent) {
+    v /= t_len;
+  }
+
+  float theta = 20.0f * math::kDegreeToRad;
+
+  // Air -> ice: cos_theta < 0, rr = 1/n
+  float dir_air[3];
+  for (int j = 0; j < 3; j++) {
+    dir_air[j] = -std::cos(theta) * norm[j] + std::sin(theta) * tangent[j];
+  }
+  auto result_air = HitSingle(dir_air, 1.0f, fid);
+
+  // Ice -> air: cos_theta > 0, rr = n
+  float dir_ice[3];
+  for (int j = 0; j < 3; j++) {
+    dir_ice[j] = std::cos(theta) * norm[j] + std::sin(theta) * tangent[j];
+  }
+  auto result_ice = HitSingle(dir_ice, 1.0f, fid);
+
+  // Both should have valid refraction (20° < critical angle)
+  EXPECT_GT(result_air.refract_weight, 0.0f);
+  EXPECT_GT(result_ice.refract_weight, 0.0f);
+
+  // Fresnel coefficients should differ because rr differs
+  EXPECT_NE(result_air.reflect_weight, result_ice.reflect_weight);
+}
+
+
+// ============================================================================
+// Propagate() tests
+// ============================================================================
+
+class PropagateTest : public ::testing::Test {
+ protected:
+  void SetUp() override { crystal_ = Crystal::CreatePrism(1.0f); }
+
+  Crystal crystal_;
+};
+
+TEST_F(PropagateTest, HorizontalRayHitsSideFace) {
+  // Ray from center (0,0,0), horizontal direction (1,0,0)
+  // Should hit a side face of the prism
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { 1.0f };
+  float pos_out[3] = {};
+  int fid_out[1] = { -1 };
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  int_bf_t fi_out(fid_out, sizeof(int));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, p_out, fi_out);
+
+  // Should hit some face (fid >= 0)
+  EXPECT_GE(fid_out[0], 0);
+  EXPECT_LT(fid_out[0], static_cast<int>(crystal_.TotalTriangles()));
+
+  // Output position should be different from input (ray traveled)
+  float dist = DiffNorm3(pos_out, pos);
+  EXPECT_GT(dist, 0.0f);
+}
+
+TEST_F(PropagateTest, VerticalRayHitsTopFace) {
+  // Ray from center (0,0,0), vertical direction (0,0,1)
+  // Should hit a top face
+  float dir[3] = { 0.0f, 0.0f, 1.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { 1.0f };
+  float pos_out[3] = {};
+  int fid_out[1] = { -1 };
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  int_bf_t fi_out(fid_out, sizeof(int));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, p_out, fi_out);
+
+  EXPECT_GE(fid_out[0], 0);
+
+  // Output z should be positive (hit top face)
+  EXPECT_GT(pos_out[2], 0.0f);
+  // Output x,y should be near zero (vertical ray from center)
+  EXPECT_NEAR(pos_out[0], 0.0f, 1e-4f);
+  EXPECT_NEAR(pos_out[1], 0.0f, 1e-4f);
+}
+
+TEST_F(PropagateTest, NegativeWeightSkipped) {
+  // w_in < 0 marks total reflection — Propagate should skip
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { -1.0f };
+  float pos_out[3] = { -999.0f, -999.0f, -999.0f };
+  int fid_out[1] = { -1 };
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  int_bf_t fi_out(fid_out, sizeof(int));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, p_out, fi_out);
+
+  // PropagateSlab skips w<0 rays: output position = input position, fid = -1
+  // (The skip preserves the initialized values from the gather phase in PropagateSlab,
+  //  but for the original position since w<0 is skipped in the scatter phase)
+  EXPECT_EQ(fid_out[0], -1);
+}
+
+TEST_F(PropagateTest, Step2SharedPosition) {
+  // 4 directions, 2 positions, step=2
+  // Rays 0,1 share pos[0], rays 2,3 share pos[1]
+  float dirs[12] = {
+    1.0f, 0.0f, 0.0f,  // ray 0
+    0.0f, 1.0f, 0.0f,  // ray 1
+    1.0f, 0.0f, 0.0f,  // ray 2 (same dir as 0)
+    0.0f, 1.0f, 0.0f,  // ray 3 (same dir as 1)
+  };
+  float positions[6] = {
+    0.0f, 0.0f, 0.0f,  // pos 0
+    0.0f, 0.0f, 0.0f,  // pos 1 (same position for simplicity)
+  };
+  float weights[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+  float pos_out[12] = {};
+  int fid_out[4] = { -1, -1, -1, -1 };
+
+  float_bf_t d_in(dirs, 3 * sizeof(float));
+  float_bf_t p_in(positions, 3 * sizeof(float));
+  float_bf_t wt_in(weights, sizeof(float));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  int_bf_t fi_out(fid_out, sizeof(int));
+
+  Propagate(crystal_, 4, 2, d_in, p_in, wt_in, p_out, fi_out);
+
+  // All rays should hit something (from center, any direction hits a face)
+  for (int i = 0; i < 4; i++) {
+    EXPECT_GE(fid_out[i], 0) << "Ray " << i << " missed";
+  }
+
+  // Rays with same direction and same position should produce same results
+  // Ray 0 (dir +x, pos 0) vs Ray 2 (dir +x, pos 1, which == pos 0)
+  EXPECT_EQ(fid_out[0], fid_out[2]);
+  for (int j = 0; j < 3; j++) {
+    EXPECT_NEAR(pos_out[j], pos_out[6 + j], 1e-4f);
+  }
+}
+
+TEST_F(PropagateTest, SlabAndTrianglePathConsistency) {
+  // Compare PropagateSlab (num=1, <= 128) vs PropagateTriangle (num=129, > 128)
+  // Only compare face IDs (PropagateTriangle has known accumulation behavior for positions)
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { 1.0f };
+
+  // PropagateSlab path (num=1)
+  float pos_out_slab[3] = {};
+  int fid_slab[1] = { -1 };
+  {
+    float_bf_t d_in(dir, 3 * sizeof(float));
+    float_bf_t p_in(pos, 3 * sizeof(float));
+    float_bf_t wt_in(w, sizeof(float));
+    float_bf_t p_out(pos_out_slab, 3 * sizeof(float));
+    int_bf_t fi_out(fid_slab, sizeof(int));
+    Propagate(crystal_, 1, 1, d_in, p_in, wt_in, p_out, fi_out);
+  }
+
+  // PropagateTriangle path (num=129, only first ray matters, rest are padding)
+  constexpr int kNum = 129;
+  std::vector<float> dirs(kNum * 3, 0.0f);
+  std::vector<float> positions(kNum * 3, 0.0f);
+  std::vector<float> weights(kNum, -1.0f);  // Mark all as skip
+  std::vector<float> pos_out_tri(kNum * 3, 0.0f);
+  std::vector<int> fid_tri(kNum, -1);
+
+  // Only first ray is active
+  dirs[0] = dir[0];
+  dirs[1] = dir[1];
+  dirs[2] = dir[2];
+  weights[0] = 1.0f;
+
+  {
+    float_bf_t d_in(dirs.data(), 3 * sizeof(float));
+    float_bf_t p_in(positions.data(), 3 * sizeof(float));
+    float_bf_t wt_in(weights.data(), sizeof(float));
+    float_bf_t p_out(pos_out_tri.data(), 3 * sizeof(float));
+    int_bf_t fi_out(fid_tri.data(), sizeof(int));
+    Propagate(crystal_, kNum, 1, d_in, p_in, wt_in, p_out, fi_out);
+  }
+
+  // Face IDs should match between the two paths
+  EXPECT_EQ(fid_slab[0], fid_tri[0]);
+  EXPECT_GE(fid_slab[0], 0);
+}
+
+TEST_F(PropagateTest, NoIntersection) {
+  // Ray starting outside the crystal, pointing away
+  // Use a point far from the crystal
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 100.0f, 100.0f, 100.0f };
+  float w[1] = { 1.0f };
+  float pos_out[3] = {};
+  int fid_out[1] = { -1 };
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  int_bf_t fi_out(fid_out, sizeof(int));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, p_out, fi_out);
+
+  // PropagateSlab finds exit faces via half-space intersection
+  // From outside the crystal, the slab method may still find an exit face
+  // (it doesn't check if the ray starts inside). This is expected behavior
+  // since Propagate assumes the ray starts inside the crystal.
+  // We just verify no crash occurs.
+  EXPECT_TRUE(true);  // No crash is the test
+}

--- a/test/test_sim_data.cpp
+++ b/test/test_sim_data.cpp
@@ -1,0 +1,407 @@
+// Tests for src/config/sim_data.hpp — RayBuffer and SimData.
+//
+// SimData has 4 hand-written special member functions (copy/move ctor + assign).
+// History: learnings.md records "manual copy/move easily miss new fields".
+// When adding a field to SimData, you MUST update:
+//   1. sim_data.cpp's static_assert(sizeof(SimData) == ...) — already exists
+//   2. The 4 special member functions in sim_data.cpp
+//   3. CopyConstructDeepCopy / CopyAssignmentDeepCopy / MoveConstruct* tests below
+// The sizeof static_assert at the top of this file is a mirror of (1),
+// forming a double safeguard so that sizeof drift is detected from both sides.
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "config/sim_data.hpp"
+#include "core/def.hpp"
+#include "core/raypath.hpp"
+
+namespace {
+
+using lumice::kInfSize;
+using lumice::RayBuffer;
+using lumice::RaySeg;
+using lumice::SimData;
+
+// Mirror of sim_data.cpp's static_assert. Only enabled on the platform where
+// the original assert was authored (macOS Apple Silicon, 64-bit). Other
+// 64-bit ABIs may differ; we keep the assertion narrow to avoid CI noise.
+#if defined(__APPLE__) && defined(__aarch64__)
+static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
+static_assert(sizeof(SimData) == 144,
+              "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
+              "and sim_data.cpp's static_assert.");
+#endif
+
+// Helper: build a RaySeg with an identifiable marker for assertions.
+RaySeg MakeRay(int marker) {
+  RaySeg r{};
+  r.w_ = static_cast<float>(marker);
+  r.fid_ = marker;
+  return r;
+}
+
+// Helper: build a fully populated SimData with rays_.size_ < rays_.capacity_
+// (capacity=8, size=5). The size != capacity input shape is load-bearing —
+// it would catch a future "memcpy size bytes instead of capacity bytes"
+// refactor that silently truncates trailing data.
+SimData MakePopulatedSimData() {
+  SimData s(8);
+  s.curr_wl_ = 550.0f;
+  s.total_intensity_ = 1.5f;
+  s.generation_ = 42;
+  s.root_ray_count_ = 7;
+  for (int i = 0; i < 5; i++) {
+    s.rays_.EmplaceBack(MakeRay(i));
+  }
+  s.outgoing_indices_ = { 0, 2, 4 };
+  s.outgoing_d_ = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+  s.outgoing_w_ = { 0.5f, 0.7f };
+  s.crystals_.emplace_back();
+  return s;
+}
+
+}  // namespace
+
+
+// =============== RayBuffer Tests ===============
+
+TEST(RayBufferTest, DefaultConstruction) {
+  RayBuffer buf;
+  EXPECT_EQ(buf.capacity_, 0u);
+  EXPECT_EQ(buf.size_, 0u);
+  EXPECT_TRUE(buf.Empty());
+  EXPECT_EQ(buf.rays(), nullptr);
+}
+
+
+TEST(RayBufferTest, CapacityConstruction) {
+  RayBuffer buf(10);
+  EXPECT_EQ(buf.capacity_, 10u);
+  EXPECT_EQ(buf.size_, 0u);
+  EXPECT_TRUE(buf.Empty());
+  EXPECT_NE(buf.rays(), nullptr);
+}
+
+
+// EmplaceBack(RaySeg) has a strict-less-than guard: `if (size_ + 1 < capacity_)`.
+// This means a buffer of capacity N can only hold N-1 elements (the last slot is
+// never written). This test pins that quirk in place by name and assertion.
+TEST(RayBufferTest, EmplaceBackLosesOneSlot) {
+  RayBuffer buf(5);
+
+  for (int i = 0; i < 4; i++) {
+    buf.EmplaceBack(MakeRay(i));
+  }
+  EXPECT_EQ(buf.size_, 4u);
+  EXPECT_FALSE(buf.Empty());
+  EXPECT_FLOAT_EQ(buf[0].w_, 0.0f);
+  EXPECT_FLOAT_EQ(buf[1].w_, 1.0f);
+  EXPECT_FLOAT_EQ(buf[2].w_, 2.0f);
+  EXPECT_FLOAT_EQ(buf[3].w_, 3.0f);
+
+  // Guard rejects further writes; size and existing data must remain unchanged.
+  buf.EmplaceBack(MakeRay(99));
+  EXPECT_EQ(buf.size_, 4u);
+  EXPECT_FLOAT_EQ(buf[0].w_, 0.0f);
+  EXPECT_FLOAT_EQ(buf[3].w_, 3.0f);
+
+  // Repeated guard hits should also leave existing data intact.
+  for (int i = 0; i < 5; i++) {
+    buf.EmplaceBack(MakeRay(88));
+  }
+  EXPECT_EQ(buf.size_, 4u);
+  EXPECT_FLOAT_EQ(buf[0].w_, 0.0f);
+  EXPECT_FLOAT_EQ(buf[3].w_, 3.0f);
+}
+
+
+TEST(RayBufferTest, EmplaceBackBatchOnEmptyDst) {
+  RayBuffer src(10);
+  for (int i = 0; i < 5; i++) {
+    src.EmplaceBack(MakeRay(i));
+  }
+  EXPECT_EQ(src.size_, 5u);
+
+  RayBuffer dst(10);
+  dst.EmplaceBack(src, 1, 3);
+  EXPECT_EQ(dst.size_, 3u);
+  EXPECT_FLOAT_EQ(dst[0].w_, 1.0f);
+  EXPECT_FLOAT_EQ(dst[1].w_, 2.0f);
+  EXPECT_FLOAT_EQ(dst[2].w_, 3.0f);
+
+  // Calling with kInfSize (size_t::max) must be clamped by buffer.size_,
+  // not propagate as an overflow.
+  RayBuffer dst2(10);
+  dst2.EmplaceBack(src, 0, kInfSize);
+  EXPECT_EQ(dst2.size_, 5u);  // clamped to src.size_
+  EXPECT_FLOAT_EQ(dst2[0].w_, 0.0f);
+  EXPECT_FLOAT_EQ(dst2[4].w_, 4.0f);
+}
+
+
+// Contract-locking test for a known quirk in batch EmplaceBack:
+//   end = std::min({ start + len, capacity_, buffer.size_ });
+// uses `capacity_` as the upper bound rather than `capacity_ - size_`. When
+// `dst` already contains data, this can cause writes past the allocated end.
+//
+// This test is DISABLED_ — GoogleTest will skip it but emit a "YOU HAVE 1
+// DISABLED TEST" reminder. It serves as a regression anchor: when the quirk
+// is fixed in a future task, removing the DISABLED_ prefix will validate
+// the fix. DO NOT delete this test; it documents the current behavior and
+// the pending fix.
+TEST(RayBufferTest, DISABLED_EmplaceBackBatchOnNonEmptyDstQuirk) {
+  // Intentionally not executed by default. To run manually:
+  //   ./unit_test --gtest_also_run_disabled_tests --gtest_filter='*Quirk*'
+  // TODO: when sim_data.cpp's batch EmplaceBack is fixed to use
+  //       `capacity_ - size_` as the upper bound, enable this test by
+  //       removing the DISABLED_ prefix and replace the FAIL with the
+  //       fixed-behavior assertions.
+  FAIL() << "Quirk anchor: batch EmplaceBack on non-empty dst writes past "
+            "capacity. Awaiting fix in a future task.";
+}
+
+
+TEST(RayBufferTest, ResetGrowsButNeverShrinks) {
+  RayBuffer buf(5);
+  for (int i = 0; i < 3; i++) {
+    buf.EmplaceBack(MakeRay(i));
+  }
+  EXPECT_EQ(buf.size_, 3u);
+
+  // Same capacity: size resets, capacity unchanged.
+  buf.Reset(5);
+  EXPECT_EQ(buf.size_, 0u);
+  EXPECT_EQ(buf.capacity_, 5u);
+  EXPECT_TRUE(buf.Empty());
+
+  // Larger capacity: grows.
+  buf.Reset(20);
+  EXPECT_EQ(buf.size_, 0u);
+  EXPECT_EQ(buf.capacity_, 20u);
+  EXPECT_NE(buf.rays(), nullptr);
+
+  // Smaller capacity: ignored, capacity stays at 20 (only-grows semantics).
+  buf.Reset(3);
+  EXPECT_EQ(buf.size_, 0u);
+  EXPECT_EQ(buf.capacity_, 20u);
+  EXPECT_TRUE(buf.Empty());
+
+  // From a default-constructed (capacity=0) buffer, Reset(N) must allocate.
+  RayBuffer empty_buf;
+  EXPECT_EQ(empty_buf.capacity_, 0u);
+  empty_buf.Reset(10);
+  EXPECT_EQ(empty_buf.capacity_, 10u);
+  EXPECT_EQ(empty_buf.size_, 0u);
+  EXPECT_NE(empty_buf.rays(), nullptr);
+}
+
+
+TEST(RayBufferTest, IterationAndIndexing) {
+  RayBuffer buf(5);
+  for (int i = 0; i < 4; i++) {
+    buf.EmplaceBack(MakeRay(i));
+  }
+
+  // begin/end pointer arithmetic equals size.
+  EXPECT_EQ(buf.end() - buf.begin(), 4);
+
+  // Range-based iteration sees all elements in order.
+  float sum = 0.0f;
+  for (const auto& r : buf) {
+    sum += r.w_;
+  }
+  EXPECT_FLOAT_EQ(sum, 6.0f);  // 0+1+2+3
+
+  // operator[] direct access matches iterated values.
+  EXPECT_FLOAT_EQ(buf[0].w_, 0.0f);
+  EXPECT_FLOAT_EQ(buf[3].w_, 3.0f);
+}
+
+
+// =============== SimData Tests ===============
+
+TEST(SimDataTest, CopyConstructDeepCopy) {
+  auto original = MakePopulatedSimData();
+  SimData copy(original);
+
+  // Scalar field assertions, each with a failure message identifying which
+  // field was missed (helps catch the "manual copy missed a field" bug class).
+  EXPECT_FLOAT_EQ(copy.curr_wl_, 550.0f) << "curr_wl_ not copied";
+  EXPECT_FLOAT_EQ(copy.total_intensity_, 1.5f) << "total_intensity_ not copied";
+  EXPECT_EQ(copy.generation_, 42u) << "generation_ not copied";
+  EXPECT_EQ(copy.root_ray_count_, 7u) << "root_ray_count_ not copied";
+
+  // rays_ field assertions.
+  EXPECT_EQ(copy.rays_.size_, 5u);
+  EXPECT_EQ(copy.rays_.capacity_, 8u);
+  for (int i = 0; i < 5; i++) {
+    EXPECT_FLOAT_EQ(copy.rays_[i].w_, original.rays_[i].w_);
+  }
+
+  // Vector field equality.
+  EXPECT_EQ(copy.outgoing_indices_, original.outgoing_indices_);
+  EXPECT_EQ(copy.outgoing_d_, original.outgoing_d_);
+  EXPECT_EQ(copy.outgoing_w_, original.outgoing_w_);
+  EXPECT_EQ(copy.crystals_.size(), original.crystals_.size());
+
+  // Deep copy independence — each pointer/container field independently.
+  copy.rays_[0].w_ = 999.0f;
+  EXPECT_FLOAT_EQ(original.rays_[0].w_, 0.0f) << "rays_ not deep-copied";
+
+  copy.outgoing_indices_.push_back(99);
+  EXPECT_EQ(original.outgoing_indices_.size(), 3u) << "outgoing_indices_ not deep-copied";
+
+  copy.outgoing_d_.clear();
+  EXPECT_EQ(original.outgoing_d_.size(), 6u) << "outgoing_d_ not deep-copied";
+
+  copy.outgoing_w_.clear();
+  EXPECT_EQ(original.outgoing_w_.size(), 2u) << "outgoing_w_ not deep-copied";
+
+  copy.crystals_.clear();
+  EXPECT_EQ(original.crystals_.size(), 1u) << "crystals_ not deep-copied";
+}
+
+
+TEST(SimDataTest, CopyAssignmentDeepCopy) {
+  auto original = MakePopulatedSimData();
+  SimData target(3);  // Different initial capacity, exercises rays_ realloc path.
+  target = original;
+
+  // Field completeness (mirror of copy ctor test).
+  EXPECT_FLOAT_EQ(target.curr_wl_, 550.0f) << "curr_wl_ not assigned";
+  EXPECT_FLOAT_EQ(target.total_intensity_, 1.5f) << "total_intensity_ not assigned";
+  EXPECT_EQ(target.generation_, 42u) << "generation_ not assigned";
+  EXPECT_EQ(target.root_ray_count_, 7u) << "root_ray_count_ not assigned";
+  EXPECT_EQ(target.rays_.size_, 5u);
+  EXPECT_EQ(target.rays_.capacity_, 8u);
+  for (int i = 0; i < 5; i++) {
+    EXPECT_FLOAT_EQ(target.rays_[i].w_, original.rays_[i].w_);
+  }
+  EXPECT_EQ(target.outgoing_indices_, original.outgoing_indices_);
+  EXPECT_EQ(target.outgoing_d_, original.outgoing_d_);
+  EXPECT_EQ(target.outgoing_w_, original.outgoing_w_);
+  EXPECT_EQ(target.crystals_.size(), 1u);
+
+  // Deep copy independence.
+  target.rays_[0].w_ = 999.0f;
+  EXPECT_FLOAT_EQ(original.rays_[0].w_, 0.0f) << "rays_ not deep-assigned";
+  target.outgoing_indices_.push_back(99);
+  EXPECT_EQ(original.outgoing_indices_.size(), 3u) << "outgoing_indices_ not deep-assigned";
+  target.crystals_.clear();
+  EXPECT_EQ(original.crystals_.size(), 1u) << "crystals_ not deep-assigned";
+
+  // Self-assignment must preserve all fields (source code has &other == this guard).
+  // Snapshot → self-assign → assert preservation (NOT assert clearing).
+  // Use an alias reference to bypass -Wself-assign-overloaded.
+  auto orig = MakePopulatedSimData();
+  const float kSnapCurrWl = orig.curr_wl_;
+  const float kSnapTotalInt = orig.total_intensity_;
+  const uint64_t kSnapGen = orig.generation_;
+  const size_t kSnapRoot = orig.root_ray_count_;
+  const size_t kSnapRaysSize = orig.rays_.size_;
+  const size_t kSnapRaysCap = orig.rays_.capacity_;
+  const float kSnapRay0W = orig.rays_[0].w_;
+  const auto kSnapOutgoingIdx = orig.outgoing_indices_;
+  const size_t kSnapCrystalsSize = orig.crystals_.size();
+
+  SimData& self_alias = orig;
+  self_alias = orig;
+
+  EXPECT_FLOAT_EQ(orig.curr_wl_, kSnapCurrWl);
+  EXPECT_FLOAT_EQ(orig.total_intensity_, kSnapTotalInt);
+  EXPECT_EQ(orig.generation_, kSnapGen);
+  EXPECT_EQ(orig.root_ray_count_, kSnapRoot);
+  EXPECT_EQ(orig.rays_.size_, kSnapRaysSize);
+  EXPECT_EQ(orig.rays_.capacity_, kSnapRaysCap);
+  EXPECT_FLOAT_EQ(orig.rays_[0].w_, kSnapRay0W);
+  EXPECT_EQ(orig.outgoing_indices_, kSnapOutgoingIdx);
+  EXPECT_EQ(orig.crystals_.size(), kSnapCrystalsSize);
+}
+
+
+TEST(SimDataTest, MoveConstructTransfersOwnership) {
+  auto original = MakePopulatedSimData();
+  RaySeg* original_ptr = original.rays_.rays_.get();
+
+  SimData moved(std::move(original));
+
+  // Moved object: pointer ownership transfer (no memcpy), all fields valid.
+  EXPECT_EQ(moved.rays_.rays_.get(), original_ptr) << "ownership transfer expected";
+  EXPECT_EQ(moved.rays_.size_, 5u);
+  EXPECT_EQ(moved.rays_.capacity_, 8u);
+  EXPECT_FLOAT_EQ(moved.curr_wl_, 550.0f);
+  EXPECT_FLOAT_EQ(moved.total_intensity_, 1.5f);
+  EXPECT_EQ(moved.generation_, 42u);
+  EXPECT_EQ(moved.root_ray_count_, 7u);
+  EXPECT_EQ(moved.outgoing_indices_.size(), 3u);
+  EXPECT_EQ(moved.outgoing_d_.size(), 6u);
+  EXPECT_EQ(moved.outgoing_w_.size(), 2u);
+  EXPECT_EQ(moved.crystals_.size(), 1u);
+
+  // Moved-from source contract — three categories:
+  // (a) rays_ pointer ownership transferred → nullptr + zeroed size/capacity.
+  EXPECT_EQ(original.rays_.rays_, nullptr);
+  EXPECT_EQ(original.rays_.size_, 0u);
+  EXPECT_EQ(original.rays_.capacity_, 0u);
+
+  // (b) std::vector members are moved-from. The C++ standard only guarantees
+  // "valid but unspecified" state, but libc++/libstdc++ both leave them empty.
+  // This assertion locks the current observed behavior; if migrating to MSVC
+  // STL or a future libc++ change, this may need to be relaxed.
+  EXPECT_TRUE(original.crystals_.empty());
+  EXPECT_TRUE(original.outgoing_indices_.empty());
+  EXPECT_TRUE(original.outgoing_d_.empty());
+  EXPECT_TRUE(original.outgoing_w_.empty());
+
+  // (c) POD scalar fields are NOT reset on move — this is the current
+  // contract. We deliberately do NOT assert curr_wl_/generation_/etc. to be
+  // zero. Future refactors that change this behavior should update both
+  // sim_data.cpp and this comment.
+}
+
+
+TEST(SimDataTest, MoveAssignAndSelfMove) {
+  // Normal move-assignment.
+  auto src = MakePopulatedSimData();
+  RaySeg* src_ptr = src.rays_.rays_.get();
+  SimData dst(3);  // Different initial capacity.
+  dst = std::move(src);
+
+  EXPECT_EQ(dst.rays_.rays_.get(), src_ptr);
+  EXPECT_EQ(dst.rays_.size_, 5u);
+  EXPECT_EQ(dst.rays_.capacity_, 8u);
+  EXPECT_FLOAT_EQ(dst.curr_wl_, 550.0f);
+  EXPECT_EQ(dst.generation_, 42u);
+  EXPECT_EQ(dst.outgoing_indices_.size(), 3u);
+  EXPECT_EQ(dst.crystals_.size(), 1u);
+
+  // Source moved-from state.
+  EXPECT_EQ(src.rays_.rays_, nullptr);
+  EXPECT_EQ(src.rays_.size_, 0u);
+  EXPECT_EQ(src.rays_.capacity_, 0u);
+  EXPECT_TRUE(src.crystals_.empty());
+  EXPECT_TRUE(src.outgoing_indices_.empty());
+
+  // Self-move-assignment must preserve all fields (source code has
+  // &other == this guard). Snapshot → self-move → assert preservation.
+  auto self = MakePopulatedSimData();
+  const float kSnapCurrWl = self.curr_wl_;
+  const uint64_t kSnapGen = self.generation_;
+  const size_t kSnapRaysSize = self.rays_.size_;
+  RaySeg* snap_rays_ptr = self.rays_.rays_.get();
+  const size_t kSnapOutgoingIdxSize = self.outgoing_indices_.size();
+  const size_t kSnapCrystalsSize = self.crystals_.size();
+
+  // Use an alias reference to bypass -Wself-move warning.
+  SimData& self_ref = self;
+  self_ref = std::move(self);
+
+  EXPECT_FLOAT_EQ(self.curr_wl_, kSnapCurrWl);
+  EXPECT_EQ(self.generation_, kSnapGen);
+  EXPECT_EQ(self.rays_.size_, kSnapRaysSize);
+  EXPECT_EQ(self.rays_.rays_.get(), snap_rays_ptr);
+  EXPECT_EQ(self.outgoing_indices_.size(), kSnapOutgoingIdxSize);
+  EXPECT_EQ(self.crystals_.size(), kSnapCrystalsSize);
+}

--- a/test/test_sim_data.cpp
+++ b/test/test_sim_data.cpp
@@ -6,8 +6,10 @@
 //   1. sim_data.cpp's static_assert(sizeof(SimData) == ...) — already exists
 //   2. The 4 special member functions in sim_data.cpp
 //   3. CopyConstructDeepCopy / CopyAssignmentDeepCopy / MoveConstruct* tests below
-// The sizeof static_assert at the top of this file is a mirror of (1),
-// forming a double safeguard so that sizeof drift is detected from both sides.
+// The sizeof static_assert at the top of this file is a redundant mirror of
+// (1), gated to the platform where the value was authored. This is NOT a true
+// double-safeguard on other platforms — the source-side assert in sim_data.cpp
+// is unconditional and remains the primary guarantee.
 
 #include <gtest/gtest.h>
 
@@ -24,9 +26,11 @@ using lumice::RayBuffer;
 using lumice::RaySeg;
 using lumice::SimData;
 
-// Mirror of sim_data.cpp's static_assert. Only enabled on the platform where
-// the original assert was authored (macOS Apple Silicon, 64-bit). Other
-// 64-bit ABIs may differ; we keep the assertion narrow to avoid CI noise.
+// Redundant mirror of sim_data.cpp's static_assert, gated to the platform
+// where the original assert was authored (macOS Apple Silicon, 64-bit).
+// Other 64-bit ABIs may differ; the unconditional assert in sim_data.cpp is
+// the primary guarantee — this mirror just adds an extra reminder on the
+// authoring platform that this test file's per-field assertions need updating.
 #if defined(__APPLE__) && defined(__aarch64__)
 static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 static_assert(sizeof(SimData) == 144,
@@ -154,12 +158,35 @@ TEST(RayBufferTest, EmplaceBackBatchOnEmptyDst) {
 TEST(RayBufferTest, DISABLED_EmplaceBackBatchOnNonEmptyDstQuirk) {
   // Intentionally not executed by default. To run manually:
   //   ./unit_test --gtest_also_run_disabled_tests --gtest_filter='*Quirk*'
+  //
   // TODO: when sim_data.cpp's batch EmplaceBack is fixed to use
-  //       `capacity_ - size_` as the upper bound, enable this test by
-  //       removing the DISABLED_ prefix and replace the FAIL with the
-  //       fixed-behavior assertions.
+  //       `capacity_ - size_` as the upper bound, remove the DISABLED_ prefix
+  //       and replace the FAIL with the assertions sketched below.
+  //
+  // Target post-fix scenario:
+  //   RayBuffer src(10);
+  //   for (int i = 0; i < 10; i++) src.EmplaceBack(MakeRay(i));
+  //   // src can hold 9 (strict-less-than guard); src.size_ == 9.
+  //
+  //   RayBuffer dst(10);
+  //   for (int i = 0; i < 6; i++) dst.EmplaceBack(MakeRay(100 + i));
+  //   // dst.size_ == 6 (also constrained to capacity-1 = 9).
+  //
+  //   dst.EmplaceBack(src, 0, /*len=*/kInfSize);
+  //   // After fix, end = min(start+len, capacity_-size_, src.size_) = min(_, 4, 9) = 4
+  //   // i.e. only 4 elements are copied (filling dst to capacity-1 = 9 minus 1 reserved slot).
+  //
+  // Target assertions (uncomment when fix lands and DISABLED_ is removed):
+  //   EXPECT_EQ(dst.size_, 9u);  // pre-existing 6 + 3 new (or whatever the
+  //                              //   fixed bound permits without overflow)
+  //   EXPECT_FLOAT_EQ(dst[5].w_, 105.0f);  // last pre-existing element intact
+  //   EXPECT_FLOAT_EQ(dst[6].w_, 0.0f);    // first appended element from src
+  //
+  // Until the fix lands, this test fails loudly when run manually so nobody
+  // mistakes the DISABLED state for "passing".
   FAIL() << "Quirk anchor: batch EmplaceBack on non-empty dst writes past "
-            "capacity. Awaiting fix in a future task.";
+            "capacity. Awaiting fix in a future task. See target assertions "
+            "in the comment block above.";
 }
 
 


### PR DESCRIPTION
## Summary

Closes the three zero-coverage gaps and three documentation errors flagged by test-audit (#141). All work was driven through the scrum lifecycle (plan → plan-review → implement → code-review → closeout → learn) for each subtask.

- **+36 unit tests** across three previously zero-coverage modules (optics physics, C API result getters, SimData/RayBuffer)
- **+1 DISABLED contract anchor** locking a known batch `EmplaceBack` quirk for future fix
- **3 doc fixes** (CI artifact name, E2E test filename, nonexistent `conftest.py` reference) applied symmetrically to English and Chinese docs

### Test breakdown
| Module | New tests | File |
|--------|-----------|------|
| `core/optics` (Sellmeier, Fresnel, HitSurface, Propagate) | 18 | `test/test_optics.cpp` (new) |
| C API result getters + server lifecycle | 8 | `test/test_c_api.cpp` (appended) |
| `config/sim_data` (RayBuffer + SimData copy/move) | 10 + 1 DISABLED | `test/test_sim_data.cpp` (new) |

### Key design decisions
- **Per-field independent assertions** in SimData deep-copy tests, each with `<< "field_name not copied"` failure messages, to surface the "manually written copy/move missed a field" bug class precisely
- **`DISABLED_` contract anchor** for the batch `EmplaceBack` overflow quirk: includes a detailed TODO and target post-fix assertion template, so a future fix has a concrete starting point
- **Lightweight test fixtures** with explicit `CommitAndWaitForIdle()` helper rather than fat `SetUp()`, keeping each test self-documenting
- **`sizeof(SimData)` mirror static_assert** in the test file (gated to macOS Apple Silicon) as a reminder that adding fields requires updating both `sim_data.cpp` and the deep-copy tests
- **`size != capacity` input shape** in deep-copy tests (capacity=8, size=5) catches a future "memcpy size bytes instead of capacity bytes" refactor

## Test plan
- [x] `./scripts/build.sh -tj release` — 214 unit tests pass (1.82s) + 1 DISABLED reported
- [x] `pytest test/e2e/ -v` — 19 E2E tests pass (56.16s)
- [x] `./scripts/build.sh -gtj release` — GUI test suite pass (18.45s)
- [x] `./scripts/format.sh` applied; clang-format/clang-tidy clean
- [x] No production code touched

## Known follow-ups (out of scope for this PR)
- Fix the batch `EmplaceBack` quirk that the `DISABLED_EmplaceBackBatchOnNonEmptyDstQuirk` test anchors
- Complete the developer-guide E2E directory tree (still missing `base.py`, `runner.py`, `test_cli.py`, etc.)
- Add a CI check for doc/code drift on the E2E directory tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)