### PR TITLE
feat(gui): aspect ratio clamp warning + overlay label sampler refactor

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -110,6 +110,10 @@ void WindowSizeCallback(GLFWwindow* /*window*/, int /*width*/, int /*height*/) {
   if (g_state.aspect_preset != AspectPreset::kFree) {
     g_state.aspect_preset = AspectPreset::kFree;
   }
+  // Manual resize takes the user out of any preset, so the "screen too small"
+  // warning is no longer meaningful — clear it so the GUI does not display a
+  // stale clamp banner against a Free preset.
+  g_state.aspect_clamp = {};
 }
 
 void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, float override_ratio) {
@@ -117,6 +121,7 @@ void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, fl
   if (preset == AspectPreset::kMatchBg) {
     ratio = override_ratio > 0.0f ? override_ratio : g_preview.GetBgAspect();
     if (!g_preview.HasBackground()) {
+      g_state.aspect_clamp = {};
       return;
     }
   } else {
@@ -126,6 +131,9 @@ void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, fl
     ratio = 1.0f / ratio;
   }
   if (ratio <= 0.0f) {
+    // kFree (or any other ratio-less preset) reaches here — no preview-region
+    // ratio to honor, so any prior clamp warning is no longer relevant.
+    g_state.aspect_clamp = {};
     return;
   }
 
@@ -139,10 +147,6 @@ void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, fl
   constexpr float kCollapsedStripWidth = 20.0f;  // Must match kCollapseBtnSize in app_panels.cpp
   float left_w = g_state.left_panel_collapsed ? kCollapsedStripWidth : kLeftPanelWidth;
   float right_w = g_state.right_panel_collapsed ? kCollapsedStripWidth : kRightPanelWidth;
-  float preview_w = std::max(1.0f, static_cast<float>(win_w) - left_w - right_w);
-  float preview_h = preview_w / ratio;
-  auto target_h = static_cast<int>(preview_h + kTopBarHeight + kStatusBarHeight);
-  int target_w = win_w;
 
   // Select the monitor containing the window center so multi-monitor users do
   // not get yanked back to primary when aspect ratio changes (v11 bug #4).
@@ -174,18 +178,10 @@ void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, fl
     glfwGetMonitorWorkarea(glfwGetPrimaryMonitor(), &work_x, &work_y, &work_w, &work_h);
   }
 
-  target_w = std::clamp(target_w, kMinWindowWidth, work_w);
-  target_h = std::clamp(target_h, kMinWindowHeight, work_h);
-
-  // If height was clamped, recalculate width to maintain ratio
-  float actual_preview_h = static_cast<float>(target_h) - kTopBarHeight - kStatusBarHeight;
-  if (actual_preview_h > 0.0f) {
-    float actual_preview_w = actual_preview_h * ratio;
-    int recalc_w = static_cast<int>(actual_preview_w + left_w + right_w);
-    if (recalc_w >= kMinWindowWidth && recalc_w <= work_w) {
-      target_w = recalc_w;
-    }
-  }
+  AspectFitResult fit =
+      ResolveAspectFit(win_w, ratio, work_w, work_h, left_w, right_w, kTopBarHeight, kStatusBarHeight);
+  int target_w = fit.target_w;
+  int target_h = fit.target_h;
 
   g_programmatic_resize = 2;  // Expect up to 2 callbacks (some platforms fire intermediate + final)
   glfwSetWindowSize(window, target_w, target_h);
@@ -213,6 +209,14 @@ void ApplyAspectRatio(GLFWwindow* window, AspectPreset preset, bool portrait, fl
   if (moved) {
     glfwSetWindowPos(window, pos_x, pos_y);
   }
+
+  // Surface the clamp signal to the GUI. Done after glfwSetWindowSize so the
+  // achieved/requested ratios written to state correspond to the size we
+  // actually asked the OS for (the resize callback may further fudge the size
+  // by ±1 px, but ResolveAspectFit already accounts for chrome rounding).
+  g_state.aspect_clamp.was_clamped = fit.was_clamped;
+  g_state.aspect_clamp.requested_preview_ratio = fit.requested_preview_ratio;
+  g_state.aspect_clamp.achieved_preview_ratio = fit.achieved_preview_ratio;
 }
 
 // Ensure CPU-side sRGB uint8 texture is available for .lmc save.

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -454,10 +454,17 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     // but we re-check here so a stale signal from a missed callback path
     // cannot leak through).
     if (g_state.aspect_clamp.was_clamped && g_state.aspect_preset != AspectPreset::kFree) {
-      ImGui::PushID("aspect_clamp_warning");
-      ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "Screen too small — preview ~%.2f:1 (export %.2f:1)",
-                         g_state.aspect_clamp.achieved_preview_ratio, g_state.aspect_clamp.requested_preview_ratio);
-      ImGui::PopID();
+      // Disabled Selectable for the static header (ImGui::Text* widgets are
+      // emitted with id=0 so they cannot be located by the GUI test engine;
+      // disabled Selectable still calls ItemAdd with a real ID derived from
+      // the label, so it is addressable while remaining non-interactive).
+      // Dynamic ratio detail follows as a plain Text below.
+      const ImVec4 kClampWarnColor = ImVec4(1.0f, 0.7f, 0.2f, 1.0f);
+      ImGui::PushStyleColor(ImGuiCol_Text, kClampWarnColor);
+      ImGui::Selectable("Screen too small for this aspect", false, ImGuiSelectableFlags_Disabled);
+      ImGui::Text("preview ~%.2f:1, export %.2f:1", g_state.aspect_clamp.achieved_preview_ratio,
+                  g_state.aspect_clamp.requested_preview_ratio);
+      ImGui::PopStyleColor();
     }
 
     ImGui::SeparatorText("Background");

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -448,6 +448,18 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     }
     ImGui::EndDisabled();
 
+    // Screen-too-small warning: rendered only when the requested aspect could
+    // not be honored AND the user is still on a non-Free preset (the
+    // ApplyAspectRatio path already clears aspect_clamp on Free / kMatchBg-no-bg,
+    // but we re-check here so a stale signal from a missed callback path
+    // cannot leak through).
+    if (g_state.aspect_clamp.was_clamped && g_state.aspect_preset != AspectPreset::kFree) {
+      ImGui::PushID("aspect_clamp_warning");
+      ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "Screen too small — preview ~%.2f:1 (export %.2f:1)",
+                         g_state.aspect_clamp.achieved_preview_ratio, g_state.aspect_clamp.requested_preview_ratio);
+      ImGui::PopID();
+    }
+
     ImGui::SeparatorText("Background");
     if (ImGui::Button("Load Bg##display")) {
       DoLoadBackground(window);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -242,6 +242,18 @@ struct GuiState {
   AspectPreset aspect_preset = AspectPreset::kFree;
   bool aspect_portrait = false;
 
+  // Runtime-derived aspect clamp info — populated by ApplyAspectRatio when an
+  // aspect preset cannot be honored on the current monitor (e.g. picking 2:1
+  // on a 1280×720 work area). Drives the warning text rendered next to the
+  // aspect-ratio combo. NOT serialized into .lmc view-prefs (it's a derived
+  // signal, recomputed on every preset change / window-size callback).
+  struct AspectClampInfo {
+    bool was_clamped = false;
+    float requested_preview_ratio = 0.0f;
+    float achieved_preview_ratio = 0.0f;
+  };
+  AspectClampInfo aspect_clamp{};
+
   // Background image overlay (view preference — does not call MarkDirty)
   std::filesystem::path bg_path;
   bool bg_show = false;

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -486,123 +486,187 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
     return s;
   };
 
-  // Sample along viewport edges
-  for (const auto& edge : edges) {
-    float edge_len = std::sqrt((edge.end_px - edge.start_px) * (edge.end_px - edge.start_px) +
-                               (edge.end_py - edge.start_py) * (edge.end_py - edge.start_py));
-    int num_samples = std::max(2, static_cast<int>(edge_len / kSampleStep));
+  // === overlay-label sample-source dispatch ===
+  // ComputeOverlayLabels combines up to 5 sample sources to produce labels.
+  // Activation rules (kept in one place to make per-(lens, visible) coverage
+  // auditable; see also LensIsFullSky in gui_constants.hpp):
+  //   1. sample_viewport_edges()        : always (every lens, every visible).
+  //   2. sample_hemisphere_equator(±1)  : !full_sky AND visible ∈ {Upper, Lower}.
+  //   3. sample_front_great_circle()    : !full_sky AND visible == Front.
+  //   4. sample_interior_latitudes()    : !full_sky AND lens != Linear; covers
+  //                                        the gap when the projection disc is
+  //                                        smaller than the viewport (e.g.
+  //                                        single-orthographic + fov=180 +
+  //                                        visible=Full) so latitude rings
+  //                                        wholly inside the disc still get a
+  //                                        text label. Per-altitude is_visible
+  //                                        filter handles Upper/Lower/Front
+  //                                        modes uniformly.
+  //   5. sample_sun_circle_interior()   : show_sun_circles AND !full_sky.
+  // LensIsFullSky is the SSOT for "is this a world-space / full-sky lens?"
+  // (dual fisheye 4-6, rectangular 7, dual orthographic 9 → true).
 
+  // Push the boundary curve a few degrees inward (toward the visible side)
+  // before sampling, so labels emitted at boundary crossings don't straddle
+  // the visible/invisible split. 3° is a visual-spacing heuristic — at typical
+  // fov+lens it projects to ~4–12 px of screen offset, which clears the
+  // text height while staying close enough to read as a "boundary label".
+  constexpr int kBoundarySamples = 360;
+  constexpr float kBoundaryInsetDeg = 3.0f;
+  const float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
+
+  // Helper: walk a parametric world-space curve and feed adjacent forward-
+  // projected sample pairs into detect_crossings. Shared by hemisphere-equator
+  // and front-great-circle samplers.
+  auto sample_curve = [&](auto curve_fn) {
     SampleAngles prev{};
     prev.valid = false;
+    for (int i = 0; i <= kBoundarySamples; i++) {
+      float t = i * (2.0f * kPi / kBoundarySamples);
+      float wx_b = 0, wy_b = 0, wz_b = 0;
+      curve_fn(t, wx_b, wy_b, wz_b);
 
-    for (int i = 0; i <= num_samples; i++) {
-      float frac = static_cast<float>(i) / num_samples;
-      float px = edge.start_px + frac * (edge.end_px - edge.start_px);
-      float py = edge.start_py + frac * (edge.end_py - edge.start_py);
-      float sx = edge.start_sx + frac * (edge.end_sx - edge.start_sx);
-      float sy = edge.start_sy + frac * (edge.end_sy - edge.start_sy);
+      FwdResult fp = WorldDirToPixel(wx_b, wy_b, wz_b, res_x, res_y, input.lens_type, input.fov, view_matrix);
+      if (!fp.valid || std::abs(fp.px) > hw || std::abs(fp.py) > hh) {
+        prev.valid = false;
+        continue;
+      }
 
-      SampleAngles cur = make_sample(px, py, sx, sy);
+      float scr_x = vp_screen_x + (fp.px + hw) / res_x * vp_screen_w;
+      float scr_y = vp_screen_y + (hh - fp.py) / res_y * vp_screen_h;
+
+      SampleAngles cur = make_sample(fp.px, fp.py, scr_x, scr_y);
       if (prev.valid && cur.valid)
         detect_crossings(prev, cur);
       prev = cur;
     }
-  }
+  };
 
-  // Hemisphere-boundary sampling: grid labels should appear at the edge of the visible sky,
-  // not just at viewport edges. There are three distinct "edges" a grid line can cross:
-  //   (1) the viewport rectangle — handled by edges[4] loop above;
-  //   (2) the equator (altitude=0) — visible in upper/lower modes as the horizon cutoff;
-  //   (3) the front-half great circle (dot(world_dir, forward)=0) — visible in front mode.
-  // Below we sample each applicable hemisphere boundary in world space, forward-project to
-  // pixels, and feed adjacent sample pairs into detect_crossings, reusing the same crossing
-  // logic as viewport edges.
-  // Restricted to view-transformed lens types (linear, single fisheye, single
-  // orthographic) because WorldDirToPixel only implements forward projection
-  // for those — see WorldDirToPixel above. Full-sky lens types (dual fisheye /
-  // rectangular / dual orthographic) are correctly handled by the viewport-edge
-  // path because those projections already show the full sphere and the
-  // hemisphere boundary coincides with the pixel cull.
-  if (!LensIsFullSky(input.lens_type)) {
-    constexpr int kBoundarySamples = 360;
+  // Source 1: viewport rectangle edges.
+  auto sample_viewport_edges = [&]() {
+    for (const auto& edge : edges) {
+      float edge_len = std::sqrt((edge.end_px - edge.start_px) * (edge.end_px - edge.start_px) +
+                                 (edge.end_py - edge.start_py) * (edge.end_py - edge.start_py));
+      int num_samples = std::max(2, static_cast<int>(edge_len / kSampleStep));
 
-    auto sample_curve = [&](auto curve_fn) {
       SampleAngles prev{};
       prev.valid = false;
-      for (int i = 0; i <= kBoundarySamples; i++) {
-        float t = i * (2.0f * kPi / kBoundarySamples);
-        float wx_b = 0, wy_b = 0, wz_b = 0;
-        curve_fn(t, wx_b, wy_b, wz_b);
 
-        FwdResult fp = WorldDirToPixel(wx_b, wy_b, wz_b, res_x, res_y, input.lens_type, input.fov, view_matrix);
-        if (!fp.valid || std::abs(fp.px) > hw || std::abs(fp.py) > hh) {
-          prev.valid = false;
-          continue;
-        }
+      for (int i = 0; i <= num_samples; i++) {
+        float frac = static_cast<float>(i) / num_samples;
+        float px = edge.start_px + frac * (edge.end_px - edge.start_px);
+        float py = edge.start_py + frac * (edge.end_py - edge.start_py);
+        float sx = edge.start_sx + frac * (edge.end_sx - edge.start_sx);
+        float sy = edge.start_sy + frac * (edge.end_sy - edge.start_sy);
 
-        float scr_x = vp_screen_x + (fp.px + hw) / res_x * vp_screen_w;
-        float scr_y = vp_screen_y + (hh - fp.py) / res_y * vp_screen_h;
-
-        SampleAngles cur = make_sample(fp.px, fp.py, scr_x, scr_y);
+        SampleAngles cur = make_sample(px, py, sx, sy);
         if (prev.valid && cur.valid)
           detect_crossings(prev, cur);
         prev = cur;
       }
-    };
-
-    // Push the boundary curve a few degrees inward (toward the visible side)
-    // before sampling, so labels emitted at boundary crossings don't straddle
-    // the visible/invisible split. 3° is a visual-spacing heuristic — at typical
-    // fov+lens it projects to ~4–12 px of screen offset, which clears the
-    // text height while staying close enough to read as a "boundary label".
-    constexpr float kBoundaryInsetDeg = 3.0f;
-    float boundary_offset = std::sin(kBoundaryInsetDeg * kDeg2Rad);
-
-    if (input.visible == 0 || input.visible == 1) {
-      // Equator: {(cos az, sin az, 0)} in world space, parameterized to match the prior loop's
-      // az_rad = -π + t convention so label positions are stable across refactor.
-      // visible=upper → push toward negative z (altitude=asin(-z) becomes positive);
-      // visible=lower → push toward positive z. After offset the world vector
-      // is renormalized so WorldDirToPixel's unit-length assumption holds.
-      float wz_sign = (input.visible == 0) ? -1.0f : +1.0f;
-      sample_curve([wz_sign, boundary_offset](float t, float& wx, float& wy, float& wz) {
-        float az = -kPi + t;
-        wx = -std::cos(az);
-        wy = -std::sin(az);
-        wz = wz_sign * boundary_offset;
-        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
-        wx /= len;
-        wy /= len;
-        wz /= len;
-      });
-    } else if (input.visible == 3) {
-      // Front hemisphere boundary: great circle perpendicular to forward. In view space this
-      // is z_view = 0 (the xy-plane); map to world via view_matrix (column-major: col0/col1 are
-      // the first two columns, i.e. view-space x and y basis expressed in world coordinates).
-      // Points: world = cos(t) * col0 + sin(t) * col1, optionally pushed toward
-      // forward (i.e. opposite of col2 = -forward) by `boundary_offset` so the
-      // boundary samples lie inside the front hemisphere.
-      sample_curve([&, boundary_offset](float t, float& wx, float& wy, float& wz) {
-        float c = std::cos(t);
-        float s = std::sin(t);
-        wx = c * view_matrix[0] + s * view_matrix[3] - boundary_offset * view_matrix[6];
-        wy = c * view_matrix[1] + s * view_matrix[4] - boundary_offset * view_matrix[7];
-        wz = c * view_matrix[2] + s * view_matrix[5] - boundary_offset * view_matrix[8];
-        float len = std::sqrt(wx * wx + wy * wy + wz * wz);
-        wx /= len;
-        wy /= len;
-        wz /= len;
-      });
     }
-  }
+  };
 
-  // Sun circles: add interior labels when circles don't intersect viewport edges.
-  // Place 4 labels evenly around each sun circle using forward projection.
-  // Same gate as the hemisphere boundary block: only view-transformed lens
-  // types (linear / single fisheye / single orthographic) need interior labels;
-  // full-sky lenses always have edges intersect the sun circle. Reusing
-  // !LensIsFullSky keeps the lens classification single-sourced.
-  if (input.show_sun_circles && !LensIsFullSky(input.lens_type)) {
+  // Source 2: equator (altitude=0). Active under visible=Upper/Lower; the wz
+  // sign chooses which side the inset offset is applied to.
+  // visible=upper → push toward negative z (altitude=asin(-z) becomes positive);
+  // visible=lower → push toward positive z. After offset the world vector
+  // is renormalized so WorldDirToPixel's unit-length assumption holds.
+  // The az_rad = -π + t parameterization preserves label positions across
+  // the v15/v16 refactors that introduced this sampler.
+  auto sample_hemisphere_equator = [&](float wz_sign) {
+    sample_curve([wz_sign, boundary_offset](float t, float& wx, float& wy, float& wz) {
+      float az = -kPi + t;
+      wx = -std::cos(az);
+      wy = -std::sin(az);
+      wz = wz_sign * boundary_offset;
+      float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+      wx /= len;
+      wy /= len;
+      wz /= len;
+    });
+  };
+
+  // Source 3: front-half great circle (dot(world_dir, forward)=0). Active
+  // under visible=Front. In view space this is the xy-plane; map to world via
+  // view_matrix (column-major: col0/col1 are view-space x/y basis vectors in
+  // world coords). Points: world = cos(t)*col0 + sin(t)*col1, then nudged
+  // toward forward (opposite of col2 = -forward) by boundary_offset so the
+  // boundary samples lie strictly inside the front hemisphere.
+  auto sample_front_great_circle = [&]() {
+    sample_curve([&](float t, float& wx, float& wy, float& wz) {
+      float c = std::cos(t);
+      float s = std::sin(t);
+      wx = c * view_matrix[0] + s * view_matrix[3] - boundary_offset * view_matrix[6];
+      wy = c * view_matrix[1] + s * view_matrix[4] - boundary_offset * view_matrix[7];
+      wz = c * view_matrix[2] + s * view_matrix[5] - boundary_offset * view_matrix[8];
+      float len = std::sqrt(wx * wx + wy * wy + wz * wz);
+      wx /= len;
+      wy /= len;
+      wz /= len;
+    });
+  };
+
+  // Source 4 (NEW): place one latitude label per ring whose forward projection
+  // lies inside the projection disc but the disc itself does not intersect any
+  // viewport edge / hemisphere boundary curve. Walks a small altitude grid
+  // (±10°…±80°) and, per altitude, samples 64 azimuths to find the first valid
+  // viewport-in + visible pixel. is_visible() handles Upper/Lower/Front modes
+  // uniformly. Output is grid-group, no background, no per-source dedup
+  // beyond the existing-text check below — bbox overlap suppression in
+  // AppendOverlayToDrawList is the second line of defence at draw time.
+  // Linear lens excluded by caller dispatch (its latitude rings are screen-
+  // space lines already covered by sample_viewport_edges).
+  auto sample_interior_latitudes = [&]() {
+    if (!input.show_grid)
+      return;
+    constexpr int kAzimuthSamples = 64;
+    constexpr int kAltitudeSteps[] = { -80, -70, -60, -50, -40, -30, -20, -10, 10, 20, 30, 40, 50, 60, 70, 80 };
+    for (int alt_deg : kAltitudeSteps) {
+      char buf[32];
+      std::snprintf(buf, sizeof(buf), "%.0f\xC2\xB0", static_cast<float>(alt_deg));
+      bool already_present = false;
+      for (const auto& l : out) {
+        if (l.group == kGroupGrid && l.text == buf) {
+          already_present = true;
+          break;
+        }
+      }
+      if (already_present)
+        continue;
+
+      const float alt_rad = static_cast<float>(alt_deg) * kDeg2Rad;
+      const float cos_a = std::cos(alt_rad);
+      const float sin_a = std::sin(alt_rad);
+
+      for (int k = 0; k < kAzimuthSamples; k++) {
+        float az = 2.0f * kPi * static_cast<float>(k) / kAzimuthSamples;
+        // Direction matched to make_sample's altitude/azimuth conventions:
+        //   altitude = asin(-z) → z = -sin(alt)
+        //   azimuth  = atan2(-y, -x) → x = -cos(alt)cos(az), y = -cos(alt)sin(az)
+        float wx = -cos_a * std::cos(az);
+        float wy = -cos_a * std::sin(az);
+        float wz = -sin_a;
+        if (!is_visible(static_cast<float>(alt_deg), wx, wy, wz))
+          continue;
+        FwdResult fp = WorldDirToPixel(wx, wy, wz, res_x, res_y, input.lens_type, input.fov, view_matrix);
+        if (!fp.valid)
+          continue;
+        if (std::abs(fp.px) > hw || std::abs(fp.py) > hh)
+          continue;
+
+        float scr_x = vp_screen_x + (fp.px + hw) / res_x * vp_screen_w;
+        float scr_y = vp_screen_y + (hh - fp.py) / res_y * vp_screen_h;
+        out.push_back({ scr_x, scr_y, std::string(buf), grid_col, false, kGroupGrid });
+        break;
+      }
+    }
+  };
+
+  // Source 5: sun-circle interior labels. Active when sun circles are enabled
+  // and the lens is view-transformed (full-sky lenses always have viewport
+  // edges intersect the sun circle).
+  auto sample_sun_circle_interior = [&]() {
     for (int ci = 0; ci < input.sun_circle_count; ci++) {
       float angle_deg = input.sun_circle_angles[ci];
       // Check if this circle already has edge labels
@@ -679,6 +743,26 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
         out.push_back({ scr_x, scr_y, std::string(buf), sun_col, true, kGroupSunCircles });
       }
     }
+  };
+
+  // === dispatch ===
+  const bool full_sky = LensIsFullSky(input.lens_type);
+
+  sample_viewport_edges();
+
+  if (!full_sky) {
+    if (input.visible == kVisibleUpper)
+      sample_hemisphere_equator(-1.0f);
+    if (input.visible == kVisibleLower)
+      sample_hemisphere_equator(+1.0f);
+    if (input.visible == kVisibleFront)
+      sample_front_great_circle();
+    if (input.lens_type != kLensTypeLinear)
+      sample_interior_latitudes();
+  }
+
+  if (input.show_sun_circles && !full_sky) {
+    sample_sun_circle_interior();
   }
 }
 

--- a/src/gui/window_sizing.hpp
+++ b/src/gui/window_sizing.hpp
@@ -2,6 +2,7 @@
 #define LUMICE_GUI_WINDOW_SIZING_HPP
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 #include "gui/gui_constants.hpp"
@@ -41,6 +42,107 @@ inline int SelectMonitorIndexByCenter(int cx, int cy, const MonitorRect* rects, 
     }
   }
   return -1;
+}
+
+// Tolerance for the "preview region matches requested aspect" check used by
+// ResolveAspectFit. 5% relative deviation is the first-version threshold —
+// large enough to absorb integer rounding from glfwSetWindowSize, small enough
+// to flag the genuine "screen too small" case (e.g. 2:1 on 1280×720).
+inline constexpr float kAspectClampTolerance = 0.05f;
+
+// Result of fitting a requested aspect ratio onto a window-sized canvas with
+// fixed panel/topbar/statusbar overhead. Returned by ResolveAspectFit.
+//
+// `requested_preview_ratio` is the input ratio (post-portrait-flip). Callers
+// must pass the already-flipped ratio rather than re-deriving from a preset.
+//
+// `achieved_preview_ratio` is the ratio of the preview region after the
+// final clamp; in practice this equals
+//   (target_w - left_w - right_w) / (target_h - topbar_h - statusbar_h)
+// using the floats *before* truncation to int target_w/target_h, so the
+// comparison against `requested_preview_ratio` is not noised by the int cast.
+//
+// `was_clamped` is true when the relative deviation of achieved vs requested
+// exceeds kAspectClampTolerance; the GUI uses this to render a warning.
+struct AspectFitResult {
+  int target_w = 0;
+  int target_h = 0;
+  float requested_preview_ratio = 0.0f;
+  float achieved_preview_ratio = 0.0f;
+  bool was_clamped = false;
+};
+
+// Pure function: given the current window width, a requested preview aspect
+// ratio (post-portrait-flip), the active monitor workarea, and the fixed
+// panel/topbar/statusbar overhead, return the size we would set the window
+// to + whether the achieved preview region matches the requested ratio.
+//
+// Replaces the inline sizing logic that lived in app.cpp::ApplyAspectRatio
+// (the "double clamp + recalc_w gate" block). The recalc_w gate previously
+// failed silently when the projected width exceeded work_w on small screens
+// (e.g. 2:1 on 1280×720), giving the user a window that barely changed and
+// a preview region whose ratio was nowhere near 2:1 — with no UI feedback.
+// This helper exposes the mismatch via was_clamped so the GUI can render
+// "Screen too small — preview shows ~X:1 (export still Y:1)".
+//
+// Caller responsibilities:
+//   * Pass `ratio > 0` (kFree / kMatchBg-without-bg paths must early-return
+//     before calling this helper).
+//   * Apply portrait flip (1/ratio) before passing in.
+//   * Pre-resolve `work_w`, `work_h` via SelectMonitorIndexByCenter +
+//     glfwGetMonitorWorkarea (kept out of this helper to preserve purity).
+inline AspectFitResult ResolveAspectFit(int current_win_w, float ratio, int work_w, int work_h, float left_w,
+                                        float right_w, float topbar_h, float statusbar_h) {
+  AspectFitResult out{};
+  out.requested_preview_ratio = ratio;
+
+  // Mirror the legacy derivation: preview_w from current win_w minus panels;
+  // target_h = preview_h + chrome; target_w starts as the unchanged win_w.
+  float preview_w = std::max(1.0f, static_cast<float>(current_win_w) - left_w - right_w);
+  float preview_h = preview_w / ratio;
+  int target_w = current_win_w;
+  auto target_h = static_cast<int>(preview_h + topbar_h + statusbar_h);
+
+  target_w = std::clamp(target_w, kMinWindowWidth, work_w);
+  target_h = std::clamp(target_h, kMinWindowHeight, work_h);
+
+  // If height was clamped, try to recalculate width to maintain ratio.
+  // The legacy gate `recalc_w <= work_w` prevented expanding past workarea;
+  // we keep that gate so the caller's glfwSetWindowSize never overflows.
+  // When the gate rejects, was_clamped will be set below via the achieved-
+  // ratio comparison rather than relying on the gate as a signal.
+  float actual_preview_h = static_cast<float>(target_h) - topbar_h - statusbar_h;
+  if (actual_preview_h > 0.0f) {
+    float actual_preview_w_candidate = actual_preview_h * ratio;
+    int recalc_w = static_cast<int>(actual_preview_w_candidate + left_w + right_w);
+    if (recalc_w >= kMinWindowWidth && recalc_w <= work_w) {
+      target_w = recalc_w;
+    }
+  }
+
+  // Compute achieved preview ratio from the final target_{w,h} we will hand
+  // to glfwSetWindowSize. Use floats for the achieved-ratio numerator/denom
+  // so cmp with requested_preview_ratio is not noised by int truncation.
+  float achieved_preview_w = static_cast<float>(target_w) - left_w - right_w;
+  float achieved_preview_h = static_cast<float>(target_h) - topbar_h - statusbar_h;
+  if (achieved_preview_h <= 0.0f || achieved_preview_w <= 0.0f) {
+    // Pathological panel widths — pretend we hit the target so we don't
+    // surface a misleading warning. Caller should never hit this in practice
+    // because kMinWindowWidth/Height already reserves room for chrome.
+    out.target_w = target_w;
+    out.target_h = target_h;
+    out.achieved_preview_ratio = ratio;
+    out.was_clamped = false;
+    return out;
+  }
+  float achieved = achieved_preview_w / achieved_preview_h;
+  float deviation = std::abs(achieved - ratio) / ratio;
+
+  out.target_w = target_w;
+  out.target_h = target_h;
+  out.achieved_preview_ratio = achieved;
+  out.was_clamped = deviation >= kAspectClampTolerance;
+  return out;
 }
 
 // Return the workarea of the monitor containing the given window's center.

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -74,6 +74,26 @@ int CountGridLabels(const std::vector<lumice::gui::OverlayLabel>& labels) {
   return n;
 }
 
+// Counts distinct grid-group label texts (i.e. unique latitude/longitude
+// values present), used by the source-4 ortho/equidist fov=180 tests below.
+int CountUniqueGridLabels(const std::vector<lumice::gui::OverlayLabel>& labels) {
+  std::vector<std::string> seen;
+  for (const auto& l : labels) {
+    if (l.group != 0)
+      continue;
+    bool dup = false;
+    for (const auto& s : seen) {
+      if (s == l.text) {
+        dup = true;
+        break;
+      }
+    }
+    if (!dup)
+      seen.push_back(l.text);
+  }
+  return static_cast<int>(seen.size());
+}
+
 // Regression test for task-orthographic-followup Step 2 dispatch: at the same
 // view config, single orthographic (lens=8) and Fisheye Equidistant (lens=2)
 // must produce comparably-sized grid label sets. Pre-fix, lens=8 fell to the
@@ -700,6 +720,66 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       std::vector<lumice::gui::OverlayLabel> labels_fisheye;
       lumice::gui::ComputeOverlayLabels(in_fisheye, 0.0f, 0.0f, 200.0f, 200.0f, labels_fisheye);
       IM_CHECK_EQ(CountSunCircleLabels(labels), CountSunCircleLabels(labels_fisheye));
+    };
+  }
+
+  // Tests for sample_interior_latitudes (Source 4) covering the disc-smaller-
+  // than-viewport regression: when a view-transformed lens projects the sky
+  // onto a disc strictly inside the viewport, latitude rings wholly inside the
+  // disc never cross any viewport edge or hemisphere-boundary curve, so the
+  // pre-source-4 dispatch produced zero latitude labels under
+  // visible=Full / Upper / Lower. Source 4 walks ±10°…±80° altitude steps
+  // (16 rings) and emits one label per ring whose forward projection lands in
+  // a valid, in-viewport, is_visible pixel.
+  //
+  // Concrete bug: lens=Fisheye Orthographic + fov=180 + visible=Full puts an
+  // inscribed disc inside a square viewport; latitude circles are concentric
+  // inside the disc → 0 labels pre-fix, ≥ 5 post-fix. The same source helps
+  // fov=180 Upper/Lower modes and is symmetric across single-fisheye lenses.
+
+  // T1: orthographic + fov=180 + visible=Full → ≥ 5 distinct latitude labels.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "ortho_fov180_full_visible_emits_latitude_labels");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeOrthographic,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 180.0f;
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+      IM_CHECK_GE(CountUniqueGridLabels(labels), 5);
+    };
+  }
+
+  // T2: orthographic + fov=180 + visible=Upper → ≥ 5 distinct latitude labels.
+  // Hemisphere-equator boundary alone covers altitude=0 only; source 4 fills
+  // the interior latitudes.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "ortho_fov180_upper_visible_emits_latitude_labels");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleUpper, lumice::gui::kLensTypeFisheyeOrthographic,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 180.0f;
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+      IM_CHECK_GE(CountUniqueGridLabels(labels), 5);
+    };
+  }
+
+  // T3: equidistant fov=180 + visible=Full → ≥ 5 distinct latitude labels.
+  // Verifies source 4 activates for all view-transformed (non-linear) lenses,
+  // not just orthographic.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "equidist_fov180_full_visible_consistent");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 180.0f;
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+      IM_CHECK_GE(CountUniqueGridLabels(labels), 5);
     };
   }
 }

--- a/test/gui/test_gui_render.cpp
+++ b/test/gui/test_gui_render.cpp
@@ -173,6 +173,60 @@ void RegisterAspectRatioTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // Test 6a: clamp warning visible when was_clamped + non-Free preset
+  // ----------------------------------------------------------------
+  // Asserts the *render path*, not the state-transition path: pure-function
+  // unit tests in test_window_sizing.cpp already cover ResolveAspectFit
+  // computing was_clamped correctly. This test simply exercises the GUI
+  // branch that surfaces the field as a TextColored item.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "aspect_ratio", "clamp_warning_visible");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+
+      gui::g_state.aspect_preset = gui::AspectPreset::k2x1;
+      gui::g_state.aspect_clamp.was_clamped = true;
+      gui::g_state.aspect_clamp.requested_preview_ratio = 2.0f;
+      gui::g_state.aspect_clamp.achieved_preview_ratio = 1.01f;
+      ctx->Yield(2);
+
+      IM_CHECK(ctx->ItemExists("**/Screen too small for this aspect"));
+    };
+  }
+
+  // Test 6b: clamp warning hidden when preset is Free (defensive re-check
+  // in app_panels.cpp prevents a stale was_clamped from leaking through).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "aspect_ratio", "clamp_warning_hidden_on_free");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+
+      gui::g_state.aspect_preset = gui::AspectPreset::kFree;
+      gui::g_state.aspect_clamp.was_clamped = true;
+      gui::g_state.aspect_clamp.requested_preview_ratio = 2.0f;
+      gui::g_state.aspect_clamp.achieved_preview_ratio = 1.01f;
+      ctx->Yield(2);
+
+      IM_CHECK(!ctx->ItemExists("**/Screen too small for this aspect"));
+    };
+  }
+
+  // Test 6c: clamp warning hidden when was_clamped is false.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "aspect_ratio", "clamp_warning_hidden_when_unclamped");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+
+      gui::g_state.aspect_preset = gui::AspectPreset::k2x1;
+      gui::g_state.aspect_clamp.was_clamped = false;
+      gui::g_state.aspect_clamp.requested_preview_ratio = 2.0f;
+      gui::g_state.aspect_clamp.achieved_preview_ratio = 2.0f;
+      ctx->Yield(2);
+
+      IM_CHECK(!ctx->ItemExists("**/Screen too small for this aspect"));
+    };
+  }
+
   // Test 6: Screen bounds — ApplyAspectRatio clamps to workarea
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "aspect_ratio", "screen_bounds");

--- a/test/test_window_sizing.cpp
+++ b/test/test_window_sizing.cpp
@@ -1,14 +1,23 @@
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "gui/gui_constants.hpp"
 #include "gui/window_sizing.hpp"
 
 namespace {
 
+using lumice::gui::AspectFitResult;
 using lumice::gui::ClampWindowSizeToWorkarea;
+using lumice::gui::kAspectClampTolerance;
+using lumice::gui::kLeftPanelWidth;
 using lumice::gui::kMinWindowHeight;
 using lumice::gui::kMinWindowWidth;
+using lumice::gui::kRightPanelWidth;
+using lumice::gui::kStatusBarHeight;
+using lumice::gui::kTopBarHeight;
 using lumice::gui::MonitorRect;
+using lumice::gui::ResolveAspectFit;
 using lumice::gui::SelectMonitorIndexByCenter;
 
 // AC2 core path: 1080p laptop workarea ≈ 1920×900 after menubar/Dock.
@@ -92,6 +101,100 @@ TEST(MonitorSelectionTest, BoundaryLeftEdgeInclusive) {
 TEST(MonitorSelectionTest, BoundaryRightEdgeExclusive) {
   constexpr MonitorRect kRects[] = { { 100, 200, 300, 400 } };
   EXPECT_EQ(SelectMonitorIndexByCenter(400, 200, kRects, 1), -1);
+}
+
+// ========== Aspect-fit clamp detection (screen-too-small feedback) ==========
+//
+// Tests use the production layout constants (kLeftPanelWidth=400, kRightPanelWidth=300,
+// kTopBarHeight=40, kStatusBarHeight=28) so they exercise the same arithmetic
+// path as ApplyAspectRatio.
+
+namespace {
+constexpr float kCollapsedStripWidth = 20.0f;  // Mirror app.cpp's local constant.
+}
+
+// Wide work area easily accommodates 2:1 — no clamp.
+TEST(AspectFitTest, FitsWithoutClampOnWideMonitor) {
+  AspectFitResult fit = ResolveAspectFit(/*current_win_w=*/1600, /*ratio=*/2.0f,
+                                         /*work_w=*/2880, /*work_h=*/1800, kLeftPanelWidth, kRightPanelWidth,
+                                         kTopBarHeight, kStatusBarHeight);
+  EXPECT_FALSE(fit.was_clamped);
+  EXPECT_FLOAT_EQ(fit.requested_preview_ratio, 2.0f);
+  EXPECT_LT(std::abs(fit.achieved_preview_ratio - 2.0f) / 2.0f, kAspectClampTolerance);
+}
+
+// 1280×720 picking 2:1 → preview region cannot reach 2:1 because chrome
+// (panels + topbar + statusbar) eats too much; was_clamped must fire.
+TEST(AspectFitTest, ClampsOnSmallScreen2x1) {
+  AspectFitResult fit = ResolveAspectFit(/*current_win_w=*/1280, /*ratio=*/2.0f,
+                                         /*work_w=*/1280, /*work_h=*/720, kLeftPanelWidth, kRightPanelWidth,
+                                         kTopBarHeight, kStatusBarHeight);
+  EXPECT_TRUE(fit.was_clamped);
+  // Achieved preview ratio should be much smaller than 2:1 — sanity-check
+  // it stays in a plausible band rather than asserting an exact value, since
+  // the recalc_w gate behavior matters more than the precise numerics.
+  EXPECT_LT(fit.achieved_preview_ratio, 2.0f);
+  EXPECT_GT(fit.achieved_preview_ratio, 0.5f);
+  EXPECT_FLOAT_EQ(fit.requested_preview_ratio, 2.0f);
+}
+
+// 16:9 on a 1280×720 monitor: depending on chrome the achieved ratio may or
+// may not exceed the 5% tolerance. We assert numerically that the helper does
+// not silently misreport — was_clamped must mirror the actual deviation.
+TEST(AspectFitTest, ClampsOnSmallScreen16x9) {
+  constexpr float kRatio = 16.0f / 9.0f;
+  AspectFitResult fit = ResolveAspectFit(/*current_win_w=*/1280, /*ratio=*/kRatio,
+                                         /*work_w=*/1280, /*work_h=*/720, kLeftPanelWidth, kRightPanelWidth,
+                                         kTopBarHeight, kStatusBarHeight);
+  // Whatever the answer, was_clamped and the deviation must agree.
+  float deviation = std::abs(fit.achieved_preview_ratio - kRatio) / kRatio;
+  EXPECT_EQ(fit.was_clamped, deviation >= kAspectClampTolerance);
+  EXPECT_FLOAT_EQ(fit.requested_preview_ratio, kRatio);
+}
+
+// Portrait 2:1 → 0.5 ratio. With wide work area the preview-w shrinks; this
+// path is chosen for coverage of the ratio < 1 branch (height-driven).
+TEST(AspectFitTest, PortraitRatio) {
+  AspectFitResult fit = ResolveAspectFit(/*current_win_w=*/1600, /*ratio=*/0.5f,
+                                         /*work_w=*/2880, /*work_h=*/1800, kLeftPanelWidth, kRightPanelWidth,
+                                         kTopBarHeight, kStatusBarHeight);
+  EXPECT_FLOAT_EQ(fit.requested_preview_ratio, 0.5f);
+  // Achieved ratio is what the helper computes from the post-clamp
+  // target_w/target_h; for portrait+wide-monitor it should still be ≤
+  // requested (preview_h grows past the screen if anything, not preview_w).
+  float deviation = std::abs(fit.achieved_preview_ratio - 0.5f) / 0.5f;
+  EXPECT_EQ(fit.was_clamped, deviation >= kAspectClampTolerance);
+}
+
+// Collapsed panels → less chrome → small monitor can now fit 2:1 closer.
+// We don't assert clamp polarity strictly (depends on numerics), but assert
+// the helper consumes the reduced overhead by producing a *less* clamped
+// achieved ratio than the equivalent expanded-panels case.
+TEST(AspectFitTest, PanelsCollapsedReducesOverhead) {
+  AspectFitResult expanded = ResolveAspectFit(/*current_win_w=*/1280, /*ratio=*/2.0f,
+                                              /*work_w=*/1280, /*work_h=*/720, kLeftPanelWidth, kRightPanelWidth,
+                                              kTopBarHeight, kStatusBarHeight);
+  AspectFitResult collapsed = ResolveAspectFit(/*current_win_w=*/1280, /*ratio=*/2.0f,
+                                               /*work_w=*/1280, /*work_h=*/720, kCollapsedStripWidth,
+                                               kCollapsedStripWidth, kTopBarHeight, kStatusBarHeight);
+  // Collapsing panels shouldn't make the achieved ratio worse on a small
+  // screen — preview region grows toward the full window width.
+  EXPECT_GE(collapsed.achieved_preview_ratio, expanded.achieved_preview_ratio);
+}
+
+// Pathological case: chrome eats 100% of available height → helper must not
+// divide by zero / NaN; was_clamped should stay false (we have no signal).
+TEST(AspectFitTest, ChromeExceedsHeightYieldsBenignDefault) {
+  AspectFitResult fit =
+      ResolveAspectFit(/*current_win_w=*/1280, /*ratio=*/2.0f,
+                       /*work_w=*/1280, /*work_h=*/kMinWindowHeight, kLeftPanelWidth, kRightPanelWidth,
+                       /*topbar_h=*/kMinWindowHeight,
+                       /*statusbar_h=*/0.0f);
+  // Whatever the achieved ratio is, was_clamped must be deterministic (not
+  // NaN-driven). The function falls back to "achieved == requested" on the
+  // pathological branch.
+  EXPECT_FALSE(fit.was_clamped);
+  EXPECT_FLOAT_EQ(fit.achieved_preview_ratio, fit.requested_preview_ratio);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- Refactor `ComputeOverlayLabels` into 5 named sampler lambdas with a top-level dispatch table; add an interior-latitude sampler so non-linear lenses with `fov=180` still emit latitude labels when the projected disc is smaller than the viewport.
- Add a screen-too-small clamp warning for the aspect-ratio preset: extract sizing math into pure `ResolveAspectFit` (`window_sizing.hpp`) returning `AspectFitResult{was_clamped, achieved/requested ratio}`, surface it via `GuiState::AspectClampInfo`, and render an inline warning next to the aspect combo when a non-Free preset cannot be honored on small monitors.

## Test plan
- [x] `./scripts/build.sh -gtj release` — all 167 GUI tests pass
- [x] `test_window_sizing.cpp` — 6 new unit tests covering wide-monitor fit, small-screen 2:1 clamp, 16:9 boundary, portrait, collapsed-panels overhead, and pathological chrome
- [x] 3 new GUI tests for `fov=180` interior latitude labels (`ortho_fov180_full/upper`, `equidist_fov180_full`)
- [x] 3 new GUI tests for the clamp-warning render branch (clamped + preset → visible; clamped + Free → hidden; not clamped → hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)