### PR TITLE
feat(gui): split overlay Line / Label toggles

### DIFF
--- a/doc/gui-guide.md
+++ b/doc/gui-guide.md
@@ -106,7 +106,7 @@ The lens choice changes the geometry of the projected image dramatically:
 
 ### Overlay
 
-Three independent auxiliary lines on top of the Render Preview: `Horizon`, `Grid`, `Sun Circles`. Each has a checkbox, a colour swatch, and an alpha slider. Sun Circles can be customised through an `Edit Circles...` popup that supports preset angles (9° / 22° / 28° / 46°) and arbitrary custom angles.
+Three independent auxiliary lines on top of the Render Preview: `Horizon`, `Grid`, `Sun Circles`. Each has a colour swatch, separate `Line` and `Label` checkboxes (toggle the projected line and the viewport-edge label independently — line-only, label-only, both, or neither), and an alpha slider. Sun Circles can be customised through an `Edit Circles...` popup that supports preset angles (9° / 22° / 28° / 46°) and arbitrary custom angles.
 
 ## Render Preview
 

--- a/doc/gui-guide.md
+++ b/doc/gui-guide.md
@@ -106,7 +106,7 @@ The lens choice changes the geometry of the projected image dramatically:
 
 ### Overlay
 
-Three independent auxiliary lines on top of the Render Preview: `Horizon`, `Grid`, `Sun Circles`. Each has a colour swatch, separate `Line` and `Label` checkboxes (toggle the projected line and the viewport-edge label independently — line-only, label-only, both, or neither), and an alpha slider. Sun Circles can be customised through an `Edit Circles...` popup that supports preset angles (9° / 22° / 28° / 46°) and arbitrary custom angles.
+Three independent auxiliary lines on top of the Render Preview: `Horizon`, `Grid`, and `Angular Distance` (iso-angular rings centered on the sun, e.g. the 22° / 46° halos). Each has a colour swatch, separate `Line` and `Label` checkboxes (toggle the projected line and the viewport-edge label independently — line-only, label-only, both, or neither), and an alpha slider. `Angular Distance` can be customised through an `Edit Angles...` popup that supports preset angles (9° / 22° / 28° / 46°) and arbitrary custom angles.
 
 ## Render Preview
 

--- a/doc/gui-guide_zh.md
+++ b/doc/gui-guide_zh.md
@@ -106,7 +106,7 @@ GUI 需要 display server 和支持 OpenGL 3.2 Core Profile 的 GPU。
 
 ### Overlay（叠加）
 
-Render Preview 上的三组互相独立的辅助线：`Horizon`（地平线）、`Grid`（网格）、`Sun Circles`（太阳圈）。每组都有复选框、颜色块和 alpha 滑块。Sun Circles 还提供 `Edit Circles...` 弹窗，支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度。
+Render Preview 上的三组互相独立的辅助线：`Horizon`（地平线）、`Grid`（网格）、`Sun Circles`（太阳圈）。每组都有颜色块、`Line` 与 `Label` 双复选框（分别控制线条和边缘标签的显隐，可独立组合 line-only / label-only / 全开 / 全关）、以及 alpha 滑块。Sun Circles 还提供 `Edit Circles...` 弹窗，支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度。
 
 ## Render Preview（渲染预览）
 

--- a/doc/gui-guide_zh.md
+++ b/doc/gui-guide_zh.md
@@ -106,11 +106,11 @@ GUI 需要 display server 和支持 OpenGL 3.2 Core Profile 的 GPU。
 
 ### Overlay（叠加）
 
-Render Preview 上的三组互相独立的辅助线：`Horizon`（地平线）、`Grid`（网格）、`Sun Circles`（太阳圈）。每组都有颜色块、`Line` 与 `Label` 双复选框（分别控制线条和边缘标签的显隐，可独立组合 line-only / label-only / 全开 / 全关）、以及 alpha 滑块。Sun Circles 还提供 `Edit Circles...` 弹窗，支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度。
+Render Preview 上的三组互相独立的辅助线：`Horizon`（地平线）、`Grid`（经纬网格）、`Angular Distance`（以太阳为中心的等角距环，例如 22°/46° 晕环）。每组都有颜色块、`Line` 与 `Label` 双复选框（分别控制线条和边缘标签的显隐，可独立组合 line-only / label-only / 全开 / 全关）、以及 alpha 滑块。`Angular Distance` 还提供 `Edit Angles...` 弹窗，支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度。
 
 ## Render Preview（渲染预览）
 
-中央区域显示实时的、按 lens 投影的冰晕图像。空闲时显示禁用态的 `Render Preview` 占位文本；模拟一开始累积光线，纹理就会逐帧更新。Horizon / Grid / Sun Circles / Compass 等 overlay 标签会按当前 lens 同步投影叠加在纹理之上。
+中央区域显示实时的、按 lens 投影的冰晕图像。空闲时显示禁用态的 `Render Preview` 占位文本；模拟一开始累积光线，纹理就会逐帧更新。Horizon / Grid / Angular Distance / Compass 等 overlay 标签会按当前 lens 同步投影叠加在纹理之上。
 
 ![Render Preview 渲染示例](figs/gui_screenshot_example_04.jpg)
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -50,6 +50,7 @@ OverlayLabelInput BuildOverlayLabelInput(const GuiState& state, const RenderConf
   input.show_horizon = state.show_horizon_label;
   input.show_grid = state.show_grid_label;
   input.show_sun_circles = state.show_sun_circles_label;
+  input.horizon_alpha = state.horizon_alpha;
 
   // Sun direction in world space (azimuth fixed at 0, only altitude matters).
   // Formula is byte-identical to RenderPreviewPanel's assignment into

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -47,9 +47,9 @@ OverlayLabelInput BuildOverlayLabelInput(const GuiState& state, const RenderConf
   input.azimuth = rc.azimuth;
   input.roll = rc.roll;
   input.visible = rc.visible;
-  input.show_horizon = state.show_horizon;
-  input.show_grid = state.show_grid;
-  input.show_sun_circles = state.show_sun_circles;
+  input.show_horizon = state.show_horizon_label;
+  input.show_grid = state.show_grid_label;
+  input.show_sun_circles = state.show_sun_circles_label;
 
   // Sun direction in world space (azimuth fixed at 0, only altitude matters).
   // Formula is byte-identical to RenderPreviewPanel's assignment into
@@ -298,7 +298,8 @@ void DoExportPreviewPng() {
 
   PreviewParams params = BuildExportParams();
   std::optional<OverlayLabelInput> overlay;
-  if (g_state.screenshot_include_overlay && (g_state.show_horizon || g_state.show_grid || g_state.show_sun_circles)) {
+  if (g_state.screenshot_include_overlay &&
+      (g_state.show_horizon_label || g_state.show_grid_label || g_state.show_sun_circles_label)) {
     overlay = BuildOverlayLabelInput(g_state, g_state.renderer);
   }
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -514,7 +514,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
     ImGui::ColorEdit3("##sun_circles_color", g_state.sun_circles_color, ImGuiColorEditFlags_NoInputs);
     ImGui::SameLine();
-    ImGui::TextUnformatted("Sun");
+    ImGui::TextUnformatted("Sun Circles");
     ImGui::SameLine();
     ImGui::Checkbox("Line##sun_circles", &g_state.show_sun_circles_line);
     ImGui::SameLine();

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -493,20 +493,35 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
   if (ImGui::CollapsingHeader("Overlay", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
     ImGui::SeparatorText("Auxiliary Lines");
-    ImGui::Checkbox("Horizon##overlay", &g_state.show_horizon);
-    ImGui::SameLine();
+    // Per-overlay row layout: color picker + name + Line / Label checkboxes; second row: Alpha slider.
     ImGui::ColorEdit3("##horizon_color", g_state.horizon_color, ImGuiColorEditFlags_NoInputs);
+    ImGui::SameLine();
+    ImGui::TextUnformatted("Horizon");
+    ImGui::SameLine();
+    ImGui::Checkbox("Line##horizon", &g_state.show_horizon_line);
+    ImGui::SameLine();
+    ImGui::Checkbox("Label##horizon", &g_state.show_horizon_label);
     SliderWithInput("Alpha##horizon", &g_state.horizon_alpha, 0.0f, 1.0f, "%.2f");
-    ImGui::Checkbox("Grid##overlay", &g_state.show_grid);
-    ImGui::SameLine();
+
     ImGui::ColorEdit3("##grid_color", g_state.grid_color, ImGuiColorEditFlags_NoInputs);
-    SliderWithInput("Alpha##grid", &g_state.grid_alpha, 0.0f, 1.0f, "%.2f");
-    ImGui::Checkbox("Sun Circles##overlay", &g_state.show_sun_circles);
     ImGui::SameLine();
+    ImGui::TextUnformatted("Grid");
+    ImGui::SameLine();
+    ImGui::Checkbox("Line##grid", &g_state.show_grid_line);
+    ImGui::SameLine();
+    ImGui::Checkbox("Label##grid", &g_state.show_grid_label);
+    SliderWithInput("Alpha##grid", &g_state.grid_alpha, 0.0f, 1.0f, "%.2f");
+
     ImGui::ColorEdit3("##sun_circles_color", g_state.sun_circles_color, ImGuiColorEditFlags_NoInputs);
+    ImGui::SameLine();
+    ImGui::TextUnformatted("Sun");
+    ImGui::SameLine();
+    ImGui::Checkbox("Line##sun_circles", &g_state.show_sun_circles_line);
+    ImGui::SameLine();
+    ImGui::Checkbox("Label##sun_circles", &g_state.show_sun_circles_label);
     SliderWithInput("Alpha##sun_circles", &g_state.sun_circles_alpha, 0.0f, 1.0f, "%.2f");
 
-    if (g_state.show_sun_circles) {
+    if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {
       if (ImGui::Button("Edit Circles...##overlay")) {
         ImGui::OpenPopup("SunCirclesEdit");
       }
@@ -645,10 +660,11 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     pp.bg.alpha = g_state.bg_alpha;
     pp.bg.aspect = g_preview.GetBgAspect();
 
-    // Auxiliary line overlay parameters
-    pp.overlay.show_horizon = g_state.show_horizon;
-    pp.overlay.show_grid = g_state.show_grid;
-    pp.overlay.show_sun_circles = g_state.show_sun_circles;
+    // Auxiliary line overlay parameters (line flags only — labels are handled
+    // separately via BuildOverlayLabelInput below).
+    pp.overlay.show_horizon = g_state.show_horizon_line;
+    pp.overlay.show_grid = g_state.show_grid_line;
+    pp.overlay.show_sun_circles = g_state.show_sun_circles_line;
     std::copy(std::begin(g_state.horizon_color), std::end(g_state.horizon_color), std::begin(pp.overlay.horizon_color));
     std::copy(std::begin(g_state.grid_color), std::end(g_state.grid_color), std::begin(pp.overlay.grid_color));
     std::copy(std::begin(g_state.sun_circles_color), std::end(g_state.sun_circles_color),
@@ -671,7 +687,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     // modals correctly occlude them). BuildOverlayLabelInput is shared with
     // DoExportPreviewPng (off-screen FBO path) so both call sites produce
     // byte-identical OverlayLabelInput for a given state.
-    if (g_state.show_horizon || g_state.show_grid || g_state.show_sun_circles) {
+    if (g_state.show_horizon_label || g_state.show_grid_label || g_state.show_sun_circles_label) {
       OverlayLabelInput label_input = BuildOverlayLabelInput(g_state, rc);
 
       // Viewport rect in absolute OS screen coordinates. DrawOverlayLabels emits to

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -495,15 +495,19 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::SeparatorText("Auxiliary Lines");
     // Per-overlay row layout: color picker + name (variable width) + Line / Label
     // checkboxes anchored at fixed X so the two checkbox columns align across rows
-    // even though the name column has different widths (Horizon / Grid / Sun Circles).
+    // even though the name column has different widths (Horizon / Grid / Angular Distance).
     // Second row: Alpha slider.
     const ImGuiStyle& style = ImGui::GetStyle();
-    float color_w = ImGui::GetFrameHeight();                  // ColorEdit3 NoInputs is a frame_h square
-    float name_col_w = ImGui::CalcTextSize("Sun Circles").x;  // widest overlay name
-    float check_box_w = ImGui::GetFrameHeight();              // checkbox tick area
+    // Anchor checkbox columns at fixed X derived from the longest overlay name
+    // plus widget metrics. The trailing pad (ItemSpacing.x × 2) protects against
+    // ColorEdit3 / CalcTextSize sub-pixel rounding under HiDPI so the long name
+    // ("Angular Distance") never overlaps the Line checkbox.
+    float color_w = ImGui::GetFrameHeight();                       // ColorEdit3 NoInputs is a frame_h square
+    float name_col_w = ImGui::CalcTextSize("Angular Distance").x;  // widest overlay name
+    float check_box_w = ImGui::GetFrameHeight();                   // checkbox tick area
     float line_text_w = ImGui::CalcTextSize("Line").x;
-    float line_col_x = color_w + style.ItemSpacing.x + name_col_w + style.ItemSpacing.x;
-    float label_col_x = line_col_x + check_box_w + style.ItemInnerSpacing.x + line_text_w + style.ItemSpacing.x;
+    float line_col_x = color_w + style.ItemSpacing.x + name_col_w + style.ItemSpacing.x * 2.0f;
+    float label_col_x = line_col_x + check_box_w + style.ItemInnerSpacing.x + line_text_w + style.ItemSpacing.x * 2.0f;
 
     auto overlay_row = [&](const char* name, const char* color_id, float* color, const char* line_id, bool* line_v,
                            const char* label_id, bool* label_v) {
@@ -524,12 +528,12 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
                 &g_state.show_grid_label);
     SliderWithInput("Alpha##grid", &g_state.grid_alpha, 0.0f, 1.0f, "%.2f");
 
-    overlay_row("Sun Circles", "##sun_circles_color", g_state.sun_circles_color, "Line##sun_circles",
+    overlay_row("Angular Distance", "##sun_circles_color", g_state.sun_circles_color, "Line##sun_circles",
                 &g_state.show_sun_circles_line, "Label##sun_circles", &g_state.show_sun_circles_label);
     SliderWithInput("Alpha##sun_circles", &g_state.sun_circles_alpha, 0.0f, 1.0f, "%.2f");
 
     if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {
-      if (ImGui::Button("Edit Circles...##overlay")) {
+      if (ImGui::Button("Edit Angles...##overlay")) {
         ImGui::OpenPopup("SunCirclesEdit");
       }
       if (ImGui::BeginPopup("SunCirclesEdit")) {

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -493,32 +493,39 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
   if (ImGui::CollapsingHeader("Overlay", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
     ImGui::SeparatorText("Auxiliary Lines");
-    // Per-overlay row layout: color picker + name + Line / Label checkboxes; second row: Alpha slider.
-    ImGui::ColorEdit3("##horizon_color", g_state.horizon_color, ImGuiColorEditFlags_NoInputs);
-    ImGui::SameLine();
-    ImGui::TextUnformatted("Horizon");
-    ImGui::SameLine();
-    ImGui::Checkbox("Line##horizon", &g_state.show_horizon_line);
-    ImGui::SameLine();
-    ImGui::Checkbox("Label##horizon", &g_state.show_horizon_label);
+    // Per-overlay row layout: color picker + name (variable width) + Line / Label
+    // checkboxes anchored at fixed X so the two checkbox columns align across rows
+    // even though the name column has different widths (Horizon / Grid / Sun Circles).
+    // Second row: Alpha slider.
+    const ImGuiStyle& style = ImGui::GetStyle();
+    float color_w = ImGui::GetFrameHeight();                  // ColorEdit3 NoInputs is a frame_h square
+    float name_col_w = ImGui::CalcTextSize("Sun Circles").x;  // widest overlay name
+    float check_box_w = ImGui::GetFrameHeight();              // checkbox tick area
+    float line_text_w = ImGui::CalcTextSize("Line").x;
+    float line_col_x = color_w + style.ItemSpacing.x + name_col_w + style.ItemSpacing.x;
+    float label_col_x = line_col_x + check_box_w + style.ItemInnerSpacing.x + line_text_w + style.ItemSpacing.x;
+
+    auto overlay_row = [&](const char* name, const char* color_id, float* color, const char* line_id, bool* line_v,
+                           const char* label_id, bool* label_v) {
+      ImGui::ColorEdit3(color_id, color, ImGuiColorEditFlags_NoInputs);
+      ImGui::SameLine();
+      ImGui::TextUnformatted(name);
+      ImGui::SameLine(line_col_x);
+      ImGui::Checkbox(line_id, line_v);
+      ImGui::SameLine(label_col_x);
+      ImGui::Checkbox(label_id, label_v);
+    };
+
+    overlay_row("Horizon", "##horizon_color", g_state.horizon_color, "Line##horizon", &g_state.show_horizon_line,
+                "Label##horizon", &g_state.show_horizon_label);
     SliderWithInput("Alpha##horizon", &g_state.horizon_alpha, 0.0f, 1.0f, "%.2f");
 
-    ImGui::ColorEdit3("##grid_color", g_state.grid_color, ImGuiColorEditFlags_NoInputs);
-    ImGui::SameLine();
-    ImGui::TextUnformatted("Grid");
-    ImGui::SameLine();
-    ImGui::Checkbox("Line##grid", &g_state.show_grid_line);
-    ImGui::SameLine();
-    ImGui::Checkbox("Label##grid", &g_state.show_grid_label);
+    overlay_row("Grid", "##grid_color", g_state.grid_color, "Line##grid", &g_state.show_grid_line, "Label##grid",
+                &g_state.show_grid_label);
     SliderWithInput("Alpha##grid", &g_state.grid_alpha, 0.0f, 1.0f, "%.2f");
 
-    ImGui::ColorEdit3("##sun_circles_color", g_state.sun_circles_color, ImGuiColorEditFlags_NoInputs);
-    ImGui::SameLine();
-    ImGui::TextUnformatted("Sun Circles");
-    ImGui::SameLine();
-    ImGui::Checkbox("Line##sun_circles", &g_state.show_sun_circles_line);
-    ImGui::SameLine();
-    ImGui::Checkbox("Label##sun_circles", &g_state.show_sun_circles_label);
+    overlay_row("Sun Circles", "##sun_circles_color", g_state.sun_circles_color, "Line##sun_circles",
+                &g_state.show_sun_circles_line, "Label##sun_circles", &g_state.show_sun_circles_label);
     SliderWithInput("Alpha##sun_circles", &g_state.sun_circles_alpha, 0.0f, 1.0f, "%.2f");
 
     if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -822,10 +822,15 @@ std::string SerializeGuiStateJson(const GuiState& state) {
   root["bg_show"] = state.bg_show;
   root["bg_alpha"] = state.bg_alpha;
 
-  // Auxiliary line overlay
-  root["overlay_horizon"] = state.show_horizon;
-  root["overlay_grid"] = state.show_grid;
-  root["overlay_sun_circles"] = state.show_sun_circles;
+  // Auxiliary line overlay (line / label visibility split since task-overlay-line-label-toggle).
+  // Old key `overlay_<x>` (single visibility) is no longer written; readers fall back to it
+  // when the new keys are absent.
+  root["overlay_horizon_line"] = state.show_horizon_line;
+  root["overlay_horizon_label"] = state.show_horizon_label;
+  root["overlay_grid_line"] = state.show_grid_line;
+  root["overlay_grid_label"] = state.show_grid_label;
+  root["overlay_sun_circles_line"] = state.show_sun_circles_line;
+  root["overlay_sun_circles_label"] = state.show_sun_circles_label;
   root["overlay_sun_circle_angles"] = state.sun_circle_angles;
   root["overlay_horizon_color"] = { state.horizon_color[0], state.horizon_color[1], state.horizon_color[2] };
   root["overlay_grid_color"] = { state.grid_color[0], state.grid_color[1], state.grid_color[2] };
@@ -958,10 +963,17 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   state.bg_show = root.value("bg_show", false);
   state.bg_alpha = root.value("bg_alpha", 1.0f);
 
-  // Auxiliary line overlay (backward compatible: missing fields use defaults)
-  state.show_horizon = root.value("overlay_horizon", false);
-  state.show_grid = root.value("overlay_grid", false);
-  state.show_sun_circles = root.value("overlay_sun_circles", false);
+  // Auxiliary line overlay (backward compatible: legacy `overlay_<x>` key maps to
+  // both line and label = legacy_value; new keys override per-axis when present).
+  bool legacy_horizon = root.value("overlay_horizon", false);
+  bool legacy_grid = root.value("overlay_grid", false);
+  bool legacy_sun_circles = root.value("overlay_sun_circles", false);
+  state.show_horizon_line = root.value("overlay_horizon_line", legacy_horizon);
+  state.show_horizon_label = root.value("overlay_horizon_label", legacy_horizon);
+  state.show_grid_line = root.value("overlay_grid_line", legacy_grid);
+  state.show_grid_label = root.value("overlay_grid_label", legacy_grid);
+  state.show_sun_circles_line = root.value("overlay_sun_circles_line", legacy_sun_circles);
+  state.show_sun_circles_label = root.value("overlay_sun_circles_label", legacy_sun_circles);
   if (root.contains("overlay_sun_circle_angles") && root["overlay_sun_circle_angles"].is_array()) {
     state.sun_circle_angles.clear();
     for (const auto& v : root["overlay_sun_circle_angles"]) {

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -264,6 +264,12 @@ struct GuiState {
   // line-only / label-only / both / none combinations. The line flags drive the
   // shader uniform path (see app_panels.cpp pp.overlay assignment), the label flags
   // drive the CPU label sampling path (see BuildOverlayLabelInput in app.cpp).
+  //
+  // Tech-debt note (task-overlay-line-label-toggle, 2026-04-29): currently 12 flat
+  // overlay-related fields (3×color + 3×alpha + 6×bool). When a fourth overlay class
+  // is added (e.g. face number overlay merged into this panel), evaluate collapsing
+  // to a substruct (per-overlay { color, alpha, line, label }) to avoid further
+  // field-name proliferation.
   bool show_horizon_line = false;
   bool show_horizon_label = false;
   bool show_grid_line = false;

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -259,10 +259,17 @@ struct GuiState {
   bool bg_show = false;
   float bg_alpha = 1.0f;
 
-  // Auxiliary line overlay (view preference — does not call MarkDirty, not in ConfigSnapshot)
-  bool show_horizon = false;
-  bool show_grid = false;
-  bool show_sun_circles = false;
+  // Auxiliary line overlay (view preference — does not call MarkDirty, not in ConfigSnapshot).
+  // Each overlay has independent toggles for line and label visibility, allowing
+  // line-only / label-only / both / none combinations. The line flags drive the
+  // shader uniform path (see app_panels.cpp pp.overlay assignment), the label flags
+  // drive the CPU label sampling path (see BuildOverlayLabelInput in app.cpp).
+  bool show_horizon_line = false;
+  bool show_horizon_label = false;
+  bool show_grid_line = false;
+  bool show_grid_label = false;
+  bool show_sun_circles_line = false;
+  bool show_sun_circles_label = false;
   std::vector<float> sun_circle_angles = { 22.0f, 46.0f };
   float horizon_color[3] = { 0.8f, 0.2f, 0.2f };
   float grid_color[3] = { 1.0f, 1.0f, 1.0f };

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -319,8 +319,10 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   float res_x = vp_screen_w;
   float res_y = vp_screen_h;
 
+  int horizon_a = static_cast<int>(input.horizon_alpha * 255);
   int grid_a = static_cast<int>(input.grid_alpha * 255);
   int sun_a = static_cast<int>(input.sun_circles_alpha * 255);
+  ImU32 horizon_col = ColorToImU32(input.horizon_color, horizon_a);
   ImU32 grid_col = ColorToImU32(input.grid_color, grid_a);
   ImU32 sun_col = ColorToImU32(input.sun_circles_color, sun_a);
 
@@ -400,6 +402,18 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   // Crossing detection helper: given two adjacent valid sample points, detect and add labels.
   auto detect_crossings = [&](const SampleAngles& prev, const SampleAngles& cur) {
     float t;
+
+    // Horizon: altitude == 0. Grid skips this latitude (see "skip 0° altitude" below)
+    // so the two paths produce a single non-overlapping "0°" label when both are on.
+    if (input.show_horizon) {
+      if (std::abs(prev.altitude - cur.altitude) < 20.0f && Crosses(prev.altitude, cur.altitude, 0.0f, &t)) {
+        float ix, iy, iz;
+        interp_dir(prev, cur, t, ix, iy, iz);
+        if (is_visible(0.0f, ix, iy, iz)) {
+          AddLabel(out, prev.screen_x, prev.screen_y, cur.screen_x, cur.screen_y, t, "%.0f\xC2\xB0", 0.0f, horizon_col);
+        }
+      }
+    }
 
     // Grid: altitude crosses multiples of 10
     if (input.show_grid) {

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -34,7 +34,7 @@ struct OverlayLabelInput {
   int sun_circle_count;
   const float* sun_circle_angles;
   float horizon_color[3], grid_color[3], sun_circles_color[3];
-  float grid_alpha, sun_circles_alpha;
+  float horizon_alpha, grid_alpha, sun_circles_alpha;
 };
 
 // Compute labels at viewport edges where overlay lines cross.

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -21,6 +21,10 @@ struct OverlayLabel {
   int group = 0;        // collision avoidance only within same group (0=grid, 1=sun circles)
 };
 
+// The show_* fields here control **label** rendering only (label sampling along
+// viewport edges). They are sourced from GuiState::show_<x>_label. The companion
+// fields GuiState::show_<x>_line are consumed by OverlayDecoration (in
+// preview_renderer.hpp), not this struct.
 struct OverlayLabelInput {
   int lens_type;
   float fov, elevation, azimuth, roll;

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -45,6 +45,11 @@ struct Exposure {
 
 // Auxiliary line overlay (horizon, altitude grid, sun circles) drawn on top
 // of the preview. sun_dir is precomputed on CPU from GuiState::sun.altitude.
+//
+// The show_* fields here control **line** rendering only (shader uniforms
+// u_show_horizon / u_show_grid / u_show_sun_circles). They are sourced from
+// GuiState::show_<x>_line. The companion fields GuiState::show_<x>_label are
+// consumed by OverlayLabelInput, not this struct.
 struct OverlayDecoration {
   bool show_horizon = false;
   bool show_grid = false;

--- a/test/gui/test_gui_export.cpp
+++ b/test/gui/test_gui_export.cpp
@@ -198,8 +198,10 @@ static void RunAcExport() {
   std::optional<gui::OverlayLabelInput> overlay;
   if (g_ac_state.with_overlay) {
     // Force some overlay content for deterministic pixel coverage in AC2.
-    gui::g_state.show_horizon = true;
-    gui::g_state.show_grid = true;
+    gui::g_state.show_horizon_line = true;
+    gui::g_state.show_horizon_label = true;
+    gui::g_state.show_grid_line = true;
+    gui::g_state.show_grid_label = true;
     overlay = gui::BuildOverlayLabelInput(gui::g_state, gui::g_state.renderer);
   }
 
@@ -1007,9 +1009,12 @@ void RegisterExportPreviewTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.roll = 0.0f;
       gui::g_state.renderer.visible = gui::kVisibleFull;
       // Disable overlay / bg in live preview so Configure*'s Disabled() is also a no-op.
-      gui::g_state.show_horizon = false;
-      gui::g_state.show_grid = false;
-      gui::g_state.show_sun_circles = false;
+      gui::g_state.show_horizon_line = false;
+      gui::g_state.show_horizon_label = false;
+      gui::g_state.show_grid_line = false;
+      gui::g_state.show_grid_label = false;
+      gui::g_state.show_sun_circles_line = false;
+      gui::g_state.show_sun_circles_label = false;
       gui::g_state.bg_show = false;
 
       g_export_test.upload_requested = true;

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -380,4 +380,84 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(loaded.renderer.fov, 90.0f);
     };
   }
+
+  // task-overlay-line-label-toggle: Test E — legacy `overlay_<x>` key (single
+  // visibility) deserializes into both line and label = legacy_value.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overlay_legacy_key_fallback");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      std::string json = R"({
+        "layers": [],
+        "renderer": {"lens_type": "linear", "fov": 90.0},
+        "overlay_horizon": true,
+        "overlay_grid": false,
+        "overlay_sun_circles": true
+      })";
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeGuiStateJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.show_horizon_line, true);
+      IM_CHECK_EQ(loaded.show_horizon_label, true);
+      IM_CHECK_EQ(loaded.show_grid_line, false);
+      IM_CHECK_EQ(loaded.show_grid_label, false);
+      IM_CHECK_EQ(loaded.show_sun_circles_line, true);
+      IM_CHECK_EQ(loaded.show_sun_circles_label, true);
+    };
+  }
+
+  // task-overlay-line-label-toggle: Test F — new keys take precedence over the
+  // legacy key when both are present (mixed-key scenario for hand-edited JSON).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overlay_new_keys_take_precedence");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      std::string json = R"({
+        "layers": [],
+        "renderer": {"lens_type": "linear", "fov": 90.0},
+        "overlay_horizon": true,
+        "overlay_horizon_line": true,
+        "overlay_horizon_label": false
+      })";
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeGuiStateJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.show_horizon_line, true);
+      IM_CHECK_EQ(loaded.show_horizon_label, false);
+    };
+  }
+
+  // task-overlay-line-label-toggle: Test G — round-trip preserves all six
+  // line/label fields independently (no collapsing back to single key on write).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overlay_roundtrip_preserves_split");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      gui::g_state.show_horizon_line = true;
+      gui::g_state.show_horizon_label = false;
+      gui::g_state.show_grid_line = false;
+      gui::g_state.show_grid_label = true;
+      gui::g_state.show_sun_circles_line = true;
+      gui::g_state.show_sun_circles_label = true;
+
+      std::string json = gui::SerializeGuiStateJson(gui::g_state);
+      IM_CHECK(!json.empty());
+
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeGuiStateJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.show_horizon_line, true);
+      IM_CHECK_EQ(loaded.show_horizon_label, false);
+      IM_CHECK_EQ(loaded.show_grid_line, false);
+      IM_CHECK_EQ(loaded.show_grid_label, true);
+      IM_CHECK_EQ(loaded.show_sun_circles_line, true);
+      IM_CHECK_EQ(loaded.show_sun_circles_label, true);
+    };
+  }
 }

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -410,6 +410,8 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
   // task-overlay-line-label-toggle: Test F — new keys take precedence over the
   // legacy key when both are present (mixed-key scenario for hand-edited JSON).
+  // Cover horizon AND grid to distinguish "all overlays handled correctly"
+  // from "only horizon special-cased".
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overlay_new_keys_take_precedence");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -421,13 +423,18 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         "renderer": {"lens_type": "linear", "fov": 90.0},
         "overlay_horizon": true,
         "overlay_horizon_line": true,
-        "overlay_horizon_label": false
+        "overlay_horizon_label": false,
+        "overlay_grid": true,
+        "overlay_grid_line": false,
+        "overlay_grid_label": true
       })";
       gui::GuiState loaded;
       bool ok = gui::DeserializeGuiStateJson(json, loaded);
       IM_CHECK(ok);
       IM_CHECK_EQ(loaded.show_horizon_line, true);
       IM_CHECK_EQ(loaded.show_horizon_label, false);
+      IM_CHECK_EQ(loaded.show_grid_line, false);
+      IM_CHECK_EQ(loaded.show_grid_label, true);
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1844,22 +1844,31 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       ResetTestState();
       ctx->Yield(2);
 
-      gui::g_state.show_horizon = true;
-      gui::g_state.show_grid = true;
-      gui::g_state.show_sun_circles = true;
+      gui::g_state.show_horizon_line = true;
+      gui::g_state.show_horizon_label = true;
+      gui::g_state.show_grid_line = true;
+      gui::g_state.show_grid_label = true;
+      gui::g_state.show_sun_circles_line = true;
+      gui::g_state.show_sun_circles_label = true;
       ctx->Yield();
 
       gui::g_state.renderer.lens_type = 4;  // Dual Fisheye EA (full-sky)
       ctx->Yield(3);
-      IM_CHECK_EQ(gui::g_state.show_horizon, true);
-      IM_CHECK_EQ(gui::g_state.show_grid, true);
-      IM_CHECK_EQ(gui::g_state.show_sun_circles, true);
+      IM_CHECK_EQ(gui::g_state.show_horizon_line, true);
+      IM_CHECK_EQ(gui::g_state.show_horizon_label, true);
+      IM_CHECK_EQ(gui::g_state.show_grid_line, true);
+      IM_CHECK_EQ(gui::g_state.show_grid_label, true);
+      IM_CHECK_EQ(gui::g_state.show_sun_circles_line, true);
+      IM_CHECK_EQ(gui::g_state.show_sun_circles_label, true);
 
       gui::g_state.renderer.lens_type = 0;  // Linear
       ctx->Yield(3);
-      IM_CHECK_EQ(gui::g_state.show_horizon, true);
-      IM_CHECK_EQ(gui::g_state.show_grid, true);
-      IM_CHECK_EQ(gui::g_state.show_sun_circles, true);
+      IM_CHECK_EQ(gui::g_state.show_horizon_line, true);
+      IM_CHECK_EQ(gui::g_state.show_horizon_label, true);
+      IM_CHECK_EQ(gui::g_state.show_grid_line, true);
+      IM_CHECK_EQ(gui::g_state.show_grid_label, true);
+      IM_CHECK_EQ(gui::g_state.show_sun_circles_line, true);
+      IM_CHECK_EQ(gui::g_state.show_sun_circles_label, true);
     };
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -5,7 +5,9 @@
 #include <cmath>
 #include <vector>
 
+#include "gui/app.hpp"
 #include "gui/gui_constants.hpp"
+#include "gui/gui_state.hpp"
 #include "gui/overlay_labels.hpp"
 #include "gui/preview_renderer.hpp"
 #include "test_gui_shared.hpp"
@@ -780,6 +782,106 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       std::vector<lumice::gui::OverlayLabel> labels;
       lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
       IM_CHECK_GE(CountUniqueGridLabels(labels), 5);
+    };
+  }
+
+  // task-overlay-line-label-toggle contract tests: BuildOverlayLabelInput reads
+  // GuiState::show_<x>_label fields (NOT show_<x>_line). The companion line
+  // routing (pp.overlay.show_<x> = g_state.show_<x>_line in RenderRightPanel)
+  // is a trivial inline assignment validated by code review + manual walk-through.
+  // These tests pin only the label-side wiring, which is the side that branches
+  // on the GuiState→OverlayLabelInput conversion function.
+  //
+  // Test A: line-only — label flag drives input, line flag is ignored by BuildOverlayLabelInput.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "line_only_label_input_false");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::GuiState s;
+      s.show_horizon_line = true;
+      s.show_horizon_label = false;
+      s.show_grid_line = true;
+      s.show_grid_label = false;
+      s.show_sun_circles_line = true;
+      s.show_sun_circles_label = false;
+      auto in = lumice::gui::BuildOverlayLabelInput(s, s.renderer);
+      IM_CHECK_EQ(in.show_horizon, false);
+      IM_CHECK_EQ(in.show_grid, false);
+      IM_CHECK_EQ(in.show_sun_circles, false);
+    };
+  }
+
+  // Test B: label-only — only label flag drives input.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "label_only_label_input_true");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::GuiState s;
+      s.show_horizon_line = false;
+      s.show_horizon_label = true;
+      s.show_grid_line = false;
+      s.show_grid_label = true;
+      s.show_sun_circles_line = false;
+      s.show_sun_circles_label = true;
+      auto in = lumice::gui::BuildOverlayLabelInput(s, s.renderer);
+      IM_CHECK_EQ(in.show_horizon, true);
+      IM_CHECK_EQ(in.show_grid, true);
+      IM_CHECK_EQ(in.show_sun_circles, true);
+    };
+  }
+
+  // Test C: both on — input reflects label flags (true).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "both_on_label_input_true");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::GuiState s;
+      s.show_horizon_line = true;
+      s.show_horizon_label = true;
+      s.show_grid_line = true;
+      s.show_grid_label = true;
+      s.show_sun_circles_line = true;
+      s.show_sun_circles_label = true;
+      auto in = lumice::gui::BuildOverlayLabelInput(s, s.renderer);
+      IM_CHECK_EQ(in.show_horizon, true);
+      IM_CHECK_EQ(in.show_grid, true);
+      IM_CHECK_EQ(in.show_sun_circles, true);
+    };
+  }
+
+  // Test D: both off — three-layer assertion to distinguish "gate intercept"
+  // from "computed-but-empty" path:
+  //   (1) precondition: GuiState label flags are all false
+  //   (2) expected: BuildOverlayLabelInput emits all-false
+  //   (3) alternative path absence: the panel-side gate triple-OR
+  //       (label_label_label) evaluates to false, proving label sampling is
+  //       gated out by source flags and not by downstream filtering.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "both_off_three_layer_assertion");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::GuiState s;
+      // (1) Precondition.
+      s.show_horizon_line = false;
+      s.show_horizon_label = false;
+      s.show_grid_line = false;
+      s.show_grid_label = false;
+      s.show_sun_circles_line = false;
+      s.show_sun_circles_label = false;
+      IM_CHECK_EQ(s.show_horizon_label, false);
+      IM_CHECK_EQ(s.show_grid_label, false);
+      IM_CHECK_EQ(s.show_sun_circles_label, false);
+      // (2) Expected: BuildOverlayLabelInput sees all-false.
+      auto in = lumice::gui::BuildOverlayLabelInput(s, s.renderer);
+      IM_CHECK_EQ(in.show_horizon, false);
+      IM_CHECK_EQ(in.show_grid, false);
+      IM_CHECK_EQ(in.show_sun_circles, false);
+      // (3) Alternative-path absence: the panel-side gate
+      //     (show_horizon_label || show_grid_label || show_sun_circles_label)
+      //     evaluates to false. This is the same expression used in
+      //     app_panels.cpp:674 / app.cpp:301 to skip label sampling entirely.
+      const bool gate_open = s.show_horizon_label || s.show_grid_label || s.show_sun_circles_label;
+      IM_CHECK_EQ(gate_open, false);
     };
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -34,6 +34,7 @@ lumice::gui::OverlayLabelInput MakeGridOnly(int visible, int lens_type, float el
   in.horizon_color[0] = in.horizon_color[1] = in.horizon_color[2] = 1.0f;
   in.grid_color[0] = in.grid_color[1] = in.grid_color[2] = 1.0f;
   in.sun_circles_color[0] = in.sun_circles_color[1] = in.sun_circles_color[2] = 1.0f;
+  in.horizon_alpha = 1.0f;
   in.grid_alpha = 1.0f;
   in.sun_circles_alpha = 1.0f;
   return in;
@@ -887,6 +888,59 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       //     replaces the OR with a bug like `&& show_grid_label`).
       const bool gate_open = s.show_horizon_label || s.show_grid_label || s.show_sun_circles_label;
       IM_CHECK_EQ(gate_open, false);
+    };
+  }
+
+  // task-overlay-line-label-toggle: horizon_label produces a "0°" edge label
+  // (latitude=0 crossing). Grid skips 0° to avoid clutter, so horizon owns this
+  // value. Use Fisheye Equidistant with fov=180 (full sky) so the equator hits
+  // the viewport edges symmetrically.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "horizon_label_emits_zero_degree");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 180.0f;
+      in.show_horizon = true;
+      in.show_grid = false;
+      in.show_sun_circles = false;
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+      // Expect at least one "0°" label (latitude=0 crossing the viewport edge).
+      int zero_deg_count = 0;
+      for (const auto& l : labels) {
+        if (l.text == "0\xC2\xB0") {
+          ++zero_deg_count;
+        }
+      }
+      IM_CHECK_GE(zero_deg_count, 1);
+    };
+  }
+
+  // task-overlay-line-label-toggle: horizon_label is independent from grid. When
+  // grid is the only label source, the existing skip-0° rule should still hold —
+  // no "0°" label emitted. Pin the rule so a future refactor that drops the
+  // grid skip would surface as a duplicate-0° regression.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_toggle", "grid_only_skips_zero_degree");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 180.0f;
+      in.show_horizon = false;
+      in.show_grid = true;
+      in.show_sun_circles = false;
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+      int zero_deg_count = 0;
+      for (const auto& l : labels) {
+        if (l.text == "0\xC2\xB0") {
+          ++zero_deg_count;
+        }
+      }
+      IM_CHECK_EQ(zero_deg_count, 0);
     };
   }
 }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -876,10 +876,15 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(in.show_horizon, false);
       IM_CHECK_EQ(in.show_grid, false);
       IM_CHECK_EQ(in.show_sun_circles, false);
-      // (3) Alternative-path absence: the panel-side gate
+      // (3) Alternative-path absence (documentary): the panel-side gate
       //     (show_horizon_label || show_grid_label || show_sun_circles_label)
       //     evaluates to false. This is the same expression used in
       //     app_panels.cpp:674 / app.cpp:301 to skip label sampling entirely.
+      //     Note: this assertion is structurally tautological — Layer 1 already
+      //     fixed all three label fields to false, so `gate_open` is mathematically
+      //     forced to false. It is kept as an executable comment that pins the
+      //     gate expression's structure (e.g. catches a future refactor that
+      //     replaces the OR with a bug like `&& show_grid_label`).
       const bool gate_open = s.show_horizon_label || s.show_grid_label || s.show_sun_circles_label;
       IM_CHECK_EQ(gate_open, false);
     };

--- a/test/test_config_snapshot.cpp
+++ b/test/test_config_snapshot.cpp
@@ -105,7 +105,8 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   target.aspect_portrait = true;
   target.bg_show = true;
   target.bg_alpha = 0.7f;
-  target.show_horizon = true;
+  target.show_horizon_line = true;
+  target.show_horizon_label = true;
   target.gui_log_level = 1;
   target.core_log_level = 2;
   target.log_to_file = true;
@@ -136,7 +137,8 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   EXPECT_TRUE(target.aspect_portrait);
   EXPECT_TRUE(target.bg_show);
   EXPECT_FLOAT_EQ(target.bg_alpha, 0.7f);
-  EXPECT_TRUE(target.show_horizon);
+  EXPECT_TRUE(target.show_horizon_line);
+  EXPECT_TRUE(target.show_horizon_label);
   EXPECT_EQ(target.gui_log_level, 1);
   EXPECT_EQ(target.core_log_level, 2);
   EXPECT_TRUE(target.log_to_file);


### PR DESCRIPTION
## Summary

- Split each Render Preview overlay (Horizon / Grid / Angular Distance) into independent **Line** and **Label** toggles, so users can pick line-only, label-only, both, or none. Backed by 3→6 boolean fields in `GuiState`.
- `.lmc` serialization gains `overlay_<x>_line` / `overlay_<x>_label` keys; the legacy `overlay_<x>` key still reads through as both flags for backward compatibility.
- UI polish: fixed-x checkbox column anchors so Line / Label checkboxes line up across rows regardless of overlay name width; renamed user-facing "Sun Circles" to "Angular Distance" (internal identifiers and serialization keys unchanged); enabling Horizon's Label now emits a `0°` edge label.
- EN/ZH `gui-guide` docs updated; GUI test count 174 → 176 plus seven new tests covering the toggle split, serialization fallback, and label gates.

## Test plan

- [x] `./scripts/build.sh -gtj release` — full GUI test suite passes
- [x] Manual: toggle Line / Label independently for each overlay and confirm rendering matches the four combinations
- [ ] Manual: load an old `.lmc` with `overlay_horizon: true` and verify both Line and Label come back enabled
- [x] Manual: enable Horizon → Label and confirm a single `0°` label appears at the viewport edge (no duplicate when Grid label is also on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)