### PR TITLE
GUI polish: edit modal unification, card layout v2, v7 UX fixes

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -130,32 +130,6 @@ void RenderTopBar(float window_width) {
     }
   }
 
-  // Ray count shortcut
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-
-  if (simulating) {
-    ImGui::BeginDisabled();
-  }
-  if (ImGui::Checkbox("Infinite##topbar", &g_state.sim.infinite)) {
-    g_state.MarkDirty();
-  }
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(120);
-  if (!g_state.sim.infinite) {
-    if (ImGui::SliderFloat("Rays(M)##topbar", &g_state.sim.ray_num_millions, 0.1f, 100.0f, "%.1f")) {
-      g_state.MarkDirty();
-    }
-  } else {
-    ImGui::BeginDisabled();
-    ImGui::SliderFloat("Rays(M)##topbar", &g_state.sim.ray_num_millions, 0.1f, 100.0f, "%.1f");
-    ImGui::EndDisabled();
-  }
-  if (simulating) {
-    ImGui::EndDisabled();
-  }
-
   // Right-panel collapse toggle — right-aligned so it sits flush with the right panel's outer edge.
   // Also note: when the right panel is already collapsed, RenderCollapsedStrip's internal button
   // still expands it; this top-bar toggle simply offers a symmetric alternate entry point.

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -158,9 +158,15 @@ void RenderTopBar(float window_width) {
   }
 
   // Right-panel collapse toggle — right-aligned so it sits flush with the right panel's outer edge.
+  // Also note: when the right panel is already collapsed, RenderCollapsedStrip's internal button
+  // still expands it; this top-bar toggle simply offers a symmetric alternate entry point.
   {
-    const char* right_toggle_label = g_state.right_panel_collapsed ? "<##right_panel_toggle" : ">##right_panel_toggle";
-    float btn_w = ImGui::CalcTextSize(right_toggle_label, nullptr, true).x + style.FramePadding.x * 2.0f;
+    const char* right_toggle_label =
+        g_state.right_panel_collapsed ? "<##right_panel_toggle" : ">##right_panel_toggle";
+    // Use the max width of both label states so the button's left edge doesn't jitter when toggled.
+    float w_expanded = ImGui::CalcTextSize(">##right_panel_toggle", nullptr, true).x;
+    float w_collapsed = ImGui::CalcTextSize("<##right_panel_toggle", nullptr, true).x;
+    float btn_w = std::max(w_expanded, w_collapsed) + style.FramePadding.x * 2.0f;
     float right_edge = ImGui::GetWindowContentRegionMax().x;
     ImGui::SameLine();
     ImGui::SetCursorPosX(right_edge - btn_w);

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -161,8 +161,7 @@ void RenderTopBar(float window_width) {
   // Also note: when the right panel is already collapsed, RenderCollapsedStrip's internal button
   // still expands it; this top-bar toggle simply offers a symmetric alternate entry point.
   {
-    const char* right_toggle_label =
-        g_state.right_panel_collapsed ? "<##right_panel_toggle" : ">##right_panel_toggle";
+    const char* right_toggle_label = g_state.right_panel_collapsed ? "<##right_panel_toggle" : ">##right_panel_toggle";
     // Use the max width of both label states so the button's left edge doesn't jitter when toggled.
     float w_expanded = ImGui::CalcTextSize(">##right_panel_toggle", nullptr, true).x;
     float w_collapsed = ImGui::CalcTextSize("<##right_panel_toggle", nullptr, true).x;
@@ -232,30 +231,26 @@ void RenderLeftPanel(float window_height) {
                ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
-  // ---- Layout: cards (scroll) + 3D preview (fixed) + toolbar ----
+  // ---- Layout: cards (scroll) + toolbar ----
   int sel_layer = GetSelectedLayerIdx();
   int sel_entry = GetSelectedEntryIdx();
   bool has_crystal = sel_layer >= 0 && sel_entry >= 0 && sel_layer < static_cast<int>(g_state.layers.size()) &&
                      sel_entry < static_cast<int>(g_state.layers[sel_layer].entries.size());
 
-  float content_w = ImGui::GetContentRegionAvail().x;
   float avail_h = ImGui::GetContentRegionAvail().y;
   auto& style = ImGui::GetStyle();
-  float separator_h = ImGui::GetTextLineHeight() + style.SeparatorTextPadding.y * 2 + style.ItemSpacing.y;
-  float controls_h = ImGui::GetFrameHeight() + style.ItemSpacing.y;
   float toolbar_h = ImGui::GetFrameHeight() + style.ItemSpacing.y;
-  float preview_size = content_w;
-  float cards_h = std::max(0.0f, avail_h - preview_size - separator_h - controls_h - toolbar_h);
+  float cards_h = std::max(0.0f, avail_h - toolbar_h);
 
+  // The inline 3D preview was removed in task-remove-bottom-preview, but GUI visual
+  // tests still capture from g_crystal_renderer's FBO. Keep the FBO update path so
+  // screenshot/smoke, screenshot/crystal_psnr and the visual/crystal_* tests observe
+  // a populated texture. The modal edit path owns the renderer when open, in which
+  // case we skip here to preserve its last write (ImGui::Image defers GPU sampling).
   if (has_crystal) {
     auto& cr = g_state.layers[sel_layer].entries[sel_entry].crystal;
-
-    // When the crystal edit modal is open, it drives g_crystal_renderer exclusively.
-    // Skip UpdateMesh+Render here so the modal's edit buffer content is the last FBO write
-    // (ImGui::Image() defers GPU sampling to RenderDrawData at frame end).
     bool modal_owns_renderer = IsCrystalModalOpen();
 
-    // Update mesh if crystal changed or selection changed
     int hash = CrystalParamHash(cr);
     if (!modal_owns_renderer && hash != g_crystal_mesh_hash) {
       int result = BuildAndUploadCrystalMesh(cr);
@@ -263,8 +258,6 @@ void RenderLeftPanel(float window_height) {
         g_crystal_mesh_hash = hash;
       }
     }
-
-    // Render to FBO (skip when crystal modal owns the renderer)
     if (!modal_owns_renderer) {
       auto crystal_style = static_cast<CrystalStyle>(g_crystal_style);
       g_crystal_renderer.Render(g_crystal_rotation, g_crystal_zoom, crystal_style);
@@ -274,48 +267,10 @@ void RenderLeftPanel(float window_height) {
   // Process thumbnail update queue before rendering cards
   g_thumbnail_cache.ProcessUpdateQueue(g_state, kMaxThumbnailUpdatesPerFrame);
 
-  // ---- Card scroll area (middle) ----
+  // ---- Card scroll area (fills panel above the toolbar) ----
   ImGui::BeginChild("##CardScroll", ImVec2(0, cards_h), ImGuiChildFlags_None);
   RenderScatteringSection(g_state);
   ImGui::EndChild();
-
-  // ---- 3D Preview (bottom, fixed) ----
-  ImGui::SeparatorText("3D Preview");
-
-  if (has_crystal) {
-    ImVec2 area_start = ImGui::GetCursorScreenPos();
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    draw_list->AddRectFilled(area_start, ImVec2(area_start.x + preview_size, area_start.y + preview_size),
-                             IM_COL32(38, 38, 38, 255));
-
-    auto tex_id = static_cast<ImTextureID>(g_crystal_renderer.GetTextureId());
-    ImVec2 uv0(0, 1);
-    ImVec2 uv1(1, 0);
-    ImGui::Image(tex_id, ImVec2(preview_size, preview_size), uv0, uv1);
-
-    ImGui::SetCursorScreenPos(area_start);
-    ImGui::InvisibleButton("##CrystalPreviewBtn", ImVec2(preview_size, preview_size));
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY);
-      ImGuiIO& io = ImGui::GetIO();
-      if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-        ApplyTrackballRotation(io.MouseDelta.x, io.MouseDelta.y);
-      }
-      if (io.MouseWheel != 0.0f) {
-        g_crystal_zoom *= (1.0f - io.MouseWheel * 0.1f);
-        g_crystal_zoom = std::max(0.5f, std::min(10.0f, g_crystal_zoom));
-      }
-    }
-    ImGui::PushItemWidth(120.0f);
-    ImGui::Combo("##CrystalStyle", &g_crystal_style, kCrystalStyleNames, kCrystalStyleCount);
-    ImGui::PopItemWidth();
-    ImGui::SameLine();
-    if (ImGui::SmallButton("Reset View")) {
-      ResetCrystalView();
-    }
-  } else {
-    ImGui::TextDisabled("No crystal selected");
-  }
 
   // ---- Bottom toolbar: layer add/delete ----
   ImGui::Spacing();

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -296,7 +296,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Re-runs simulation; accumulated rays reset");
     }
-    SliderWithInput("EV##display", &r.exposure_offset, -3.0f, 7.0f, "%.1f");
+    SliderWithInput("EV##display", &r.exposure_offset, -6.0f, 6.0f, "%.1f");
 
     ImGui::SeparatorText("Aspect Ratio");
     int preset_idx = static_cast<int>(g_state.aspect_preset);

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -232,37 +232,10 @@ void RenderLeftPanel(float window_height) {
                    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
   // ---- Layout: cards (scroll) + toolbar ----
-  int sel_layer = GetSelectedLayerIdx();
-  int sel_entry = GetSelectedEntryIdx();
-  bool has_crystal = sel_layer >= 0 && sel_entry >= 0 && sel_layer < static_cast<int>(g_state.layers.size()) &&
-                     sel_entry < static_cast<int>(g_state.layers[sel_layer].entries.size());
-
   float avail_h = ImGui::GetContentRegionAvail().y;
   auto& style = ImGui::GetStyle();
   float toolbar_h = ImGui::GetFrameHeight() + style.ItemSpacing.y;
   float cards_h = std::max(0.0f, avail_h - toolbar_h);
-
-  // The inline 3D preview was removed in task-remove-bottom-preview, but GUI visual
-  // tests still capture from g_crystal_renderer's FBO. Keep the FBO update path so
-  // screenshot/smoke, screenshot/crystal_psnr and the visual/crystal_* tests observe
-  // a populated texture. The modal edit path owns the renderer when open, in which
-  // case we skip here to preserve its last write (ImGui::Image defers GPU sampling).
-  if (has_crystal) {
-    auto& cr = g_state.layers[sel_layer].entries[sel_entry].crystal;
-    bool modal_owns_renderer = IsCrystalModalOpen();
-
-    int hash = CrystalParamHash(cr);
-    if (!modal_owns_renderer && hash != g_crystal_mesh_hash) {
-      int result = BuildAndUploadCrystalMesh(cr);
-      if (result != 0) {
-        g_crystal_mesh_hash = hash;
-      }
-    }
-    if (!modal_owns_renderer) {
-      auto crystal_style = static_cast<CrystalStyle>(g_crystal_style);
-      g_crystal_renderer.Render(g_crystal_rotation, g_crystal_zoom, crystal_style);
-    }
-  }
 
   // Process thumbnail update queue before rendering cards
   g_thumbnail_cache.ProcessUpdateQueue(g_state, kMaxThumbnailUpdatesPerFrame);

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -26,6 +26,18 @@ void RenderTopBar(float window_width) {
                ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                    ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse);
 
+  // Left-panel collapse toggle (placed before Run/Stop; owns the leftmost slot of the top bar
+  // so it can never overlap with panel-internal headers).
+  {
+    const char* left_toggle_label = g_panel_collapsed ? ">##left_panel_toggle" : "<##left_panel_toggle";
+    if (ImGui::Button(left_toggle_label)) {
+      g_panel_collapsed = !g_panel_collapsed;
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("|");
+    ImGui::SameLine();
+  }
+
   // Run/Stop — fixed width to prevent layout shift
   bool simulating = (g_state.sim_state == SimState::kSimulating);
   const auto& style = ImGui::GetStyle();
@@ -143,6 +155,18 @@ void RenderTopBar(float window_width) {
   }
   if (simulating) {
     ImGui::EndDisabled();
+  }
+
+  // Right-panel collapse toggle — right-aligned so it sits flush with the right panel's outer edge.
+  {
+    const char* right_toggle_label = g_state.right_panel_collapsed ? "<##right_panel_toggle" : ">##right_panel_toggle";
+    float btn_w = ImGui::CalcTextSize(right_toggle_label, nullptr, true).x + style.FramePadding.x * 2.0f;
+    float right_edge = ImGui::GetWindowContentRegionMax().x;
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(right_edge - btn_w);
+    if (ImGui::Button(right_toggle_label)) {
+      g_state.right_panel_collapsed = !g_state.right_panel_collapsed;
+    }
   }
 
   ImGui::End();
@@ -329,11 +353,6 @@ void RenderLeftPanel(float window_height) {
   }
 
   ImGui::End();
-
-  // Collapse button overlay at top-right of left panel (offset inward to avoid scrollbar)
-  if (OverlayButton("<", kLeftPanelWidth - kCollapseBtnSize - 20, kTopBarHeight + 4)) {
-    g_panel_collapsed = true;
-  }
 }
 
 void RenderRightPanel(GLFWwindow* window, float window_width, float window_height) {
@@ -545,11 +564,6 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
   }
 
   ImGui::End();
-
-  // Collapse button overlay at top-right of right panel (symmetric with left panel)
-  if (OverlayButton(">", panel_x + kRightPanelWidth - kCollapseBtnSize - 4, kTopBarHeight + 4)) {
-    g_state.right_panel_collapsed = true;
-  }
 }
 
 void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_height) {

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -325,9 +325,9 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
     ImGui::SeparatorText("Camera");
     ImGui::BeginDisabled(full_sky);
-    SliderWithInput("Elevation##view", &r.elevation, -90.0f, 90.0f, "%.1f");
-    SliderWithInput("Azimuth##view", &r.azimuth, -180.0f, 180.0f, "%.1f");
-    SliderWithInput("Roll##view", &r.roll, -180.0f, 180.0f, "%.1f");
+    SliderWithInput("Elevation##view", &r.elevation, -90.0f, 90.0f, "%.2f");
+    SliderWithInput("Azimuth##view", &r.azimuth, -180.0f, 180.0f, "%.2f");
+    SliderWithInput("Roll##view", &r.roll, -180.0f, 180.0f, "%.2f");
     ImGui::EndDisabled();
 
     ImGui::PopItemWidth();

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -244,7 +244,7 @@ void RenderLeftPanel(float window_height) {
   RenderScatteringSection(g_state);
   ImGui::EndChild();
 
-  // ---- Bottom toolbar: layer add/delete ----
+  // ---- Bottom toolbar: add layer only (per-layer delete lives on the header row) ----
   ImGui::Spacing();
   if (ImGui::SmallButton("+ Layer")) {
     Layer new_layer;
@@ -252,30 +252,6 @@ void RenderLeftPanel(float window_height) {
     g_state.layers.push_back(std::move(new_layer));
     g_thumbnail_cache.OnLayerStructureChanged();
     g_state.MarkDirty();
-  }
-  ImGui::SameLine();
-  bool can_delete_layer = g_state.layers.size() > 1;
-  if (!can_delete_layer) {
-    ImGui::BeginDisabled();
-  }
-  if (ImGui::SmallButton("- Layer")) {
-    int del_idx = GetSelectedLayerIdx();
-    if (del_idx >= 0 && del_idx < static_cast<int>(g_state.layers.size()) && g_state.layers.size() > 1) {
-      g_state.layers.erase(g_state.layers.begin() + del_idx);
-      if (GetSelectedLayerIdx() >= static_cast<int>(g_state.layers.size())) {
-        SetSelectedLayerIdx(static_cast<int>(g_state.layers.size()) - 1);
-      }
-      // Clamp entry index for new selected layer
-      auto& new_entries = g_state.layers[GetSelectedLayerIdx()].entries;
-      if (GetSelectedEntryIdx() >= static_cast<int>(new_entries.size())) {
-        SetSelectedEntryIdx(static_cast<int>(new_entries.size()) - 1);
-      }
-      g_thumbnail_cache.OnLayerStructureChanged();
-      g_state.MarkDirty();
-    }
-  }
-  if (!can_delete_layer) {
-    ImGui::EndDisabled();
   }
 
   // Process edit request: open modal if an edit button was clicked

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -7,7 +7,6 @@
 
 #include "config/render_config.hpp"
 #include "gui/app.hpp"
-#include "gui/crystal_preview.hpp"
 #include "gui/edit_modals.hpp"
 #include "gui/gui_constants.hpp"
 #include "gui/gui_logger.hpp"
@@ -272,7 +271,6 @@ void RenderLeftPanel(float window_height) {
         SetSelectedEntryIdx(static_cast<int>(new_entries.size()) - 1);
       }
       g_thumbnail_cache.OnLayerStructureChanged();
-      g_crystal_mesh_hash = -1;  // Force preview refresh
       g_state.MarkDirty();
     }
   }

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "gui/app.hpp"
+#include "gui/gui_constants.hpp"
 #include "gui/gui_state.hpp"
 #include "lumice.h"
 
@@ -15,7 +16,7 @@ namespace lumice::gui {
 float g_crystal_rotation[16] = {
   1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
 };
-float g_crystal_zoom = 1.4f;
+float g_crystal_zoom = kDefaultCrystalZoom;
 int g_crystal_style = 1;      // Default: Hidden Line (index into kCrystalStyleNames)
 int g_crystal_mesh_hash = 0;  // Hash of crystal params for change detection
 
@@ -61,7 +62,7 @@ void ResetCrystalView() {
   g_crystal_rotation[13] = 0;
   g_crystal_rotation[14] = 0;
   g_crystal_rotation[15] = 1;
-  g_crystal_zoom = 1.4f;
+  g_crystal_zoom = kDefaultCrystalZoom;
 }
 
 // Apply incremental rotation around axis (dx, dy) from mouse drag

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -15,7 +15,7 @@ namespace lumice::gui {
 float g_crystal_rotation[16] = {
   1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
 };
-float g_crystal_zoom = 2.5f;
+float g_crystal_zoom = 1.4f;
 int g_crystal_style = 1;      // Default: Hidden Line (index into kCrystalStyleNames)
 int g_crystal_mesh_hash = 0;  // Hash of crystal params for change detection
 
@@ -61,7 +61,7 @@ void ResetCrystalView() {
   g_crystal_rotation[13] = 0;
   g_crystal_rotation[14] = 0;
   g_crystal_rotation[15] = 1;
-  g_crystal_zoom = 2.5f;
+  g_crystal_zoom = 1.4f;
 }
 
 // Apply incremental rotation around axis (dx, dy) from mouse drag

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -193,16 +193,4 @@ int BuildAndUploadCrystalMesh(const CrystalConfig& cr) {
   return CrystalParamHash(cr);
 }
 
-void UpdateCrystalPreviewRenderer(const CrystalConfig& cr) {
-  int hash = CrystalParamHash(cr);
-  if (hash != g_crystal_mesh_hash) {
-    int result = BuildAndUploadCrystalMesh(cr);
-    if (result != 0) {
-      g_crystal_mesh_hash = hash;
-    }
-  }
-  auto style = static_cast<CrystalStyle>(g_crystal_style);
-  g_crystal_renderer.Render(g_crystal_rotation, g_crystal_zoom, style);
-}
-
 }  // namespace lumice::gui

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -193,4 +193,16 @@ int BuildAndUploadCrystalMesh(const CrystalConfig& cr) {
   return CrystalParamHash(cr);
 }
 
+void UpdateCrystalPreviewRenderer(const CrystalConfig& cr) {
+  int hash = CrystalParamHash(cr);
+  if (hash != g_crystal_mesh_hash) {
+    int result = BuildAndUploadCrystalMesh(cr);
+    if (result != 0) {
+      g_crystal_mesh_hash = hash;
+    }
+  }
+  auto style = static_cast<CrystalStyle>(g_crystal_style);
+  g_crystal_renderer.Render(g_crystal_rotation, g_crystal_zoom, style);
+}
+
 }  // namespace lumice::gui

--- a/src/gui/crystal_preview.hpp
+++ b/src/gui/crystal_preview.hpp
@@ -26,6 +26,12 @@ bool BuildCrystalMeshData(const CrystalConfig& cr, LUMICE_CrystalMesh* out);
 // then upload to g_crystal_renderer. Returns the computed param hash, or 0 on failure.
 int BuildAndUploadCrystalMesh(const CrystalConfig& cr);
 
+// Rebuild the crystal mesh (if params changed since last upload) and render it into
+// g_crystal_renderer's FBO using the shared rotation/zoom/style state. Intended for
+// callers that need to drive the FBO explicitly (e.g. GUI visual tests that capture
+// from g_crystal_renderer.GetTextureId()).
+void UpdateCrystalPreviewRenderer(const CrystalConfig& cr);
+
 }  // namespace lumice::gui
 
 #endif  // LUMICE_GUI_CRYSTAL_PREVIEW_HPP

--- a/src/gui/crystal_preview.hpp
+++ b/src/gui/crystal_preview.hpp
@@ -26,12 +26,6 @@ bool BuildCrystalMeshData(const CrystalConfig& cr, LUMICE_CrystalMesh* out);
 // then upload to g_crystal_renderer. Returns the computed param hash, or 0 on failure.
 int BuildAndUploadCrystalMesh(const CrystalConfig& cr);
 
-// Rebuild the crystal mesh (if params changed since last upload) and render it into
-// g_crystal_renderer's FBO using the shared rotation/zoom/style state. Intended for
-// callers that need to drive the FBO explicitly (e.g. GUI visual tests that capture
-// from g_crystal_renderer.GetTextureId()).
-void UpdateCrystalPreviewRenderer(const CrystalConfig& cr);
-
 }  // namespace lumice::gui
 
 #endif  // LUMICE_GUI_CRYSTAL_PREVIEW_HPP

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -630,8 +630,7 @@ void RenderEditModals(GuiState& state) {
     const bool crystal_dirty = g_crystal_buf != g_crystal_buf_snapshot;
     const bool axis_dirty = g_axis_buf[0] != g_axis_buf_snapshot[0] || g_axis_buf[1] != g_axis_buf_snapshot[1] ||
                             g_axis_buf[2] != g_axis_buf_snapshot[2];
-    const bool filter_dirty =
-        g_filter_buf_removed ? g_filter_initial_present : (filter_cmp != g_filter_buf_snapshot);
+    const bool filter_dirty = g_filter_buf_removed ? g_filter_initial_present : (filter_cmp != g_filter_buf_snapshot);
     const char* crystal_label = crystal_dirty ? "Crystal *###crystal_tab" : "Crystal###crystal_tab";
     const char* axis_label = axis_dirty ? "Axis *###axis_tab" : "Axis###axis_tab";
     const char* filter_label = filter_dirty ? "Filter *###filter_tab" : "Filter###filter_tab";

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1,6 +1,7 @@
 #include "gui/edit_modals.hpp"
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -22,6 +23,11 @@ namespace lumice::gui {
 // ============================================================
 
 enum class ActiveModal { kNone, kCrystal, kAxis, kFilter };
+
+// Minimum width applied to the three edit popups (Crystal/Axis/Filter) so inner
+// SliderWithInput controls have a usable drag range. AlwaysAutoResize still
+// governs height; SetNextWindowSizeConstraints adds the width floor.
+constexpr float kEditModalMinWidth = 560.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;
@@ -564,6 +570,7 @@ void RenderEditModals(GuiState& state) {
   }
 
   // Crystal modal — guard ensures popup closes if entry was deleted externally
+  ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
   if (ImGui::BeginPopupModal("Edit Crystal", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
     if (g_active_modal != ActiveModal::kCrystal) {
       ImGui::CloseCurrentPopup();
@@ -574,6 +581,7 @@ void RenderEditModals(GuiState& state) {
   }
 
   // Axis modal
+  ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
   if (ImGui::BeginPopupModal("Edit Axis", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
     if (g_active_modal != ActiveModal::kAxis) {
       ImGui::CloseCurrentPopup();
@@ -584,6 +592,7 @@ void RenderEditModals(GuiState& state) {
   }
 
   // Filter modal
+  ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
   if (ImGui::BeginPopupModal("Edit Filter", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
     if (g_active_modal != ActiveModal::kFilter) {
       ImGui::CloseCurrentPopup();

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -516,6 +516,10 @@ void CommitAllBuffers(GuiState& state) {
     return;
   }
   auto& entry = state.layers[ly].entries[en];
+  // Diff-gate: snapshot before applying buffers so we can skip render-invalidation
+  // when OK is pressed without any actual change (e.g. open Edit, click OK on
+  // finite-rays preview — must not clear the rendered image or arm Revert).
+  const EntryCard old_entry = entry;
   // g_crystal_buf carries the Crystal-tab edits; overlay axis edits from the
   // Axis tab so the unified commit reflects both.
   entry.crystal = g_crystal_buf;
@@ -533,10 +537,12 @@ void CommitAllBuffers(GuiState& state) {
       entry.filter = g_filter_buf;
     }
   }
-  g_thumbnail_cache.Invalidate(ly, en);
-  state.MarkDirty();
-  state.MarkFilterDirty();
-  g_crystal_mesh_hash = -1;
+  if (entry != old_entry) {
+    g_thumbnail_cache.Invalidate(ly, en);
+    state.MarkDirty();
+    state.MarkFilterDirty();
+    g_crystal_mesh_hash = -1;
+  }
 }
 
 }  // namespace

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -206,6 +206,20 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
 // Crystal Modal
 // ============================================================
 
+static void HandleCrystalPreviewInteraction(bool hovered, bool active) {
+  ImGuiIO& io = ImGui::GetIO();
+  if (active && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+    ApplyTrackballRotation(io.MouseDelta.x, io.MouseDelta.y);
+  }
+  if (hovered) {
+    ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY);
+    if (io.MouseWheel != 0.0f) {
+      g_crystal_zoom *= (1.0f - io.MouseWheel * 0.1f);
+      g_crystal_zoom = std::max(0.5f, std::min(10.0f, g_crystal_zoom));
+    }
+  }
+}
+
 static void RenderCrystalModal(GuiState& state) {
   auto& cr = g_crystal_buf;
 
@@ -227,22 +241,13 @@ static void RenderCrystalModal(GuiState& state) {
 
   // -- 3D Preview --
   auto tex_id = static_cast<ImTextureID>(g_crystal_renderer.GetTextureId());
+  ImVec2 preview_pos = ImGui::GetCursorScreenPos();
   ImGui::Image(tex_id, ImVec2(kPreviewSize, kPreviewSize), ImVec2(0, 1), ImVec2(1, 0));
 
-  // Trackball interaction on preview
-  ImVec2 preview_min = ImGui::GetItemRectMin();
-  ImVec2 preview_max = ImGui::GetItemRectMax();
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY);
-    ImGuiIO& io = ImGui::GetIO();
-    if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-      ApplyTrackballRotation(io.MouseDelta.x, io.MouseDelta.y);
-    }
-    if (io.MouseWheel != 0.0f) {
-      g_crystal_zoom *= (1.0f - io.MouseWheel * 0.1f);
-      g_crystal_zoom = std::max(0.5f, std::min(10.0f, g_crystal_zoom));
-    }
-  }
+  // Overlay InvisibleButton to consume mouse clicks and prevent modal window drag.
+  ImGui::SetCursorScreenPos(preview_pos);
+  ImGui::InvisibleButton("##modal_preview_interact", ImVec2(kPreviewSize, kPreviewSize));
+  HandleCrystalPreviewInteraction(ImGui::IsItemHovered(), ImGui::IsItemActive());
 
   // Style combo + Reset View
   ImGui::PushItemWidth(120.0f);

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -48,6 +48,14 @@ static FilterConfig g_filter_buf;
 static char g_raypath_buf[256];
 // Buffered "Remove Filter" intent: applied on modal-level OK, undone by Cancel.
 static bool g_filter_buf_removed = false;
+// Snapshot of g_filter_buf at modal open + initial presence flag. Used by
+// CommitAllBuffers to decide whether to write entry.filter at all: when the
+// entry had no filter originally AND the user did not touch any field, OK
+// must leave entry.filter as nullopt (otherwise default-constructed values
+// like sym_p=b=d=true would silently turn into a "* In PBD" filter that
+// blocks all rays).
+static FilterConfig g_filter_buf_snapshot;
+static bool g_filter_initial_present = false;
 
 // Crystal modal: trackball state saved on open, restored on Cancel
 static float g_saved_rotation[16];
@@ -190,6 +198,8 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   g_filter_buf = entry.filter.value_or(FilterConfig{});
   snprintf(g_raypath_buf, sizeof(g_raypath_buf), "%s", g_filter_buf.raypath_text.c_str());
   g_filter_buf_removed = false;
+  g_filter_buf_snapshot = g_filter_buf;
+  g_filter_initial_present = entry.filter.has_value();
 
   // Save trackball state for Cancel restoration
   std::memcpy(g_saved_rotation, g_crystal_rotation, sizeof(g_saved_rotation));
@@ -480,6 +490,8 @@ void ResetModalState() {
   g_axis_buf[2] = {};
   g_filter_buf = {};
   g_filter_buf_removed = false;
+  g_filter_buf_snapshot = {};
+  g_filter_initial_present = false;
   g_raypath_buf[0] = '\0';
   std::memset(g_saved_rotation, 0, sizeof(g_saved_rotation));
   g_saved_zoom = 1.0f;
@@ -514,7 +526,16 @@ void CommitAllBuffers(GuiState& state) {
     entry.filter = std::nullopt;
   } else {
     g_filter_buf.raypath_text = g_raypath_buf;
-    entry.filter = g_filter_buf;
+    // Preserve the no-filter state for entries that had no filter and the user
+    // didn't touch any filter field — committing the default-constructed buffer
+    // would silently create an "* In PBD" filter that blocks all rays.
+    const FilterConfig& s = g_filter_buf_snapshot;
+    const bool buf_changed = g_filter_buf.action != s.action || g_filter_buf.raypath_text != s.raypath_text ||
+                             g_filter_buf.sym_p != s.sym_p || g_filter_buf.sym_b != s.sym_b ||
+                             g_filter_buf.sym_d != s.sym_d || g_filter_buf.name != s.name;
+    if (g_filter_initial_present || buf_changed) {
+      entry.filter = g_filter_buf;
+    }
   }
   g_thumbnail_cache.Invalidate(ly, en);
   state.MarkDirty();

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -279,11 +279,11 @@ static void RenderCrystalModal(GuiState& state) {
 
   // -- Parameters --
   if (cr.type == CrystalType::kPrism) {
-    SliderWithInput("Height##modal_cr", &cr.height, 0.01f, 100.0f, "%.2f", SliderScale::kLogLinear);
+    SliderWithInput("Height##modal_cr", &cr.height, 0.01f, 100.0f, "%.2f", SliderScale::kLog);
   } else {
-    SliderWithInput("Prism H##modal_cr", &cr.prism_h, 0.0f, 100.0f, "%.2f", SliderScale::kLogLinear);
-    SliderWithInput("Upper H##modal_cr", &cr.upper_h, 0.0f, 100.0f, "%.2f", SliderScale::kLogLinear);
-    SliderWithInput("Lower H##modal_cr", &cr.lower_h, 0.0f, 100.0f, "%.2f", SliderScale::kLogLinear);
+    SliderWithInput("Prism H##modal_cr", &cr.prism_h, 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear);
+    SliderWithInput("Upper H##modal_cr", &cr.upper_h, 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear);
+    SliderWithInput("Lower H##modal_cr", &cr.lower_h, 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear);
     SliderWithPresetEdit("Upper A##modal_cr", &cr.upper_alpha, 0.1f, 90.0f, "%.1f", SliderScale::kLinear, kWedgePresets,
                          kWedgePresetCount);
     SliderWithPresetEdit("Lower A##modal_cr", &cr.lower_alpha, 0.1f, 90.0f, "%.1f", SliderScale::kLinear, kWedgePresets,

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -401,6 +401,12 @@ static void RenderFilterModal(GuiState& /*state*/) {
     ImGui::TextColored(ImVec4(0.9f, 0.5f, 0.1f, 1.0f), "Filter will be removed on OK.");
   }
 
+  // Filter tab edit controls are disabled while a Remove intent is pending.
+  // The raw field values remain in-buffer so that Undo Remove can restore
+  // them; CommitAllBuffers honors g_filter_buf_removed by writing nullopt
+  // without reading the buffer values.
+  ImGui::BeginDisabled(g_filter_buf_removed);
+
   // Action combo
   ImGui::Combo("Action##filter_modal", &g_filter_buf.action, kFilterActionNames, kFilterActionCount);
 
@@ -456,11 +462,22 @@ static void RenderFilterModal(GuiState& /*state*/) {
   ImGui::SameLine();
   ImGui::Checkbox("D##filter_modal", &g_filter_buf.sym_d);
 
+  ImGui::EndDisabled();
+
   ImGui::Spacing();
   // Remove Filter — buffers the intent; modal-level OK will write nullopt.
   // Cancel still discards (since g_filter_buf_removed is reset on next open).
-  if (ImGui::Button("Remove Filter##filter", ImVec2(120, 0))) {
-    g_filter_buf_removed = true;
+  // While the Remove intent is pending, this button toggles to "Undo Remove"
+  // to restore editability. Use distinct ImGui IDs so the two states have
+  // independent button hashes and existing test selectors keep resolving.
+  if (g_filter_buf_removed) {
+    if (ImGui::Button("Undo Remove##filter_undo", ImVec2(120, 0))) {
+      g_filter_buf_removed = false;
+    }
+  } else {
+    if (ImGui::Button("Remove Filter##filter", ImVec2(120, 0))) {
+      g_filter_buf_removed = true;
+    }
   }
 
   // OK / Cancel handled at modal level (RenderEditModals).

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -27,7 +27,7 @@ enum class ActiveModal { kNone, kCrystal, kAxis, kFilter };
 // Minimum width applied to the three edit popups (Crystal/Axis/Filter) so inner
 // SliderWithInput controls have a usable drag range. AlwaysAutoResize still
 // governs height; SetNextWindowSizeConstraints adds the width floor.
-constexpr float kEditModalMinWidth = 560.0f;
+constexpr float kEditModalMinWidth = 432.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;
@@ -237,10 +237,15 @@ static void RenderCrystalModal(GuiState& state) {
   g_crystal_renderer.Render(g_crystal_rotation, g_crystal_zoom, crystal_style);
 
   // Layout: 3D preview on top, crystal parameters below
-  constexpr float kPreviewSize = 200.0f;
+  constexpr float kPreviewSize = 320.0f;
 
-  // -- 3D Preview --
+  // -- 3D Preview (horizontally centered) --
   auto tex_id = static_cast<ImTextureID>(g_crystal_renderer.GetTextureId());
+  float avail_w = ImGui::GetContentRegionAvail().x;
+  float offset_x = (avail_w - kPreviewSize) * 0.5f;
+  if (offset_x > 0.0f) {
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offset_x);
+  }
   ImVec2 preview_pos = ImGui::GetCursorScreenPos();
   ImGui::Image(tex_id, ImVec2(kPreviewSize, kPreviewSize), ImVec2(0, 1), ImVec2(1, 0));
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -529,11 +529,7 @@ void CommitAllBuffers(GuiState& state) {
     // Preserve the no-filter state for entries that had no filter and the user
     // didn't touch any filter field — committing the default-constructed buffer
     // would silently create an "* In PBD" filter that blocks all rays.
-    const FilterConfig& s = g_filter_buf_snapshot;
-    const bool buf_changed = g_filter_buf.action != s.action || g_filter_buf.raypath_text != s.raypath_text ||
-                             g_filter_buf.sym_p != s.sym_p || g_filter_buf.sym_b != s.sym_b ||
-                             g_filter_buf.sym_d != s.sym_d || g_filter_buf.name != s.name;
-    if (g_filter_initial_present || buf_changed) {
+    if (g_filter_initial_present || g_filter_buf != g_filter_buf_snapshot) {
       entry.filter = g_filter_buf;
     }
   }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -22,22 +22,32 @@ namespace lumice::gui {
 // Modal state (file scope — not shared via gui_state.hpp)
 // ============================================================
 
-enum class ActiveModal { kNone, kCrystal, kAxis, kFilter };
+enum class ActiveModal { kNone, kOpen };
+enum class ActiveTab { kCrystal, kAxis, kFilter };
 
-// Minimum width applied to the three edit popups (Crystal/Axis/Filter) so inner
-// SliderWithInput controls have a usable drag range. AlwaysAutoResize still
-// governs height; SetNextWindowSizeConstraints adds the width floor.
+// Minimum width applied to the unified edit popup so inner SliderWithInput
+// controls have a usable drag range. AlwaysAutoResize still governs height;
+// SetNextWindowSizeConstraints adds the width floor.
 constexpr float kEditModalMinWidth = 432.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;
 static int g_modal_entry_idx = -1;
 
+// Active tab is updated each frame inside the corresponding BeginTabItem true-branch
+// (ImGui doesn't auto-write user state). The OpenEditModal path always sets it
+// explicitly together with g_pending_tab_select=true to drive first-frame selection;
+// at other times its value reflects the ImGui TabBar's currently active tab.
+static ActiveTab g_active_tab = ActiveTab::kCrystal;
+static bool g_pending_tab_select = false;
+
 // Edit buffers
 static CrystalConfig g_crystal_buf;
 static AxisDist g_axis_buf[3];  // zenith, azimuth, roll
 static FilterConfig g_filter_buf;
 static char g_raypath_buf[256];
+// Buffered "Remove Filter" intent: applied on modal-level OK, undone by Cancel.
+static bool g_filter_buf_removed = false;
 
 // Crystal modal: trackball state saved on open, restored on Cancel
 static float g_saved_rotation[16];
@@ -170,35 +180,39 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   g_modal_layer_idx = ly;
   g_modal_entry_idx = en;
 
+  // Initialize all three buffers (regardless of req.target) so any tab the user
+  // switches to shows the entry's current values. Modal-level OK commits all
+  // three atomically; Cancel discards all.
+  g_crystal_buf = entry.crystal;
+  g_axis_buf[0] = entry.crystal.zenith;
+  g_axis_buf[1] = entry.crystal.azimuth;
+  g_axis_buf[2] = entry.crystal.roll;
+  g_filter_buf = entry.filter.value_or(FilterConfig{});
+  snprintf(g_raypath_buf, sizeof(g_raypath_buf), "%s", g_filter_buf.raypath_text.c_str());
+  g_filter_buf_removed = false;
+
+  // Save trackball state for Cancel restoration
+  std::memcpy(g_saved_rotation, g_crystal_rotation, sizeof(g_saved_rotation));
+  g_saved_zoom = g_crystal_zoom;
+  g_modal_mesh_hash = 0;  // Force mesh update on first frame
+
   switch (req.target) {
     case EditTarget::kCrystal:
-      g_active_modal = ActiveModal::kCrystal;
-      g_crystal_buf = entry.crystal;
-      // Save trackball state for Cancel restoration
-      std::memcpy(g_saved_rotation, g_crystal_rotation, sizeof(g_saved_rotation));
-      g_saved_zoom = g_crystal_zoom;
-      g_modal_mesh_hash = 0;  // Force mesh update on first frame
+      g_active_tab = ActiveTab::kCrystal;
       break;
     case EditTarget::kAxis:
-      g_active_modal = ActiveModal::kAxis;
-      g_axis_buf[0] = entry.crystal.zenith;
-      g_axis_buf[1] = entry.crystal.azimuth;
-      g_axis_buf[2] = entry.crystal.roll;
+      g_active_tab = ActiveTab::kAxis;
       break;
     case EditTarget::kFilter:
-      g_active_modal = ActiveModal::kFilter;
-      if (entry.filter.has_value()) {
-        g_filter_buf = entry.filter.value();
-      } else {
-        g_filter_buf = FilterConfig{};
-      }
-      snprintf(g_raypath_buf, sizeof(g_raypath_buf), "%s", g_filter_buf.raypath_text.c_str());
+      g_active_tab = ActiveTab::kFilter;
       break;
     default:
       return;
   }
 
+  g_active_modal = ActiveModal::kOpen;
   g_pending_open = true;
+  g_pending_tab_select = true;
 }
 
 
@@ -220,7 +234,7 @@ static void HandleCrystalPreviewInteraction(bool hovered, bool active) {
   }
 }
 
-static void RenderCrystalModal(GuiState& state) {
+static void RenderCrystalModal(GuiState& /*state*/) {
   auto& cr = g_crystal_buf;
 
   // Update mesh if crystal params changed
@@ -305,31 +319,7 @@ static void RenderCrystalModal(GuiState& state) {
     ImGui::TreePop();
   }
 
-  ImGui::Separator();
-
-  // -- OK / Cancel --
-  if (ImGui::Button("OK##crystal", ImVec2(80, 0))) {
-    int ly = g_modal_layer_idx;
-    int en = g_modal_entry_idx;
-    if (ly >= 0 && ly < static_cast<int>(state.layers.size()) && en >= 0 &&
-        en < static_cast<int>(state.layers[ly].entries.size())) {
-      state.layers[ly].entries[en].crystal = cr;
-      g_thumbnail_cache.Invalidate(ly, en);
-      state.MarkDirty();
-      g_crystal_mesh_hash = -1;  // Force left panel preview refresh
-    }
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Cancel##crystal", ImVec2(80, 0))) {
-    // Restore trackball state
-    std::memcpy(g_crystal_rotation, g_saved_rotation, sizeof(g_crystal_rotation));
-    g_crystal_zoom = g_saved_zoom;
-    g_crystal_mesh_hash = -1;  // Force left panel to re-render model crystal
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
+  // OK / Cancel handled at modal level (RenderEditModals).
 }
 
 
@@ -337,7 +327,7 @@ static void RenderCrystalModal(GuiState& state) {
 // Axis Modal
 // ============================================================
 
-static void RenderAxisModal(GuiState& state) {
+static void RenderAxisModal(GuiState& /*state*/) {
   // Preset buttons
   ImGui::Text("Presets:");
   ImGui::SameLine();
@@ -380,29 +370,7 @@ static void RenderAxisModal(GuiState& state) {
   RenderAxisDist("Azimuth", g_axis_buf[1], 0.0f, 360.0f);
   RenderAxisDist("Roll", g_axis_buf[2], 0.0f, 360.0f);
 
-  ImGui::Separator();
-
-  // OK / Cancel
-  if (ImGui::Button("OK##axis", ImVec2(80, 0))) {
-    int ly = g_modal_layer_idx;
-    int en = g_modal_entry_idx;
-    if (ly >= 0 && ly < static_cast<int>(state.layers.size()) && en >= 0 &&
-        en < static_cast<int>(state.layers[ly].entries.size())) {
-      auto& crystal = state.layers[ly].entries[en].crystal;
-      crystal.zenith = g_axis_buf[0];
-      crystal.azimuth = g_axis_buf[1];
-      crystal.roll = g_axis_buf[2];
-      g_thumbnail_cache.Invalidate(ly, en);
-      state.MarkDirty();
-    }
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Cancel##axis", ImVec2(80, 0))) {
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
+  // OK / Cancel handled at modal level (RenderEditModals).
 }
 
 
@@ -410,26 +378,18 @@ static void RenderAxisModal(GuiState& state) {
 // Filter Modal
 // ============================================================
 
-static void RenderFilterModal(GuiState& state) {
-  // Resolve the parent entry so we can use its crystal kind for face-number
-  // validation. If the entry was destroyed while the modal is open, close
-  // and bail out instead of reading out-of-range data.
-  const int ly = g_modal_layer_idx;
-  const int en = g_modal_entry_idx;
-  if (ly < 0 || ly >= static_cast<int>(state.layers.size()) || en < 0 ||
-      en >= static_cast<int>(state.layers[ly].entries.size())) {
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-    return;
+static void RenderFilterModal(GuiState& /*state*/) {
+  // Validation kind is derived from g_crystal_buf (the in-flight buffer of the
+  // Crystal tab) rather than the entry, because the user may switch the type
+  // in the Crystal tab before committing — the validator should match what
+  // will actually be written on OK.
+  const lumice::CrystalKind kind =
+      (g_crystal_buf.type == CrystalType::kPrism) ? lumice::CrystalKind::kPrism : lumice::CrystalKind::kPyramid;
+
+  // "Remove Filter" intent — buffered, applied on modal-level OK.
+  if (g_filter_buf_removed) {
+    ImGui::TextColored(ImVec4(0.9f, 0.5f, 0.1f, 1.0f), "Filter will be removed on OK.");
   }
-  const auto& entry_for_kind = state.layers[ly].entries[en];
-  // Map the GUI-only `gui::CrystalType` (which currently exposes only kPrism
-  // and kPyramid) to the coarser `lumice::CrystalKind` accepted by the
-  // validator. If new CrystalType values are added to the GUI in the future,
-  // extend this mapping (and lumice::CrystalKind) explicitly — do not rely on
-  // the ternary falling through to kPyramid.
-  const lumice::CrystalKind kind = (entry_for_kind.crystal.type == CrystalType::kPrism) ? lumice::CrystalKind::kPrism :
-                                                                                          lumice::CrystalKind::kPyramid;
 
   // Action combo
   ImGui::Combo("Action##filter_modal", &g_filter_buf.action, kFilterActionNames, kFilterActionCount);
@@ -486,42 +446,14 @@ static void RenderFilterModal(GuiState& state) {
   ImGui::SameLine();
   ImGui::Checkbox("D##filter_modal", &g_filter_buf.sym_d);
 
-  ImGui::Separator();
-
-  // OK / Cancel / Remove Filter
-  bool ok_disabled = (validation != RaypathValidation::kValid);
-  if (ok_disabled) {
-    ImGui::BeginDisabled();
-  }
-  if (ImGui::Button("OK##filter", ImVec2(80, 0))) {
-    // Commit only when the buffer is fully valid. The top-of-function guard
-    // already validated ly/en, so we can reuse them directly.
-    if (validation == RaypathValidation::kValid) {
-      g_filter_buf.raypath_text = g_raypath_buf;
-      state.layers[ly].entries[en].filter = g_filter_buf;
-      state.MarkFilterDirty();
-    }
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
-  if (ok_disabled) {
-    ImGui::EndDisabled();
-  }
-
-  ImGui::SameLine();
-  if (ImGui::Button("Cancel##filter", ImVec2(80, 0))) {
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
-  }
-
-  ImGui::SameLine();
+  ImGui::Spacing();
+  // Remove Filter — buffers the intent; modal-level OK will write nullopt.
+  // Cancel still discards (since g_filter_buf_removed is reset on next open).
   if (ImGui::Button("Remove Filter##filter", ImVec2(120, 0))) {
-    // Indices were validated at the top of this frame.
-    state.layers[ly].entries[en].filter = std::nullopt;
-    state.MarkFilterDirty();
-    g_active_modal = ActiveModal::kNone;
-    ImGui::CloseCurrentPopup();
+    g_filter_buf_removed = true;
   }
+
+  // OK / Cancel handled at modal level (RenderEditModals).
 }
 
 
@@ -529,12 +461,17 @@ static void RenderFilterModal(GuiState& state) {
 // Public API
 // ============================================================
 
-bool IsCrystalModalOpen() {
-  return g_active_modal == ActiveModal::kCrystal;
+// True only when the unified edit modal is open AND the Crystal tab is the
+// active one. Used by visual-smoke tests to detect FBO contention with the
+// modal's per-frame g_crystal_renderer.Render() call.
+bool IsEditModalCrystalTabActive() {
+  return g_active_modal == ActiveModal::kOpen && g_active_tab == ActiveTab::kCrystal;
 }
 
 void ResetModalState() {
   g_active_modal = ActiveModal::kNone;
+  g_active_tab = ActiveTab::kCrystal;
+  g_pending_tab_select = false;
   g_modal_layer_idx = -1;
   g_modal_entry_idx = -1;
   g_crystal_buf = {};
@@ -542,6 +479,7 @@ void ResetModalState() {
   g_axis_buf[1] = {};
   g_axis_buf[2] = {};
   g_filter_buf = {};
+  g_filter_buf_removed = false;
   g_raypath_buf[0] = '\0';
   std::memset(g_saved_rotation, 0, sizeof(g_saved_rotation));
   g_saved_zoom = 1.0f;
@@ -549,66 +487,142 @@ void ResetModalState() {
   g_modal_mesh_hash = 0;
 }
 
+namespace {
+
+// Validation kind based on the in-flight Crystal-tab buffer (not the entry),
+// because the user may switch crystal type before committing.
+lumice::CrystalKind CurrentValidationKind() {
+  return (g_crystal_buf.type == CrystalType::kPrism) ? lumice::CrystalKind::kPrism : lumice::CrystalKind::kPyramid;
+}
+
+// Apply all three buffers atomically to the entry; called by modal-level OK.
+void CommitAllBuffers(GuiState& state) {
+  const int ly = g_modal_layer_idx;
+  const int en = g_modal_entry_idx;
+  if (ly < 0 || ly >= static_cast<int>(state.layers.size()) || en < 0 ||
+      en >= static_cast<int>(state.layers[ly].entries.size())) {
+    return;
+  }
+  auto& entry = state.layers[ly].entries[en];
+  // g_crystal_buf carries the Crystal-tab edits; overlay axis edits from the
+  // Axis tab so the unified commit reflects both.
+  entry.crystal = g_crystal_buf;
+  entry.crystal.zenith = g_axis_buf[0];
+  entry.crystal.azimuth = g_axis_buf[1];
+  entry.crystal.roll = g_axis_buf[2];
+  if (g_filter_buf_removed) {
+    entry.filter = std::nullopt;
+  } else {
+    g_filter_buf.raypath_text = g_raypath_buf;
+    entry.filter = g_filter_buf;
+  }
+  g_thumbnail_cache.Invalidate(ly, en);
+  state.MarkDirty();
+  state.MarkFilterDirty();
+  g_crystal_mesh_hash = -1;
+}
+
+}  // namespace
+
 void RenderEditModals(GuiState& state) {
-  // Deferred OpenPopup: must happen outside BeginPopupModal
-  if (g_pending_open && g_active_modal != ActiveModal::kNone) {
-    switch (g_active_modal) {
-      case ActiveModal::kCrystal:
-        ImGui::OpenPopup("Edit Crystal");
-        break;
-      case ActiveModal::kAxis:
-        ImGui::OpenPopup("Edit Axis");
-        break;
-      case ActiveModal::kFilter:
-        ImGui::OpenPopup("Edit Filter");
-        break;
-      default:
-        break;
-    }
+  // Deferred OpenPopup: must happen outside BeginPopupModal.
+  if (g_pending_open && g_active_modal == ActiveModal::kOpen) {
+    ImGui::OpenPopup("Edit Entry");
     g_pending_open = false;
   }
 
-  // Index validity guard: if the target entry was deleted while modal is open, close it
-  if (g_active_modal != ActiveModal::kNone) {
+  // Index validity guard: if the target entry was deleted while modal is open, close it.
+  if (g_active_modal == ActiveModal::kOpen) {
     bool valid = g_modal_layer_idx >= 0 && g_modal_layer_idx < static_cast<int>(state.layers.size()) &&
                  g_modal_entry_idx >= 0 &&
                  g_modal_entry_idx < static_cast<int>(state.layers[g_modal_layer_idx].entries.size());
     if (!valid) {
       g_active_modal = ActiveModal::kNone;
-      // If a popup was open, it will simply not render this frame
     }
   }
 
-  // Crystal modal — guard ensures popup closes if entry was deleted externally
   ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
-  if (ImGui::BeginPopupModal("Edit Crystal", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    if (g_active_modal != ActiveModal::kCrystal) {
+  if (ImGui::BeginPopupModal("Edit Entry", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+    if (g_active_modal != ActiveModal::kOpen) {
       ImGui::CloseCurrentPopup();
-    } else {
-      RenderCrystalModal(state);
+      ImGui::EndPopup();
+      return;
     }
-    ImGui::EndPopup();
-  }
 
-  // Axis modal
-  ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
-  if (ImGui::BeginPopupModal("Edit Axis", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    if (g_active_modal != ActiveModal::kAxis) {
-      ImGui::CloseCurrentPopup();
-    } else {
-      RenderAxisModal(state);
-    }
-    ImGui::EndPopup();
-  }
+    // Snapshot the SetSelected flags BEFORE any BeginTabItem body runs —
+    // each body writes g_active_tab, which would otherwise overwrite the
+    // pending selection before later tabs (e.g. Filter) read it.
+    const ImGuiTabItemFlags crystal_flags = (g_pending_tab_select && g_active_tab == ActiveTab::kCrystal) ?
+                                                ImGuiTabItemFlags_SetSelected :
+                                                ImGuiTabItemFlags_None;
+    const ImGuiTabItemFlags axis_flags = (g_pending_tab_select && g_active_tab == ActiveTab::kAxis) ?
+                                             ImGuiTabItemFlags_SetSelected :
+                                             ImGuiTabItemFlags_None;
+    const ImGuiTabItemFlags filter_flags = (g_pending_tab_select && g_active_tab == ActiveTab::kFilter) ?
+                                               ImGuiTabItemFlags_SetSelected :
+                                               ImGuiTabItemFlags_None;
 
-  // Filter modal
-  ImGui::SetNextWindowSizeConstraints(ImVec2(kEditModalMinWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
-  if (ImGui::BeginPopupModal("Edit Filter", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    if (g_active_modal != ActiveModal::kFilter) {
-      ImGui::CloseCurrentPopup();
-    } else {
-      RenderFilterModal(state);
+    if (ImGui::BeginTabBar("##edit_modal_tabs")) {
+      if (ImGui::BeginTabItem("Crystal", nullptr, crystal_flags)) {
+        g_active_tab = ActiveTab::kCrystal;
+        RenderCrystalModal(state);
+        ImGui::EndTabItem();
+      }
+      if (ImGui::BeginTabItem("Axis", nullptr, axis_flags)) {
+        g_active_tab = ActiveTab::kAxis;
+        RenderAxisModal(state);
+        ImGui::EndTabItem();
+      }
+      if (ImGui::BeginTabItem("Filter", nullptr, filter_flags)) {
+        g_active_tab = ActiveTab::kFilter;
+        RenderFilterModal(state);
+        ImGui::EndTabItem();
+      }
+      ImGui::EndTabBar();
+      // Consumed pending selection after BeginTabItem reads the flag.
+      g_pending_tab_select = false;
     }
+
+    ImGui::Separator();
+    // Modal-level OK / Cancel.
+    // OK gate: when the user has buffered a Remove Filter intent, raypath
+    // validation is irrelevant (we won't write the buffer); otherwise validate
+    // the in-flight raypath against the Crystal-tab buffer's type.
+    bool ok_disabled = false;
+    const char* ok_tooltip = nullptr;
+    if (!g_filter_buf_removed) {
+      g_filter_buf.raypath_text = g_raypath_buf;
+      const auto v = ValidateRaypathText(g_filter_buf.raypath_text, CurrentValidationKind());
+      if (v.state != RaypathValidation::kValid) {
+        ok_disabled = true;
+        ok_tooltip = "Filter raypath invalid — fix it in the Filter tab";
+      }
+    }
+
+    if (ok_disabled) {
+      ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("OK##edit_modal", ImVec2(80, 0))) {
+      CommitAllBuffers(state);
+      g_active_modal = ActiveModal::kNone;
+      ImGui::CloseCurrentPopup();
+    }
+    if (ok_disabled) {
+      ImGui::EndDisabled();
+    }
+    if (ok_disabled && ok_tooltip != nullptr && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip("%s", ok_tooltip);
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel##edit_modal", ImVec2(80, 0))) {
+      // Restore trackball state (Crystal tab's only side-effect that survives Cancel).
+      std::memcpy(g_crystal_rotation, g_saved_rotation, sizeof(g_crystal_rotation));
+      g_crystal_zoom = g_saved_zoom;
+      g_crystal_mesh_hash = -1;
+      g_active_modal = ActiveModal::kNone;
+      ImGui::CloseCurrentPopup();
+    }
+
     ImGui::EndPopup();
   }
 }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -57,6 +57,14 @@ static bool g_filter_buf_removed = false;
 static FilterConfig g_filter_buf_snapshot;
 static bool g_filter_initial_present = false;
 
+// Snapshots captured on OpenEditModal for per-tab dirty-mark computation.
+// Filter already has its own snapshot above (used for a separate purpose in
+// CommitAllBuffers). Crystal / Axis were previously not snapshotted; they are
+// now needed so the tab label can append " *" when the in-flight buffer
+// diverges from the value at modal-open time.
+static CrystalConfig g_crystal_buf_snapshot;
+static AxisDist g_axis_buf_snapshot[3];
+
 // Crystal modal: trackball state saved on open, restored on Cancel
 static float g_saved_rotation[16];
 static float g_saved_zoom;
@@ -200,6 +208,10 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   g_filter_buf_removed = false;
   g_filter_buf_snapshot = g_filter_buf;
   g_filter_initial_present = entry.filter.has_value();
+  g_crystal_buf_snapshot = g_crystal_buf;
+  g_axis_buf_snapshot[0] = g_axis_buf[0];
+  g_axis_buf_snapshot[1] = g_axis_buf[1];
+  g_axis_buf_snapshot[2] = g_axis_buf[2];
 
   // Save trackball state for Cancel restoration
   std::memcpy(g_saved_rotation, g_crystal_rotation, sizeof(g_saved_rotation));
@@ -602,18 +614,40 @@ void RenderEditModals(GuiState& state) {
                                                ImGuiTabItemFlags_SetSelected :
                                                ImGuiTabItemFlags_None;
 
+    // Per-tab dirty detection. The label picks up a trailing " *" when the
+    // in-flight buffer differs from the snapshot taken at modal-open. All
+    // labels share a fixed `###` suffix — with three hashes ImGui derives the
+    // internal ID purely from the `###suffix` portion, so the display string
+    // can vary ("Crystal" vs "Crystal *") without changing the tab's hash
+    // (otherwise the tab would lose its SelectedTabId the moment dirty flips,
+    // falling back to the first tab and hiding the user's work-in-progress).
+    FilterConfig filter_cmp = g_filter_buf;
+    filter_cmp.raypath_text = g_raypath_buf;
+    // Note: g_filter_buf_removed may be true while g_filter_initial_present is
+    // false — the user can click Remove on an entry that had no filter (a
+    // no-op for committed state). filter_dirty resolves to false in that case
+    // via the ternary below.
+    const bool crystal_dirty = g_crystal_buf != g_crystal_buf_snapshot;
+    const bool axis_dirty = g_axis_buf[0] != g_axis_buf_snapshot[0] || g_axis_buf[1] != g_axis_buf_snapshot[1] ||
+                            g_axis_buf[2] != g_axis_buf_snapshot[2];
+    const bool filter_dirty =
+        g_filter_buf_removed ? g_filter_initial_present : (filter_cmp != g_filter_buf_snapshot);
+    const char* crystal_label = crystal_dirty ? "Crystal *###crystal_tab" : "Crystal###crystal_tab";
+    const char* axis_label = axis_dirty ? "Axis *###axis_tab" : "Axis###axis_tab";
+    const char* filter_label = filter_dirty ? "Filter *###filter_tab" : "Filter###filter_tab";
+
     if (ImGui::BeginTabBar("##edit_modal_tabs")) {
-      if (ImGui::BeginTabItem("Crystal", nullptr, crystal_flags)) {
+      if (ImGui::BeginTabItem(crystal_label, nullptr, crystal_flags)) {
         g_active_tab = ActiveTab::kCrystal;
         RenderCrystalModal(state);
         ImGui::EndTabItem();
       }
-      if (ImGui::BeginTabItem("Axis", nullptr, axis_flags)) {
+      if (ImGui::BeginTabItem(axis_label, nullptr, axis_flags)) {
         g_active_tab = ActiveTab::kAxis;
         RenderAxisModal(state);
         ImGui::EndTabItem();
       }
-      if (ImGui::BeginTabItem("Filter", nullptr, filter_flags)) {
+      if (ImGui::BeginTabItem(filter_label, nullptr, filter_flags)) {
         g_active_tab = ActiveTab::kFilter;
         RenderFilterModal(state);
         ImGui::EndTabItem();

--- a/src/gui/edit_modals.hpp
+++ b/src/gui/edit_modals.hpp
@@ -14,10 +14,10 @@ void OpenEditModal(const EditRequest& req, GuiState& state);
 // outside any Begin/End block, in the same scope as RenderUnsavedPopup.
 void RenderEditModals(GuiState& state);
 
-// Returns true if the Crystal edit modal is currently open.
-// Used by RenderLeftPanel to skip 3D preview UpdateMesh+Render
-// (the modal drives the shared FBO renderer exclusively).
-bool IsCrystalModalOpen();
+// Returns true when the unified edit modal is open AND the Crystal tab is the
+// active one. Used by visual-smoke tests to detect FBO contention with the
+// modal's per-frame g_crystal_renderer.Render() call.
+bool IsEditModalCrystalTabActive();
 
 // Reset all modal-internal static state (active modal, edit buffers, pending flags).
 // Called by test teardown (ResetTestState) to prevent state leakage between tests.

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -8,7 +8,7 @@ constexpr int kInitWindowWidth = 1600;
 constexpr int kInitWindowHeight = 980;
 constexpr int kMinWindowWidth = 1024;
 constexpr int kMinWindowHeight = 640;
-constexpr float kLeftPanelWidth = 360.0f;
+constexpr float kLeftPanelWidth = 400.0f;
 constexpr float kRightPanelWidth = 300.0f;
 constexpr float kTopBarHeight = 40.0f;
 constexpr float kStatusBarHeight = 28.0f;
@@ -46,8 +46,11 @@ constexpr float kInputWidth = 60.0f;
 // Card thumbnail (offscreen crystal rendering)
 // Currently used for both FBO render resolution and UI display size.
 // If HiDPI support is needed later, split into separate render/display constants.
-constexpr int kThumbnailSize = 64;
+constexpr int kThumbnailSize = 96;
 constexpr int kMaxThumbnailUpdatesPerFrame = 2;
+
+// Vertical gap between stacked hover-action buttons (Delete on top, Duplicate below).
+constexpr float kHoverBtnGap = 4.0f;
 
 // Default camera zoom for the crystal renderer. Lower value → crystal fills
 // more of the canvas (screen coverage ≈ 1/zoom). Must stay in sync between

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -4,10 +4,22 @@
 namespace lumice::gui {
 
 // Layout constants
+// Initial window size. Height is bound to the right-panel content footprint:
+// when adding new control groups / expanding existing groups, re-evaluate this
+// constant to avoid spawning a scrollbar on fresh install. On constrained
+// displays (e.g. 1080p + large Dock, Windows 125% scaling), main.cpp clamps
+// the actual creation size via glfwGetMonitorWorkarea — see
+// ClampInitWindowSize() in main.cpp / ClampWindowSizeToWorkarea() in
+// window_sizing.hpp.
 constexpr int kInitWindowWidth = 1600;
 constexpr int kInitWindowHeight = 980;
 constexpr int kMinWindowWidth = 1024;
 constexpr int kMinWindowHeight = 640;
+// Safe margin for OS window decorations (title bar + borders). Deducted from
+// the monitor work area (which already excludes menubar/Dock/taskbar) to
+// compute the usable creation size. 50 px covers the typical 28-32 px
+// decoration on macOS/Windows/Linux with ~1.5x buffer.
+constexpr int kWindowDecorationMargin = 50;
 constexpr float kLeftPanelWidth = 400.0f;
 constexpr float kRightPanelWidth = 300.0f;
 constexpr float kTopBarHeight = 40.0f;

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -5,7 +5,7 @@ namespace lumice::gui {
 
 // Layout constants
 constexpr int kInitWindowWidth = 1600;
-constexpr int kInitWindowHeight = 900;
+constexpr int kInitWindowHeight = 980;
 constexpr int kMinWindowWidth = 1024;
 constexpr int kMinWindowHeight = 640;
 constexpr float kLeftPanelWidth = 360.0f;

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -49,6 +49,12 @@ constexpr float kInputWidth = 60.0f;
 constexpr int kThumbnailSize = 64;
 constexpr int kMaxThumbnailUpdatesPerFrame = 2;
 
+// Default camera zoom for the crystal renderer. Lower value → crystal fills
+// more of the canvas (screen coverage ≈ 1/zoom). Must stay in sync between
+// the thumbnail cache and the edit-modal preview so the crystal does not
+// visually jump when opening the modal.
+constexpr float kDefaultCrystalZoom = 1.4f;
+
 // Auxiliary line overlay
 constexpr int kMaxSunCircles = 16;
 

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -177,7 +177,8 @@ struct EntryCard {
   }
   friend bool operator!=(const EntryCard& a, const EntryCard& b) { return !(a == b); }
 };
-static_assert(sizeof(EntryCard) == 192, "EntryCard fields changed; update operator== and this size");
+static_assert(sizeof(EntryCard) == 192,
+              "EntryCard size changed (check CrystalConfig/AxisDist/EntryCard operator== for new fields)");
 
 struct Layer {
   float probability = 0.0f;  // Probability of multi-scatter continuation (0 = single scatter), range [0,1]

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -177,8 +177,14 @@ struct EntryCard {
   }
   friend bool operator!=(const EntryCard& a, const EntryCard& b) { return !(a == b); }
 };
+// Apple Silicon + libc++ only — std::string SSO buffer differs between libc++
+// (24 bytes) and libstdc++ (32 bytes), so the absolute sizeof differs per
+// platform. Pinning the Apple build is enough to catch an accidental field
+// addition during local dev; Linux/Windows CI still compiles the struct.
+#if defined(__APPLE__) && defined(__aarch64__)
 static_assert(sizeof(EntryCard) == 192,
               "EntryCard size changed (check CrystalConfig/AxisDist/EntryCard operator== for new fields)");
+#endif
 
 struct Layer {
   float probability = 0.0f;  // Probability of multi-scatter continuation (0 = single scatter), range [0,1]

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -28,6 +28,11 @@ struct AxisDist {
   AxisDistType type = AxisDistType::kUniform;
   float mean = 0.0f;
   float std = 0.0f;  // Gauss: standard deviation; Uniform: full range; Zigzag: amplitude; Laplacian: scale
+
+  friend bool operator==(const AxisDist& a, const AxisDist& b) {
+    return a.type == b.type && a.mean == b.mean && a.std == b.std;
+  }
+  friend bool operator!=(const AxisDist& a, const AxisDist& b) { return !(a == b); }
 };
 
 // GUI-only data structure: crystal geometry + axis distribution.
@@ -52,6 +57,15 @@ struct CrystalConfig {
   AxisDist zenith{ AxisDistType::kUniform, 0.0f, 360.0f };
   AxisDist azimuth{ AxisDistType::kUniform, 0.0f, 360.0f };
   AxisDist roll{ AxisDistType::kUniform, 0.0f, 360.0f };
+
+  friend bool operator==(const CrystalConfig& a, const CrystalConfig& b) {
+    return a.name == b.name && a.type == b.type && a.height == b.height && a.prism_h == b.prism_h &&
+           a.upper_h == b.upper_h && a.lower_h == b.lower_h && a.upper_alpha == b.upper_alpha &&
+           a.lower_alpha == b.lower_alpha &&
+           std::equal(std::begin(a.face_distance), std::end(a.face_distance), std::begin(b.face_distance)) &&
+           a.zenith == b.zenith && a.azimuth == b.azimuth && a.roll == b.roll;
+  }
+  friend bool operator!=(const CrystalConfig& a, const CrystalConfig& b) { return !(a == b); }
 };
 
 struct SunConfig {
@@ -148,11 +162,22 @@ struct FilterConfig {
 };
 
 // GUI-only data structure: one crystal+filter entry card in the layer model.
+//
+// operator== exists so CommitAllBuffers (edit_modals.cpp) can skip render-invalidation
+// when the OK button doesn't actually change the entry. Adding a field here without
+// updating operator== would silently break that gate; the static_assert below catches
+// such omissions at compile time (update both together).
 struct EntryCard {
   CrystalConfig crystal;
   std::optional<FilterConfig> filter;
   float proportion = 100.0f;
+
+  friend bool operator==(const EntryCard& a, const EntryCard& b) {
+    return a.crystal == b.crystal && a.filter == b.filter && a.proportion == b.proportion;
+  }
+  friend bool operator!=(const EntryCard& a, const EntryCard& b) { return !(a == b); }
 };
+static_assert(sizeof(EntryCard) == 192, "EntryCard fields changed; update operator== and this size");
 
 struct Layer {
   float probability = 0.0f;  // Probability of multi-scatter continuation (0 = single scatter), range [0,1]

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -131,6 +131,20 @@ struct FilterConfig {
   bool sym_p = true;
   bool sym_b = true;
   bool sym_d = true;
+
+  // Used by edit_modals.cpp to detect whether the user actually modified the
+  // filter buffer (so an untouched OK on a previously-empty filter doesn't
+  // silently materialize a default-constructed filter into entry.filter).
+  //
+  // ⚠️ When adding a new field above, also:
+  //   1. Compare it here in operator==
+  //   2. Update file_io.cpp serialization (Serialize/ParseFilterFromGuiJson)
+  //   3. Update edit_modals.cpp Filter tab UI to expose it
+  friend bool operator==(const FilterConfig& a, const FilterConfig& b) {
+    return a.name == b.name && a.action == b.action && a.raypath_text == b.raypath_text && a.sym_p == b.sym_p &&
+           a.sym_b == b.sym_b && a.sym_d == b.sym_d;
+  }
+  friend bool operator!=(const FilterConfig& a, const FilterConfig& b) { return !(a == b); }
 };
 
 // GUI-only data structure: one crystal+filter entry card in the layer model.

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -204,8 +204,8 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  // Initialize crystal renderer (256x256 FBO)
-  if (!gui::g_crystal_renderer.Init(256, 256)) {
+  // Initialize crystal renderer (512x512 FBO — supersamples the 320px modal preview)
+  if (!gui::g_crystal_renderer.Init(512, 512)) {
     GUI_LOG_ERROR("Failed to initialize crystal renderer");
     return 1;
   }

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -21,6 +21,7 @@
 #include "gui/gl_init.h"
 #include "gui/gui_logger.hpp"
 #include "gui/log_sink.hpp"
+#include "gui/window_sizing.hpp"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
@@ -80,7 +81,27 @@ int main(int argc, char** argv) {
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
 
-  GLFWwindow* window = glfwCreateWindow(gui::kInitWindowWidth, gui::kInitWindowHeight, "Lumice", nullptr, nullptr);
+  // Clamp the requested initial size to what the current monitor can actually
+  // display — workarea already excludes OS bars (menubar/Dock/taskbar); we
+  // deduct kWindowDecorationMargin for title bar + borders. Without this,
+  // kInitWindowHeight=980 can be silently shrunk by the OS on 1080p displays
+  // with a large Dock or 125% DPI scaling, spawning a scrollbar on the right
+  // panel. Falls through to defaults on headless / nullptr-monitor environments.
+  int init_w = gui::kInitWindowWidth;
+  int init_h = gui::kInitWindowHeight;
+  if (GLFWmonitor* primary = glfwGetPrimaryMonitor()) {
+    int wx = 0;
+    int wy = 0;
+    int ww = 0;
+    int wh = 0;
+    glfwGetMonitorWorkarea(primary, &wx, &wy, &ww, &wh);
+    if (ww > 0 && wh > 0) {
+      auto [w, h] = gui::ClampWindowSizeToWorkarea(init_w, init_h, ww, wh);
+      init_w = w;
+      init_h = h;
+    }
+  }
+  GLFWwindow* window = glfwCreateWindow(init_w, init_h, "Lumice", nullptr, nullptr);
   if (!window) {
     fprintf(stderr, "Failed to create GLFW window\n");
     glfwTerminate();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -493,32 +493,37 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   ImGuiID hover_persist_id = ImGui::GetID("##card_hover_persist");
   bool hover_prev = ImGui::GetStateStorage()->GetBool(hover_persist_id, false);
 
+  // Use frame-height spacing so each row reserves room for the Edit button (taller than text);
+  // otherwise Row 0-2 buttons would overlap the prop. slider in Row 3.
+  float row_h = ImGui::GetFrameHeightWithSpacing();
+  float spacing_x = ImGui::GetStyle().ItemSpacing.x;
+  float spacing_y = ImGui::GetStyle().ItemSpacing.y;
+
+  // Thumbnail display size matches the right column's content height:
+  // top of Row 0 (= thumb_pos.y) to bottom of Row 3 (= row_h*4 - spacing_y).
+  // Square (W=H) so the crystal aspect is preserved. kThumbnailSize is the FBO
+  // render resolution; ImGui scales the texture to thumb_display_size on draw.
+  float thumb_display_size = row_h * 4.0f - spacing_y;
+
   // Left column: crystal thumbnail (or grey placeholder if not yet rendered)
   ImVec2 thumb_pos = ImGui::GetCursorScreenPos();
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
   auto thumb_tex = g_thumbnail_cache.GetTexture(layer_idx, entry_idx);
-  constexpr float kThumbSize = static_cast<float>(kThumbnailSize);
+  ImVec2 thumb_br(thumb_pos.x + thumb_display_size, thumb_pos.y + thumb_display_size);
   if (thumb_tex != 0) {
     // OpenGL texture Y-axis is flipped relative to ImGui: uv0=(0,1) uv1=(1,0)
-    draw_list->AddImage(static_cast<ImTextureID>(thumb_tex), thumb_pos,
-                        ImVec2(thumb_pos.x + kThumbSize, thumb_pos.y + kThumbSize), ImVec2(0, 1), ImVec2(1, 0));
+    draw_list->AddImage(static_cast<ImTextureID>(thumb_tex), thumb_pos, thumb_br, ImVec2(0, 1), ImVec2(1, 0));
   } else {
-    draw_list->AddRectFilled(thumb_pos, ImVec2(thumb_pos.x + kThumbSize, thumb_pos.y + kThumbSize),
-                             IM_COL32(60, 60, 60, 255));
+    draw_list->AddRectFilled(thumb_pos, thumb_br, IM_COL32(60, 60, 60, 255));
   }
-  draw_list->AddRect(thumb_pos, ImVec2(thumb_pos.x + kThumbSize, thumb_pos.y + kThumbSize),
-                     IM_COL32(100, 100, 100, 255));
+  draw_list->AddRect(thumb_pos, thumb_br, IM_COL32(100, 100, 100, 255));
 
   // Right column — layout matches SliderWithInput's three-column model:
   //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
   // so Row 1-3 align column boundaries with Row 4 automatically.
-  float right_x = thumb_pos.x + kThumbnailSize + ImGui::GetStyle().ItemSpacing.x;
-  float spacing_x = ImGui::GetStyle().ItemSpacing.x;
-  float avail_w = ImGui::GetContentRegionAvail().x - kThumbnailSize - spacing_x;
+  float right_x = thumb_pos.x + thumb_display_size + spacing_x;
+  float avail_w = ImGui::GetContentRegionAvail().x - thumb_display_size - spacing_x;
   float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x * 2);
-  // Use frame-height spacing so each row reserves room for the Edit button (taller than text);
-  // otherwise Row 0-2 buttons would overlap the prop. slider in Row 3.
-  float row_h = ImGui::GetFrameHeightWithSpacing();
 
   auto emit_row = [&](int row_idx, const char* text_content, const char* btn_id, EditTarget target,
                       const char* row_label, bool clip_text) {
@@ -572,13 +577,15 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   //   duplicate y: delete_y + btn_h + kHoverBtnGap
   char dup_id[32];
   char del_id[32];
-  // "\xC3\x97" is U+00D7 MULTIPLICATION SIGN (×) in UTF-8; Latin-1 range is
-  // covered by ImGui's default Proggy Clean font.
-  snprintf(dup_id, sizeof(dup_id), "+##dup_%d_%d", layer_idx, entry_idx);
+  // Glyphs: "D" for Duplicate (less ambiguous than "+", which reads as "Add"),
+  // "\xC3\x97" (U+00D7 ×) for Delete. Both ASCII / Latin-1 — covered by ImGui's
+  // default Proggy Clean font; replacing them with proper SVG icons is tracked
+  // in backlog as "GUI icon font integration (FontAwesome)".
+  snprintf(dup_id, sizeof(dup_id), "D##dup_%d_%d", layer_idx, entry_idx);
   snprintf(del_id, sizeof(del_id), "\xC3\x97##del_%d_%d", layer_idx, entry_idx);
 
   float frame_pad_x = ImGui::GetStyle().FramePadding.x;
-  float dup_glyph_w = ImGui::CalcTextSize("+").x;
+  float dup_glyph_w = ImGui::CalcTextSize("D").x;
   float del_glyph_w = ImGui::CalcTextSize("\xC3\x97").x;
   float btn_w = std::max(dup_glyph_w, del_glyph_w) + frame_pad_x * 2.0f;
   float btn_h = ImGui::GetFrameHeight();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -540,10 +540,22 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   }
 
   // Hover action buttons: stacked vertically at the right edge of the card —
-  // Delete (×) on top, Duplicate (+) below, separated by kHoverBtnGap. Alpha is
+  // Delete (×) on top, Duplicate (D) below, separated by kHoverBtnGap. Alpha is
   // driven by previous-frame hover state; buttons are always in the ImGui tree
   // so click paths remain stable, only visibility transitions.
-  // Coordinate strategy (recorded for task-hover-btn-debt):
+  //
+  // Fast-swipe mitigation: vertical stacking (v6/card-layout-v2) prevents a
+  // single horizontal swipe from crossing the always-hit-tested Delete button,
+  // which was the original backlog concern. Confirm dialog / undo intentionally
+  // avoided — v5 verified that BeginDisabled(!hover_prev) and clicked+hover_prev
+  // both break imgui_test_engine MouseMove+Yield+ItemClick timing.
+  //
+  // AutoResizeY first-frame drift (backlog Minor 3): ImGuiChildFlags_AutoResizeY
+  // only auto-fits the Y dimension; X is driven by the parent layout and stable
+  // on the first frame. The Y coordinates (del_y/dup_y) anchor to card_top, not
+  // WindowSize.y, so they are also frame-stable. No positional fix needed.
+  //
+  // Coordinate strategy:
   //   x: card_right - btn_w - kHoverBtnPad
   //   delete y: card_top + kHoverBtnPad
   //   duplicate y: delete_y + btn_h + kHoverBtnGap

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -663,7 +663,18 @@ void RenderLayer(GuiState& state, int layer_idx) {
     // Multi-scatter probability slider
     char prob_id[32];
     snprintf(prob_id, sizeof(prob_id), "Prob.##layer_%d", layer_idx);
+    bool single_layer = state.layers.size() <= 1;
+    if (single_layer) {
+      ImGui::BeginDisabled();
+    }
     DIRTY_IF(SliderWithInput(prob_id, &layer.probability, 0.0f, 1.0f, "%.2f"));
+    if (single_layer) {
+      ImGui::EndDisabled();
+    }
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip(single_layer ? "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer." :
+                                       "Fraction of rays continuing to the next layer");
+    }
 
     // Render entry cards with deferred deletion
     int pending_delete_entry = -1;

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -161,19 +161,16 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
     return "None";
   }
   const auto& fc = f.value();
-  // NOTE: the "raypath " prefix is hardcoded because FilterConfig currently supports only
-  // raypath-type filters. When a second filter type is added, introduce FilterConfig::type
-  // and map the type enum to the prefix string here.
-  std::string result = "raypath ";
-  result += (fc.action == 0) ? "In " : "Out ";
-
+  // Format: "<raypath_text or *> <In|Out>[ <sym>]". Example: "1-3 In PBD".
+  std::string result;
   if (fc.raypath_text.size() > 12) {
-    result += fc.raypath_text.substr(0, 12) + "...";
+    result = fc.raypath_text.substr(0, 12) + "...";
   } else if (!fc.raypath_text.empty()) {
-    result += fc.raypath_text;
+    result = fc.raypath_text;
   } else {
-    result += "*";
+    result = "*";
   }
+  result += (fc.action == 0) ? " In" : " Out";
 
   std::string sym;
   if (fc.sym_p)
@@ -519,11 +516,13 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   float spacing_x = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x - kThumbnailSize - spacing_x;
   float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x * 2);
-  float line_h = ImGui::GetTextLineHeightWithSpacing();
+  // Use frame-height spacing so each row reserves room for the Edit button (taller than text);
+  // otherwise Row 0-2 buttons would overlap the prop. slider in Row 3.
+  float row_h = ImGui::GetFrameHeightWithSpacing();
 
   auto emit_row = [&](int row_idx, const char* text_content, const char* btn_id, EditTarget target,
                       const char* row_label, bool clip_text) {
-    ImVec2 line_start(right_x, thumb_pos.y + line_h * static_cast<float>(row_idx));
+    ImVec2 line_start(right_x, thumb_pos.y + row_h * static_cast<float>(row_idx));
     ImGui::SetCursorScreenPos(line_start);
     if (clip_text) {
       ImVec2 clip_min = line_start;
@@ -545,48 +544,55 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
 
   // Row 1: Crystal type
   const char* type_name = (entry.crystal.type == CrystalType::kPrism) ? "Prism" : "Pyramid";
-  emit_row(0, type_name, "Edit##cr", EditTarget::kCrystal, "crystal", false);
+  emit_row(0, type_name, "Edit##cr", EditTarget::kCrystal, "Crystal", false);
 
   // Row 2: Axis preset
   std::string preset = AxisPresetName(entry.crystal);
-  emit_row(1, preset.c_str(), "Edit##ax", EditTarget::kAxis, "axis", false);
+  emit_row(1, preset.c_str(), "Edit##ax", EditTarget::kAxis, "Axis", false);
 
   // Row 3: Filter summary (may exceed text_w — clip so it doesn't overlap the Edit button)
   std::string filter_text = FilterSummary(entry.filter);
-  emit_row(2, filter_text.c_str(), "Edit##fi", EditTarget::kFilter, "filter", true);
+  emit_row(2, filter_text.c_str(), "Edit##fi", EditTarget::kFilter, "Filter", true);
 
   // Row 4: Proportion — reuse SliderWithInput for [slider][input] "prop." layout
-  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + line_h * 3.0f));
+  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + row_h * 3.0f));
   char prop_label[32];
   snprintf(prop_label, sizeof(prop_label), "prop.##prop_%d_%d", layer_idx, entry_idx);
   if (SliderWithInput(prop_label, &entry.proportion, 0.0f, 100.0f, "%.1f")) {
     state.MarkDirty();
   }
 
-  // Hover action buttons: render at top-right of card (inside child) with alpha
-  // driven by previous-frame hover state. They are always in the ImGui tree so
-  // click paths remain stable; only visibility transitions.
+  // Hover action buttons: stacked vertically at the right edge of the card —
+  // Delete (×) on top, Duplicate (+) below, separated by kHoverBtnGap. Alpha is
+  // driven by previous-frame hover state; buttons are always in the ImGui tree
+  // so click paths remain stable, only visibility transitions.
+  // Coordinate strategy (recorded for task-hover-btn-debt):
+  //   x: card_right - btn_w - kHoverBtnPad
+  //   delete y: card_top + kHoverBtnPad
+  //   duplicate y: delete_y + btn_h + kHoverBtnGap
   char dup_id[32];
   char del_id[32];
-  snprintf(dup_id, sizeof(dup_id), "Duplicate##%d_%d", layer_idx, entry_idx);
-  snprintf(del_id, sizeof(del_id), "x##%d_%d", layer_idx, entry_idx);
+  // "\xC3\x97" is U+00D7 MULTIPLICATION SIGN (×) in UTF-8; Latin-1 range is
+  // covered by ImGui's default Proggy Clean font.
+  snprintf(dup_id, sizeof(dup_id), "+##dup_%d_%d", layer_idx, entry_idx);
+  snprintf(del_id, sizeof(del_id), "\xC3\x97##del_%d_%d", layer_idx, entry_idx);
 
   float frame_pad_x = ImGui::GetStyle().FramePadding.x;
-  float btn_spacing = ImGui::GetStyle().ItemSpacing.x;
-  float dup_w = ImGui::CalcTextSize("Duplicate").x + frame_pad_x * 2.0f;
-  float del_w = ImGui::CalcTextSize("x").x + frame_pad_x * 2.0f;
-  float hover_row_w = dup_w + btn_spacing + del_w;
+  float dup_glyph_w = ImGui::CalcTextSize("+").x;
+  float del_glyph_w = ImGui::CalcTextSize("\xC3\x97").x;
+  float btn_w = std::max(dup_glyph_w, del_glyph_w) + frame_pad_x * 2.0f;
+  float btn_h = ImGui::GetFrameHeight();
   constexpr float kHoverBtnPad = 2.0f;
   ImVec2 card_win_pos = ImGui::GetWindowPos();
   ImVec2 card_win_sz = ImGui::GetWindowSize();
-  ImGui::SetCursorScreenPos(
-      ImVec2(card_win_pos.x + card_win_sz.x - hover_row_w - kHoverBtnPad, card_win_pos.y + kHoverBtnPad));
+  float btn_x = card_win_pos.x + card_win_sz.x - btn_w - kHoverBtnPad;
+  float del_y = card_win_pos.y + kHoverBtnPad;
+  float dup_y = del_y + btn_h + kHoverBtnGap;
 
   ImGui::PushStyleVar(ImGuiStyleVar_Alpha, hover_prev ? 1.0f : 0.0f);
-  bool dup_clicked = ImGui::SmallButton(dup_id);
-  ImGui::SameLine();
-  // Delete button: red when enabled (destructive action); auto-greyed when
+  // Delete button (top): red when enabled (destructive action); auto-greyed when
   // disabled (only one entry in layer — cannot remove last entry).
+  ImGui::SetCursorScreenPos(ImVec2(btn_x, del_y));
   bool can_delete_entry = state.layers[layer_idx].entries.size() > 1;
   if (can_delete_entry) {
     PushDestructiveStyle();
@@ -599,6 +605,9 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   } else {
     ImGui::EndDisabled();
   }
+  // Duplicate button (below)
+  ImGui::SetCursorScreenPos(ImVec2(btn_x, dup_y));
+  bool dup_clicked = ImGui::SmallButton(dup_id);
   ImGui::PopStyleVar();
 
   if (dup_clicked) {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -190,9 +190,8 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
   if (expr)            \
   state.MarkDirty()
 
-// Card layout constants (kThumbnailSize is in gui_constants.hpp)
-constexpr float kCardHeight = 84.0f;
-constexpr float kCardSpacing = 4.0f;
+// Card layout: height is driven by ImGuiChildFlags_AutoResizeY so font/theme
+// changes adapt automatically (kThumbnailSize lives in gui_constants.hpp).
 
 }  // namespace
 
@@ -471,7 +470,7 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.25f, 0.35f, 0.55f, 0.4f));
   }
 
-  ImGui::BeginChild("##card", ImVec2(0, kCardHeight), ImGuiChildFlags_Borders);
+  ImGui::BeginChild("##card", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
 
   // Click anywhere in card to select
   if (ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -161,7 +161,10 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
     return "None";
   }
   const auto& fc = f.value();
-  std::string result;
+  // NOTE: the "raypath " prefix is hardcoded because FilterConfig currently supports only
+  // raypath-type filters. When a second filter type is added, introduce FilterConfig::type
+  // and map the type enum to the prefix string here.
+  std::string result = "raypath ";
   result += (fc.action == 0) ? "In " : "Out ";
 
   if (fc.raypath_text.size() > 12) {
@@ -497,47 +500,56 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   draw_list->AddRect(thumb_pos, ImVec2(thumb_pos.x + kThumbSize, thumb_pos.y + kThumbSize),
                      IM_COL32(100, 100, 100, 255));
 
-  // Right column
+  // Right column — layout matches SliderWithInput's three-column model:
+  //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
+  // so Row 1-3 align column boundaries with Row 4 automatically.
   float right_x = thumb_pos.x + kThumbnailSize + ImGui::GetStyle().ItemSpacing.x;
-  float right_w = ImGui::GetContentRegionAvail().x - kThumbnailSize - ImGui::GetStyle().ItemSpacing.x;
+  float spacing_x = ImGui::GetStyle().ItemSpacing.x;
+  float avail_w = ImGui::GetContentRegionAvail().x - kThumbnailSize - spacing_x;
+  float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x * 2);
+  float line_h = ImGui::GetTextLineHeightWithSpacing();
 
-  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y));
+  auto emit_row = [&](int row_idx, const char* text_content, const char* btn_id, EditTarget target,
+                      const char* row_label, bool clip_text) {
+    ImVec2 line_start(right_x, thumb_pos.y + line_h * static_cast<float>(row_idx));
+    ImGui::SetCursorScreenPos(line_start);
+    if (clip_text) {
+      ImVec2 clip_min = line_start;
+      ImVec2 clip_max(line_start.x + text_w, line_start.y + ImGui::GetTextLineHeight() + 2.0f);
+      ImGui::PushClipRect(clip_min, clip_max, true);
+      ImGui::TextUnformatted(text_content);
+      ImGui::PopClipRect();
+    } else {
+      ImGui::TextUnformatted(text_content);
+    }
+    ImGui::SameLine();
+    ImGui::SetCursorScreenPos(ImVec2(line_start.x + text_w + spacing_x, line_start.y));
+    if (ImGui::Button(btn_id, ImVec2(kInputWidth, 0))) {
+      g_edit_request = { target, layer_idx, entry_idx };
+    }
+    ImGui::SameLine();
+    ImGui::TextUnformatted(row_label);
+  };
 
-  // Row 1: Crystal type + Edit
+  // Row 1: Crystal type
   const char* type_name = (entry.crystal.type == CrystalType::kPrism) ? "Prism" : "Pyramid";
-  ImGui::Text("%s", type_name);
-  ImGui::SameLine(right_w - 30);
-  if (ImGui::SmallButton("E##cr")) {
-    g_edit_request = { EditTarget::kCrystal, layer_idx, entry_idx };
-  }
+  emit_row(0, type_name, "Edit##cr", EditTarget::kCrystal, "crystal", false);
 
-  // Row 2: Axis preset + Edit
+  // Row 2: Axis preset
   std::string preset = AxisPresetName(entry.crystal);
-  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + ImGui::GetTextLineHeightWithSpacing()));
-  ImGui::Text("%s", preset.c_str());
-  ImGui::SameLine(right_w - 30);
-  if (ImGui::SmallButton("E##ax")) {
-    g_edit_request = { EditTarget::kAxis, layer_idx, entry_idx };
-  }
+  emit_row(1, preset.c_str(), "Edit##ax", EditTarget::kAxis, "axis", false);
 
-  // Row 3: Filter summary + Edit
+  // Row 3: Filter summary (may exceed text_w — clip so it doesn't overlap the Edit button)
   std::string filter_text = FilterSummary(entry.filter);
-  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + ImGui::GetTextLineHeightWithSpacing() * 2));
-  ImGui::Text("%s", filter_text.c_str());
-  ImGui::SameLine(right_w - 30);
-  if (ImGui::SmallButton("E##fi")) {
-    g_edit_request = { EditTarget::kFilter, layer_idx, entry_idx };
-  }
+  emit_row(2, filter_text.c_str(), "Edit##fi", EditTarget::kFilter, "filter", true);
 
-  // Row 4: Proportion slider (compact)
-  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + ImGui::GetTextLineHeightWithSpacing() * 3));
-  ImGui::PushItemWidth(right_w - 50);
-  char prop_id[32];
-  snprintf(prop_id, sizeof(prop_id), "##prop_%d_%d", layer_idx, entry_idx);
-  if (ImGui::SliderFloat(prop_id, &entry.proportion, 0.0f, 100.0f, "%.1f")) {
+  // Row 4: Proportion — reuse SliderWithInput for [slider][input] "prop." layout
+  ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + line_h * 3.0f));
+  char prop_label[32];
+  snprintf(prop_label, sizeof(prop_label), "prop.##prop_%d_%d", layer_idx, entry_idx);
+  if (SliderWithInput(prop_label, &entry.proportion, 0.0f, 100.0f, "%.1f")) {
     state.MarkDirty();
   }
-  ImGui::PopItemWidth();
 
   ImGui::EndChild();  // ##card — must be unconditional
 

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -196,6 +196,22 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
 // Card layout: height is driven by ImGuiChildFlags_AutoResizeY so font/theme
 // changes adapt automatically (kThumbnailSize lives in gui_constants.hpp).
 
+// Destructive action button palette (delete/remove). Shared by entry-card and
+// layer-header "x" buttons so the visual language stays consistent.
+constexpr ImVec4 kBtnDestructiveNormal{ 0.70f, 0.22f, 0.22f, 1.0f };
+constexpr ImVec4 kBtnDestructiveHovered{ 0.85f, 0.30f, 0.30f, 1.0f };
+constexpr ImVec4 kBtnDestructiveActive{ 0.60f, 0.15f, 0.15f, 1.0f };
+
+void PushDestructiveStyle() {
+  ImGui::PushStyleColor(ImGuiCol_Button, kBtnDestructiveNormal);
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, kBtnDestructiveHovered);
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, kBtnDestructiveActive);
+}
+
+void PopDestructiveStyle() {
+  ImGui::PopStyleColor(3);
+}
+
 }  // namespace
 
 
@@ -573,15 +589,13 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // disabled (only one entry in layer — cannot remove last entry).
   bool can_delete_entry = state.layers[layer_idx].entries.size() > 1;
   if (can_delete_entry) {
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.70f, 0.22f, 0.22f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.85f, 0.30f, 0.30f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.60f, 0.15f, 0.15f, 1.0f));
+    PushDestructiveStyle();
   } else {
     ImGui::BeginDisabled();
   }
   bool delete_clicked = ImGui::SmallButton(del_id);
   if (can_delete_entry) {
-    ImGui::PopStyleColor(3);
+    PopDestructiveStyle();
   } else {
     ImGui::EndDisabled();
   }
@@ -642,15 +656,13 @@ void RenderLayer(GuiState& state, int layer_idx) {
   float layer_del_w = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
   ImGui::SameLine(ImGui::GetContentRegionMax().x - layer_del_w);
   if (can_delete_layer) {
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.70f, 0.22f, 0.22f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.85f, 0.30f, 0.30f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.60f, 0.15f, 0.15f, 1.0f));
+    PushDestructiveStyle();
   } else {
     ImGui::BeginDisabled();
   }
   bool layer_delete_clicked = ImGui::SmallButton(layer_del_id);
   if (can_delete_layer) {
-    ImGui::PopStyleColor(3);
+    PopDestructiveStyle();
   } else {
     ImGui::EndDisabled();
   }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -475,14 +475,10 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
 
   ImGui::BeginChild("##card", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
 
-  // Click anywhere in card to select
-  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-    if (!is_selected) {
-      g_crystal_mesh_hash = -1;  // Force 3D preview refresh on selection change
-    }
-    g_selected_layer = layer_idx;
-    g_selected_entry = entry_idx;
-  }
+  // Previous-frame hover state controls the alpha of the hover-action buttons
+  // (always-render + alpha transition to keep click paths stable).
+  ImGuiID hover_persist_id = ImGui::GetID("##card_hover_persist");
+  bool hover_prev = ImGui::GetStateStorage()->GetBool(hover_persist_id, false);
 
   // Left column: crystal thumbnail (or grey placeholder if not yet rendered)
   ImVec2 thumb_pos = ImGui::GetCursorScreenPos();
@@ -551,29 +547,74 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     state.MarkDirty();
   }
 
+  // Hover action buttons: render at top-right of card (inside child) with alpha
+  // driven by previous-frame hover state. They are always in the ImGui tree so
+  // click paths remain stable; only visibility transitions.
+  char dup_id[32];
+  char del_id[32];
+  snprintf(dup_id, sizeof(dup_id), "Duplicate##%d_%d", layer_idx, entry_idx);
+  snprintf(del_id, sizeof(del_id), "x##%d_%d", layer_idx, entry_idx);
+
+  float frame_pad_x = ImGui::GetStyle().FramePadding.x;
+  float btn_spacing = ImGui::GetStyle().ItemSpacing.x;
+  float dup_w = ImGui::CalcTextSize("Duplicate").x + frame_pad_x * 2.0f;
+  float del_w = ImGui::CalcTextSize("x").x + frame_pad_x * 2.0f;
+  float hover_row_w = dup_w + btn_spacing + del_w;
+  constexpr float kHoverBtnPad = 2.0f;
+  ImVec2 card_win_pos = ImGui::GetWindowPos();
+  ImVec2 card_win_sz = ImGui::GetWindowSize();
+  ImGui::SetCursorScreenPos(
+      ImVec2(card_win_pos.x + card_win_sz.x - hover_row_w - kHoverBtnPad, card_win_pos.y + kHoverBtnPad));
+
+  ImGui::PushStyleVar(ImGuiStyleVar_Alpha, hover_prev ? 1.0f : 0.0f);
+  bool dup_clicked = ImGui::SmallButton(dup_id);
+  ImGui::SameLine();
+  // Delete button: red when enabled (destructive action); auto-greyed when
+  // disabled (only one entry in layer — cannot remove last entry).
+  bool can_delete_entry = state.layers[layer_idx].entries.size() > 1;
+  if (can_delete_entry) {
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.70f, 0.22f, 0.22f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.85f, 0.30f, 0.30f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.60f, 0.15f, 0.15f, 1.0f));
+  } else {
+    ImGui::BeginDisabled();
+  }
+  bool delete_clicked = ImGui::SmallButton(del_id);
+  if (can_delete_entry) {
+    ImGui::PopStyleColor(3);
+  } else {
+    ImGui::EndDisabled();
+  }
+  ImGui::PopStyleVar();
+
+  if (dup_clicked) {
+    auto& entries = state.layers[layer_idx].entries;
+    entries.push_back(entry);  // deep copy
+    g_thumbnail_cache.OnLayerStructureChanged();
+    state.MarkDirty();
+  }
+
+  // Click-to-select: anywhere on the card that is NOT a widget (edit buttons,
+  // hover action buttons, or the proportion slider).
+  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
+      !ImGui::IsAnyItemHovered()) {
+    if (!is_selected) {
+      g_crystal_mesh_hash = -1;  // Force 3D preview refresh on selection change
+    }
+    g_selected_layer = layer_idx;
+    g_selected_entry = entry_idx;
+  }
+
+  // Persist hover state for next frame (computed while still inside the child
+  // window so widget hover does not disqualify it).
+  bool hover_now = ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
+  ImGui::GetStateStorage()->SetBool(hover_persist_id, hover_now);
+
   ImGui::EndChild();  // ##card — must be unconditional
 
   if (is_selected) {
     ImGui::PopStyleColor();
   }
-
-  // Buttons after the card (on same line or next line)
-  // Copy button
-  char copy_id[32];
-  snprintf(copy_id, sizeof(copy_id), "Copy##%d_%d", layer_idx, entry_idx);
-  if (ImGui::SmallButton(copy_id)) {
-    // Deep copy this entry and append to the same layer
-    auto& entries = state.layers[layer_idx].entries;
-    entries.push_back(entry);  // copy
-    g_thumbnail_cache.OnLayerStructureChanged();
-    state.MarkDirty();
-  }
-
-  // Delete button (returns whether clicked)
-  ImGui::SameLine();
-  char del_id[32];
-  snprintf(del_id, sizeof(del_id), "x##%d_%d", layer_idx, entry_idx);
-  bool delete_clicked = ImGui::SmallButton(del_id);
 
   ImGui::PopID();
   return delete_clicked;
@@ -590,7 +631,47 @@ void RenderLayer(GuiState& state, int layer_idx) {
   char header_label[32];
   snprintf(header_label, sizeof(header_label), "Layer %d", layer_idx + 1);
 
-  if (ImGui::CollapsingHeader(header_label, ImGuiTreeNodeFlags_DefaultOpen)) {
+  bool header_open =
+      ImGui::CollapsingHeader(header_label, ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowItemOverlap);
+
+  // Right-aligned delete button on the header row. Only enabled when more than
+  // one layer exists (the scattering model requires at least one layer).
+  char layer_del_id[32];
+  snprintf(layer_del_id, sizeof(layer_del_id), "x##layer_%d", layer_idx);
+  bool can_delete_layer = state.layers.size() > 1;
+  float layer_del_w = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+  ImGui::SameLine(ImGui::GetContentRegionMax().x - layer_del_w);
+  if (can_delete_layer) {
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.70f, 0.22f, 0.22f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.85f, 0.30f, 0.30f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.60f, 0.15f, 0.15f, 1.0f));
+  } else {
+    ImGui::BeginDisabled();
+  }
+  bool layer_delete_clicked = ImGui::SmallButton(layer_del_id);
+  if (can_delete_layer) {
+    ImGui::PopStyleColor(3);
+  } else {
+    ImGui::EndDisabled();
+  }
+  if (layer_delete_clicked && can_delete_layer) {
+    state.layers.erase(state.layers.begin() + layer_idx);
+    if (g_selected_layer >= static_cast<int>(state.layers.size())) {
+      g_selected_layer = static_cast<int>(state.layers.size()) - 1;
+    }
+    if (g_selected_layer >= 0) {
+      auto& sel_entries = state.layers[g_selected_layer].entries;
+      if (g_selected_entry >= static_cast<int>(sel_entries.size())) {
+        g_selected_entry = static_cast<int>(sel_entries.size()) - 1;
+      }
+    }
+    g_thumbnail_cache.OnLayerStructureChanged();
+    state.MarkDirty();
+    ImGui::PopID();
+    return;  // Skip rendering the rest; layer has been erased.
+  }
+
+  if (header_open) {
     // Multi-scatter probability slider
     char prob_id[32];
     snprintf(prob_id, sizeof(prob_id), "Prob.##layer_%d", layer_idx);
@@ -620,7 +701,7 @@ void RenderLayer(GuiState& state, int layer_idx) {
     // Add entry button
     ImGui::Spacing();
     char add_id[32];
-    snprintf(add_id, sizeof(add_id), "+ Entry##layer_%d", layer_idx);
+    snprintf(add_id, sizeof(add_id), "+ Crystal##layer_%d", layer_idx);
     if (ImGui::SmallButton(add_id)) {
       layer.entries.emplace_back();
       g_thumbnail_cache.OnLayerStructureChanged();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -91,10 +91,6 @@ static bool RenderNonlinearSlider(const char* slider_id, float* value, float min
   return changed;
 }
 
-// ---- Selection state ----
-int g_selected_layer = 0;
-int g_selected_entry = 0;
-
 // ---- Edit request state ----
 EditRequest g_edit_request;
 
@@ -450,26 +446,8 @@ void ResetEditRequest() {
   g_edit_request = EditRequest{};
 }
 
-int GetSelectedLayerIdx() {
-  return g_selected_layer;
-}
-
-int GetSelectedEntryIdx() {
-  return g_selected_entry;
-}
-
-void SetSelectedLayerIdx(int idx) {
-  g_selected_layer = idx;
-}
-
-void SetSelectedEntryIdx(int idx) {
-  g_selected_entry = idx;
-}
-
 void ResetPendingDeleteState() {
   g_edit_request = EditRequest{};
-  g_selected_layer = 0;
-  g_selected_entry = 0;
 }
 
 
@@ -477,14 +455,8 @@ void ResetPendingDeleteState() {
 
 bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   auto& entry = state.layers[layer_idx].entries[entry_idx];
-  bool is_selected = (g_selected_layer == layer_idx && g_selected_entry == entry_idx);
 
   ImGui::PushID(entry_idx);
-
-  // Highlight selected card
-  if (is_selected) {
-    ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.25f, 0.35f, 0.55f, 0.4f));
-  }
 
   ImGui::BeginChild("##card", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
 
@@ -624,27 +596,12 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     state.MarkDirty();
   }
 
-  // Click-to-select: anywhere on the card that is NOT a widget (edit buttons,
-  // hover action buttons, or the proportion slider).
-  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
-      !ImGui::IsAnyItemHovered()) {
-    if (!is_selected) {
-      g_crystal_mesh_hash = -1;  // Force 3D preview refresh on selection change
-    }
-    g_selected_layer = layer_idx;
-    g_selected_entry = entry_idx;
-  }
-
   // Persist hover state for next frame (computed while still inside the child
   // window so widget hover does not disqualify it).
   bool hover_now = ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
   ImGui::GetStateStorage()->SetBool(hover_persist_id, hover_now);
 
   ImGui::EndChild();  // ##card — must be unconditional
-
-  if (is_selected) {
-    ImGui::PopStyleColor();
-  }
 
   ImGui::PopID();
   return delete_clicked;
@@ -684,15 +641,6 @@ void RenderLayer(GuiState& state, int layer_idx) {
   }
   if (layer_delete_clicked && can_delete_layer) {
     state.layers.erase(state.layers.begin() + layer_idx);
-    if (g_selected_layer >= static_cast<int>(state.layers.size())) {
-      g_selected_layer = static_cast<int>(state.layers.size()) - 1;
-    }
-    if (g_selected_layer >= 0) {
-      auto& sel_entries = state.layers[g_selected_layer].entries;
-      if (g_selected_entry >= static_cast<int>(sel_entries.size())) {
-        g_selected_entry = static_cast<int>(sel_entries.size()) - 1;
-      }
-    }
     g_thumbnail_cache.OnLayerStructureChanged();
     state.MarkDirty();
     ImGui::PopID();
@@ -719,10 +667,6 @@ void RenderLayer(GuiState& state, int layer_idx) {
     if (pending_delete_entry >= 0 && layer.entries.size() > 1) {
       layer.entries.erase(layer.entries.begin() + pending_delete_entry);
       g_thumbnail_cache.OnLayerStructureChanged();
-      // Clamp selected entry if needed
-      if (g_selected_layer == layer_idx && g_selected_entry >= static_cast<int>(layer.entries.size())) {
-        g_selected_entry = static_cast<int>(layer.entries.size()) - 1;
-      }
       state.MarkDirty();
     }
 

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -664,16 +664,16 @@ void RenderLayer(GuiState& state, int layer_idx) {
     char prob_id[32];
     snprintf(prob_id, sizeof(prob_id), "Prob.##layer_%d", layer_idx);
     bool single_layer = state.layers.size() <= 1;
-    if (single_layer) {
-      ImGui::BeginDisabled();
-    }
+    ImGui::BeginDisabled(single_layer);
+    ImGui::BeginGroup();
     DIRTY_IF(SliderWithInput(prob_id, &layer.probability, 0.0f, 1.0f, "%.2f"));
-    if (single_layer) {
-      ImGui::EndDisabled();
-    }
+    ImGui::EndGroup();
+    ImGui::EndDisabled();
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      ImGui::SetTooltip(single_layer ? "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer." :
-                                       "Fraction of rays continuing to the next layer");
+      const char* prob_tip = single_layer
+                                 ? "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer."
+                                 : "Fraction of rays continuing to the next layer";
+      ImGui::SetTooltip("%s", prob_tip);
     }
 
     // Render entry cards with deferred deletion

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -670,9 +670,9 @@ void RenderLayer(GuiState& state, int layer_idx) {
     ImGui::EndGroup();
     ImGui::EndDisabled();
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      const char* prob_tip = single_layer
-                                 ? "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer."
-                                 : "Fraction of rays continuing to the next layer";
+      const char* prob_tip = single_layer ?
+                                 "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer." :
+                                 "Fraction of rays continuing to the next layer";
       ImGui::SetTooltip("%s", prob_tip);
     }
 

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -28,12 +28,6 @@ struct EditRequest {
 const EditRequest& GetEditRequest();
 void ResetEditRequest();
 
-// ---- Selection state accessors ----
-int GetSelectedLayerIdx();
-int GetSelectedEntryIdx();
-void SetSelectedLayerIdx(int idx);
-void SetSelectedEntryIdx(int idx);
-
 // ---- Axis distribution controls (shared between panels and edit modals) ----
 
 // Render axis distribution controls (combo + mean + std sliders).

--- a/src/gui/thumbnail_cache.cpp
+++ b/src/gui/thumbnail_cache.cpp
@@ -257,7 +257,7 @@ void ThumbnailCache::RenderThumbnail(int layer_idx, int entry_idx, const GuiStat
   GetThumbnailRotation(preset, rotation);
 
   // Render to the shared renderer's FBO
-  constexpr float kThumbnailZoom = 2.5f;
+  constexpr float kThumbnailZoom = 1.4f;
   renderer_.Render(rotation, kThumbnailZoom, CrystalStyle::kHiddenLine);
 
   // Ensure per-entry texture exists

--- a/src/gui/thumbnail_cache.cpp
+++ b/src/gui/thumbnail_cache.cpp
@@ -257,8 +257,7 @@ void ThumbnailCache::RenderThumbnail(int layer_idx, int entry_idx, const GuiStat
   GetThumbnailRotation(preset, rotation);
 
   // Render to the shared renderer's FBO
-  constexpr float kThumbnailZoom = 1.4f;
-  renderer_.Render(rotation, kThumbnailZoom, CrystalStyle::kHiddenLine);
+  renderer_.Render(rotation, kDefaultCrystalZoom, CrystalStyle::kHiddenLine);
 
   // Ensure per-entry texture exists
   uint64_t key = MakeKey(layer_idx, entry_idx);

--- a/src/gui/window_sizing.hpp
+++ b/src/gui/window_sizing.hpp
@@ -1,0 +1,23 @@
+#ifndef LUMICE_GUI_WINDOW_SIZING_HPP
+#define LUMICE_GUI_WINDOW_SIZING_HPP
+
+#include <algorithm>
+#include <utility>
+
+#include "gui/gui_constants.hpp"
+
+namespace lumice::gui {
+
+// Pure function: clamp desired window size to the usable work area.
+// workarea already excludes OS bars (menubar/Dock/taskbar) per GLFW docs;
+// kWindowDecorationMargin covers the remaining title-bar + border cost.
+// kMinWindowWidth/Height serve as a hard floor against pathological workarea.
+inline std::pair<int, int> ClampWindowSizeToWorkarea(int desired_w, int desired_h, int work_w, int work_h) {
+  int max_w = std::max(kMinWindowWidth, work_w - kWindowDecorationMargin);
+  int max_h = std::max(kMinWindowHeight, work_h - kWindowDecorationMargin);
+  return { std::min(desired_w, max_w), std::min(desired_h, max_h) };
+}
+
+}  // namespace lumice::gui
+
+#endif  // LUMICE_GUI_WINDOW_SIZING_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(unit_test
   "${PROJ_TEST_DIR}/test_sim_data.cpp"
   "${PROJ_TEST_DIR}/test_simulator.cpp"
   "${PROJ_TEST_DIR}/test_threading_pool.cpp"
+  "${PROJ_TEST_DIR}/test_window_sizing.cpp"
   "${PROJ_TEST_DIR}/test_main.cpp")
 target_include_directories(unit_test
   PRIVATE ${PROJ_TEST_DIR})

--- a/test/gui/references/crystal_prism_default.png
+++ b/test/gui/references/crystal_prism_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66f8c7f39999cbba8ba203b838f7f0ca867f949fb7c5cd5d584f0fdc9acb3809
-size 3384
+oid sha256:4b6b5451c90106b8c8a50ed011dadc1977f3e174c2eaf5f270761e46b44604c4
+size 2984

--- a/test/gui/references/crystal_pyramid_default.png
+++ b/test/gui/references/crystal_pyramid_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:952b2d67faca229e8407e3d9f91170a438e661ac04feb64f5fcbff5b6c230f6f
-size 2924
+oid sha256:bddef17d162a43cf5eb0a5410345ad14fecb07b30c28cdf4e7d2412ec55e3ae7
+size 3388

--- a/test/gui/references/crystal_shaded.png
+++ b/test/gui/references/crystal_shaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4e05ef7f4ad4721052dd0f5dd40be5792ef697184eb31f12e6fa136e454c0c5
-size 2957
+oid sha256:c5d4a6ce6d41a93d7563538c0ec753e2608338aeb66084f4291374a12ceaa4a4
+size 3365

--- a/test/gui/references/crystal_wireframe.png
+++ b/test/gui/references/crystal_wireframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:822274ffda7ed885cae773535c579c05179c706c79e057abbf972d10e7ce6183
-size 2903
+oid sha256:252b43f17d4d48c7b3fa6e85e0f6a9536fb7ee74942ee173dfa7930174edc537
+size 3409

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -169,10 +169,12 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       // Verify filter is set
       IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
 
-      // Open filter modal, click Remove to clear
+      // Open filter modal, click Remove (buffered) then OK to commit removal.
       ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);  // popup open + Filter tab activation (SetSelected first-frame)
+      ctx->ItemClick("**/Remove Filter##filter");
       ctx->Yield(2);
-      ctx->ItemClick("Edit Filter/Remove Filter##filter");
+      ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
       // Verify filter is cleared
@@ -399,11 +401,11 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
 
       // Write 0 via the input widget — should be clamped to min (0.01)
-      ctx->ItemInputValue("Edit Crystal/##Height##modal_cr_input", 0.0f);
+      ctx->ItemInputValue("**/##Height##modal_cr_input", 0.0f);
       ctx->Yield();
 
       // Click OK to commit
-      ctx->ItemClick("Edit Crystal/OK##crystal");
+      ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
       // Height should be clamped to >= 0.01 (kLogLinear with min=0.01)
@@ -427,11 +429,11 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
 
       // Write 0 to Upper H — should be allowed (min=0.0 for kLogLinear)
-      ctx->ItemInputValue("Edit Crystal/##Upper H##modal_cr_input", 0.0f);
+      ctx->ItemInputValue("**/##Upper H##modal_cr_input", 0.0f);
       ctx->Yield();
 
       // Click OK
-      ctx->ItemClick("Edit Crystal/OK##crystal");
+      ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
       IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal.upper_h, 0.0f);
@@ -754,7 +756,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
 
       // Click Cancel in the modal
-      ctx->ItemClick("Edit Crystal/Cancel##crystal");
+      ctx->ItemClick("**/Cancel##edit_modal");
       ctx->Yield(2);
 
       // State unchanged
@@ -778,11 +780,11 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
 
       // Modify height via the input widget in the modal
-      ctx->ItemInputValue("Edit Crystal/##Height##modal_cr_input", 5.0f);
+      ctx->ItemInputValue("**/##Height##modal_cr_input", 5.0f);
       ctx->Yield();
 
       // Click OK to commit buffer to state
-      ctx->ItemClick("Edit Crystal/OK##crystal");
+      ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
       // Height should be updated to 5.0
@@ -805,7 +807,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
 
       // Click OK to set the default filter on the entry
-      ctx->ItemClick("Edit Filter/OK##filter");
+      ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
       // Filter should now be set (modal OK commits filter buffer to state)

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -814,4 +814,31 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
     };
   }
+
+  // p2_modal/filter_modal_ok_change_creates_filter — open filter modal on empty
+  // entry, modify a field (action), click OK: entry.filter must be created.
+  // Covers the buf_changed=true && !initial_present branch of CommitAllBuffers.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "filter_modal_ok_change_creates_filter");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Entry starts with no filter.
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
+
+      // Open filter modal, type a raypath (touches g_filter_buf via g_raypath_buf
+      // sync in CommitAllBuffers), click OK.
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(3);
+      ctx->ItemInputValue("**/Raypath##filter_modal", "1-3");
+      ctx->Yield();
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // Filter must now exist with the typed raypath.
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].filter->raypath_text, std::string("1-3"));
+    };
+  }
 }

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -137,8 +137,8 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
 
-      // Add an entry via the "+ Entry" button in layer 0
-      ctx->ItemClick("**/+ Entry##layer_0");
+      // Add an entry via the "+ Crystal" button in layer 0
+      ctx->ItemClick("**/+ Crystal##layer_0");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 
@@ -271,10 +271,10 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
 
-      // Select the new layer (idx 1) then delete it
+      // Delete layer 1 via its per-layer header "x" button
       gui::SetSelectedLayerIdx(1);
       ctx->Yield();
-      ctx->ItemClick("**/- Layer");
+      ctx->ItemClick("**/x##layer_1");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
     };
@@ -294,8 +294,8 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
 
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
 
-      // Copy the entry
-      ctx->ItemClick("**/Copy##0_0");
+      // Duplicate the entry (hover button; test engine locates by ID even when alpha=0)
+      ctx->ItemClick("**/Duplicate##0_0");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -792,26 +792,26 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_modal/filter_modal_ok_sets_filter — open filter modal on empty entry, click OK to set filter
+  // p2_modal/filter_modal_ok_no_change_keeps_nullopt — open filter modal on empty
+  // entry, click OK without touching anything: entry must stay nullopt (otherwise
+  // a default-constructed filter "* In PBD" silently blocks all rays).
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "filter_modal_ok_sets_filter");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "filter_modal_ok_no_change_keeps_nullopt");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);
 
-      // Entry starts with no filter
+      // Entry starts with no filter.
       IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
 
-      // Open filter modal
+      // Open filter modal, click OK immediately without modifying anything.
       ctx->ItemClick("**/Edit##fi");
       ctx->Yield(3);
-
-      // Click OK to set the default filter on the entry
       ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
 
-      // Filter should now be set (modal OK commits filter buffer to state)
-      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+      // Filter must still be nullopt.
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
     };
   }
 }

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -169,7 +169,7 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
 
       // Open filter modal, click Remove to clear
-      ctx->ItemClick("**/E##fi");
+      ctx->ItemClick("**/Edit##fi");
       ctx->Yield(2);
       ctx->ItemClick("Edit Filter/Remove Filter##filter");
       ctx->Yield(2);
@@ -396,7 +396,7 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal.type, gui::CrystalType::kPrism);
 
       // Open crystal modal
-      ctx->ItemClick("**/E##cr");
+      ctx->ItemClick("**/Edit##cr");
       ctx->Yield(3);
 
       // Write 0 via the input widget — should be clamped to min (0.01)
@@ -424,7 +424,7 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       ctx->Yield();
 
       // Open crystal modal
-      ctx->ItemClick("**/E##cr");
+      ctx->ItemClick("**/Edit##cr");
       ctx->Yield(3);
 
       // Write 0 to Upper H — should be allowed (min=0.0 for kLogLinear)
@@ -751,7 +751,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       float height_before = cr.height;
 
       // Click Edit Crystal button on the first entry card
-      ctx->ItemClick("**/E##cr");
+      ctx->ItemClick("**/Edit##cr");
       ctx->Yield(3);
 
       // Click Cancel in the modal
@@ -775,7 +775,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       float initial_height = gui::g_state.layers[0].entries[0].crystal.height;
 
       // Open crystal modal
-      ctx->ItemClick("**/E##cr");
+      ctx->ItemClick("**/Edit##cr");
       ctx->Yield(3);
 
       // Modify height via the input widget in the modal
@@ -802,7 +802,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
 
       // Open filter modal
-      ctx->ItemClick("**/E##fi");
+      ctx->ItemClick("**/Edit##fi");
       ctx->Yield(3);
 
       // Click OK to set the default filter on the entry

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -202,69 +202,6 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
     };
   }
-
-  // P1: Mouse wheel over crystal preview should zoom only, not scroll parent panel
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_crystal", "preview_scroll_isolation");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      ResetTestState();
-      ctx->Yield(2);
-
-      // Left panel now renders cards directly (no tabs) — just let layout settle
-      ctx->Yield(3);  // Let layout settle: mesh rebuild → FBO render
-
-      ImGuiWindow* panel = ctx->GetWindowByRef("##LeftPanel");
-      IM_CHECK(panel != nullptr);
-
-      FILE* diag = fopen("/tmp/lumice_scroll_test.log", "w");
-
-      // Default state: scroll at top (0). Panel should have scrollable content.
-      float scroll_max = panel->ScrollMax.y;
-      if (diag) {
-        fprintf(diag, "scroll_max=%.1f content=%.1f panel_h=%.1f scroll=%.1f\n", scroll_max, panel->ContentSize.y,
-                panel->Size.y, panel->Scroll.y);
-      }
-      IM_CHECK(scroll_max > 0.0f);  // Panel content must overflow for this test
-
-      // Panel scroll is at 0 (top), so scrolling DOWN is possible.
-      // The 3D Preview is partially visible near the bottom of the visible area.
-      float scroll_before = panel->Scroll.y;
-      float zoom_before = gui::g_crystal_zoom;
-
-      // Move mouse into the visible portion of the crystal preview.
-      // Preview starts at ~(content_h - preview_size) from content top.
-      // At scroll=0, visible range is [0, panel_h]. Preview top is at
-      // content_h - scroll_max - preview_size, approximately.
-      // Use 85% of visible panel height to target the preview area.
-      ImVec2 panel_pos = panel->Pos;
-      float panel_w = panel->Size.x;
-      ImVec2 preview_center(panel_pos.x + panel_w * 0.5f, panel_pos.y + panel->Size.y * 0.85f);
-      if (diag) {
-        fprintf(diag, "mouse=(%.1f,%.1f) scroll_before=%.1f zoom_before=%.3f\n", preview_center.x, preview_center.y,
-                scroll_before, zoom_before);
-      }
-
-      ctx->MouseMoveToPos(preview_center);
-      ctx->Yield();
-
-      // Scroll DOWN (negative delta = scroll content down in ImGui)
-      ctx->MouseWheelY(-3.0f);
-      ctx->Yield(2);
-
-      float scroll_after = panel->Scroll.y;
-      float zoom_after = gui::g_crystal_zoom;
-      if (diag) {
-        fprintf(diag, "scroll: %.1f -> %.1f, zoom: %.3f -> %.3f\n", scroll_before, scroll_after, zoom_before,
-                zoom_after);
-        fclose(diag);
-      }
-
-      // Zoom should have changed (mouse was over preview)
-      IM_CHECK(zoom_after != zoom_before);
-      // Panel scroll should NOT have changed
-      IM_CHECK_EQ(scroll_after, scroll_before);
-    };
-  }
 }
 
 // P2 tests

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdio>
+#include <cstring>
 #include <thread>
 
 #include "test_gui_shared.hpp"
@@ -241,6 +242,64 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       // Filter must survive the round-trip since Remove was undone.
       IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+    };
+  }
+
+  // P1: scrum-gui-polish-v7 152.6 — Edit modal tab titles carry a trailing
+  // " *" marker when the in-flight buffer diverges from its open-time
+  // snapshot. Tab IDs are anchored to stable "###<slug>_tab" suffixes so the
+  // label change does not reset SelectedTabId; the test reads the truncated
+  // display string from ItemInfo().DebugLabel. Covers AC #1 / #2 / #3 / #4 / #5.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit_modal", "tab_dirty_mark");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      auto is_dirty = [&](const char* tab_ref) -> bool {
+        auto info = ctx->ItemInfo(tab_ref);
+        return info.ID != 0 && std::strstr(info.DebugLabel, "*") != nullptr;
+      };
+
+      ResetTestState();
+      ctx->Yield(2);
+      const float orig_h = gui::g_state.layers[0].entries[0].crystal.height;
+
+      // AC #1: on modal open, no tab carries a dirty marker.
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      IM_CHECK(!is_dirty("**/###crystal_tab"));
+      IM_CHECK(!is_dirty("**/###axis_tab"));
+      IM_CHECK(!is_dirty("**/###filter_tab"));
+
+      // AC #2: editing Crystal's Height only dirties the Crystal tab.
+      ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h + 1.0f);
+      ctx->Yield(2);
+      IM_CHECK(is_dirty("**/###crystal_tab"));
+      IM_CHECK(!is_dirty("**/###axis_tab"));
+      IM_CHECK(!is_dirty("**/###filter_tab"));
+
+      // AC #3: restoring the original value clears the dirty marker.
+      ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h);
+      ctx->Yield(2);
+      IM_CHECK(!is_dirty("**/###crystal_tab"));
+
+      // AC #5: Cancel discards buffer; reopening shows no marker.
+      ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h + 2.0f);
+      ctx->Yield(2);
+      ctx->ItemClick("**/Cancel##edit_modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      IM_CHECK(!is_dirty("**/###crystal_tab"));
+
+      // AC #4: OK commits new baseline; reopening shows no marker.
+      ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h + 3.0f);
+      ctx->Yield(2);
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      IM_CHECK(!is_dirty("**/###crystal_tab"));
+      ctx->ItemClick("**/Cancel##edit_modal");
+      ctx->Yield(2);
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -273,8 +273,6 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
 
       // Delete layer 1 via its per-layer header "x" button
-      gui::SetSelectedLayerIdx(1);
-      ctx->Yield();
       ctx->ItemClick("**/x##layer_1");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -296,7 +296,7 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
 
       // Duplicate the entry (hover button; ID is always addressable even at alpha=0).
-      ctx->ItemClick("**/+##dup_0_0");
+      ctx->ItemClick("**/D##dup_0_0");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -182,6 +182,68 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
     };
   }
 
+  // P1: scrum-gui-polish-v7 152.5 — Remove Filter marks the edit controls as
+  // disabled (Raypath InputText) so the "will be removed on OK" banner is
+  // consistent with the rest of the Filter tab.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_filter", "remove_disables_controls");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::FilterConfig f;
+      f.raypath_text = "3-1-5";
+      gui::g_state.layers[0].entries[0].filter = f;
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      // Before Remove: Raypath control is enabled.
+      auto info_before = ctx->ItemInfo("**/Raypath##filter_modal");
+      IM_CHECK((info_before.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      ctx->ItemClick("**/Remove Filter##filter");
+      ctx->Yield(2);
+      // After Remove: Raypath control is disabled.
+      auto info_after = ctx->ItemInfo("**/Raypath##filter_modal");
+      IM_CHECK((info_after.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+
+      // Cancel so we don't leave state polluted for later tests.
+      ctx->ItemClick("**/Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
+  // P1: scrum-gui-polish-v7 152.5 — Undo Remove restores editability and
+  // committing OK keeps the filter present (the buffered Remove intent was
+  // reverted before commit).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_filter", "undo_remove_restores_controls");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::FilterConfig f;
+      f.raypath_text = "3-1-5";
+      gui::g_state.layers[0].entries[0].filter = f;
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Remove Filter##filter");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Undo Remove##filter_undo");
+      ctx->Yield(2);
+
+      // Controls restored to enabled state.
+      auto info = ctx->ItemInfo("**/Raypath##filter_modal");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+      // Filter must survive the round-trip since Remove was undone.
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+    };
+  }
+
   // P1: Edit modal OK without any change must NOT clear the rendered preview
   // or arm Revert. Regression guard for scrum-gui-polish-v7 152.2: previously
   // CommitAllBuffers unconditionally MarkFilterDirty()'d after any OK,

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -182,6 +182,42 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
     };
   }
 
+  // P1: Edit modal OK without any change must NOT clear the rendered preview
+  // or arm Revert. Regression guard for scrum-gui-polish-v7 152.2: previously
+  // CommitAllBuffers unconditionally MarkFilterDirty()'d after any OK,
+  // wiping snapshot_intensity + flipping sim_state to kModified.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit", "ok_no_change_preserves_state");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Simulate "finite rays just finished": sim_state == kDone with a
+      // non-zero snapshot intensity that the diff-gate must preserve.
+      gui::g_state.sim_state = gui::GuiState::SimState::kDone;
+      gui::g_state.snapshot_intensity = 0.5f;
+      gui::g_state.intensity_locked = false;
+      gui::g_state.dirty = false;
+      ctx->Yield();
+
+      // Open Edit Entry modal and immediately click OK (no field touched).
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // Render-invalidation must not have fired:
+      //   - sim_state still kDone (no kModified ⇒ Revert button stays hidden)
+      //   - snapshot_intensity preserved (no display clear)
+      //   - intensity_locked still false (no upload lock armed)
+      //   - dirty still false (no spurious unsaved-changes flag)
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kDone));
+      IM_CHECK_EQ(gui::g_state.snapshot_intensity, 0.5f);
+      IM_CHECK(!gui::g_state.intensity_locked);
+      IM_CHECK(!gui::g_state.dirty);
+    };
+  }
+
   // P1: Unsaved Changes Popup
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_file", "unsaved_popup");

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -142,10 +142,10 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 
-      // Delete the new entry (x##0_1 for layer 0, entry 1). The hover button
+      // Delete the new entry (×##del_0_1 for layer 0, entry 1). The hover button
       // is always in the ImGui tree (alpha=0 when not hovered) so test engine
       // can click it by ID even if the card is not hovered.
-      ctx->ItemClick("**/x##0_1");
+      ctx->ItemClick("**/\xC3\x97##del_0_1");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
     };
@@ -296,7 +296,7 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
 
       // Duplicate the entry (hover button; ID is always addressable even at alpha=0).
-      ctx->ItemClick("**/Duplicate##0_0");
+      ctx->ItemClick("**/+##dup_0_0");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -142,8 +142,9 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 
-      // Delete the new entry (x##0_1 for layer 0, entry 1)
-      // Entries can only be deleted when layer has >1 entries
+      // Delete the new entry (x##0_1 for layer 0, entry 1). The hover button
+      // is always in the ImGui tree (alpha=0 when not hovered) so test engine
+      // can click it by ID even if the card is not hovered.
       ctx->ItemClick("**/x##0_1");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
@@ -294,7 +295,7 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
 
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 1);
 
-      // Duplicate the entry (hover button; test engine locates by ID even when alpha=0)
+      // Duplicate the entry (hover button; ID is always addressable even at alpha=0).
       ctx->ItemClick("**/Duplicate##0_0");
       ctx->Yield();
       IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -208,13 +208,50 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
 
       // Render-invalidation must not have fired:
       //   - sim_state still kDone (no kModified ⇒ Revert button stays hidden)
-      //   - snapshot_intensity preserved (no display clear)
+      //   - snapshot_intensity preserved (>0 rather than ==0.5 so future
+      //     normalization changes don't break the semantic assertion)
       //   - intensity_locked still false (no upload lock armed)
       //   - dirty still false (no spurious unsaved-changes flag)
       IM_CHECK_EQ(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kDone));
-      IM_CHECK_EQ(gui::g_state.snapshot_intensity, 0.5f);
+      IM_CHECK_GT(gui::g_state.snapshot_intensity, 0.0f);
       IM_CHECK(!gui::g_state.intensity_locked);
       IM_CHECK(!gui::g_state.dirty);
+    };
+  }
+
+  // P1: Positive-path counterpart of ok_no_change_preserves_state — when the
+  // OK actually changes the entry (here: Remove Filter on an entry that has
+  // one), render-invalidation MUST fire. Guards against a regressed diff-gate
+  // where operator== wrongly returns true.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit", "ok_with_change_invalidates");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Stage a filter on the entry so Remove Filter is a real change.
+      gui::FilterConfig f;
+      f.raypath_text = "3-1-5";
+      gui::g_state.layers[0].entries[0].filter = f;
+      // "finite rays just finished" snapshot state.
+      gui::g_state.sim_state = gui::GuiState::SimState::kDone;
+      gui::g_state.snapshot_intensity = 0.5f;
+      gui::g_state.intensity_locked = false;
+      gui::g_state.dirty = false;
+      ctx->Yield();
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Remove Filter##filter");
+      ctx->Yield(2);
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // Render-invalidation MUST have fired (all four effects):
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kModified));
+      IM_CHECK_EQ(gui::g_state.snapshot_intensity, 0.0f);
+      IM_CHECK(gui::g_state.intensity_locked);
+      IM_CHECK(gui::g_state.dirty);
     };
   }
 

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -250,6 +250,9 @@ int main(int argc, char** argv) {
   ImGuiTestEngineIO& test_io = ImGuiTestEngine_GetIO(engine);
   test_io.ConfigVerboseLevel = ImGuiTestVerboseLevel_Info;
   test_io.ConfigVerboseLevelOnError = ImGuiTestVerboseLevel_Debug;
+  // Stream test engine diagnostics to stderr so failing tests surface their
+  // IM_CHECK errors on the build log (default discards them).
+  test_io.ConfigLogToTTY = true;
   test_io.ConfigRunSpeed = ImGuiTestRunSpeed_Fast;
   test_io.ConfigNoThrottle = true;
 

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "gui/app.hpp"
+#include "gui/crystal_preview.hpp"
 #include "gui/file_io.hpp"
 #include "gui/panels.hpp"
 #include "imgui.h"

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -7,6 +7,8 @@
 
 #include "gui/app.hpp"
 #include "gui/crystal_preview.hpp"
+#include "gui/crystal_renderer.hpp"
+#include "gui/edit_modals.hpp"
 #include "gui/file_io.hpp"
 #include "gui/panels.hpp"
 #include "imgui.h"

--- a/test/gui/test_gui_visual.cpp
+++ b/test/gui/test_gui_visual.cpp
@@ -4,17 +4,39 @@
 
 #include "test_gui_shared.hpp"
 
+// Rebuild the crystal mesh (if changed) and render it into g_crystal_renderer's
+// FBO so tests can capture from it. Test-only helper; the modal guard mirrors
+// the previous in-panel logic so the edit modal's FBO content is not overwritten.
+static void DriveCrystalPreviewFboForTest() {
+  if (gui::IsCrystalModalOpen()) {
+    return;
+  }
+  int sel_layer = gui::GetSelectedLayerIdx();
+  int sel_entry = gui::GetSelectedEntryIdx();
+  if (sel_layer < 0 || sel_entry < 0 || sel_layer >= static_cast<int>(gui::g_state.layers.size()) ||
+      sel_entry >= static_cast<int>(gui::g_state.layers[sel_layer].entries.size())) {
+    return;
+  }
+  const auto& cr = gui::g_state.layers[sel_layer].entries[sel_entry].crystal;
+  int hash = gui::CrystalParamHash(cr);
+  if (hash != gui::g_crystal_mesh_hash) {
+    int result = gui::BuildAndUploadCrystalMesh(cr);
+    if (result != 0) {
+      gui::g_crystal_mesh_hash = hash;
+    }
+  }
+  auto style = static_cast<gui::CrystalStyle>(gui::g_crystal_style);
+  gui::g_crystal_renderer.Render(gui::g_crystal_rotation, gui::g_crystal_zoom, style);
+}
+
 // GuiFunc that renders GUI and captures crystal texture when requested.
 //
 // Note: the left panel no longer updates g_crystal_renderer's FBO every frame
-// (task-remove-bottom-preview). Tests that want to capture the crystal must
-// arrange the FBO explicitly — this GuiFunc drives UpdateCrystalPreviewRenderer
+// (task-remove-bottom-preview). Tests using this GuiFunc drive the FBO here
 // on the selected entry's crystal before sampling the texture.
 static void ScreenshotGuiFunc(ImGuiTestContext* /*ctx*/) {
   if (g_capture.capture_requested && !g_capture.capture_done) {
-    if (!gui::g_state.layers.empty() && !gui::g_state.layers[0].entries.empty()) {
-      gui::UpdateCrystalPreviewRenderer(gui::g_state.layers[0].entries[0].crystal);
-    }
+    DriveCrystalPreviewFboForTest();
     int w = gui::g_crystal_renderer.Width();
     int h = gui::g_crystal_renderer.Height();
     auto tex_id = static_cast<unsigned int>(gui::g_crystal_renderer.GetTextureId());

--- a/test/gui/test_gui_visual.cpp
+++ b/test/gui/test_gui_visual.cpp
@@ -4,11 +4,17 @@
 
 #include "test_gui_shared.hpp"
 
-// GuiFunc that renders GUI and captures crystal texture when requested
+// GuiFunc that renders GUI and captures crystal texture when requested.
+//
+// Note: the left panel no longer updates g_crystal_renderer's FBO every frame
+// (task-remove-bottom-preview). Tests that want to capture the crystal must
+// arrange the FBO explicitly — this GuiFunc drives UpdateCrystalPreviewRenderer
+// on the selected entry's crystal before sampling the texture.
 static void ScreenshotGuiFunc(ImGuiTestContext* /*ctx*/) {
-  // Normal GUI rendering is handled by the main loop.
-  // Capture crystal texture on main thread when requested.
   if (g_capture.capture_requested && !g_capture.capture_done) {
+    if (!gui::g_state.layers.empty() && !gui::g_state.layers[0].entries.empty()) {
+      gui::UpdateCrystalPreviewRenderer(gui::g_state.layers[0].entries[0].crystal);
+    }
     int w = gui::g_crystal_renderer.Width();
     int h = gui::g_crystal_renderer.Height();
     auto tex_id = static_cast<unsigned int>(gui::g_crystal_renderer.GetTextureId());

--- a/test/gui/test_gui_visual.cpp
+++ b/test/gui/test_gui_visual.cpp
@@ -11,13 +11,12 @@ static void DriveCrystalPreviewFboForTest() {
   if (gui::IsCrystalModalOpen()) {
     return;
   }
-  int sel_layer = gui::GetSelectedLayerIdx();
-  int sel_entry = gui::GetSelectedEntryIdx();
-  if (sel_layer < 0 || sel_entry < 0 || sel_layer >= static_cast<int>(gui::g_state.layers.size()) ||
-      sel_entry >= static_cast<int>(gui::g_state.layers[sel_layer].entries.size())) {
+  // Visual smoke tests configure entry [0][0] only. If a multi-entry visual test
+  // is later added, change this helper to accept layer/entry indices.
+  if (gui::g_state.layers.empty() || gui::g_state.layers[0].entries.empty()) {
     return;
   }
-  const auto& cr = gui::g_state.layers[sel_layer].entries[sel_entry].crystal;
+  const auto& cr = gui::g_state.layers[0].entries[0].crystal;
   int hash = gui::CrystalParamHash(cr);
   if (hash != gui::g_crystal_mesh_hash) {
     int result = gui::BuildAndUploadCrystalMesh(cr);

--- a/test/gui/test_gui_visual.cpp
+++ b/test/gui/test_gui_visual.cpp
@@ -8,7 +8,7 @@
 // FBO so tests can capture from it. Test-only helper; the modal guard mirrors
 // the previous in-panel logic so the edit modal's FBO content is not overwritten.
 static void DriveCrystalPreviewFboForTest() {
-  if (gui::IsCrystalModalOpen()) {
+  if (gui::IsEditModalCrystalTabActive()) {
     return;
   }
   // Visual smoke tests configure entry [0][0] only. If a multi-entry visual test

--- a/test/test_window_sizing.cpp
+++ b/test/test_window_sizing.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include "gui/gui_constants.hpp"
+#include "gui/window_sizing.hpp"
+
+namespace {
+
+using lumice::gui::ClampWindowSizeToWorkarea;
+using lumice::gui::kMinWindowHeight;
+using lumice::gui::kMinWindowWidth;
+
+// AC2 core path: 1080p laptop workarea ≈ 1920×900 after menubar/Dock.
+// Default (1600, 980) height must be clamped to 900 - 50 = 850.
+TEST(WindowSizingTest, ClampsHeightOnConstrained1080p) {
+  auto [w, h] = ClampWindowSizeToWorkarea(1600, 980, 1920, 900);
+  EXPECT_EQ(w, 1600);
+  EXPECT_EQ(h, 850);
+}
+
+// High-DPI dev monitor (e.g. MacBook 2880×1800 workarea): default size fits,
+// no clamp should happen.
+TEST(WindowSizingTest, NoClampOnHighResDisplay) {
+  auto [w, h] = ClampWindowSizeToWorkarea(1600, 980, 2880, 1800);
+  EXPECT_EQ(w, 1600);
+  EXPECT_EQ(h, 980);
+}
+
+// Small 1366×768 laptop: both width and height must clamp.
+TEST(WindowSizingTest, ClampsBothWidthAndHeight) {
+  auto [w, h] = ClampWindowSizeToWorkarea(1600, 980, 1366, 768);
+  EXPECT_EQ(w, 1316);  // 1366 - 50
+  EXPECT_EQ(h, 718);   // 768 - 50
+}
+
+// Pathological tiny workarea: floor must hold at kMinWindow{Width,Height}
+// rather than shrinking below the documented minimum.
+TEST(WindowSizingTest, FloorsAtMinWindowSize) {
+  auto [w, h] = ClampWindowSizeToWorkarea(1600, 980, 800, 600);
+  EXPECT_EQ(w, kMinWindowWidth);
+  EXPECT_EQ(h, kMinWindowHeight);
+}
+
+// Boundary: workarea - margin == desired → no clamp change.
+TEST(WindowSizingTest, ExactBoundaryNoChange) {
+  auto [w, h] = ClampWindowSizeToWorkarea(1600, 980, 1650, 1030);
+  EXPECT_EQ(w, 1600);
+  EXPECT_EQ(h, 980);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Consolidates multiple GUI polish scrums (v4 / v5 / v6 / v7) into a single feature branch. Covers edit modal unification, card layout refinement, slider scale work, and the 2026-04-19 v7 UX pass.

### scrum-gui-polish-v7 (latest — 6 subtasks)

- **explore-render-invalidation-semantics** + **render-invalidation-impl**: Added an entry-level diff-gate at `CommitAllBuffers` entry; now OK with no actual change no longer clears the rendered preview or arms Revert (also fixed a spurious `MarkFilterDirty` path).
- **ev-range-extend**: EV slider range `[-3, +7]` → `[-6, +6]`.
- **layer-prob-tooltip**: Disable the Layer Prob. slider when only one layer exists; restored the hover tooltip using `BeginGroup` + `IsItemHovered(AllowWhenDisabled)` so the hit-test covers the full row.
- **filter-remove-clear-text**: While a Remove intent is pending, all Filter-tab edit controls are disabled; the Remove button toggles to "Undo Remove" for symmetrical recovery. Added 2 GUI tests.
- **modal-tab-dirty-mark**: Edit modal tab titles now carry a trailing `*` when the in-flight buffer diverges from the open-time snapshot. Uses `###<slug>_tab` suffixes so the display string can change without resetting `SelectedTabId`. Added 1 GUI test covering AC #1-#5.

### Earlier work bundled on this branch

- Unified Crystal / Axis / Filter modals into a single tabbed dialog (scrum-gui-polish-v6).
- Card layout v2: entry card re-stacking, hover action buttons, selection highlight removal, destructive style palette.
- Slider polish: log / log-linear / sqrt scales, minimum modal width, drag-bug fix on crystal preview.
- `operator==` added on `EntryCard`, `CrystalConfig`, `AxisDist`, `FilterConfig` to support diff-gating.

### Test delta

GUI test count: **71 → 74** (3 new tests for v7: `remove_disables_controls`, `undo_remove_restores_controls`, `tab_dirty_mark`). All 74 pass locally on macOS.

## Test plan

- [x] `./scripts/build.sh -gtj release` passes (unit 1/1 + GUI 74/74)
- [x] CI green on Ubuntu / macOS / Windows
- [x] Manual: open edit modal, edit Crystal Height → `Crystal *` appears; Undo / OK clears it
- [x] Manual: Filter modal → Remove → all edit controls grayed; Undo Remove → restored
- [x] Manual: single-layer entry → Prob. slider grayed with tooltip "Always 0 for a single layer."
- [x] Manual: EV slider drag to ±6; save `.lmc`, reopen → value preserved
- [x] Manual: Edit modal OK with no change → rendered preview unchanged, Revert not armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)