### PR TITLE
feat(gui): polish overlay labels and orthographic lens behavior

### DIFF
--- a/doc/coordinate-convention_zh.md
+++ b/doc/coordinate-convention_zh.md
@@ -50,12 +50,12 @@ Lumice 使用**数学习惯**的方位角约定：
 
 以下姿态是四个内置 axis preset 的特征姿态。每条描述固定**均值**朝向；实际采样朝向叠加 §7 中的 Gauss / Uniform 扰动。
 
-### 5.1 Plate（板状）
+### 5.1 Plate（片晶）
 
 - `N1` 指向世界 `+z`（c-axis 垂直）
 - 晶体绕 `N1`（即世界 `+z`）自由旋转
 
-### 5.2 Column（柱状）
+### 5.2 Column（柱晶）
 
 - `N1` 位于 `xy` 平面（c-axis 水平）
 - `N1` 绕世界 `+z` 旋转（由 `azimuth` 采样）
@@ -105,7 +105,7 @@ R(azimuth, zenith, roll) = Rz(azimuth − 180°) · Ry(−zenith) · Rz(roll)
 
 ## 8. azimuth − 180° 偏移
 
-azimuth 项的 `−180°` 偏移由局部帧选择 `N3 = +x` 决定。若不加偏移，Parry 默认 `(zenith = 90°, azimuth = 0°, roll = 0°)` 会把 `N3` 映射到世界 `−x` 而非 `+z`，与 §5.3 描述矛盾。
+azimuth 项的 `−180°` 偏移由局部坐标架选择 `N3 = +x` 决定。若不加偏移，Parry 默认 `(zenith = 90°, azimuth = 0°, roll = 0°)` 会把 `N3` 映射到世界 `−x` 而非 `+z`，与 §5.3 描述矛盾。
 
 Parry 默认下的数值验证：
 
@@ -127,7 +127,7 @@ N3_world = R · (1, 0, 0)
 
 ## 9. 相机视角约定
 
-相机帧独立于晶体帧，由 `render[].view` 下的 `(elevation, azimuth, roll)` 参数化。
+相机坐标架独立于晶体坐标架，由 `render[].view` 下的 `(elevation, azimuth, roll)` 参数化。
 
 ### 9.1 朝向
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -670,7 +670,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
 
       static std::vector<OverlayLabel> labels;
       ComputeOverlayLabels(label_input, vp_sx, vp_sy, vp_sw, vp_sh, labels);
-      DrawOverlayLabels(labels);
+      DrawOverlayLabels(labels, vp_sx, vp_sy, vp_sw, vp_sh);
     }
 
     // Mouse interaction: orbit with drag, FOV with scroll.

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -642,9 +642,16 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     if (g_state.show_horizon || g_state.show_grid || g_state.show_sun_circles) {
       OverlayLabelInput label_input = BuildOverlayLabelInput(g_state, rc);
 
-      // Convert viewport from framebuffer pixels to ImGui logical screen coordinates
-      float vp_sx = panel_x;
-      float vp_sy = kTopBarHeight;
+      // Viewport rect in absolute OS screen coordinates. DrawOverlayLabels emits to
+      // ImGui::GetWindowDrawList(), and with ImGuiConfigFlags_ViewportsEnable (gui-polish-v15)
+      // draw list coordinates are absolute screen space, not relative to the host GLFW window.
+      // Anchor (panel_x, kTopBarHeight) through MainVpPos() so labels stay glued to the
+      // preview viewport when the host window is dragged or sits on a non-primary monitor.
+      // Note: the export_fbo_renderer.cpp path passes (0, 0, w, h) intentionally — it owns a
+      // self-allocated ImDrawList targeting an off-screen FBO and must NOT add this offset.
+      ImVec2 vp_origin = MainVpPos(panel_x, kTopBarHeight);
+      float vp_sx = vp_origin.x;
+      float vp_sy = vp_origin.y;
       float vp_sw = panel_width;
       float vp_sh = preview_height;
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -363,7 +363,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // Copy-model renderer: GuiState always owns a valid renderer by default construction.
   auto& r = g_state.renderer;
-  bool full_sky = (r.lens_type >= 4);
+  bool full_sky = LensIsFullSky(r.lens_type);
 
   // ---- View Group ----
   if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -569,7 +569,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     auto& r = g_state.renderer;
     float max_fov = MaxFov(static_cast<LensParam::LensType>(r.lens_type));
     r.fov = std::min(r.fov, max_fov);
-    if (r.lens_type >= 4) {  // Full-sky lenses: force view angles to zero
+    if (LensIsFullSky(r.lens_type)) {  // Full-sky lenses: force view angles to zero
       r.elevation = 0.0f;
       r.azimuth = 0.0f;
       r.roll = 0.0f;
@@ -660,9 +660,11 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
       DrawOverlayLabels(labels);
     }
 
-    // Mouse interaction: orbit with drag, FOV with scroll
-    // Disabled for full-sky lens types (dual fisheye, rectangular)
-    bool full_sky = (rc.lens_type >= 4);
+    // Mouse interaction: orbit with drag, FOV with scroll.
+    // Disabled for lenses in kFullSkyLensTypes (dual fisheye 4-6, rectangular 7,
+    // dual orthographic 9): their shader path skips the view matrix so view
+    // angles + FOV have no visual effect.
+    bool full_sky = LensIsFullSky(rc.lens_type);
     ImVec2 avail = ImGui::GetContentRegionAvail();
     ImGui::InvisibleButton("##preview_interact", avail);
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -369,7 +369,20 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
   if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
     ImGui::SeparatorText("Projection");
-    ImGui::Combo("Lens Type##view", &r.lens_type, kLensTypeNames, kLensTypeCount);
+    // Use BeginCombo + Selectable to honour kLensTypePresentationOrder (gui_state.hpp).
+    // The enum value (r.lens_type) is preserved unchanged; only the display order differs.
+    if (ImGui::BeginCombo("Lens Type##view", kLensTypeNames[r.lens_type])) {
+      for (int idx : kLensTypePresentationOrder) {
+        bool selected = (r.lens_type == idx);
+        if (ImGui::Selectable(kLensTypeNames[idx], selected)) {
+          r.lens_type = idx;
+        }
+        if (selected) {
+          ImGui::SetItemDefaultFocus();
+        }
+      }
+      ImGui::EndCombo();
+    }
     float max_fov = MaxFov(static_cast<LensParam::LensType>(r.lens_type));
     ImGui::BeginDisabled(full_sky);
     SliderWithInput("FOV##view", &r.fov, 1.0f, max_fov, "%.0f");

--- a/src/gui/export_fbo_renderer.cpp
+++ b/src/gui/export_fbo_renderer.cpp
@@ -62,7 +62,7 @@ void RenderOverlayToFbo(const OverlayLabelInput& overlay_input, int dst_w, int d
   ResetDrawListForNewFrame(dl);
   dl.PushTextureID(ImGui::GetIO().Fonts->TexID);
   dl.PushClipRect(ImVec2(0.0f, 0.0f), ImVec2(static_cast<float>(dst_w), static_cast<float>(dst_h)));
-  AppendOverlayToDrawList(&dl, labels);
+  AppendOverlayToDrawList(&dl, labels, 0.0f, 0.0f, static_cast<float>(dst_w), static_cast<float>(dst_h));
   dl.PopClipRect();
   dl.PopTextureID();
 

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -102,6 +102,30 @@ enum LensType : int {
   kLensTypeDualFisheyeOrthographic = 9,
 };
 
+// Lenses whose shader path skips the view matrix (full-sphere mapping):
+// dual fisheye (4-6), rectangular (7), dual orthographic (9). For these,
+// elevation/azimuth/roll/FOV slider have no visual effect and are disabled in UI.
+// SINGLE SOURCE OF TRUTH for the "full-sky" set: any new LensType must
+// reconfirm membership here. The size assert below catches new enum values
+// that forget to update the policy.
+inline constexpr int kFullSkyLensTypes[] = {
+  kLensTypeDualFisheyeEqualArea, kLensTypeDualFisheyeEquidist,     kLensTypeDualFisheyeStereographic,
+  kLensTypeRectangular,          kLensTypeDualFisheyeOrthographic,
+};
+inline constexpr int kFullSkyLensTypeCount = sizeof(kFullSkyLensTypes) / sizeof(*kFullSkyLensTypes);
+static_assert(kFullSkyLensTypeCount == 5,
+              "kFullSkyLensTypes count changed: review whether the new LensType "
+              "should be in the full-sky set, then update this assert.");
+
+inline constexpr bool LensIsFullSky(int lens_type) {
+  for (int v : kFullSkyLensTypes) {
+    if (v == lens_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Visible region selector. Order must match kVisibleNames in gui_state.hpp.
 enum Visible : int {
   kVisibleUpper = 0,

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -105,17 +105,23 @@ enum LensType : int {
 // Lenses whose shader path skips the view matrix (full-sphere mapping):
 // dual fisheye (4-6), rectangular (7), dual orthographic (9). For these,
 // elevation/azimuth/roll/FOV slider have no visual effect and are disabled in UI.
-// SINGLE SOURCE OF TRUTH for the "full-sky" set: any new LensType must
-// reconfirm membership here. The size assert below catches new enum values
-// that forget to update the policy.
+// SINGLE SOURCE OF TRUTH for the "full-sky" set.
+//
+// Two-layer guarding:
+//   * kLensTypePresentationOrder's static_assert(== kLensTypeCount) in
+//     gui_state.hpp forces a developer to ACK every new LensType — that's
+//     where the "did you classify this lens?" prompt fires.
+//   * The static_assert below only guards kFullSkyLensTypes itself: it
+//     catches accidental edits to this array (size drift) and reminds the
+//     reviewer to update the literal alongside any policy change here.
 inline constexpr int kFullSkyLensTypes[] = {
   kLensTypeDualFisheyeEqualArea, kLensTypeDualFisheyeEquidist,     kLensTypeDualFisheyeStereographic,
   kLensTypeRectangular,          kLensTypeDualFisheyeOrthographic,
 };
 inline constexpr int kFullSkyLensTypeCount = sizeof(kFullSkyLensTypes) / sizeof(*kFullSkyLensTypes);
 static_assert(kFullSkyLensTypeCount == 5,
-              "kFullSkyLensTypes count changed: review whether the new LensType "
-              "should be in the full-sky set, then update this assert.");
+              "kFullSkyLensTypes count changed: update both the array and this "
+              "literal in lockstep with the policy change.");
 
 inline constexpr bool LensIsFullSky(int lens_type) {
   for (int v : kFullSkyLensTypes) {

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -101,6 +101,26 @@ static_assert(sizeof(kLensTypeNames) / sizeof(*kLensTypeNames) == kLensTypeCount
 static_assert(kLensTypeDualFisheyeOrthographic == kLensTypeCount - 1,
               "LensType enum terminal value must match kLensTypeCount - 1");
 
+// Display order for the Lens Type combo. Decoupled from enum values so that
+// orthographic variants group with their fisheye / dual-fisheye siblings
+// without breaking shader and JSON serialization (which use the enum value
+// directly as the wire index). The static_assert below pins the array length
+// to kLensTypeCount so every new LensType is forced to declare a slot here.
+inline constexpr int kLensTypePresentationOrder[] = {
+  kLensTypeLinear,
+  kLensTypeFisheyeEqualArea,
+  kLensTypeFisheyeEquidist,
+  kLensTypeFisheyeStereographic,
+  kLensTypeFisheyeOrthographic,
+  kLensTypeDualFisheyeEqualArea,
+  kLensTypeDualFisheyeEquidist,
+  kLensTypeDualFisheyeStereographic,
+  kLensTypeDualFisheyeOrthographic,
+  kLensTypeRectangular,
+};
+static_assert(sizeof(kLensTypePresentationOrder) / sizeof(*kLensTypePresentationOrder) == kLensTypeCount,
+              "kLensTypePresentationOrder must list every LensType exactly once");
+
 // Dual fisheye overlap: max |sky.z| for the overlap zone.
 // = sin(5°) ≈ 0.0872. Each hemisphere extends 5° past the equator.
 // This constant defines the GUI's internal texture format overlap. It is passed to core via

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -106,6 +106,10 @@ static_assert(kLensTypeDualFisheyeOrthographic == kLensTypeCount - 1,
 // without breaking shader and JSON serialization (which use the enum value
 // directly as the wire index). The static_assert below pins the array length
 // to kLensTypeCount so every new LensType is forced to declare a slot here.
+// Note: the size assert does NOT check for duplicates — a value listed twice
+// while another is omitted has the same length but silently hides the
+// omitted lens from the combo. When adding/renaming entries, manually
+// verify that every LensType appears here exactly once.
 inline constexpr int kLensTypePresentationOrder[] = {
   kLensTypeLinear,
   kLensTypeFisheyeEqualArea,

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -639,7 +639,8 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   }
 }
 
-void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels) {
+void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels, float vp_screen_x,
+                             float vp_screen_y, float vp_screen_w, float vp_screen_h) {
   if (dl == nullptr || labels.empty())
     return;
 
@@ -654,6 +655,10 @@ void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& la
   for (const auto& label : labels) {
     ImVec2 text_size = ImGui::CalcTextSize(label.text.c_str());
     ImVec2 pos(label.screen_x - text_size.x * 0.5f, label.screen_y - text_size.y * 0.5f);
+    // Push the text glyph rect inside the viewport so it doesn't straddle the
+    // panel border / export-PNG edge. Collision-avoidance below uses the
+    // clamped bbox so labels pushed into the same corner don't pile up.
+    pos = detail::ClampLabelPosToViewport(pos, text_size, vp_screen_x, vp_screen_y, vp_screen_w, vp_screen_h);
     ImVec2 bbox_min(pos.x - kLabelPadding, pos.y - kLabelPadding);
     ImVec2 bbox_max(pos.x + text_size.x + kLabelPadding, pos.y + text_size.y + kLabelPadding);
 
@@ -684,8 +689,9 @@ void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& la
   }
 }
 
-void DrawOverlayLabels(const std::vector<OverlayLabel>& labels) {
-  AppendOverlayToDrawList(ImGui::GetWindowDrawList(), labels);
+void DrawOverlayLabels(const std::vector<OverlayLabel>& labels, float vp_screen_x, float vp_screen_y, float vp_screen_w,
+                       float vp_screen_h) {
+  AppendOverlayToDrawList(ImGui::GetWindowDrawList(), labels, vp_screen_x, vp_screen_y, vp_screen_w, vp_screen_h);
 }
 
 namespace detail {
@@ -701,6 +707,29 @@ void PixelToWorldDirForTesting(float px, float py, float res_x, float res_y, int
     *out_y = r.y;
     *out_z = r.z;
   }
+}
+
+ImVec2 ClampLabelPosToViewport(ImVec2 pos, ImVec2 text_size, float vp_x, float vp_y, float vp_w, float vp_h) {
+  // kViewportInsetPx is a small visual padding (in screen-space pixels) keeping the
+  // text glyph rect away from the absolute viewport edge — guards against the
+  // half-pixel anti-aliasing fringe and the panel border 1 px line. 2 px is a
+  // visual-padding heuristic, not a precise geometric boundary; revisit if a
+  // future HiDPI-aware UI pass requires resolution-scaled padding.
+  constexpr float kViewportInsetPx = 2.0f;
+
+  // Only clamp if the viewport actually has room for the text + 2×inset. If
+  // the viewport is narrower / shorter than that (extreme corner case for
+  // panel collapse / tiny export targets), fall back to the original pos so
+  // the legacy "centered on label anchor" behaviour is preserved.
+  if (vp_w > text_size.x + 2.0f * kViewportInsetPx) {
+    pos.x = std::max(pos.x, vp_x + kViewportInsetPx);
+    pos.x = std::min(pos.x, vp_x + vp_w - text_size.x - kViewportInsetPx);
+  }
+  if (vp_h > text_size.y + 2.0f * kViewportInsetPx) {
+    pos.y = std::max(pos.y, vp_y + kViewportInsetPx);
+    pos.y = std::min(pos.y, vp_y + vp_h - text_size.y - kViewportInsetPx);
+  }
+  return pos;
 }
 
 }  // namespace detail

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -540,7 +540,7 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
     // fov+lens it projects to ~4–12 px of screen offset, which clears the
     // text height while staying close enough to read as a "boundary label".
     constexpr float kBoundaryInsetDeg = 3.0f;
-    const float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
+    float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
 
     if (input.visible == 0 || input.visible == 1) {
       // Equator: {(cos az, sin az, 0)} in world space, parameterized to match the prior loop's
@@ -548,7 +548,7 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
       // visible=upper → push toward negative z (altitude=asin(-z) becomes positive);
       // visible=lower → push toward positive z. After offset the world vector
       // is renormalized so WorldDirToPixel's unit-length assumption holds.
-      const float wz_sign = (input.visible == 0) ? -1.0f : +1.0f;
+      float wz_sign = (input.visible == 0) ? -1.0f : +1.0f;
       sample_curve([wz_sign, boundary_offset](float t, float& wx, float& wy, float& wz) {
         float az = -kPi + t;
         wx = -std::cos(az);

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -534,25 +534,48 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
       }
     };
 
+    // Push the boundary curve a few degrees inward (toward the visible side)
+    // before sampling, so labels emitted at boundary crossings don't straddle
+    // the visible/invisible split. 3° is a visual-spacing heuristic — at typical
+    // fov+lens it projects to ~4–12 px of screen offset, which clears the
+    // text height while staying close enough to read as a "boundary label".
+    constexpr float kBoundaryInsetDeg = 3.0f;
+    const float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
+
     if (input.visible == 0 || input.visible == 1) {
       // Equator: {(cos az, sin az, 0)} in world space, parameterized to match the prior loop's
       // az_rad = -π + t convention so label positions are stable across refactor.
-      sample_curve([](float t, float& wx, float& wy, float& wz) {
+      // visible=upper → push toward negative z (altitude=asin(-z) becomes positive);
+      // visible=lower → push toward positive z. After offset the world vector
+      // is renormalized so WorldDirToPixel's unit-length assumption holds.
+      const float wz_sign = (input.visible == 0) ? -1.0f : +1.0f;
+      sample_curve([wz_sign, boundary_offset](float t, float& wx, float& wy, float& wz) {
         float az = -kPi + t;
         wx = -std::cos(az);
         wy = -std::sin(az);
-        wz = 0.0f;
+        wz = wz_sign * boundary_offset;
+        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+        wx /= len;
+        wy /= len;
+        wz /= len;
       });
     } else if (input.visible == 3) {
       // Front hemisphere boundary: great circle perpendicular to forward. In view space this
       // is z_view = 0 (the xy-plane); map to world via view_matrix (column-major: col0/col1 are
       // the first two columns, i.e. view-space x and y basis expressed in world coordinates).
-      // Points: world = cos(t) * col0 + sin(t) * col1.
-      sample_curve([&](float t, float& wx, float& wy, float& wz) {
-        float c = std::cos(t), s = std::sin(t);
-        wx = c * view_matrix[0] + s * view_matrix[3];
-        wy = c * view_matrix[1] + s * view_matrix[4];
-        wz = c * view_matrix[2] + s * view_matrix[5];
+      // Points: world = cos(t) * col0 + sin(t) * col1, optionally pushed toward
+      // forward (i.e. opposite of col2 = -forward) by `boundary_offset` so the
+      // boundary samples lie inside the front hemisphere.
+      sample_curve([&, boundary_offset](float t, float& wx, float& wy, float& wz) {
+        float c = std::cos(t);
+        float s = std::sin(t);
+        wx = c * view_matrix[0] + s * view_matrix[3] - boundary_offset * view_matrix[6];
+        wy = c * view_matrix[1] + s * view_matrix[4] - boundary_offset * view_matrix[7];
+        wz = c * view_matrix[2] + s * view_matrix[5] - boundary_offset * view_matrix[8];
+        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+        wx /= len;
+        wy /= len;
+        wz /= len;
       });
     }
   }

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -122,6 +122,21 @@ InvResult RectangularInv(float px, float py, float res_x, float res_y) {
   return { -cl * std::cos(lon), -cl * std::sin(lon), -std::sin(lat), true };
 }
 
+// The two range-based dispatches below depend on consecutive enum values:
+// (lens_type - kLensTypeFisheyeEqualArea) must equal FisheyeInv's type
+// argument 0/1/2 across the [EqualArea, Equidist, Stereographic] band, and
+// likewise for the dual fisheye band. Pin the contract at compile time so
+// inserting a new fisheye enum mid-band is a build break, not a silent
+// label-position regression.
+static_assert(kLensTypeFisheyeEquidist - kLensTypeFisheyeEqualArea == 1,
+              "Fisheye enum band must remain consecutive (EqualArea→Equidist→Stereographic).");
+static_assert(kLensTypeFisheyeStereographic - kLensTypeFisheyeEqualArea == 2,
+              "Fisheye enum band must remain consecutive (EqualArea→Equidist→Stereographic).");
+static_assert(kLensTypeDualFisheyeEquidist - kLensTypeDualFisheyeEqualArea == 1,
+              "Dual fisheye enum band must remain consecutive.");
+static_assert(kLensTypeDualFisheyeStereographic - kLensTypeDualFisheyeEqualArea == 2,
+              "Dual fisheye enum band must remain consecutive.");
+
 // Compute world direction for a pixel offset from viewport center.
 // Synced with shader main() (preview_renderer.cpp:317-332). Dispatch table:
 //   lens 0           → LinearInv               (view-transformed)
@@ -672,5 +687,22 @@ void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& la
 void DrawOverlayLabels(const std::vector<OverlayLabel>& labels) {
   AppendOverlayToDrawList(ImGui::GetWindowDrawList(), labels);
 }
+
+namespace detail {
+
+// Test-only thin wrapper exposing the anonymous-namespace PixelToWorldDir so
+// unit tests can pin per-lens dispatch. See overlay_labels.hpp for contract.
+void PixelToWorldDirForTesting(float px, float py, float res_x, float res_y, int lens_type, float fov,
+                               const float view_matrix[9], float* out_x, float* out_y, float* out_z, bool* out_valid) {
+  InvResult r = PixelToWorldDir(px, py, res_x, res_y, lens_type, fov, view_matrix);
+  *out_valid = r.valid;
+  if (r.valid) {
+    *out_x = r.x;
+    *out_y = r.y;
+    *out_z = r.z;
+  }
+}
+
+}  // namespace detail
 
 }  // namespace lumice::gui

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -198,9 +198,14 @@ struct FwdResult {
 
 FwdResult WorldDirToPixel(float wx, float wy, float wz, float res_x, float res_y, int lens_type, float fov,
                           const float view_matrix[9]) {
-  // For types 0-3: transform world→view by multiplying with transpose of view matrix
+  // View transform applies to all view-transformed lens types — i.e. NOT full-sky.
+  // This mirrors the inverse projection's classification: linear (0), single fisheye
+  // (1-3), and single orthographic (8) all carry view matrix; dual fisheye (4-6),
+  // rectangular (7), and dual orthographic (9) skip it. Reusing LensIsFullSky as the
+  // single source of truth keeps WorldDirToPixel coupled to the same lens-class
+  // policy as RenderRightPanel / RenderPreviewPanel.
   float dx = wx, dy = wy, dz = wz;
-  bool needs_view = (lens_type >= 0 && lens_type <= 3);
+  bool needs_view = !LensIsFullSky(lens_type);
   if (needs_view) {
     // view_matrix is column-major: M[col*3+row]. Transpose = rows become columns.
     dx = view_matrix[0] * wx + view_matrix[1] * wy + view_matrix[2] * wz;
@@ -211,12 +216,13 @@ FwdResult WorldDirToPixel(float wx, float wy, float wz, float res_x, float res_y
   float half_fov = fov * 0.5f * kDeg2Rad;
   float short_edge = std::min(res_x, res_y);
 
-  if (lens_type == 0) {  // Linear
+  if (lens_type == kLensTypeLinear) {
     if (dz >= 0)
       return { 0, 0, false };  // behind camera (shader convention: camera looks -z)
     float focal = short_edge * 0.5f / std::tan(half_fov);
     return { dx / (-dz) * focal, dy / (-dz) * focal, true };
-  } else if (lens_type >= 1 && lens_type <= 3) {  // Fisheye
+  } else if ((lens_type >= kLensTypeFisheyeEqualArea && lens_type <= kLensTypeFisheyeStereographic) ||
+             lens_type == kLensTypeFisheyeOrthographic) {  // Single fisheye family (incl. orthographic)
     float img_radius = short_edge * 0.5f;
     float theta = std::acos(std::clamp(-dz, -1.0f, 1.0f));  // angle from -z axis
     float rho = std::sqrt(dx * dx + dy * dy);
@@ -224,19 +230,27 @@ FwdResult WorldDirToPixel(float wx, float wy, float wz, float res_x, float res_y
       return { 0, 0, true };  // on optical axis
 
     float r_norm;
-    int type = lens_type - 1;
-    if (type == 0) {
+    if (lens_type == kLensTypeFisheyeEqualArea) {
       r_norm = std::sin(theta * 0.5f) / std::sin(half_fov * 0.5f);
-    } else if (type == 1) {
+    } else if (lens_type == kLensTypeFisheyeEquidist) {
       r_norm = theta / half_fov;
-    } else {
+    } else if (lens_type == kLensTypeFisheyeStereographic) {
       r_norm = std::tan(theta * 0.5f) / std::tan(half_fov * 0.5f);
+    } else {  // kLensTypeFisheyeOrthographic — shader: r_norm = sin(θ) / sin(fov/2)
+      // Domain guard: directions past the orthographic disc edge (θ > half_fov)
+      // project to r_norm > 1 in the inverse path; reject them here so the
+      // sun-circle interior-label placement doesn't draw off-disc.
+      if (theta > half_fov)
+        return { 0, 0, false };
+      r_norm = std::sin(theta) / std::sin(half_fov);
     }
     float scale = r_norm * img_radius / rho;
     return { dx * scale, dy * scale, true };
   }
-  // Types 4-7: not needed for sun circle interior labels (they use world space directly,
-  // and the full sky is always visible, so sun circles always intersect viewport edges).
+  // Full-sky lens types (dual fisheye 4-6, rectangular 7, dual orthographic 9):
+  // their shader paths skip the view matrix and the entire sphere is always
+  // visible, so sun circles always intersect viewport edges and don't need
+  // interior labels. Returning invalid lets the caller fall back to edge labels.
   return { 0, 0, false };
 }
 
@@ -503,11 +517,13 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   // Below we sample each applicable hemisphere boundary in world space, forward-project to
   // pixels, and feed adjacent sample pairs into detect_crossings, reusing the same crossing
   // logic as viewport edges.
-  // Restricted to lens_type 0-3 because WorldDirToPixel only implements forward projection
-  // for those (overlay_labels.cpp:198-200). Dual fisheye / rectangular lens boundaries are
-  // correctly handled by the viewport-edge path because those projections already show the
-  // full sphere and the boundary coincides with the pixel cull.
-  if (input.lens_type >= 0 && input.lens_type <= 3) {
+  // Restricted to view-transformed lens types (linear, single fisheye, single
+  // orthographic) because WorldDirToPixel only implements forward projection
+  // for those — see WorldDirToPixel above. Full-sky lens types (dual fisheye /
+  // rectangular / dual orthographic) are correctly handled by the viewport-edge
+  // path because those projections already show the full sphere and the
+  // hemisphere boundary coincides with the pixel cull.
+  if (!LensIsFullSky(input.lens_type)) {
     constexpr int kBoundarySamples = 360;
 
     auto sample_curve = [&](auto curve_fn) {
@@ -582,7 +598,11 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
 
   // Sun circles: add interior labels when circles don't intersect viewport edges.
   // Place 4 labels evenly around each sun circle using forward projection.
-  if (input.show_sun_circles && input.lens_type >= 0 && input.lens_type <= 3) {
+  // Same gate as the hemisphere boundary block: only view-transformed lens
+  // types (linear / single fisheye / single orthographic) need interior labels;
+  // full-sky lenses always have edges intersect the sun circle. Reusing
+  // !LensIsFullSky keeps the lens classification single-sourced.
+  if (input.show_sun_circles && !LensIsFullSky(input.lens_type)) {
     for (int ci = 0; ci < input.sun_circle_count; ci++) {
       float angle_deg = input.sun_circle_angles[ci];
       // Check if this circle already has edge labels

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -33,23 +33,29 @@ InvResult LinearInv(float px, float py, float res_x, float res_y, float half_fov
   return { px / len, py / len, -focal / len, true };
 }
 
-// Synced with shader fisheyeInverse (preview_renderer.cpp line ~167-185)
+// Synced with shader fisheyeInverse (preview_renderer.cpp:167-189). type:
+// 0=equal_area, 1=equidistant, 2=stereographic, 3=orthographic.
 InvResult FisheyeInv(float px, float py, float res_x, float res_y, float half_fov, int type) {
   float img_radius = std::min(res_x, res_y) * 0.5f;
   float r = std::sqrt(px * px + py * py) / img_radius;
 
   float theta;
-  if (type == 0) {  // equal area
+  if (type == 0) {  // equal area: r_norm = sin(θ/2) / sin(fov/4)
     float s = r * std::sin(half_fov * 0.5f);
     if (s > 1.0f)
       return { 0, 0, 0, false };
     theta = 2.0f * std::asin(s);
-  } else if (type == 1) {  // equidistant
+  } else if (type == 1) {  // equidistant: r_norm = θ / half_fov
     theta = r * half_fov;
     if (theta >= kPi)
       return { 0, 0, 0, false };
-  } else {  // stereographic
+  } else if (type == 2) {  // stereographic: r_norm = tan(θ/2) / tan(fov/4)
     theta = 2.0f * std::atan(r * std::tan(half_fov * 0.5f));
+  } else {  // orthographic (type == 3): r_norm = sin(θ) / sin(fov/2)
+    float s = r * std::sin(half_fov);
+    if (s > 1.0f)
+      return { 0, 0, 0, false };
+    theta = std::asin(s);
   }
 
   float phi = std::atan2(py, px);
@@ -78,15 +84,19 @@ InvResult DualFisheyeInv(float px, float py, float res_x, float res_y, int type)
 
   float half_pi = kPi * 0.5f;
   float theta;
-  if (type == 0) {
+  if (type == 0) {  // equal area
     float s = use_r * std::sin(half_pi * 0.5f);
     if (s > 1.0f)
       return { 0, 0, 0, false };
     theta = 2.0f * std::asin(s);
-  } else if (type == 1) {
+  } else if (type == 1) {  // equidistant
     theta = use_r * half_pi;
-  } else {
+  } else if (type == 2) {  // stereographic
     theta = 2.0f * std::atan(use_r * std::tan(half_pi * 0.5f));
+  } else {  // orthographic (type == 3): use_r is already normalised; θ = asin(use_r)
+    if (use_r > 1.0f)
+      return { 0, 0, 0, false };
+    theta = std::asin(use_r);
   }
 
   float phi = std::atan2(use_y, use_x);
@@ -113,23 +123,38 @@ InvResult RectangularInv(float px, float py, float res_x, float res_y) {
 }
 
 // Compute world direction for a pixel offset from viewport center.
-// Synced with shader main() (preview_renderer.cpp line ~302-318).
+// Synced with shader main() (preview_renderer.cpp:317-332). Dispatch table:
+//   lens 0           → LinearInv               (view-transformed)
+//   lens 1-3         → FisheyeInv (type 0-2)   (view-transformed)
+//   lens 4-6         → DualFisheyeInv          (world-space, no view)
+//   lens 7           → RectangularInv          (world-space, no view)
+//   lens 8 (single ortho) → FisheyeInv(type=3) (view-transformed)
+//   lens 9 (dual ortho)   → DualFisheyeInv(3)  (world-space, no view)
 InvResult PixelToWorldDir(float px, float py, float res_x, float res_y, int lens_type, float fov,
                           const float view_matrix[9]) {
   float half_fov = fov * 0.5f * kDeg2Rad;
 
   InvResult r;
   bool needs_view = true;
-  if (lens_type == 0) {
+  if (lens_type == kLensTypeLinear) {
     r = LinearInv(px, py, res_x, res_y, half_fov);
-  } else if (lens_type >= 1 && lens_type <= 3) {
-    r = FisheyeInv(px, py, res_x, res_y, half_fov, lens_type - 1);
-  } else if (lens_type >= 4 && lens_type <= 6) {
-    r = DualFisheyeInv(px, py, res_x, res_y, lens_type - 4);
+  } else if (lens_type >= kLensTypeFisheyeEqualArea && lens_type <= kLensTypeFisheyeStereographic) {
+    r = FisheyeInv(px, py, res_x, res_y, half_fov, lens_type - kLensTypeFisheyeEqualArea);
+  } else if (lens_type >= kLensTypeDualFisheyeEqualArea && lens_type <= kLensTypeDualFisheyeStereographic) {
+    r = DualFisheyeInv(px, py, res_x, res_y, lens_type - kLensTypeDualFisheyeEqualArea);
     needs_view = false;
-  } else {
+  } else if (lens_type == kLensTypeRectangular) {
     r = RectangularInv(px, py, res_x, res_y);
     needs_view = false;
+  } else if (lens_type == kLensTypeFisheyeOrthographic) {
+    // Single orthographic: shader uses fisheyeInverse(type=3) and applies view matrix.
+    r = FisheyeInv(px, py, res_x, res_y, half_fov, 3);
+  } else if (lens_type == kLensTypeDualFisheyeOrthographic) {
+    // Dual orthographic: shader uses dualFisheyeInverse(type=3), no view matrix.
+    r = DualFisheyeInv(px, py, res_x, res_y, 3);
+    needs_view = false;
+  } else {
+    r = { 0, 0, 0, false };
   }
 
   if (!r.valid)

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -9,7 +9,12 @@
 namespace lumice::gui {
 
 struct OverlayLabel {
-  float screen_x, screen_y;  // ImGui logical screen coordinates
+  // Draw list screen coordinates. With ImGuiConfigFlags_ViewportsEnable enabled
+  // (gui-polish-v15), these are absolute OS screen coordinates; the caller of
+  // ComputeOverlayLabels owns the conversion from window-local to screen space.
+  // For self-owned ImDrawList targets (e.g. export_fbo_renderer rendering to an
+  // off-screen FBO), the caller passes a (0, 0) origin and these stay in FBO space.
+  float screen_x, screen_y;
   std::string text;
   ImU32 color;
   bool has_bg = false;  // draw semi-transparent black background behind text
@@ -29,7 +34,12 @@ struct OverlayLabelInput {
 };
 
 // Compute labels at viewport edges where overlay lines cross.
-// vp_screen_* are in ImGui logical (window) coordinates.
+// vp_screen_* are in the same coordinate space as the target ImDrawList:
+//   - For ImGui::GetWindowDrawList() under ImGuiConfigFlags_ViewportsEnable,
+//     this is absolute OS screen space (caller must add vp->Pos offset).
+//   - For self-owned ImDrawList targets (off-screen FBO), this is FBO-local
+//     space starting at (0, 0).
+// Output OverlayLabel.screen_x/y inherit this same coordinate space.
 void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, float vp_screen_y, float vp_screen_w,
                           float vp_screen_h, std::vector<OverlayLabel>& out);
 

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -46,12 +46,25 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
 // Draw labels using the current ImGui window's draw list (so modals/popups correctly
 // occlude the labels), with collision avoidance. Caller must invoke this inside an
 // active ImGui::Begin/End pair.
-void DrawOverlayLabels(const std::vector<OverlayLabel>& labels);
+//
+// `vp_screen_*` is the same viewport rect the caller passed to ComputeOverlayLabels
+// (same coordinate space — see ComputeOverlayLabels comment above). Each label's
+// rendered text bounding box is clamped inside `vp_screen_* + kViewportInsetPx`
+// so labels never straddle the viewport edge — see detail::ClampLabelPosToViewport.
+//
+// Coverage asymmetry: this viewport clamp is unconditional (all lens types,
+// all visible modes). The companion hemisphere-boundary inset (~3° push toward
+// the visible side) is applied at compute time inside ComputeOverlayLabels and
+// is gated to lens 0–3 + visible=upper/lower/front (see overlay_labels.cpp).
+void DrawOverlayLabels(const std::vector<OverlayLabel>& labels, float vp_screen_x, float vp_screen_y, float vp_screen_w,
+                       float vp_screen_h);
 
 // Append overlay labels to an arbitrary ImDrawList (with collision avoidance).
 // Used by DrawOverlayLabels for the preview window's draw list and by
 // export_fbo_renderer for a self-owned list targeting an off-screen FBO.
-void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels);
+// `vp_screen_*` semantics match DrawOverlayLabels.
+void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels, float vp_screen_x,
+                             float vp_screen_y, float vp_screen_w, float vp_screen_h);
 
 namespace detail {
 
@@ -75,6 +88,19 @@ namespace detail {
 //                       left untouched in that case.
 void PixelToWorldDirForTesting(float px, float py, float res_x, float res_y, int lens_type, float fov,
                                const float view_matrix[9], float* out_x, float* out_y, float* out_z, bool* out_valid);
+
+// Clamp a label's anchor position so the rendered text bounding box stays
+// inside the viewport rect with `kViewportInsetPx` margin on each side.
+// `pos` is the desktop-relative top-left of the text glyph rect (caller has
+// already subtracted half of `text_size` from the label's center). The returned
+// position keeps `[pos.x, pos.x + text_size.x] ⊂ [vp_x + inset, vp_x + vp_w − inset]`
+// (and similarly for y), unless the viewport is too narrow to fit the text +
+// 2×inset — in that case the original pos is returned unchanged (rendering
+// degrades to "centered on label anchor", matching legacy behaviour).
+//
+// Pure function — exposed in detail:: for unit testing
+// (`overlay_labels/clamp_label_pos_*` tests).
+ImVec2 ClampLabelPosToViewport(ImVec2 pos, ImVec2 text_size, float vp_x, float vp_y, float vp_w, float vp_h);
 
 }  // namespace detail
 

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -53,6 +53,31 @@ void DrawOverlayLabels(const std::vector<OverlayLabel>& labels);
 // export_fbo_renderer for a self-owned list targeting an off-screen FBO.
 void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels);
 
+namespace detail {
+
+// Pure-function inverse projection used by ComputeOverlayLabels. Exposed
+// here so unit tests can pin the per-lens-type dispatch (especially the
+// orthographic branches added in task-orthographic-followup) without the
+// edge-sampling layer in between.
+//
+// Inputs:
+//   px, py            pixel offset from viewport center (shader convention)
+//   res_x, res_y      viewport width / height in pixels
+//   lens_type         LensType enum value (0..9)
+//   fov               horizontal field-of-view in degrees
+//   view_matrix       column-major 3x3 from BuildViewMatrix (preview_renderer.hpp);
+//                     ignored by full-sky lens branches that don't view-transform.
+//
+// Outputs:
+//   out_x/out_y/out_z   world-space unit direction (only set when *out_valid is true)
+//   out_valid           false if the pixel falls outside the projection domain
+//                       (asin guard, |lat| > π/2, etc.); the xyz outputs are
+//                       left untouched in that case.
+void PixelToWorldDirForTesting(float px, float py, float res_x, float res_y, int lens_type, float fov,
+                               const float view_matrix[9], float* out_x, float* out_y, float* out_z, bool* out_valid);
+
+}  // namespace detail
+
 }  // namespace lumice::gui
 
 #endif  // LUMICE_GUI_OVERLAY_LABELS_HPP

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -49,8 +49,9 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
 //
 // `vp_screen_*` is the same viewport rect the caller passed to ComputeOverlayLabels
 // (same coordinate space — see ComputeOverlayLabels comment above). Each label's
-// rendered text bounding box is clamped inside `vp_screen_* + kViewportInsetPx`
-// so labels never straddle the viewport edge — see detail::ClampLabelPosToViewport.
+// rendered text bounding box is clamped at least 2 px inside each viewport edge
+// (`kViewportInsetPx` in detail::ClampLabelPosToViewport) so labels never straddle
+// the viewport edge.
 //
 // Coverage asymmetry: this viewport clamp is unconditional (all lens types,
 // all visible modes). The companion hemisphere-boundary inset (~3° push toward
@@ -90,7 +91,8 @@ void PixelToWorldDirForTesting(float px, float py, float res_x, float res_y, int
                                const float view_matrix[9], float* out_x, float* out_y, float* out_z, bool* out_valid);
 
 // Clamp a label's anchor position so the rendered text bounding box stays
-// inside the viewport rect with `kViewportInsetPx` margin on each side.
+// inside the viewport rect with at least 2 px (`kViewportInsetPx`) margin
+// on each side.
 // `pos` is the desktop-relative top-left of the text glyph rect (caller has
 // already subtracted half of `text_size` from the label's center). The returned
 // position keeps `[pos.x, pos.x + text_size.x] ⊂ [vp_x + inset, vp_x + vp_w − inset]`

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1788,19 +1788,15 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_render/lens_full_sky_view_controls_disabled — guards the full-sky set
-  // {dual fisheye, rectangular, dual orthographic} from accidentally gaining
-  // view controls. If kFullSkyLensTypes ever loses any of these, this test
-  // catches the regression.
+  // p2_render/lens_full_sky_view_controls_disabled — guards every entry in
+  // gui::kFullSkyLensTypes from accidentally gaining view controls. The loop
+  // iterates the SSOT array directly (not a local copy) so any future
+  // addition / removal in kFullSkyLensTypes automatically updates the test
+  // coverage, closing the loop with the static_assert in gui_constants.hpp.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_full_sky_view_controls_disabled");
     t->TestFunc = [](ImGuiTestContext* ctx) {
-      const int kFullSkyLenses[] = {
-        gui::kLensTypeDualFisheyeEqualArea,     gui::kLensTypeDualFisheyeEquidist,
-        gui::kLensTypeDualFisheyeStereographic, gui::kLensTypeRectangular,
-        gui::kLensTypeDualFisheyeOrthographic,
-      };
-      for (int lens : kFullSkyLenses) {
+      for (int lens : gui::kFullSkyLensTypes) {
         ResetTestState();
         ctx->Yield(2);
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1751,6 +1751,73 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_render/lens_orthographic_view_controls — single orthographic must allow
+  // elevation/azimuth/roll edits and NOT be force-zeroed (issue subpoint 2),
+  // and FOV slider must remain effective up to its 180° clamp (issue subpoint 3).
+  // Regression guard for the LensIsFullSky() refactor (task-orthographic-followup
+  // Step 1): the previous `lens_type >= 4` heuristic incorrectly flagged single
+  // orthographic (lens=8) as full-sky, disabling all view controls.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_orthographic_view_controls");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeOrthographic;
+      gui::g_state.renderer.fov = 120.0f;
+      gui::g_state.renderer.elevation = 30.0f;
+      gui::g_state.renderer.azimuth = 45.0f;
+      gui::g_state.renderer.roll = 10.0f;
+      ctx->Yield(3);
+
+      // Single orthographic must NOT be force-zeroed by the per-frame full-sky guard.
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 30.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 45.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 10.0f);
+
+      // FOV slider must accept values up to 180° without being clamped lower.
+      gui::g_state.renderer.fov = 170.0f;
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.fov, 170.0f);
+
+      // Pushing past 180° is clamped (already covered by lens_orthographic_selection,
+      // re-asserted here to keep the "FOV adjustable + clamped" invariant explicit).
+      gui::g_state.renderer.fov = 220.0f;
+      ctx->Yield(3);
+      IM_CHECK_LE(gui::g_state.renderer.fov, 180.0f);
+    };
+  }
+
+  // p2_render/lens_full_sky_view_controls_disabled — guards the full-sky set
+  // {dual fisheye, rectangular, dual orthographic} from accidentally gaining
+  // view controls. If kFullSkyLensTypes ever loses any of these, this test
+  // catches the regression.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_full_sky_view_controls_disabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      const int kFullSkyLenses[] = {
+        gui::kLensTypeDualFisheyeEqualArea,     gui::kLensTypeDualFisheyeEquidist,
+        gui::kLensTypeDualFisheyeStereographic, gui::kLensTypeRectangular,
+        gui::kLensTypeDualFisheyeOrthographic,
+      };
+      for (int lens : kFullSkyLenses) {
+        ResetTestState();
+        ctx->Yield(2);
+
+        gui::g_state.renderer.lens_type = lens;
+        gui::g_state.renderer.elevation = 30.0f;
+        gui::g_state.renderer.azimuth = 45.0f;
+        gui::g_state.renderer.roll = 10.0f;
+        ctx->Yield(3);
+
+        // Per-frame full-sky guard must zero these for every lens in the set.
+        IM_CHECK_EQ(gui::g_state.renderer.elevation, 0.0f);
+        IM_CHECK_EQ(gui::g_state.renderer.azimuth, 0.0f);
+        IM_CHECK_EQ(gui::g_state.renderer.roll, 0.0f);
+      }
+    };
+  }
+
   // p2_render/modal_layout_toggle_bit — switching modal_layout_vertical is safe
   // (view preference state-level test; layout dispatch is exercised only indirectly
   // through subsequent modal open, which would require a live popup — omitted to

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -5,7 +5,9 @@
 #include <cmath>
 #include <vector>
 
+#include "gui/gui_constants.hpp"
 #include "gui/overlay_labels.hpp"
+#include "gui/preview_renderer.hpp"
 #include "test_gui_shared.hpp"
 
 namespace {
@@ -97,12 +99,14 @@ void SingleOrthoLatTestFunc(ImGuiTestContext* ctx) {
   constexpr float kVpW = 200.0f;
   constexpr float kVpH = 200.0f;
 
-  auto in_ortho = MakeGridOnly(/*visible=Full*/ 2, /*lens=Single Orthographic*/ 8, /*elev*/ 0.0f, /*az*/ 0.0f);
+  auto in_ortho = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeOrthographic,
+                               /*elev*/ 0.0f, /*az*/ 0.0f);
   in_ortho.fov = 60.0f;
   std::vector<lumice::gui::OverlayLabel> labels_ortho;
   lumice::gui::ComputeOverlayLabels(in_ortho, kVpX, kVpY, kVpW, kVpH, labels_ortho);
 
-  auto in_fisheye = MakeGridOnly(/*visible=Full*/ 2, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
+  auto in_fisheye = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
+                                 /*elev*/ 0.0f, /*az*/ 0.0f);
   in_fisheye.fov = 60.0f;
   std::vector<lumice::gui::OverlayLabel> labels_fisheye;
   lumice::gui::ComputeOverlayLabels(in_fisheye, kVpX, kVpY, kVpW, kVpH, labels_fisheye);
@@ -342,5 +346,131 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "single_orthographic_dispatch_matches_fisheye");
     t->TestFunc = SingleOrthoLatTestFunc;
+  }
+
+  // Pure-function contract tests for the orthographic dispatch in
+  // detail::PixelToWorldDirForTesting (added in task-orthographic-followup
+  // Step 2). These pin the radial mapping at known pixels so a future
+  // regression in FisheyeInv(type=3) / DualFisheyeInv(type=3) (e.g. asin
+  // input sign flipped, or the type=3 branch silently aliased back to
+  // stereographic) breaks the test rather than silently mis-orienting
+  // labels at runtime.
+
+  // Single orthographic at fov=180° has the analytic property that
+  // r_norm = sin(θ), i.e. the disc edge (r_norm=1) maps to θ=90°.
+  // Center pixel (px=py=0) → θ=0 → fisheyeInverse returns view dir (0, 0, -1)
+  // (camera-space "looking forward"). With elev=0,az=0,roll=0 the view
+  // matrix maps view (0, 0, -1) to world (-1, 0, 0): world forward.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "pixel_to_world_dir_single_ortho_center");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      float view[9];
+      lumice::gui::BuildViewMatrix(/*elev*/ 0.0f, /*az*/ 0.0f, /*roll*/ 0.0f, view);
+
+      float wx = 0;
+      float wy = 0;
+      float wz = 0;
+      bool valid = false;
+      lumice::gui::detail::PixelToWorldDirForTesting(0.0f, 0.0f, 200.0f, 200.0f,
+                                                     lumice::gui::kLensTypeFisheyeOrthographic,
+                                                     /*fov*/ 180.0f, view, &wx, &wy, &wz, &valid);
+
+      IM_CHECK(valid);
+      // World forward at (elev=0, az=0) is -x.
+      IM_CHECK_LT(std::abs(wx - (-1.0f)), 1e-4f);
+      IM_CHECK_LT(std::abs(wy), 1e-4f);
+      IM_CHECK_LT(std::abs(wz), 1e-4f);
+    };
+  }
+
+  // Top-edge midpoint at fov=180°: r_norm=1 → θ=π/2. With phi=π/2 (py>0),
+  // view dir = (0, 1, 0) which the (elev=0,az=0,roll=0) view matrix maps to
+  // world dir (0, 0, -1). altitude = asin(-wz) = asin(1) = 90° — the zenith.
+  // This is the load-bearing assertion for "上半 = 正纬度": the highest
+  // possible altitude reachable in single orthographic must surface at the
+  // top of the viewport. Pre-fix RectangularInv mapped (0, hh) to lat=-π/2
+  // (negative), the precise inverse of this expectation.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "pixel_to_world_dir_single_ortho_top_zenith");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      float view[9];
+      lumice::gui::BuildViewMatrix(0.0f, 0.0f, 0.0f, view);
+
+      float wx = 0;
+      float wy = 0;
+      float wz = 0;
+      bool valid = false;
+      // py = +100 = +hh on a 200x200 viewport (shader convention: +py is image up).
+      lumice::gui::detail::PixelToWorldDirForTesting(0.0f, 100.0f, 200.0f, 200.0f,
+                                                     lumice::gui::kLensTypeFisheyeOrthographic,
+                                                     /*fov*/ 180.0f, view, &wx, &wy, &wz, &valid);
+
+      IM_CHECK(valid);
+      IM_CHECK_LT(std::abs(wx), 1e-3f);
+      IM_CHECK_LT(std::abs(wy), 1e-3f);
+      // -wz = sin(altitude); altitude=+90° → -wz = +1 → wz = -1.
+      IM_CHECK_LT(std::abs(wz - (-1.0f)), 1e-3f);
+    };
+  }
+
+  // Dual orthographic at the upper-hemisphere disc center
+  // (px=-circle_radius, py=0): use_r=0, theta=0, world dir = (0, 0, -1)
+  // (zenith). Same load-bearing assertion as the single ortho top-zenith
+  // test, but exercises DualFisheyeInv(type=3) which has no other coverage
+  // (ComputeOverlayLabels' edge sampling can't reach lens=9 — see notes
+  // in SingleOrthoLatTestFunc).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "pixel_to_world_dir_dual_ortho_left_disc_center");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // view_matrix is unused for lens=9 (no view transform). Use identity-ish
+      // value so any accidental application would surface in the assertions.
+      float view[9];
+      lumice::gui::BuildViewMatrix(0.0f, 0.0f, 0.0f, view);
+
+      // Viewport 200x200 → short_res = min(100, 200) = 100, circle_radius = 50.
+      // Left circle center is at (-circle_radius, 0) = (-50, 0) in pixel coords.
+      float wx = 0;
+      float wy = 0;
+      float wz = 0;
+      bool valid = false;
+      lumice::gui::detail::PixelToWorldDirForTesting(-50.0f, 0.0f, 200.0f, 200.0f,
+                                                     lumice::gui::kLensTypeDualFisheyeOrthographic,
+                                                     /*fov*/ 170.0f, view, &wx, &wy, &wz, &valid);
+
+      IM_CHECK(valid);
+      IM_CHECK_LT(std::abs(wx), 1e-3f);
+      IM_CHECK_LT(std::abs(wy), 1e-3f);
+      // Left disc center → upper-hemisphere zenith → wz = -1.
+      IM_CHECK_LT(std::abs(wz - (-1.0f)), 1e-3f);
+    };
+  }
+
+  // Dual orthographic right disc center → lower-hemisphere zenith (z = +1).
+  // Symmetric pair to the left-disc test; failing this would indicate the
+  // in_left/in_right branch in DualFisheyeInv is mis-attributing samples.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "pixel_to_world_dir_dual_ortho_right_disc_center");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      float view[9];
+      lumice::gui::BuildViewMatrix(0.0f, 0.0f, 0.0f, view);
+
+      float wx = 0;
+      float wy = 0;
+      float wz = 0;
+      bool valid = false;
+      lumice::gui::detail::PixelToWorldDirForTesting(50.0f, 0.0f, 200.0f, 200.0f,
+                                                     lumice::gui::kLensTypeDualFisheyeOrthographic,
+                                                     /*fov*/ 170.0f, view, &wx, &wy, &wz, &valid);
+
+      IM_CHECK(valid);
+      IM_CHECK_LT(std::abs(wx), 1e-3f);
+      IM_CHECK_LT(std::abs(wy), 1e-3f);
+      // Right disc center → lower-hemisphere zenith → wz = +1.
+      IM_CHECK_LT(std::abs(wz - 1.0f), 1e-3f);
+    };
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -72,6 +72,58 @@ int CountGridLabels(const std::vector<lumice::gui::OverlayLabel>& labels) {
   return n;
 }
 
+// Regression test for task-orthographic-followup Step 2 dispatch: at the same
+// view config, single orthographic (lens=8) and Fisheye Equidistant (lens=2)
+// must produce comparably-sized grid label sets. Pre-fix, lens=8 fell to the
+// RectangularInv fallback in PixelToWorldDir, producing a label set with
+// completely different geometry (and the symptomatic upside-down latitude
+// labels reported in issue subpoint 4). The orthographic / equidistant
+// fisheye pair shares the same projection topology (single disc, view-matrix
+// applied), so their label counts on the same viewport differ only in the
+// radial mapping detail — well within ±50% of each other in practice.
+//
+// Note (dual orthographic, lens=9): a parallel test for lens=9 is omitted
+// intentionally. Dual fisheye / orthographic projections always size their
+// twin discs to fit exactly in the viewport (circle_radius = min(W/2, H)/2),
+// so viewport edges are at most tangent to the discs — never a chord — and
+// ComputeOverlayLabels' edge-sampling loop yields no valid sample pairs for
+// any lens=9 configuration. The fix for lens=9 in PixelToWorldDir uses the
+// same dispatch pattern as lens=8 (FisheyeInv vs DualFisheyeInv with type=3),
+// so the lens=8 regression below is sufficient coverage of the dispatch.
+void SingleOrthoLatTestFunc(ImGuiTestContext* ctx) {
+  IM_UNUSED(ctx);
+  constexpr float kVpX = 0.0f;
+  constexpr float kVpY = 0.0f;
+  constexpr float kVpW = 200.0f;
+  constexpr float kVpH = 200.0f;
+
+  auto in_ortho = MakeGridOnly(/*visible=Full*/ 2, /*lens=Single Orthographic*/ 8, /*elev*/ 0.0f, /*az*/ 0.0f);
+  in_ortho.fov = 60.0f;
+  std::vector<lumice::gui::OverlayLabel> labels_ortho;
+  lumice::gui::ComputeOverlayLabels(in_ortho, kVpX, kVpY, kVpW, kVpH, labels_ortho);
+
+  auto in_fisheye = MakeGridOnly(/*visible=Full*/ 2, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
+  in_fisheye.fov = 60.0f;
+  std::vector<lumice::gui::OverlayLabel> labels_fisheye;
+  lumice::gui::ComputeOverlayLabels(in_fisheye, kVpX, kVpY, kVpW, kVpH, labels_fisheye);
+
+  int n_ortho = CountGridLabels(labels_ortho);
+  int n_fisheye = CountGridLabels(labels_fisheye);
+
+  // Both must be non-zero (sanity).
+  IM_CHECK_GT(n_ortho, 0);
+  IM_CHECK_GT(n_fisheye, 0);
+
+  // The two single-fisheye-class projections differ only in radial mapping —
+  // edge-sampling crossings should cluster at similar counts. Ratio guard
+  // catches regressions like the pre-fix Rectangular fallback (which would
+  // give a count off by a large factor from the fisheye reference).
+  // Pick a generous ±50% band to absorb radial-mapping nonlinearities while
+  // still failing under a wholly different projection.
+  IM_CHECK_GE(n_ortho * 2, n_fisheye);  // n_ortho >= n_fisheye / 2
+  IM_CHECK_LE(n_ortho, n_fisheye * 2);  // n_ortho <= n_fisheye * 2
+}
+
 }  // namespace
 
 void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
@@ -284,5 +336,11 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
         IM_CHECK_LT(std::abs((b.screen_y - a.screen_y) - kDy), kEps);
       }
     };
+  }
+
+  // Test: single orthographic dispatch — see SingleOrthoLatTestFunc above.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "single_orthographic_dispatch_matches_fisheye");
+    t->TestFunc = SingleOrthoLatTestFunc;
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -474,4 +474,144 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       IM_CHECK_LT(std::abs(wz - 1.0f), 1e-3f);
     };
   }
+
+  // detail::ClampLabelPosToViewport contract — pure function tests for the
+  // viewport-inset behaviour added in task-overlay-label-edge-inset Step 1.
+  // Pin all four edges and the "no-op when label fits centred" path.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_left_edge");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Viewport: (10, 20, 200, 100). Label glyph 30×14 placed at pos.x=5
+      // (i.e. would extend from x=5 to x=35 — overlaps left edge x=10).
+      // Expected: clamped to vp_x + 2 = 12.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(5.0f, 50.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 200.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 12.0f);
+      IM_CHECK_EQ(clamped.y, 50.0f);  // y stayed put (50 inside [20+2, 20+100-14-2] = [22, 104])
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_right_edge");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Label at pos.x=195 with text width 30 would extend to x=225, past
+      // vp.x + vp.w = 210. Clamp to 210 - 30 - 2 = 178.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(195.0f, 50.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 200.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 178.0f);
+      IM_CHECK_EQ(clamped.y, 50.0f);
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_top_edge");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Label at pos.y=15 (above vp_y=20). Clamp to vp_y + 2 = 22.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(50.0f, 15.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 200.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 50.0f);
+      IM_CHECK_EQ(clamped.y, 22.0f);
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_bottom_edge");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Label at pos.y=110. Bottom edge: vp_y + vp_h - text_h - 2 = 20 + 100 - 14 - 2 = 104.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(50.0f, 110.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 200.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 50.0f);
+      IM_CHECK_EQ(clamped.y, 104.0f);
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_no_clamp_when_inside");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Label fully inside viewport — pos returned unchanged.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(50.0f, 50.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 200.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 50.0f);
+      IM_CHECK_EQ(clamped.y, 50.0f);
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_viewport_too_narrow");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Viewport width 20 cannot fit text width 30 + 2×2 inset → fallback
+      // path returns original pos so legacy "centered on anchor" survives.
+      ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(5.0f, 50.0f), ImVec2(30.0f, 14.0f), 10.0f,
+                                                                    20.0f, 20.0f, 100.0f);
+      IM_CHECK_EQ(clamped.x, 5.0f);  // unchanged
+      IM_CHECK_EQ(clamped.y, 50.0f);
+    };
+  }
+
+  // Hemisphere boundary inset — verify the inward-shifted boundary curve
+  // produces world directions on the visible side. Re-implement the equator
+  // / front-half lambdas at test level (same formulas as overlay_labels.cpp:540-)
+  // and assert the inset direction. This avoids the "label text source
+  // confusion" problem (latitude vs azimuth same %.0f° format) that ruled
+  // out a label-text-based regression test in the plan.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "hemisphere_boundary_inset_upper_pushes_negative_z");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Mirror the lambda in overlay_labels.cpp: equator inset for visible=upper
+      // shifts wz by -sin(3°) before renormalisation, then renormalises.
+      constexpr float kBoundaryInsetDeg = 3.0f;
+      const float pi = 3.14159265358979323846f;
+      const float deg2rad = pi / 180.0f;
+      const float boundary_offset = std::sin(kBoundaryInsetDeg * deg2rad);
+
+      // For visible=upper, every sample on the offset equator must have wz < 0
+      // (altitude = asin(-wz) > 0, i.e. inside upper hemisphere).
+      // Sample 8 evenly-spaced t values along the boundary curve.
+      for (int i = 0; i < 8; ++i) {
+        float t = i * (2.0f * pi / 8.0f);
+        float az = -pi + t;
+        float wx = -std::cos(az);
+        float wy = -std::sin(az);
+        float wz = -1.0f * boundary_offset;
+        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+        wx /= len;
+        wy /= len;
+        wz /= len;
+        IM_CHECK_LT_NO_RET(wz, 0.0f);  // upper-hemisphere visible side
+        // Magnitude check: altitude should be ≈ 3° (asin(0.0523/len) ≈ 3°).
+        float altitude_deg = std::asin(-wz) * 180.0f / pi;
+        IM_CHECK_GT_NO_RET(altitude_deg, 2.5f);
+        IM_CHECK_LT_NO_RET(altitude_deg, 3.5f);
+      }
+    };
+  }
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "hemisphere_boundary_inset_lower_pushes_positive_z");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Symmetric pair of upper test — visible=lower shifts wz by +sin(3°).
+      constexpr float kBoundaryInsetDeg = 3.0f;
+      const float pi = 3.14159265358979323846f;
+      const float deg2rad = pi / 180.0f;
+      const float boundary_offset = std::sin(kBoundaryInsetDeg * deg2rad);
+
+      for (int i = 0; i < 8; ++i) {
+        float t = i * (2.0f * pi / 8.0f);
+        float az = -pi + t;
+        float wx = -std::cos(az);
+        float wy = -std::sin(az);
+        float wz = +1.0f * boundary_offset;
+        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+        wx /= len;
+        wy /= len;
+        wz /= len;
+        IM_CHECK_GT_NO_RET(wz, 0.0f);  // lower-hemisphere visible side
+        float altitude_deg = std::asin(-wz) * 180.0f / pi;
+        IM_CHECK_LT_NO_RET(altitude_deg, -2.5f);
+        IM_CHECK_GT_NO_RET(altitude_deg, -3.5f);
+      }
+    };
+  }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -540,8 +540,11 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "clamp_label_pos_viewport_too_narrow");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       IM_UNUSED(ctx);
-      // Viewport width 20 cannot fit text width 30 + 2×2 inset → fallback
-      // path returns original pos so legacy "centered on anchor" survives.
+      // x fallback: viewport width 20 cannot fit text width 30 + 2×2 inset
+      // (`vp_w > text_size.x + 2×kViewportInsetPx` is false), so x is left
+      // untouched to preserve the legacy "centered on anchor" rendering.
+      // y is processed normally (vp_h=100 ≫ text_h+4=18) but happens to need
+      // no clamp here (pos.y=50 already inside [22, 104]).
       ImVec2 clamped = lumice::gui::detail::ClampLabelPosToViewport(ImVec2(5.0f, 50.0f), ImVec2(30.0f, 14.0f), 10.0f,
                                                                     20.0f, 20.0f, 100.0f);
       IM_CHECK_EQ(clamped.x, 5.0f);  // unchanged

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -2,6 +2,7 @@
 // Direct (non-interactive) tests: instantiate OverlayLabelInput, call
 // ComputeOverlayLabels, inspect result labels.
 
+#include <cmath>
 #include <vector>
 
 #include "gui/overlay_labels.hpp"
@@ -244,6 +245,44 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       IM_CHECK(g_capture.begin_succeeded);
       IM_CHECK_GT(g_capture.wnd_after, g_capture.wnd_before);
       IM_CHECK_EQ(g_capture.fg_after, g_capture.fg_before);
+    };
+  }
+
+  // Test G: ComputeOverlayLabels output translates linearly with vp_screen origin.
+  // Contract: for any (vp_x, vp_y) offset, every emitted OverlayLabel.screen_x/y
+  // must shift by exactly that amount; label count and ordering stay identical.
+  // Regression for gui-polish-v16: caller in RenderPreviewPanel forgot to convert
+  // (panel_x, kTopBarHeight) through MainVpPos() into OS screen coords, which made
+  // overlay labels stick to the desktop origin instead of the host window when the
+  // window was dragged or sat on a non-primary monitor.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "screen_origin_translation_invariance");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(/*visible=*/2, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
+
+      constexpr float kVpW = 800.0f;
+      constexpr float kVpH = 400.0f;
+      constexpr float kDx = 123.0f;
+      constexpr float kDy = 45.0f;
+      constexpr float kEps = 1e-3f;
+
+      std::vector<lumice::gui::OverlayLabel> labels_origin;
+      std::vector<lumice::gui::OverlayLabel> labels_shifted;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, kVpW, kVpH, labels_origin);
+      lumice::gui::ComputeOverlayLabels(in, kDx, kDy, kVpW, kVpH, labels_shifted);
+
+      IM_CHECK_GT(static_cast<int>(labels_origin.size()), 0);
+      IM_CHECK_EQ(labels_shifted.size(), labels_origin.size());
+
+      for (size_t i = 0; i < labels_origin.size(); ++i) {
+        const auto& a = labels_origin[i];
+        const auto& b = labels_shifted[i];
+        IM_CHECK_EQ(a.text, b.text);
+        IM_CHECK_EQ(a.group, b.group);
+        IM_CHECK_LT(std::abs((b.screen_x - a.screen_x) - kDx), kEps);
+        IM_CHECK_LT(std::abs((b.screen_y - a.screen_y) - kDy), kEps);
+      }
     };
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -656,4 +656,50 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       }
     };
   }
+
+  // Single orthographic must emit sun-circle interior labels for circles that
+  // don't intersect the viewport edge — same coverage as single fisheye.
+  // Pre-fix, the interior-label block in ComputeOverlayLabels was gated to
+  // `lens_type 0-3`, leaving lens=8 with no interior labels and a silent UX
+  // regression discovered during scrum-gui-polish-v16 manual verification.
+  // Post-fix uses `!LensIsFullSky(...)` and lens=8 falls through to the same
+  // path as lens=2.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "single_orthographic_sun_circle_interior_labels");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Sun directly forward (camera-forward = -x at elev=0,az=0). A small
+      // 5° angular-distance circle centred on the sun stays well inside the
+      // orthographic disc, so all 4 interior labels at 0/90/180/270° around
+      // the circle should land within viewport bounds and survive cull.
+      // Note: existing MakeSunOnly callers use `const float sun_back[3]` /
+      // `const float angle` and so trigger the same clang-tidy
+      // "Invalid case style for constant" warnings — kept here without
+      // `const` to avoid spreading the violation into new code (see
+      // learnings/code-quality.md "项目 clang-tidy ... 函数内 const 局部").
+      float sun_forward[3] = { -1.0f, 0.0f, 0.0f };
+      float angle = 5.0f;
+      auto in_ortho = MakeSunOnly(/*visible=Full*/ 2, sun_forward, &angle, 1);
+      in_ortho.lens_type = lumice::gui::kLensTypeFisheyeOrthographic;
+      in_ortho.fov = 60.0f;
+
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in_ortho, /*vp_x*/ 0.0f, /*vp_y*/ 0.0f,
+                                        /*vp_w*/ 200.0f, /*vp_h*/ 200.0f, labels);
+
+      // Expect ≥ 1 sun-circle label (the 4 placement points are evenly spaced;
+      // viewport-bounds + collision-avoidance may drop some, but at least one
+      // should survive for a small circle near the optical axis).
+      IM_CHECK_GT(CountSunCircleLabels(labels), 0);
+
+      // Cross-check: the same configuration with lens=Fisheye Equidistant
+      // (lens=2) should produce the same label count, since the two single-
+      // fisheye-class projections share the interior-label code path.
+      auto in_fisheye = in_ortho;
+      in_fisheye.lens_type = lumice::gui::kLensTypeFisheyeEquidist;
+      std::vector<lumice::gui::OverlayLabel> labels_fisheye;
+      lumice::gui::ComputeOverlayLabels(in_fisheye, 0.0f, 0.0f, 200.0f, 200.0f, labels_fisheye);
+      IM_CHECK_EQ(CountSunCircleLabels(labels), CountSunCircleLabels(labels_fisheye));
+    };
+  }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -562,16 +562,16 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       // Mirror the lambda in overlay_labels.cpp: equator inset for visible=upper
       // shifts wz by -sin(3°) before renormalisation, then renormalises.
       constexpr float kBoundaryInsetDeg = 3.0f;
-      const float pi = 3.14159265358979323846f;
-      const float deg2rad = pi / 180.0f;
-      const float boundary_offset = std::sin(kBoundaryInsetDeg * deg2rad);
+      constexpr float kPi = 3.14159265f;
+      constexpr float kDeg2Rad = kPi / 180.0f;
+      float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
 
       // For visible=upper, every sample on the offset equator must have wz < 0
       // (altitude = asin(-wz) > 0, i.e. inside upper hemisphere).
       // Sample 8 evenly-spaced t values along the boundary curve.
       for (int i = 0; i < 8; ++i) {
-        float t = i * (2.0f * pi / 8.0f);
-        float az = -pi + t;
+        float t = i * (2.0f * kPi / 8.0f);
+        float az = -kPi + t;
         float wx = -std::cos(az);
         float wy = -std::sin(az);
         float wz = -1.0f * boundary_offset;
@@ -581,7 +581,7 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
         wz /= len;
         IM_CHECK_LT_NO_RET(wz, 0.0f);  // upper-hemisphere visible side
         // Magnitude check: altitude should be ≈ 3° (asin(0.0523/len) ≈ 3°).
-        float altitude_deg = std::asin(-wz) * 180.0f / pi;
+        float altitude_deg = std::asin(-wz) * 180.0f / kPi;
         IM_CHECK_GT_NO_RET(altitude_deg, 2.5f);
         IM_CHECK_LT_NO_RET(altitude_deg, 3.5f);
       }
@@ -593,13 +593,13 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       IM_UNUSED(ctx);
       // Symmetric pair of upper test — visible=lower shifts wz by +sin(3°).
       constexpr float kBoundaryInsetDeg = 3.0f;
-      const float pi = 3.14159265358979323846f;
-      const float deg2rad = pi / 180.0f;
-      const float boundary_offset = std::sin(kBoundaryInsetDeg * deg2rad);
+      constexpr float kPi = 3.14159265f;
+      constexpr float kDeg2Rad = kPi / 180.0f;
+      float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
 
       for (int i = 0; i < 8; ++i) {
-        float t = i * (2.0f * pi / 8.0f);
-        float az = -pi + t;
+        float t = i * (2.0f * kPi / 8.0f);
+        float az = -kPi + t;
         float wx = -std::cos(az);
         float wy = -std::sin(az);
         float wz = +1.0f * boundary_offset;
@@ -608,9 +608,48 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
         wy /= len;
         wz /= len;
         IM_CHECK_GT_NO_RET(wz, 0.0f);  // lower-hemisphere visible side
-        float altitude_deg = std::asin(-wz) * 180.0f / pi;
+        float altitude_deg = std::asin(-wz) * 180.0f / kPi;
         IM_CHECK_LT_NO_RET(altitude_deg, -2.5f);
         IM_CHECK_GT_NO_RET(altitude_deg, -3.5f);
+      }
+    };
+  }
+
+  // Smoke test for the visible=front boundary inset path. The front-half
+  // boundary in overlay_labels.cpp is a great circle perpendicular to forward
+  // (col2 = -forward), pushed by `-boundary_offset · col2` to land inside the
+  // visible front hemisphere. With identity-ish view matrix from
+  // BuildViewMatrix(elev=0, az=0, roll=0), col2 = (1, 0, 0) → forward = -x →
+  // pushing along -col2 means subtracting (boundary_offset, 0, 0). Replicate
+  // the lambda formula and assert dot(world, col2) < 0 (i.e. world has
+  // strictly more `-forward` content, i.e. lies on the visible front side).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "hemisphere_boundary_inset_front_pushes_along_forward");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      float view[9];
+      lumice::gui::BuildViewMatrix(0.0f, 0.0f, 0.0f, view);
+
+      constexpr float kBoundaryInsetDeg = 3.0f;
+      constexpr float kPi = 3.14159265f;
+      constexpr float kDeg2Rad = kPi / 180.0f;
+      float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
+
+      for (int i = 0; i < 8; ++i) {
+        float t_param = i * (2.0f * kPi / 8.0f);
+        float c = std::cos(t_param);
+        float s = std::sin(t_param);
+        float wx = c * view[0] + s * view[3] - boundary_offset * view[6];
+        float wy = c * view[1] + s * view[4] - boundary_offset * view[7];
+        float wz = c * view[2] + s * view[5] - boundary_offset * view[8];
+        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+        wx /= len;
+        wy /= len;
+        wz /= len;
+        // dot(world, col2) must be < 0 so the sample sits on the visible
+        // front side (shader cull: dot(world, col2) > 0 → invisible).
+        float dot_col2 = wx * view[6] + wy * view[7] + wz * view[8];
+        IM_CHECK_LT_NO_RET(dot_col2, 0.0f);
       }
     };
   }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -285,7 +285,8 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       g_capture.begin_succeeded = ok;
       if (ok) {
         g_capture.wnd_before = ImGui::GetWindowDrawList()->VtxBuffer.Size;
-        lumice::gui::DrawOverlayLabels(labels);
+        // Mock viewport rect aligned with the host window size set above.
+        lumice::gui::DrawOverlayLabels(labels, 0.0f, 0.0f, 200.0f, 100.0f);
         g_capture.wnd_after = ImGui::GetWindowDrawList()->VtxBuffer.Size;
       }
       ImGui::End();


### PR DESCRIPTION
## Summary
- Anchor overlay labels to the main viewport so they stay visually attached when the window is resized or moved
- Polish orthographic lens handling: group it with fisheye in the lens combo, fix `PixelToWorldDir` dispatch, and introduce a `LensIsFullSky` helper
- Improve overlay label placement: viewport clamping, inward inset along the hemisphere boundary, and a single interior label for the orthographic sun circle

## Test plan
- [x] `./scripts/build.sh -gtj release` (GUI tests)
- [x] Manual GUI smoke: resize window and verify overlay labels track the main viewport
- [x] Manual GUI smoke: switch between orthographic / fisheye / other lenses and verify label placement near hemisphere edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)