### PR TITLE
feat(gui): four UX interaction improvements

### DIFF
--- a/src/config/raypath_validation.hpp
+++ b/src/config/raypath_validation.hpp
@@ -1,0 +1,109 @@
+#ifndef CONFIG_RAYPATH_VALIDATION_HPP_
+#define CONFIG_RAYPATH_VALIDATION_HPP_
+
+#include <cctype>
+#include <string>
+
+namespace lumice {
+
+/// Validation state for raypath text input.
+enum class RaypathValidation {
+  kValid,       ///< All tokens are non-negative integers; safe to submit.
+  kIncomplete,  ///< Trailing/leading separator; user is still typing.
+  kInvalid,     ///< Contains non-numeric tokens or empty interior tokens.
+};
+
+/// Validate a raypath text string (dash- or comma-separated face indices).
+///
+/// Rules:
+///   - Empty string → kValid (means "no raypath filter").
+///   - Trailing separator (e.g. "3-5-") → kIncomplete.
+///   - Leading separator (e.g. "-3") → kIncomplete.
+///   - Consecutive separators in the middle (e.g. "3--5") → kInvalid.
+///   - Any token that is not a non-negative integer → kInvalid.
+///   - All tokens are non-negative integers → kValid.
+///
+/// This function is pure-stdlib (no GUI dependency) and suitable for unit testing.
+inline RaypathValidation ValidateRaypathText(const std::string& text) {
+  if (text.empty()) {
+    return RaypathValidation::kValid;
+  }
+
+  // Check leading separator
+  bool has_leading_sep = (text.front() == '-' || text.front() == ',');
+  // Check trailing separator
+  bool has_trailing_sep = (text.back() == '-' || text.back() == ',');
+
+  if (has_trailing_sep || has_leading_sep) {
+    // Could still be kInvalid if there are bad tokens in the middle.
+    // But first check: if the entire string is just separators, it's kIncomplete.
+    bool all_separators = true;
+    for (char c : text) {
+      if (c != '-' && c != ',') {
+        all_separators = false;
+        break;
+      }
+    }
+    if (all_separators) {
+      return RaypathValidation::kIncomplete;
+    }
+  }
+
+  // Tokenize: split by '-' and ','
+  // Walk through the string, split on separators, validate each token.
+  bool prev_was_sep = false;
+  bool in_token = false;
+  bool found_interior_empty = false;
+  bool found_bad_token = false;
+  int token_start = 0;
+  int token_count = 0;
+
+  for (int i = 0; i <= static_cast<int>(text.size()); ++i) {
+    bool is_sep = (i < static_cast<int>(text.size())) && (text[i] == '-' || text[i] == ',');
+    bool is_end = (i == static_cast<int>(text.size()));
+
+    if (is_sep || is_end) {
+      if (in_token) {
+        // Validate the token [token_start, i)
+        std::string token = text.substr(token_start, i - token_start);
+        // Check: all characters must be digits
+        bool all_digits = true;
+        for (char c : token) {
+          if (!std::isdigit(static_cast<unsigned char>(c))) {
+            all_digits = false;
+            break;
+          }
+        }
+        if (!all_digits || token.empty()) {
+          found_bad_token = true;
+        }
+        token_count++;
+        in_token = false;
+      } else if (is_sep && prev_was_sep) {
+        // Consecutive separators in the middle → empty interior token
+        found_interior_empty = true;
+      }
+      prev_was_sep = is_sep;
+    } else {
+      if (!in_token) {
+        token_start = i;
+        in_token = true;
+      }
+      prev_was_sep = false;
+    }
+  }
+
+  if (found_bad_token || found_interior_empty) {
+    return RaypathValidation::kInvalid;
+  }
+
+  if (has_trailing_sep || has_leading_sep) {
+    return RaypathValidation::kIncomplete;
+  }
+
+  return RaypathValidation::kValid;
+}
+
+}  // namespace lumice
+
+#endif  // CONFIG_RAYPATH_VALIDATION_HPP_

--- a/src/config/raypath_validation.hpp
+++ b/src/config/raypath_validation.hpp
@@ -15,12 +15,12 @@ enum class RaypathValidation {
 
 /// Validate a raypath text string (dash- or comma-separated face indices).
 ///
-/// Rules:
+/// Rules (evaluated in priority order):
 ///   - Empty string → kValid (means "no raypath filter").
+///   - Consecutive separators anywhere (e.g. "3--5", "--3") → kInvalid.
+///   - Any token that is not a non-negative integer → kInvalid.
 ///   - Trailing separator (e.g. "3-5-") → kIncomplete.
 ///   - Leading separator (e.g. "-3") → kIncomplete.
-///   - Consecutive separators in the middle (e.g. "3--5") → kInvalid.
-///   - Any token that is not a non-negative integer → kInvalid.
 ///   - All tokens are non-negative integers → kValid.
 ///
 /// This function is pure-stdlib (no GUI dependency) and suitable for unit testing.
@@ -66,7 +66,8 @@ inline RaypathValidation ValidateRaypathText(const std::string& text) {
       if (in_token) {
         // Validate the token [token_start, i)
         std::string token = text.substr(token_start, i - token_start);
-        // Check: all characters must be digits
+        // Check: all characters must be digits.
+        // Note: token is guaranteed non-empty because in_token is only set when a non-separator char is seen.
         bool all_digits = true;
         for (char c : token) {
           if (!std::isdigit(static_cast<unsigned char>(c))) {
@@ -74,7 +75,7 @@ inline RaypathValidation ValidateRaypathText(const std::string& text) {
             break;
           }
         }
-        if (!all_digits || token.empty()) {
+        if (!all_digits) {
           found_bad_token = true;
         }
         token_count++;

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -844,7 +844,7 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   // Sim
   if (root.contains("sim")) {
     auto& js = root["sim"];
-    state.sim.ray_num_millions = js.value("ray_num_millions", 1.0f);
+    state.sim.ray_num_millions = js.value("ray_num_millions", SimConfig{}.ray_num_millions);
     state.sim.max_hits = js.value("max_hits", 8);
     state.sim.infinite = js.value("infinite", false);
   }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -845,8 +845,8 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   if (root.contains("sim")) {
     auto& js = root["sim"];
     state.sim.ray_num_millions = js.value("ray_num_millions", SimConfig{}.ray_num_millions);
-    state.sim.max_hits = js.value("max_hits", 8);
-    state.sim.infinite = js.value("infinite", false);
+    state.sim.max_hits = js.value("max_hits", SimConfig{}.max_hits);
+    state.sim.infinite = js.value("infinite", SimConfig{}.infinite);
   }
 
   // Scattering

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -48,6 +48,8 @@ static const char* kLensTypeJsonNames[] = { "linear",
                                             "rectangular" };
 
 static const char* kVisibleJsonNames[] = { "upper", "lower", "full", "front" };
+static_assert(sizeof(kVisibleJsonNames) / sizeof(kVisibleJsonNames[0]) == kVisibleCount,
+              "kVisibleJsonNames must match kVisibleCount");
 static const char* kAspectPresetJsonNames[] = { "free", "16:9", "3:2", "4:3", "1:1", "match_background" };
 static_assert(sizeof(kAspectPresetJsonNames) / sizeof(kAspectPresetJsonNames[0]) == kAspectPresetCount,
               "kAspectPresetJsonNames must match kAspectPresetCount");

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -47,7 +47,7 @@ static const char* kLensTypeJsonNames[] = { "linear",
                                             "dual_fisheye_stereographic",
                                             "rectangular" };
 
-static const char* kVisibleJsonNames[] = { "upper", "lower", "full" };
+static const char* kVisibleJsonNames[] = { "upper", "lower", "full", "front" };
 static const char* kAspectPresetJsonNames[] = { "free", "16:9", "3:2", "4:3", "1:1", "match_background" };
 static_assert(sizeof(kAspectPresetJsonNames) / sizeof(kAspectPresetJsonNames[0]) == kAspectPresetCount,
               "kAspectPresetJsonNames must match kAspectPresetCount");

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -57,7 +57,7 @@ static_assert(sizeof(kAspectPresetJsonNames) / sizeof(kAspectPresetJsonNames[0])
 
 // ========== Shared helpers ==========
 
-static std::vector<int> ParseRaypathText(const std::string& text) {
+std::vector<int> ParseRaypathText(const std::string& text) {
   std::vector<int> result;
   // Normalize: replace ',' with '-' so both separators are accepted
   std::string normalized = text;

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -54,6 +54,9 @@ std::filesystem::path ShowExportJsonDialog();
 std::filesystem::path ShowOpenImageDialog();
 
 
+// Parse dash/comma-separated raypath text into face indices (tolerant: skips invalid tokens).
+std::vector<int> ParseRaypathText(const std::string& text);
+
 }  // namespace lumice::gui
 
 #endif  // LUMICE_GUI_FILE_IO_HPP

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -98,8 +98,8 @@ constexpr float kDualFisheyeOverlap = 0.0872f;
 inline const char* const kSpectrumNames[] = { "D50", "D55", "D65", "D75", "A", "E" };
 constexpr int kSpectrumCount = 6;
 
-inline const char* const kVisibleNames[] = { "Upper", "Lower", "Full" };
-constexpr int kVisibleCount = 3;
+inline const char* const kVisibleNames[] = { "Upper", "Lower", "Full", "Front" };
+constexpr int kVisibleCount = 4;  // must stay in sync with fragment shader u_visible range
 
 inline const int kSimResolutions[] = { 512, 1024, 2048, 4096 };
 constexpr int kSimResolutionCount = 4;
@@ -112,7 +112,7 @@ struct RenderConfig {
   float azimuth = 0.0f;
   float roll = 0.0f;
   int sim_resolution_index = 1;  // Index into kSimResolutions (default 1024)
-  int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full)
+  int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full, 3=front)
   float background[3] = { 0.0f, 0.0f, 0.0f };
   float ray_color[3] = { 1.0f, 1.0f, 1.0f };
   float opacity = 1.0f;

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -60,7 +60,7 @@ struct SunConfig {
 };
 
 struct SimConfig {
-  float ray_num_millions = 1.0f;
+  float ray_num_millions = 5.0f;
   int max_hits = 8;
   bool infinite = false;
 };

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -288,13 +288,15 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   };
 
   // Hemisphere visibility check: returns true if the given altitude is in the visible hemisphere.
-  // visible: 0=upper (alt>=0), 1=lower (alt<=0), 2=full (always visible).
+  // visible: 0=upper (alt>=0), 1=lower (alt<=0), 2=full (always visible), 3=front (always visible).
+  // Note: front mode visibility depends on 3D view direction (dot product with camera forward),
+  // which cannot be determined from altitude alone. All labels are shown as a known limitation.
   auto is_visible = [&](float alt) -> bool {
     if (input.visible == 0)
       return alt >= -0.5f;  // small tolerance for edge labels
     if (input.visible == 1)
       return alt <= 0.5f;
-    return true;
+    return true;  // full(2) and front(3): show all labels
   };
 
   // Crossing detection helper: given two adjacent valid sample points, detect and add labels.
@@ -401,7 +403,9 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   // When visible = upper(0) or lower(1), add the hemisphere boundary (equator) as an extra edge.
   // The equator is defined by altitude = 0 (world_dir.z = 0). Sample it in world space
   // and forward-project to pixel coordinates.
-  if (input.visible != 2 && input.lens_type >= 0 && input.lens_type <= 3) {
+  // Note: front(3) hemisphere boundary is a view-dependent great circle, not drawn here.
+  // Was: input.visible != 2 (excluded only full mode)
+  if ((input.visible == 0 || input.visible == 1) && input.lens_type >= 0 && input.lens_type <= 3) {
     constexpr int kEquatorSamples = 360;
     SampleAngles prev{};
     prev.valid = false;

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -890,8 +890,21 @@ void RenderFilterTab(GuiState& state) {
     state.MarkFilterDirty();
   }
 
-  // Validate current raypath text; background color reflects previous-frame value (normal for ImGui immediate mode).
-  auto validation = ValidateRaypathText(f.raypath_text);
+  // Persistent edit buffer: tracks what the user is typing, independent of f.raypath_text
+  // (which only holds the last validated value sent to server). Resyncs when:
+  //   - selected filter changes (user clicks a different filter)
+  //   - f.raypath_text changes externally (e.g. config file load)
+  static char raypath_edit_buf[256] = {};
+  static int raypath_edit_filter_idx = -1;
+  static std::string raypath_edit_committed;
+  if (raypath_edit_filter_idx != state.selected_filter || raypath_edit_committed != f.raypath_text) {
+    raypath_edit_filter_idx = state.selected_filter;
+    raypath_edit_committed = f.raypath_text;
+    snprintf(raypath_edit_buf, sizeof(raypath_edit_buf), "%s", f.raypath_text.c_str());
+  }
+
+  // Validate the edit buffer for visual feedback.
+  auto validation = ValidateRaypathText(raypath_edit_buf);
   int style_pushes = 0;
   if (validation == RaypathValidation::kIncomplete) {
     ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.6f, 0.4f, 0.1f, 0.6f));  // Orange
@@ -901,13 +914,14 @@ void RenderFilterTab(GuiState& state) {
     style_pushes = 1;
   }
 
-  char raypath_buf[256];
-  snprintf(raypath_buf, sizeof(raypath_buf), "%s", f.raypath_text.c_str());
-  if (ImGui::InputText("Raypath", raypath_buf, sizeof(raypath_buf))) {
-    f.raypath_text = raypath_buf;
-    // Update validation to current-frame value so hint text is accurate this frame.
-    validation = ValidateRaypathText(f.raypath_text);
+  if (ImGui::InputText("Raypath", raypath_edit_buf, sizeof(raypath_edit_buf))) {
+    // Revalidate after edit; only commit to model state on kValid.
+    // f.raypath_text always holds the last valid value, preventing other dirty triggers
+    // (e.g. symmetry checkbox) from submitting invalid text via FillLumiceConfig.
+    validation = ValidateRaypathText(raypath_edit_buf);
     if (validation == RaypathValidation::kValid) {
+      f.raypath_text = raypath_edit_buf;
+      raypath_edit_committed = f.raypath_text;
       state.MarkFilterDirty();
     }
   }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -17,9 +17,47 @@ namespace lumice::gui {
 namespace {
 // LogLinear hybrid mapping constants.
 // Tuned for prism_h [0, 100] range. Re-validate before reusing for other ranges.
-// REQUIRES: min_val == 0 at call site.
+// REQUIRES: min_val == 0, max_val > kLogLinearX0 at call site.
 constexpr float kLogLinearX0 = 0.01f;       // Value threshold: linear below, log above
 constexpr float kLogLinearTSwitch = 0.15f;  // Slider position threshold (fraction of [0,1])
+
+// Log-scale: compute normalized [0,1] position from value in [min_val, max_val].
+static float LogValueToNorm(float value, float min_val, float max_val) {
+  value = std::max(value, min_val);
+  float log_ratio = std::log(max_val / min_val);
+  float norm = std::log(value / min_val) / log_ratio;
+  return std::clamp(norm, 0.0f, 1.0f);
+}
+
+// Log-scale: compute value from normalized [0,1] position.
+static float LogNormToValue(float norm, float min_val, float max_val) {
+  float log_ratio = std::log(max_val / min_val);
+  return min_val * std::exp(norm * log_ratio);
+}
+
+// LogLinear hybrid: compute normalized [0,1] position from value in [0, max_val].
+// Linear in [0, x0], log in [x0, max_val], C0 continuous at x0.
+static float LogLinearValueToNorm(float value, float max_val) {
+  value = std::clamp(value, 0.0f, max_val);
+  float log_ratio = std::log(max_val / kLogLinearX0);
+  float norm;
+  if (value <= kLogLinearX0) {
+    norm = kLogLinearTSwitch * value / kLogLinearX0;
+  } else {
+    norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(value / kLogLinearX0) / log_ratio;
+  }
+  return std::clamp(norm, 0.0f, 1.0f);
+}
+
+// LogLinear hybrid: compute value from normalized [0,1] position.
+static float LogLinearNormToValue(float norm, float max_val) {
+  float log_ratio = std::log(max_val / kLogLinearX0);
+  if (norm <= kLogLinearTSwitch) {
+    return kLogLinearX0 * norm / kLogLinearTSwitch;
+  }
+  float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
+  return kLogLinearX0 * std::exp(t_log * log_ratio);
+}
 }  // namespace
 
 // Compute slider width and prepare IDs for the [slider] [input] Label layout.
@@ -77,34 +115,16 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
     }
   } else if (scale == SliderScale::kLog && min_val > 0.0f) {
     // Log-scale slider: uniform resolution across orders of magnitude.
-    // Slider operates on normalized [0,1] position; actual value = min * exp(norm * log(max/min)).
-    *value = std::max(*value, min_val);  // Defend against 0/negative from InputFloat
-    float log_ratio = std::log(max_val / min_val);
-    float norm = std::log(*value / min_val) / log_ratio;
-    norm = std::clamp(norm, 0.0f, 1.0f);
+    float norm = LogValueToNorm(*value, min_val, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
-      *value = min_val * std::exp(norm * log_ratio);
+      *value = LogNormToValue(norm, min_val, max_val);
       changed = true;
     }
   } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
-    // LogLinear hybrid: linear [0, x0] for t in [0, t_switch], log [x0, max] for t in [t_switch, 1].
-    // Allows reaching zero while keeping log-scale feel for larger values.
-    *value = std::clamp(*value, 0.0f, max_val);
-    float log_ratio = std::log(max_val / kLogLinearX0);
-    float norm;
-    if (*value <= kLogLinearX0) {
-      norm = kLogLinearTSwitch * *value / kLogLinearX0;
-    } else {
-      norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(*value / kLogLinearX0) / log_ratio;
-    }
-    norm = std::clamp(norm, 0.0f, 1.0f);
+    // LogLinear hybrid: linear near zero, log above x0. Allows reaching zero.
+    float norm = LogLinearValueToNorm(*value, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
-      if (norm <= kLogLinearTSwitch) {
-        *value = kLogLinearX0 * norm / kLogLinearTSwitch;
-      } else {
-        float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
-        *value = kLogLinearX0 * std::exp(t_log * log_ratio);
-      }
+      *value = LogLinearNormToValue(norm, max_val);
       changed = true;
     }
   } else {
@@ -196,31 +216,15 @@ static bool SliderWithPreset(const char* label, float* value, float min_val, flo
       changed = true;
     }
   } else if (scale == SliderScale::kLog && min_val > 0.0f) {
-    *value = std::max(*value, min_val);
-    float log_ratio = std::log(max_val / min_val);
-    float norm = std::log(*value / min_val) / log_ratio;
-    norm = std::clamp(norm, 0.0f, 1.0f);
+    float norm = LogValueToNorm(*value, min_val, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
-      *value = min_val * std::exp(norm * log_ratio);
+      *value = LogNormToValue(norm, min_val, max_val);
       changed = true;
     }
   } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
-    *value = std::clamp(*value, 0.0f, max_val);
-    float log_ratio = std::log(max_val / kLogLinearX0);
-    float norm;
-    if (*value <= kLogLinearX0) {
-      norm = kLogLinearTSwitch * *value / kLogLinearX0;
-    } else {
-      norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(*value / kLogLinearX0) / log_ratio;
-    }
-    norm = std::clamp(norm, 0.0f, 1.0f);
+    float norm = LogLinearValueToNorm(*value, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
-      if (norm <= kLogLinearTSwitch) {
-        *value = kLogLinearX0 * norm / kLogLinearTSwitch;
-      } else {
-        float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
-        *value = kLogLinearX0 * std::exp(t_log * log_ratio);
-      }
+      *value = LogLinearNormToValue(norm, max_val);
       changed = true;
     }
   } else {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "config/raypath_validation.hpp"
 #include "config/render_config.hpp"
 #include "gui/gui_constants.hpp"
 #include "gui/gui_state.hpp"
@@ -889,13 +890,36 @@ void RenderFilterTab(GuiState& state) {
     state.MarkFilterDirty();
   }
 
+  // Validate current raypath text; background color reflects previous-frame value (normal for ImGui immediate mode).
+  auto validation = ValidateRaypathText(f.raypath_text);
+  int style_pushes = 0;
+  if (validation == RaypathValidation::kIncomplete) {
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.6f, 0.4f, 0.1f, 0.6f));  // Orange
+    style_pushes = 1;
+  } else if (validation == RaypathValidation::kInvalid) {
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.7f, 0.15f, 0.15f, 0.6f));  // Red
+    style_pushes = 1;
+  }
+
   char raypath_buf[256];
   snprintf(raypath_buf, sizeof(raypath_buf), "%s", f.raypath_text.c_str());
   if (ImGui::InputText("Raypath", raypath_buf, sizeof(raypath_buf))) {
     f.raypath_text = raypath_buf;
-    state.MarkFilterDirty();
+    // Update validation to current-frame value so hint text is accurate this frame.
+    validation = ValidateRaypathText(f.raypath_text);
+    if (validation == RaypathValidation::kValid) {
+      state.MarkFilterDirty();
+    }
   }
-  ImGui::TextDisabled("Face indices separated by '-', e.g. 3-1-5-7-4 (comma also accepted)");
+  ImGui::PopStyleColor(style_pushes);
+
+  if (validation == RaypathValidation::kIncomplete) {
+    ImGui::TextColored(ImVec4(0.9f, 0.7f, 0.2f, 1.0f), "Incomplete input");
+  } else if (validation == RaypathValidation::kInvalid) {
+    ImGui::TextColored(ImVec4(0.9f, 0.2f, 0.2f, 1.0f), "Invalid input");
+  } else {
+    ImGui::TextDisabled("Face indices separated by '-', e.g. 3-1-5-7-4 (comma also accepted)");
+  }
 
   ImGui::Text("Symmetry:");
   ImGui::SameLine();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -14,6 +14,14 @@
 
 namespace lumice::gui {
 
+namespace {
+// LogLinear hybrid mapping constants.
+// Tuned for prism_h [0, 100] range. Re-validate before reusing for other ranges.
+// REQUIRES: min_val == 0 at call site.
+constexpr float kLogLinearX0 = 0.01f;       // Value threshold: linear below, log above
+constexpr float kLogLinearTSwitch = 0.15f;  // Slider position threshold (fraction of [0,1])
+}  // namespace
+
 // Compute slider width and prepare IDs for the [slider] [input] Label layout.
 // Writes slider_id and input_id buffers, returns the computed slider width.
 static float PrepareSliderLayout(const char* label, char* display_label_out, size_t display_buf_size, char* slider_id,
@@ -76,6 +84,27 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
     norm = std::clamp(norm, 0.0f, 1.0f);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
       *value = min_val * std::exp(norm * log_ratio);
+      changed = true;
+    }
+  } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
+    // LogLinear hybrid: linear [0, x0] for t in [0, t_switch], log [x0, max] for t in [t_switch, 1].
+    // Allows reaching zero while keeping log-scale feel for larger values.
+    *value = std::clamp(*value, 0.0f, max_val);
+    float log_ratio = std::log(max_val / kLogLinearX0);
+    float norm;
+    if (*value <= kLogLinearX0) {
+      norm = kLogLinearTSwitch * *value / kLogLinearX0;
+    } else {
+      norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(*value / kLogLinearX0) / log_ratio;
+    }
+    norm = std::clamp(norm, 0.0f, 1.0f);
+    if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
+      if (norm <= kLogLinearTSwitch) {
+        *value = kLogLinearX0 * norm / kLogLinearTSwitch;
+      } else {
+        float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
+        *value = kLogLinearX0 * std::exp(t_log * log_ratio);
+      }
       changed = true;
     }
   } else {
@@ -157,13 +186,41 @@ static bool SliderWithPreset(const char* label, float* value, float min_val, flo
 
   bool changed = false;
 
-  // Slider (sqrt scale)
+  // Slider (nonlinear scale support)
   ImGui::PushItemWidth(slider_w);
   if (scale == SliderScale::kSqrt && min_val >= 0.0f) {
     float sqrt_val = std::sqrt(std::max(*value, 0.0f));
     float sqrt_max = std::sqrt(max_val);
     if (ImGui::SliderFloat(slider_id, &sqrt_val, 0.0f, sqrt_max, "")) {
       *value = sqrt_val * sqrt_val;
+      changed = true;
+    }
+  } else if (scale == SliderScale::kLog && min_val > 0.0f) {
+    *value = std::max(*value, min_val);
+    float log_ratio = std::log(max_val / min_val);
+    float norm = std::log(*value / min_val) / log_ratio;
+    norm = std::clamp(norm, 0.0f, 1.0f);
+    if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
+      *value = min_val * std::exp(norm * log_ratio);
+      changed = true;
+    }
+  } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
+    *value = std::clamp(*value, 0.0f, max_val);
+    float log_ratio = std::log(max_val / kLogLinearX0);
+    float norm;
+    if (*value <= kLogLinearX0) {
+      norm = kLogLinearTSwitch * *value / kLogLinearX0;
+    } else {
+      norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(*value / kLogLinearX0) / log_ratio;
+    }
+    norm = std::clamp(norm, 0.0f, 1.0f);
+    if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "")) {
+      if (norm <= kLogLinearTSwitch) {
+        *value = kLogLinearX0 * norm / kLogLinearTSwitch;
+      } else {
+        float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
+        *value = kLogLinearX0 * std::exp(t_log * log_ratio);
+      }
       changed = true;
     }
   } else {
@@ -540,7 +597,7 @@ void RenderCrystalTab(GuiState& state) {
   if (cr.type == CrystalType::kPrism) {
     DIRTY_IF(SliderWithInput("Height", &cr.height, 0.01f, 100.0f, "%.3f", SliderScale::kLog));
   } else {
-    DIRTY_IF(SliderWithInput("Prism H", &cr.prism_h, 0.0f, 100.0f, "%.3f", SliderScale::kSqrt));
+    DIRTY_IF(SliderWithInput("Prism H", &cr.prism_h, 0.0f, 100.0f, "%.3f", SliderScale::kLogLinear));
     DIRTY_IF(SliderWithInput("Upper H", &cr.upper_h, 0.0f, 1.0f, "%.2f"));
     DIRTY_IF(SliderWithInput("Lower H", &cr.lower_h, 0.0f, 1.0f, "%.2f"));
   }

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -6,7 +6,7 @@ namespace lumice::gui {
 struct GuiState;
 
 // Slider scale modes for SliderWithInput
-enum class SliderScale { kLinear, kSqrt, kLog };
+enum class SliderScale { kLinear, kSqrt, kLog, kLogLinear };
 
 // Slider + InputFloat + label text, laid out as: [slider] [input] Label
 // Uses a fixed label column width so vertically stacked sliders align.

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -329,8 +329,11 @@ void main() {
     // In equirect convention: lat = asin(-dz), lat > 0 means upper sky
     float lat = asin(clamp(-world_dir.z, -1.0, 1.0));
     pixel_visible = true;
-    if (u_visible == 0 && lat < 0.0) pixel_visible = false;
-    if (u_visible == 1 && lat > 0.0) pixel_visible = false;
+    if (u_visible == 0 && lat < 0.0) pixel_visible = false;   // upper: discard lower hemisphere
+    if (u_visible == 1 && lat > 0.0) pixel_visible = false;   // lower: discard upper hemisphere
+    // 3=front: discard back hemisphere. u_view_matrix[2] = -forward (see BuildViewMatrix),
+    // so dot(world_dir, u_view_matrix[2]) > 0 means world_dir is behind the camera.
+    if (u_visible == 3 && dot(world_dir, u_view_matrix[2]) > 0.0) pixel_visible = false;
 
     if (pixel_visible) {
       vec3 tex_color = sampleDualFisheye(world_dir);

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -658,8 +658,8 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       // Write small value in linear region → should preserve exactly
       ctx->ItemInputValue("**/##Prism H_input", 0.005f);
       ctx->Yield();
-      IM_CHECK_GE(gui::g_state.crystals[0].prism_h, 0.004f);
-      IM_CHECK_LE(gui::g_state.crystals[0].prism_h, 0.006f);
+      IM_CHECK_GE(gui::g_state.crystals[0].prism_h, 0.0049f);
+      IM_CHECK_LE(gui::g_state.crystals[0].prism_h, 0.0051f);
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -630,6 +630,39 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p1_slider/pyramid_prism_h_loglinear_zero — kLogLinear scale allows prism_h to reach 0
+  // SliderWithInput("Prism H", ..., kLogLinear) → "##Prism H_input".
+  // kLogLinear hybrid mapping: linear near zero, log above x0=0.01.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_slider", "pyramid_prism_h_loglinear_zero");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      ctx->ItemClick("##LeftPanel/ConfigTabs/Crystal");
+      ctx->Yield(2);
+
+      // Switch to pyramid type
+      gui::g_state.crystals[0].type = gui::CrystalType::kPyramid;
+      ctx->Yield(3);
+
+      // Write 0 → kLogLinear allows reaching exactly 0
+      ctx->ItemInputValue("**/##Prism H_input", 0.0f);
+      ctx->Yield();
+      IM_CHECK_EQ(gui::g_state.crystals[0].prism_h, 0.0f);
+
+      // Write max value → should clamp to 100
+      ctx->ItemInputValue("**/##Prism H_input", 100.0f);
+      ctx->Yield();
+      IM_CHECK_EQ(gui::g_state.crystals[0].prism_h, 100.0f);
+
+      // Write small value in linear region → should preserve exactly
+      ctx->ItemInputValue("**/##Prism H_input", 0.005f);
+      ctx->Yield();
+      IM_CHECK_GE(gui::g_state.crystals[0].prism_h, 0.004f);
+      IM_CHECK_LE(gui::g_state.crystals[0].prism_h, 0.006f);
+    };
+  }
+
   // p1_slider/altitude_negative_boundaries — sun altitude ±90°
   // SliderWithInput("Altitude", ...) is also in RenderSceneTab (panels.cpp:598)
   {

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -413,3 +413,12 @@ TEST(ValidateRaypathTextTest, TokenWithSpace_IsInvalid) {
 TEST(ValidateRaypathTextTest, SpecialChars_IsInvalid) {
   EXPECT_EQ(ValidateRaypathText("3-(-1)-5"), RaypathValidation::kInvalid);
 }
+
+TEST(ValidateRaypathTextTest, MultiDigitNumbers_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("12-345-6"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, DoubleLeadingSeparator_IsInvalid) {
+  // "--3": second '-' creates an empty interior token → kInvalid (not kIncomplete)
+  EXPECT_EQ(ValidateRaypathText("--3"), RaypathValidation::kInvalid);
+}

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -1,4 +1,5 @@
-// Unit tests for filter subsystem: RaypathFilter, ComplexFilter, symmetry, hash consistency.
+// Unit tests for filter subsystem: RaypathFilter, ComplexFilter, symmetry, hash consistency,
+// and raypath text validation.
 #include <gtest/gtest.h>
 
 #include <nlohmann/json.hpp>
@@ -6,6 +7,7 @@
 #include <vector>
 
 #include "config/filter_config.hpp"
+#include "config/raypath_validation.hpp"
 #include "core/crystal.hpp"
 #include "core/def.hpp"
 #include "core/filter.hpp"
@@ -327,4 +329,87 @@ TEST_F(FilterTest, ComplexFilter_Propagation) {
   // Should NOT match non-P variants or different paths
   EXPECT_FALSE(filter->Check(MakeRay({ 3, 7 })));
   EXPECT_FALSE(filter->Check(MakeRay({ 3, 1 })));
+}
+
+
+// ========== ValidateRaypathText Tests ==========
+
+TEST(ValidateRaypathTextTest, EmptyString_IsValid) {
+  EXPECT_EQ(ValidateRaypathText(""), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, SingleDigit_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("3"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, MultipleDashSeparated_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("3-1-5"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, CommaSeparated_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("3,1,5"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, MixedSeparators_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("3-1,5"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, Zero_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("0"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, LongPath_IsValid) {
+  EXPECT_EQ(ValidateRaypathText("3-1-5-7-4"), RaypathValidation::kValid);
+}
+
+TEST(ValidateRaypathTextTest, TrailingDash_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("3-5-"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, SingleTrailingDash_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("3-"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, TrailingComma_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("3,"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, SingleDash_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("-"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, SingleComma_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText(","), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, LeadingDashSingle_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("-3"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, LeadingDashMultiple_IsIncomplete) {
+  EXPECT_EQ(ValidateRaypathText("-3-5"), RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateRaypathTextTest, NonNumericToken_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("3-abc-5"), RaypathValidation::kInvalid);
+}
+
+TEST(ValidateRaypathTextTest, PureNonNumeric_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("abc"), RaypathValidation::kInvalid);
+}
+
+TEST(ValidateRaypathTextTest, ConsecutiveDashes_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("3--5"), RaypathValidation::kInvalid);
+}
+
+TEST(ValidateRaypathTextTest, ConsecutiveCommas_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("3,,5"), RaypathValidation::kInvalid);
+}
+
+TEST(ValidateRaypathTextTest, TokenWithSpace_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("3- -5"), RaypathValidation::kInvalid);
+}
+
+TEST(ValidateRaypathTextTest, SpecialChars_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText("3-(-1)-5"), RaypathValidation::kInvalid);
 }


### PR DESCRIPTION
## Summary

Four independent GUI interaction improvements based on user feedback:

- **Front hemisphere mode**: Add `Front` option to visible hemisphere selector. In fisheye projection, clips the rear hemisphere via `dot(world_dir, view_forward)` in the fragment shader. Includes serialization support (`"front"` in `.lmc`) and overlay label adaptation.
- **Raypath filter validation**: Three-state input validation (valid / incomplete / invalid) with colored background feedback. Persistent edit buffer separated from model state to prevent invalid text from being submitted through indirect dirty triggers. 21 new unit tests.
- **Pyramid height slider nonlinear mapping**: New `kLogLinear` hybrid mapping for Pyramid `prism_h` — linear near zero (reachable) transitioning to logarithmic for large values. Extracted 4 static helpers to eliminate kLog/kLogLinear code duplication.
- **Default ray count 5M**: Changed GUI default from 1M to 5M. Unified deserialization fallbacks to reference `SimConfig{}` struct defaults instead of hardcoded literals.

10 files changed, +378 −30, 9 commits.

## Test plan

- [x] `./scripts/build.sh -tj release` — compile + unit tests pass
- [x] 61/61 GUI interaction tests pass (including new `pyramid_prism_h_loglinear_zero`)
- [x] 21 new raypath validation unit tests pass
- [x] `./scripts/build.sh -gtj release` — full GUI regression (needs display server)
- [x] Manual verification: fisheye + Front mode renders only front hemisphere
- [ ] Manual verification: raypath input shows orange/red feedback for incomplete/invalid input
- [x] Manual verification: Pyramid height slider reaches zero smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)