### PR TITLE
feat(gui): Globe lens with trackball, overlay labels, and view reset

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -488,14 +488,14 @@ The render configuration defines the renderer parameters.
 
 ```json
 {
-  "type": "linear" | "fisheye_equal_area" | "fisheye_equidistant" | "fisheye_stereographic" | "dual_fisheye_equal_area" | "dual_fisheye_equidistant" | "dual_fisheye_stereographic" | "rectangular" | "fisheye_orthographic" | "dual_fisheye_orthographic",
+  "type": "linear" | "fisheye_equal_area" | "fisheye_equidistant" | "fisheye_stereographic" | "dual_fisheye_equal_area" | "dual_fisheye_equidistant" | "dual_fisheye_stereographic" | "rectangular" | "fisheye_orthographic" | "dual_fisheye_orthographic" | "globe",
   "fov": <angle>  // or "f": <focal length>
 }
 ```
 
 **Defaults**:
 - `type`: "linear"
-- `fov`: 90.0 (degrees)
+- `fov`: 90.0 (degrees); `globe` defaults to 30.0
 
 **Note**:
 - `fov` is the **full diagonal field of view** in degrees. For `rectangular` and `dual_*` types, `fov` is ignored (these are always full-sky projections).
@@ -508,6 +508,15 @@ The render configuration defines the renderer parameters.
   - Stereographic: `fov = 4·arctan(d/(2f))`
   - Orthographic: `fov = 2·arcsin(d/f)` (requires `f ≥ 12mm` for fov=180)
   - Rectangular: `f` is ignored (always full-sky)
+  - Globe: `f` is not supported (use `fov` directly)
+
+**`globe` lens (outside-in perspective view of the celestial sphere)**:
+- Projection model: a pinhole perspective camera placed at distance `D = 4.0` (in unit-sphere radii) from the unit sphere centered at the world origin, looking toward the sphere center. The shader ray-traces against the unit sphere and shades the sample pointed to by the hit point.
+- `fov` range: `(0°, 90°]`; default `30°`. With the default the sphere fills approximately 96% of the viewport's short edge.
+- `view.roll`: stored as a normal `view` field, but at render time it is **forced to 0** for the `globe` lens; the right-panel Roll slider is greyed out while `globe` is selected. Switching to a non-Globe lens restores the stored value (the field is preserved, only the rendered roll is overridden).
+- `view.azimuth` / `view.elevation` semantics: under `globe`, they describe the **observer's orbit around the sphere**, not the camera's own attitude. The view matrix is mathematically the same as for inside-out lenses, but the user-facing intuition is inverted (Az/El point the camera *at* a place on the sphere instead of *toward* a direction in the sky).
+- `view.elevation` clamp under `globe`: trackball drag and the right-panel slider both clamp to `[-89°, +89°]` to avoid the view-matrix degeneracy at ±90°.
+- `.lmc` compatibility: no new fields are introduced; older `.lmc` files load unchanged.
 
 #### view (View Configuration)
 
@@ -600,7 +609,7 @@ The render configuration defines the renderer parameters.
 - `scene.light_source.type` must be "sun"
 - `filter[].type` must be "none", "raypath", "entry_exit", "direction", "crystal", or "complex"
 - `render[].visible` must be "upper", "lower", or "full"
-- `render[].lens.type` must be "linear", "fisheye_equal_area", "fisheye_equidistant", "fisheye_stereographic", "dual_fisheye_equal_area", "dual_fisheye_equidistant", "dual_fisheye_stereographic", "rectangular", "fisheye_orthographic", or "dual_fisheye_orthographic"
+- `render[].lens.type` must be "linear", "fisheye_equal_area", "fisheye_equidistant", "fisheye_stereographic", "dual_fisheye_equal_area", "dual_fisheye_equidistant", "dual_fisheye_stereographic", "rectangular", "fisheye_orthographic", "dual_fisheye_orthographic", or "globe"
 
 ## Common Configuration Errors
 

--- a/doc/configuration_zh.md
+++ b/doc/configuration_zh.md
@@ -506,14 +506,14 @@
 
 ```json
 {
-  "type": "linear" | "fisheye_equal_area" | "fisheye_equidistant" | "fisheye_stereographic" | "dual_fisheye_equal_area" | "dual_fisheye_equidistant" | "dual_fisheye_stereographic" | "rectangular" | "fisheye_orthographic" | "dual_fisheye_orthographic",
+  "type": "linear" | "fisheye_equal_area" | "fisheye_equidistant" | "fisheye_stereographic" | "dual_fisheye_equal_area" | "dual_fisheye_equidistant" | "dual_fisheye_stereographic" | "rectangular" | "fisheye_orthographic" | "dual_fisheye_orthographic" | "globe",
   "fov": <角度>  // 或 "f": <焦距>
 }
 ```
 
 **默认值**：
 - `type`: "linear"
-- `fov`: 90.0（度）
+- `fov`: 90.0（度）；`globe` 默认 30.0
 
 **注意**：
 - `fov` 为**全对角线视场角**（度）。`rectangular` 和 `dual_*` 类型会忽略 `fov`（始终为全天投影）。
@@ -526,6 +526,15 @@
   - Stereographic: `fov = 4·arctan(d/(2f))`
   - Orthographic: `fov = 2·arcsin(d/f)`（`f ≥ 12mm` 时 fov=180）
   - Rectangular: `f` 被忽略（始终全天投影）
+  - Globe: 不支持 `f`，请直接使用 `fov`
+
+**`globe` 镜头（外部观察天球的透视视角）**：
+- 投影模型：相机位于距单位球心 `D = 4.0`（单位球半径为单位）处，朝球心方向看；shader 对单位球做光线—球面求交，命中点对应的样本被着色。
+- `fov` 范围：`(0°, 90°]`，默认 `30°`。默认 fov 下球面占视口短边约 96%。
+- `view.roll`：作为常规 `view` 字段保存，但渲染时**强制为 0**（仅 `globe` 适用）；右侧面板 Roll slider 在选中 `globe` 时置灰；切回非 Globe lens 时恢复原值（字段保留，仅渲染时屏蔽）。
+- `view.azimuth` / `view.elevation` 语义：在 `globe` 下表示**观察者绕球公转的视角**，而非相机自身姿态。view 矩阵与 inside-out lens 完全相同，但用户心智反转（Az/El 指向球面上某个点，而非天空中某个方向）。
+- `view.elevation` 在 `globe` 下被 clamp 到 `[-89°, +89°]`，避免 ±90° 的 view-matrix 退化；trackball drag 与右侧 slider 共享此约束。
+- `.lmc` 兼容性：未引入新字段，旧 `.lmc` 加载行为不变。
 
 #### view（视角配置）
 
@@ -618,7 +627,7 @@
 - `scene.light_source.type` 必须是 "sun"
 - `filter[].type` 必须是 "none"、"raypath"、"entry_exit"、"direction"、"crystal" 或 "complex"
 - `render[].visible` 必须是 "upper"、"lower" 或 "full"
-- `render[].lens.type` 必须是 "linear"、"fisheye_equal_area"、"fisheye_equidistant"、"fisheye_stereographic"、"dual_fisheye_equal_area"、"dual_fisheye_equidistant"、"dual_fisheye_stereographic"、"rectangular"、"fisheye_orthographic" 或 "dual_fisheye_orthographic"
+- `render[].lens.type` 必须是 "linear"、"fisheye_equal_area"、"fisheye_equidistant"、"fisheye_stereographic"、"dual_fisheye_equal_area"、"dual_fisheye_equidistant"、"dual_fisheye_stereographic"、"rectangular"、"fisheye_orthographic"、"dual_fisheye_orthographic" 或 "globe"
 - `scene.ray_num` 必须是正整数或字符串 `"infinite"`
 
 ## 常见配置错误

--- a/src/config/render_config.cpp
+++ b/src/config/render_config.cpp
@@ -106,6 +106,11 @@ void from_json(const nlohmann::json& j, LensParam& l) {
         }
         l.fov_ = std::asin(d / f) * 2 * math::kRadToDegree;
         break;
+      case LensParam::kGlobe:
+        // Globe is not a physical pinhole lens; there is no f→fov mapping.
+        // Reject the f input path explicitly so misuse fails loudly instead of silently leaving fov_ undefined.
+        throw nlohmann::detail::out_of_range::create(
+            kErrCodeInvalidValue, "globe lens does not support f-derived fov; use fov field directly", j);
     }
   } else {
     throw nlohmann::detail::out_of_range::create(kErrCodeMissingKey, "missing key [fov] or [f]", j);
@@ -129,6 +134,8 @@ float MaxFov(LensParam::LensType type) {
     case LensParam::kFisheyeOrthographic:
     case LensParam::kDualFisheyeOrthographic:
       return 180.0f;  // sin(theta) aliases past pi/2; theta > pi/2 rejected
+    case LensParam::kGlobe:
+      return 90.0f;  // beyond 90° wide-angle distortion grows without enlarging the sphere on screen
     default:
       return 360.0f;  // equal area, equidistant, dual fisheye, rectangular
   }

--- a/src/config/render_config.hpp
+++ b/src/config/render_config.hpp
@@ -40,6 +40,7 @@ struct LensParam {
     kRectangular,
     kFisheyeOrthographic,
     kDualFisheyeOrthographic,
+    kGlobe,
   };
 
   LensType type_;
@@ -59,6 +60,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(  // declear
         { LensParam::kRectangular, "rectangular" },
         { LensParam::kFisheyeOrthographic, "fisheye_orthographic" },
         { LensParam::kDualFisheyeOrthographic, "dual_fisheye_orthographic" },
+        { LensParam::kGlobe, "globe" },
     })
 
 void to_json(nlohmann::json& j, const LensParam& l);

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -45,7 +45,7 @@ OverlayLabelInput BuildOverlayLabelInput(const GuiState& state, const RenderConf
   input.fov = rc.fov;
   input.elevation = rc.elevation;
   input.azimuth = rc.azimuth;
-  input.roll = rc.roll;
+  input.roll = EffectiveRollForLens(rc.lens_type, rc.roll);
   input.visible = rc.visible;
   input.show_horizon = state.show_horizon_label;
   input.show_grid = state.show_grid_label;

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -376,12 +376,21 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
         bool selected = (r.lens_type == idx);
         if (ImGui::Selectable(kLensTypeNames[idx], selected)) {
           if (r.lens_type != idx) {
+            bool was_globe = (r.lens_type == kLensTypeGlobe);
+            bool now_globe = (idx == kLensTypeGlobe);
             r.lens_type = idx;
+            ViewDefaults d = DefaultViewParamsFor(idx);
             // Reset fov to the new lens' default so e.g. first-time entry to
-            // Globe uses 30° instead of inheriting Linear's 90°. Other view
-            // fields (az/el/roll) are preserved. .lmc loading and tests bypass
-            // this combo by writing lens_type directly, so they keep their fov.
-            r.fov = DefaultViewParamsFor(idx).fov;
+            // Globe uses 30° instead of inheriting Linear's 90°. .lmc loading
+            // and tests bypass this combo by writing lens_type directly, so
+            // they keep their fov.
+            r.fov = d.fov;
+            // Crossing the Globe boundary inverts the view direction (Globe is
+            // outside-in), so reset az to the target lens' default. el/roll
+            // are preserved — only az has the inversion semantics.
+            if (was_globe != now_globe) {
+              r.azimuth = d.azimuth;
+            }
           }
         }
         if (selected) {

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -375,7 +375,14 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
       for (int idx : kLensTypePresentationOrder) {
         bool selected = (r.lens_type == idx);
         if (ImGui::Selectable(kLensTypeNames[idx], selected)) {
-          r.lens_type = idx;
+          if (r.lens_type != idx) {
+            r.lens_type = idx;
+            // Reset fov to the new lens' default so e.g. first-time entry to
+            // Globe uses 30° instead of inheriting Linear's 90°. Other view
+            // fields (az/el/roll) are preserved. .lmc loading and tests bypass
+            // this combo by writing lens_type directly, so they keep their fov.
+            r.fov = DefaultViewParamsFor(idx).fov;
+          }
         }
         if (selected) {
           ImGui::SetItemDefaultFocus();
@@ -762,8 +769,24 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
       ImGuiIO& io = ImGui::GetIO();
       if (is_active && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
         ImVec2 delta = io.MouseDelta;
-        rc.azimuth -= delta.x * 0.3f;
-        rc.elevation += delta.y * 0.3f;
+        // Globe is outside-in: u_view_matrix * (0,0,D) yields camera world
+        // position, so +az/+el move the camera and the sphere drifts in the
+        // opposite direction. Flip both signs so a right/down drag moves the
+        // sphere right/down, matching the inside-out lenses' feel.
+        if (rc.lens_type == kLensTypeGlobe) {
+          rc.azimuth += delta.x * 0.3f;
+          rc.elevation -= delta.y * 0.3f;
+        } else {
+          rc.azimuth -= delta.x * 0.3f;
+          rc.elevation += delta.y * 0.3f;
+        }
+        // Wrap azimuth into [-180, 180] so dragging past the slider's clamp
+        // boundary continues seamlessly instead of getting pinned at ±180.
+        if (rc.azimuth > 180.0f) {
+          rc.azimuth -= 360.0f;
+        } else if (rc.azimuth < -180.0f) {
+          rc.azimuth += 360.0f;
+        }
         // Globe lens needs a tighter clamp to avoid view-matrix degeneracy at
         // ±90°; inside-out lenses keep the existing ±90° range.
         float el_lim = (rc.lens_type == kLensTypeGlobe) ? 89.0f : 90.0f;

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -389,12 +389,40 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::EndDisabled();
     ImGui::Combo("Visible##view", &r.visible, kVisibleNames, kVisibleCount);
 
+    bool is_globe = (r.lens_type == kLensTypeGlobe);
     ImGui::SeparatorText("Camera");
+    if (is_globe) {
+      ImGui::TextDisabled("(?)");
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "In Globe lens, Az/El/Roll control the observer's orbit\n"
+            "around the sphere, not the camera's own attitude.\n"
+            "Roll is locked to 0 in this mode (slider is greyed out).");
+      }
+    }
+    float el_lim = is_globe ? 89.0f : 90.0f;
     ImGui::BeginDisabled(full_sky);
-    SliderWithInput("Elevation##view", &r.elevation, -90.0f, 90.0f, "%.2f");
+    SliderWithInput("Elevation##view", &r.elevation, -el_lim, el_lim, "%.2f");
     SliderWithInput("Azimuth##view", &r.azimuth, -180.0f, 180.0f, "%.2f");
+    ImGui::EndDisabled();
+    ImGui::BeginDisabled(full_sky || is_globe);
     SliderWithInput("Roll##view", &r.roll, -180.0f, 180.0f, "%.2f");
     ImGui::EndDisabled();
+
+    ImGui::Separator();
+    float btn_w = ImGui::CalcTextSize("Reset").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+    float avail = ImGui::GetContentRegionAvail().x;
+    if (avail > btn_w) {
+      ImGui::SameLine(avail - btn_w);
+    }
+    if (ImGui::SmallButton("Reset##view")) {
+      ViewDefaults d = DefaultViewParamsFor(r.lens_type);
+      r.fov = d.fov;
+      r.elevation = d.elevation;
+      r.azimuth = d.azimuth;
+      r.roll = d.roll;
+      g_state.MarkDirty();
+    }
 
     ImGui::PopItemWidth();
   }
@@ -659,7 +687,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     pp.view_proj.fov = rc.fov;
     pp.view_proj.elevation = rc.elevation;
     pp.view_proj.azimuth = rc.azimuth;
-    pp.view_proj.roll = rc.roll;
+    pp.view_proj.roll = EffectiveRollForLens(rc.lens_type, rc.roll);
     pp.view_proj.visible = rc.visible;
     pp.exposure.intensity_factor = std::pow(2.0f, rc.exposure_offset);
     pp.exposure.intensity_scale =
@@ -736,7 +764,10 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
         ImVec2 delta = io.MouseDelta;
         rc.azimuth -= delta.x * 0.3f;
         rc.elevation += delta.y * 0.3f;
-        rc.elevation = std::max(-90.0f, std::min(90.0f, rc.elevation));
+        // Globe lens needs a tighter clamp to avoid view-matrix degeneracy at
+        // ±90°; inside-out lenses keep the existing ±90° range.
+        float el_lim = (rc.lens_type == kLensTypeGlobe) ? 89.0f : 90.0f;
+        rc.elevation = std::max(-el_lim, std::min(el_lim, rc.elevation));
       }
 
       if (is_hovered && io.MouseWheel != 0.0f) {

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -100,6 +100,7 @@ enum LensType : int {
   kLensTypeRectangular = 7,
   kLensTypeFisheyeOrthographic = 8,
   kLensTypeDualFisheyeOrthographic = 9,
+  kLensTypeGlobe = 10,
 };
 
 // Lenses whose shader path skips the view matrix (full-sphere mapping):

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -133,6 +133,38 @@ inline constexpr bool LensIsFullSky(int lens_type) {
   return false;
 }
 
+// Lenses whose default FOV is 180 degrees (full hemispheric fisheye family).
+// SINGLE SOURCE OF TRUTH for the "FOV=180" set; do NOT confuse with
+// kFullSkyLensTypes (which classifies skip-view-matrix shader paths). These
+// two sets overlap but are not equal: e.g. kLensTypeRectangular is full-sky
+// but its default FOV is 90, not 180.
+//
+// The static_assert below guards array size; ordering is enforced by
+// kLensTypePresentationOrder in gui_state.hpp.
+inline constexpr int kFov180LensTypes[] = {
+  kLensTypeFisheyeEqualArea,     kLensTypeFisheyeEquidist,     kLensTypeFisheyeStereographic,
+  kLensTypeDualFisheyeEqualArea, kLensTypeDualFisheyeEquidist, kLensTypeDualFisheyeStereographic,
+};
+inline constexpr int kFov180LensTypeCount = sizeof(kFov180LensTypes) / sizeof(*kFov180LensTypes);
+static_assert(kFov180LensTypeCount == 6,
+              "kFov180LensTypes count changed: update both the array and this "
+              "literal in lockstep with the policy change.");
+
+inline constexpr bool LensIsFov180(int lens_type) {
+  for (int v : kFov180LensTypes) {
+    if (v == lens_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Globe lens camera distance (eye-space). The camera sits at (0, 0, D) looking
+// toward the unit sphere centered at the origin. Must match GLSL globeInverse
+// in preview_renderer.cpp shader source (search "kGlobeCameraD" anchor in the
+// shader string).
+inline constexpr float kGlobeCameraD = 4.0f;
+
 // Visible region selector. Order must match kVisibleNames in gui_state.hpp.
 enum Visible : int {
   kVisibleUpper = 0,

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -166,6 +166,40 @@ struct RenderConfig {
   bool operator!=(const RenderConfig& o) const { return !(*this == o); }
 };
 
+// Resettable subset of RenderConfig (the View `Reset` button targets these
+// four fields). Adding a resettable field here requires adding the matching
+// field to RenderConfig and updating every DefaultViewParamsFor branch.
+struct ViewDefaults {
+  float fov;
+  float elevation;
+  float azimuth;
+  float roll;
+};
+
+// Default view parameters per lens type, used by the View `Reset` button.
+// Uses explicit lens-type sets (kFov180LensTypes / explicit orthographic /
+// kLensTypeGlobe) instead of range comparisons, so adding a new LensType
+// fails the kFov180LensTypeCount static_assert rather than silently picking
+// a default.
+inline ViewDefaults DefaultViewParamsFor(int lens_type) {
+  float fov = 90.0f;  // linear / rectangular / orthographic family / fallback
+  if (LensIsFov180(lens_type)) {
+    fov = 180.0f;
+  } else if (lens_type == kLensTypeGlobe) {
+    fov = 30.0f;
+  }
+  // Orthographic single + dual already fall through to 90; no extra branch.
+  return { fov, 0.0f, 0.0f, 0.0f };
+}
+
+// Globe lens forces roll=0 at render time without writing back to the stored
+// RenderConfig.roll (so switching back to a non-Globe lens preserves the
+// user's prior roll value). Apply this helper at every ViewParam.roll fill
+// site that feeds BuildViewMatrix or overlay label projection.
+inline float EffectiveRollForLens(int lens_type, float stored_roll) {
+  return (lens_type == kLensTypeGlobe) ? 0.0f : stored_roll;
+}
+
 // Filter action
 inline const char* const kFilterActionNames[] = { "Filter In", "Filter Out" };
 constexpr int kFilterActionCount = 2;

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -94,12 +94,12 @@ inline const char* const kLensTypeNames[] = {
   "Rectangular",
   "Fisheye Orthographic",
   "Dual Fisheye Orthographic",
+  "Globe",
 };
-constexpr int kLensTypeCount = 10;
+constexpr int kLensTypeCount = 11;
 static_assert(sizeof(kLensTypeNames) / sizeof(*kLensTypeNames) == kLensTypeCount,
               "kLensTypeNames length must match kLensTypeCount");
-static_assert(kLensTypeDualFisheyeOrthographic == kLensTypeCount - 1,
-              "LensType enum terminal value must match kLensTypeCount - 1");
+static_assert(kLensTypeGlobe == kLensTypeCount - 1, "LensType enum terminal value must match kLensTypeCount - 1");
 
 // Display order for the Lens Type combo. Decoupled from enum values so that
 // orthographic variants group with their fisheye / dual-fisheye siblings
@@ -121,6 +121,7 @@ inline constexpr int kLensTypePresentationOrder[] = {
   kLensTypeDualFisheyeStereographic,
   kLensTypeDualFisheyeOrthographic,
   kLensTypeRectangular,
+  kLensTypeGlobe,
 };
 static_assert(sizeof(kLensTypePresentationOrder) / sizeof(*kLensTypePresentationOrder) == kLensTypeCount,
               "kLensTypePresentationOrder must list every LensType exactly once");

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -183,13 +183,18 @@ struct ViewDefaults {
 // a default.
 inline ViewDefaults DefaultViewParamsFor(int lens_type) {
   float fov = 90.0f;  // linear / rectangular / orthographic family / fallback
+  float azimuth = 0.0f;
   if (LensIsFov180(lens_type)) {
     fov = 180.0f;
   } else if (lens_type == kLensTypeGlobe) {
     fov = 30.0f;
+    // Globe is outside-in: az=0 puts the camera behind the sphere, opposite to
+    // every inside-out lens. Default az=-180 so first-time entry / Reset shows
+    // the same direction users see in non-Globe projections at az=0.
+    azimuth = -180.0f;
   }
   // Orthographic single + dual already fall through to 90; no extra branch.
-  return { fov, 0.0f, 0.0f, 0.0f };
+  return { fov, 0.0f, azimuth, 0.0f };
 }
 
 // Globe lens forces roll=0 at render time without writing back to the stored

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -168,6 +168,40 @@ InvResult PixelToWorldDir(float px, float py, float res_x, float res_y, int lens
     // Dual orthographic: shader uses dualFisheyeInverse(type=3), no view matrix.
     r = DualFisheyeInv(px, py, res_x, res_y, 3);
     needs_view = false;
+  } else if (lens_type == kLensTypeGlobe) {
+    // Mirror shader globeInverse (preview_renderer.cpp:270-288). Camera sits at
+    // eye-space (0, 0, D); intersect ray with the unit sphere at the origin and
+    // return hit_eye as a unit-length eye-space direction. The needs_view branch
+    // below applies view_matrix (eye → world), matching shader's
+    // result = u_view_matrix * hit_eye — these two paths are mathematically
+    // equivalent.
+    float short_edge = std::min(res_x, res_y);
+    float focal = short_edge * 0.5f / std::tan(half_fov);
+    float dx = px;
+    float dy = py;
+    float dz = -focal;
+    float dlen = std::sqrt(dx * dx + dy * dy + dz * dz);
+    dx /= dlen;
+    dy /= dlen;
+    dz /= dlen;
+    float b = kGlobeCameraD * dz;  // dot(O, d), O = (0, 0, D)
+    float c = kGlobeCameraD * kGlobeCameraD - 1.0f;
+    float disc = b * b - c;
+    if (disc < 0.0f) {
+      r = { 0, 0, 0, false };  // ray misses sphere
+    } else {
+      float t = -b - std::sqrt(disc);
+      if (t <= 0.0f) {
+        r = { 0, 0, 0, false };  // hit behind camera
+      } else {
+        float hx = t * dx;
+        float hy = t * dy;
+        float hz = kGlobeCameraD + t * dz;
+        r = { hx, hy, hz, true };
+      }
+    }
+    // needs_view stays true: hit_eye is in eye space; the public block multiplies
+    // by view_matrix to move it to world space.
   } else {
     r = { 0, 0, 0, false };
   }
@@ -246,6 +280,21 @@ FwdResult WorldDirToPixel(float wx, float wy, float wz, float res_x, float res_y
     }
     float scale = r_norm * img_radius / rho;
     return { dx * scale, dy * scale, true };
+  }
+  if (lens_type == kLensTypeGlobe) {
+    // (dx,dy,dz) is the unit-length world dir transformed to eye-space. The world
+    // point on the sphere surface in this direction is P_eye = (dx,dy,dz). With
+    // the camera at O = (0,0,D), the front hemisphere visible to the camera is
+    // P_eye.z > 1/D. See plan §3 design point 4 for the derivation.
+    if (dz <= 1.0f / kGlobeCameraD) {
+      return { 0, 0, false };
+    }
+    float focal = short_edge * 0.5f / std::tan(half_fov);
+    float denom = kGlobeCameraD - dz;
+    if (denom <= 1e-6f) {
+      return { 0, 0, false };
+    }
+    return { dx / denom * focal, dy / denom * focal, true };
   }
   // Full-sky lens types (dual fisheye 4-6, rectangular 7, dual orthographic 9):
   // their shader paths skip the view matrix and the entire sphere is always

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -197,6 +197,15 @@ InvResult PixelToWorldDir(float px, float py, float res_x, float res_y, int lens
         float hx = t * dx;
         float hy = t * dy;
         float hz = kGlobeCameraD + t * dz;
+        // Mathematically |hit_eye| == 1 on the unit sphere; normalize to absorb
+        // float error near grazing incidence (disc ≈ 0), matching FisheyeInv's
+        // explicit normalization style.
+        float hn = std::sqrt(hx * hx + hy * hy + hz * hz);
+        if (hn > 0.0f) {
+          hx /= hn;
+          hy /= hn;
+          hz /= hn;
+        }
         r = { hx, hy, hz, true };
       }
     }
@@ -280,20 +289,18 @@ FwdResult WorldDirToPixel(float wx, float wy, float wz, float res_x, float res_y
     }
     float scale = r_norm * img_radius / rho;
     return { dx * scale, dy * scale, true };
-  }
-  if (lens_type == kLensTypeGlobe) {
+  } else if (lens_type == kLensTypeGlobe) {
     // (dx,dy,dz) is the unit-length world dir transformed to eye-space. The world
     // point on the sphere surface in this direction is P_eye = (dx,dy,dz). With
     // the camera at O = (0,0,D), the front hemisphere visible to the camera is
-    // P_eye.z > 1/D. See plan §3 design point 4 for the derivation.
+    // P_eye.z > 1/D. See plan §3 design point 4 for the derivation. After this
+    // visibility filter, denom = D - dz lies in [D - 1, D - 1/D] = [3.0, 3.75]
+    // for D=4.0, so it never approaches zero.
     if (dz <= 1.0f / kGlobeCameraD) {
       return { 0, 0, false };
     }
     float focal = short_edge * 0.5f / std::tan(half_fov);
     float denom = kGlobeCameraD - dz;
-    if (denom <= 1e-6f) {
-      return { 0, 0, false };
-    }
     return { dx / denom * focal, dy / denom * focal, true };
   }
   // Full-sky lens types (dual fisheye 4-6, rectangular 7, dual orthographic 9):

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -268,6 +268,7 @@ vec4 rectangularInverse(vec2 pos) {
 // the world origin (camera always looks at the sphere center); if that ever changes
 // this function must switch to mat4 + explicit world-space ray-sphere intersection.
 vec4 globeInverse(vec2 pos, float half_fov) {
+  // kGlobeCameraDist must match kGlobeCameraD in src/gui/gui_constants.hpp.
   const float kGlobeCameraDist = 4.0;
   float short_edge = min(u_resolution.x, u_resolution.y);
   float focal = short_edge * 0.5 / tan(half_fov);

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -26,7 +26,7 @@ in vec2 v_ndc;               // NDC position [-1, 1]
 
 uniform sampler2D u_texture;
 uniform vec2 u_resolution;   // viewport size in pixels
-uniform int u_lens_type;     // 0=linear, 1-3=fisheye, 4-6=dual fisheye, 7=rectangular, 8=fisheye_orthographic, 9=dual_fisheye_orthographic
+uniform int u_lens_type;     // 0=linear, 1-3=fisheye, 4-6=dual fisheye, 7=rectangular, 8=fisheye_orthographic, 9=dual_fisheye_orthographic, 10=globe
 uniform float u_fov;         // full FOV in degrees
 uniform mat3 u_view_matrix;  // view-to-world rotation (inverse view)
 uniform int u_visible;       // 0=upper, 1=lower, 2=full
@@ -257,6 +257,36 @@ vec4 rectangularInverse(vec2 pos) {
   return vec4(d, 1.0);
 }
 
+// Globe (outside-in unit sphere): pinhole camera at (0,0,+D) in eye space looking
+// toward -z; sphere of radius 1 sits at the origin. Returns the world-space unit
+// vector pointing from the sphere center to the ray-sphere hit. needs_view_transform
+// must be set false by the caller (u_view_matrix is applied here directly).
+//
+// kGlobeCameraDist = 4.0 chosen so default fov=30° gives sphere angular diameter
+// ~28.96° (~96% of short edge), matching the crystal preview's zoom=1 distance scale.
+// Treating hit_eye as a direction is valid because the sphere center coincides with
+// the world origin (camera always looks at the sphere center); if that ever changes
+// this function must switch to mat4 + explicit world-space ray-sphere intersection.
+vec4 globeInverse(vec2 pos, float half_fov) {
+  const float kGlobeCameraDist = 4.0;
+  float short_edge = min(u_resolution.x, u_resolution.y);
+  float focal = short_edge * 0.5 / tan(half_fov);
+  vec3 d = normalize(vec3(pos, -focal));  // ray dir in eye space
+
+  // Solve |O + t*d|^2 = 1 with O = (0, 0, D):
+  //   t^2 + 2*D*d.z*t + (D^2 - 1) = 0
+  float b = kGlobeCameraDist * d.z;  // = dot(O, d)
+  float c = kGlobeCameraDist * kGlobeCameraDist - 1.0;
+  float disc = b * b - c;
+  if (disc < 0.0) return vec4(0.0, 0.0, 0.0, 0.0);  // ray misses sphere
+  float t = -b - sqrt(disc);                        // closest positive root (d.z < 0)
+  if (t <= 0.0) return vec4(0.0, 0.0, 0.0, 0.0);    // hit behind camera
+
+  vec3 hit_eye = vec3(0.0, 0.0, kGlobeCameraDist) + t * d;  // unit-length on sphere
+  vec3 hit_world = u_view_matrix * hit_eye;
+  return vec4(normalize(hit_world), 1.0);
+}
+
 // Overlay auxiliary lines on top of final_color.
 // world_dir must be a valid world-space direction.
 vec3 overlayAuxLines(vec3 world_dir, vec3 color) {
@@ -329,6 +359,9 @@ void main() {
   } else if (u_lens_type == 9) {   // kLensTypeDualFisheyeOrthographic
     result = dualFisheyeInverse(pos, 3);
     needs_view_transform = false;  // Core dual fisheye works in world space
+  } else if (u_lens_type == 10) {  // kLensTypeGlobe
+    result = globeInverse(pos, half_fov);
+    needs_view_transform = false;  // globeInverse already returned world-space dir
   }
   // else: unknown u_lens_type → result.w = 0 (black). static_assert in gui_state.hpp
   // pins kLensTypeCount so any out-of-range value is a compile-time catchable mismatch.

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1879,58 +1879,161 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_render/lens_globe_trackball — DEGRADED (Path C per plan §3 Step 3
-  // decision tree). The main-viewport "##preview_interact" InvisibleButton is
-  // created only when g_preview.HasTexture() || g_preview.HasBackground() is
-  // true (app_panels.cpp:669); under ResetTestState (no simulation yet, no
-  // texture uploaded) the button is not rendered, so neither Path A
-  // (ItemDragWithDelta) nor Path B (ItemHold + IO MouseDelta injection) can
-  // address it — both depend on ItemExists succeeding.
-  // Falling back to Path C: assert the trackball-adjacent state-level
-  // invariants that DO hold without an active drag handler:
-  //   1) Globe lens preserves a non-zero pre-set roll across multiple frames
-  //      (no spurious zero-out from any per-frame Globe code path).
-  //   2) Globe lens does NOT auto-modify azimuth / elevation in the absence
-  //      of user input (proxy for "trackball is dormant unless dragged").
-  // Trackball math (drag → azimuth, clamp at ±89) is left to manual GUI
-  // verification; revisit with a follow-up task that either provides a
-  // texture upload helper for tests or refactors the drag handler into a
-  // testable pure function (see scratchpad/backlog.md for the tracked item).
+  // p2_render/lens_*trackball — Path A real-drag coverage upgrade (scrum 175.2).
+  // Five contract tests over the drag handler at app_panels.cpp:776-793:
+  //   T1 lens_globe_trackball              — Globe az direction (+dx → +az)
+  //   T2 lens_fisheye_trackball            — non-Globe az direction (+dx → -az)
+  //   T3 lens_globe_trackball_az_wrap      — az wrap across ±180°
+  //   T4 lens_globe_trackball_el_clamp     — Globe el clamp at +89°
+  //   T5 lens_fisheye_trackball_el_clamp   — non-Globe el clamp at +90°
   //
-  // Difference vs lens_globe_view_controls (avoid being mistaken for a
-  // duplicate when triaging coverage):
-  //   - lens_globe_view_controls: 3-yield window, focuses on "field assigned
-  //     under Globe is preserved across one render cycle" (functional check).
-  //   - lens_globe_trackball (Path C): 10-yield window split across two
-  //     blocks, focuses on "no cross-frame drift", and crucially keeps the
-  //     test ID "trackball" so a future follow-up can replace the assertion
-  //     body with real drag coverage WITHOUT renaming the test (preserving
-  //     the issue.md AC3 mapping at the test-name level).
+  // The main-viewport "##preview_interact" InvisibleButton is rendered only
+  // when g_preview.HasTexture() || g_preview.HasBackground() is true (see
+  // app_panels.cpp:676). The shared GuiFunc below uploads a synth texture so
+  // the button becomes addressable; this mirrors the BgOverlayGuiFunc pattern
+  // in test_gui_bg.cpp:8-14. The local static upload-done flag isolates this
+  // group from g_export_test, avoiding cross-file shared-state coupling.
+  static bool s_trackball_upload_done = false;
+  auto trackball_gui_func = [](ImGuiTestContext* /*ctx*/) {
+    if (!s_trackball_upload_done) {
+      InitSynthTexture();
+      gui::g_preview.UploadTexture(g_synth_tex.data(), kSynthTexW, kSynthTexH);
+      s_trackball_upload_done = true;
+    }
+  };
+
+  // T1: Globe drag direction. dx=+60 px @ 0.3 sensitivity → az ≈ +18°.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball");
+    t->GuiFunc = trackball_gui_func;
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
-      ctx->Yield(2);
+      s_trackball_upload_done = false;
+      ctx->Yield(3);
+      IM_CHECK(gui::g_preview.HasTexture());
 
       gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
       gui::g_state.renderer.fov = 60.0f;
-      gui::g_state.renderer.azimuth = 12.0f;
-      gui::g_state.renderer.elevation = -8.0f;
-      // Pre-set non-zero roll: must stay 7.0 across yields under Globe lens.
-      gui::g_state.renderer.roll = 7.0f;
-      ctx->Yield(5);
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      gui::g_state.renderer.roll = 0.0f;
+      ctx->Yield(2);
 
-      // Trackball does not run (no drag input, no addressable preview button).
-      // State must be exactly what we wrote — Globe must not clobber any field.
-      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 12.0f);
-      IM_CHECK_EQ(gui::g_state.renderer.elevation, -8.0f);
-      IM_CHECK_EQ(gui::g_state.renderer.roll, 7.0f);
+      ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(60.0f, 0.0f));
+      ctx->Yield(2);
 
-      // Multiple additional yields: still unchanged (no drift).
-      ctx->Yield(5);
-      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 12.0f);
-      IM_CHECK_EQ(gui::g_state.renderer.elevation, -8.0f);
-      IM_CHECK_EQ(gui::g_state.renderer.roll, 7.0f);
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, 17.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, 19.0f);
+      IM_CHECK_LT(std::fabs(gui::g_state.renderer.elevation), 0.5f);
+      IM_CHECK_LT(std::fabs(gui::g_state.renderer.roll), 0.001f);
+    };
+  }
+
+  // T2: non-Globe drag direction is opposite (sign flip in app_panels.cpp:780).
+  // dx=+60 px → az ≈ -18° on FisheyeEquidist.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_fisheye_trackball");
+    t->GuiFunc = trackball_gui_func;
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      s_trackball_upload_done = false;
+      ctx->Yield(3);
+      IM_CHECK(gui::g_preview.HasTexture());
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      gui::g_state.renderer.roll = 0.0f;
+      ctx->Yield(2);
+
+      ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(60.0f, 0.0f));
+      ctx->Yield(2);
+
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, -19.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, -17.0f);
+      IM_CHECK_LT(std::fabs(gui::g_state.renderer.elevation), 0.5f);
+      IM_CHECK_LT(std::fabs(gui::g_state.renderer.roll), 0.001f);
+    };
+  }
+
+  // T3: az wrap across +180°. Start az=170, drag dx=+200 → 170 + 60 = 230 →
+  // wrap by -360 → -130. Validates app_panels.cpp:783-789.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball_az_wrap");
+    t->GuiFunc = trackball_gui_func;
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      s_trackball_upload_done = false;
+      ctx->Yield(3);
+      IM_CHECK(gui::g_preview.HasTexture());
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.azimuth = 170.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      gui::g_state.renderer.roll = 0.0f;
+      ctx->Yield(2);
+
+      ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(200.0f, 0.0f));
+      ctx->Yield(2);
+
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, -131.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, -129.0f);
+    };
+  }
+
+  // T4: Globe el clamps at ±89° (tighter than non-Globe ±90°). Globe formula
+  // is `el -= dy * 0.3` (app_panels.cpp:778), so dy=-1000 drives +300 toward
+  // the upper limit — far past +89, which std::min collapses to exactly 89.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball_el_clamp");
+    t->GuiFunc = trackball_gui_func;
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      s_trackball_upload_done = false;
+      ctx->Yield(3);
+      IM_CHECK(gui::g_preview.HasTexture());
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      gui::g_state.renderer.roll = 0.0f;
+      ctx->Yield(2);
+
+      ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(0.0f, -1000.0f));
+      ctx->Yield(2);
+
+      IM_CHECK_GE(gui::g_state.renderer.elevation, 89.0f);
+      IM_CHECK_LT(gui::g_state.renderer.elevation, 89.5f);
+    };
+  }
+
+  // T5: non-Globe el clamps at ±90° (looser limit branch in app_panels.cpp:792).
+  // Non-Globe formula is `el += dy * 0.3` (app_panels.cpp:781), so dy=+1000
+  // drives +300 toward +90.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_fisheye_trackball_el_clamp");
+    t->GuiFunc = trackball_gui_func;
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      s_trackball_upload_done = false;
+      ctx->Yield(3);
+      IM_CHECK(gui::g_preview.HasTexture());
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      gui::g_state.renderer.roll = 0.0f;
+      ctx->Yield(2);
+
+      ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(0.0f, 1000.0f));
+      ctx->Yield(2);
+
+      IM_CHECK_GE(gui::g_state.renderer.elevation, 90.0f);
+      IM_CHECK_LT(gui::g_state.renderer.elevation, 90.5f);
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1833,11 +1833,10 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.fov = 360.0f;
       ctx->Yield(3);
 
-      // Switch to Globe (MaxFov=90). fov must drop to <= 90.
+      // Switch to Globe (MaxFov=90). The per-frame clamp pulls fov to 90.
       gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
       ctx->Yield(3);
-      IM_CHECK_LE(gui::g_state.renderer.fov, 90.0f);
-      IM_CHECK_GT(gui::g_state.renderer.fov, 0.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.fov, 90.0f);
 
       // Push fov past the cap; the per-frame clamp pulls it back to <= 90.
       gui::g_state.renderer.fov = 200.0f;
@@ -1896,7 +1895,17 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
   // Trackball math (drag → azimuth, clamp at ±89) is left to manual GUI
   // verification; revisit with a follow-up task that either provides a
   // texture upload helper for tests or refactors the drag handler into a
-  // testable pure function (see progress.md DECISION entry for context).
+  // testable pure function (see SUMMARY backlog entry for context).
+  //
+  // Difference vs lens_globe_view_controls (avoid being mistaken for a
+  // duplicate when triaging coverage):
+  //   - lens_globe_view_controls: 3-yield window, focuses on "field assigned
+  //     under Globe is preserved across one render cycle" (functional check).
+  //   - lens_globe_trackball (Path C): 10-yield window split across two
+  //     blocks, focuses on "no cross-frame drift", and crucially keeps the
+  //     test ID "trackball" so a future follow-up can replace the assertion
+  //     body with real drag coverage WITHOUT renaming the test (preserving
+  //     the issue.md AC3 mapping at the test-name level).
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -1941,14 +1950,16 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       // Sanity: the Reset button must be addressable on the default lens.
       IM_CHECK(ctx->ItemExists("**/Reset##view"));
 
-      const int lens_set[] = { gui::kLensTypeFisheyeEquidist, gui::kLensTypeGlobe };
+      int lens_set[] = { gui::kLensTypeFisheyeEquidist, gui::kLensTypeGlobe };
       for (int lens : lens_set) {
         ResetTestState();
         ctx->Yield(2);
 
         gui::g_state.renderer.lens_type = lens;
-        const int visible_before = gui::g_state.renderer.visible;
         ctx->Yield(3);
+        // Capture visible AFTER the lens-switch frame settles, so the snapshot
+        // reflects any per-frame normalization the new lens may apply.
+        int visible_before = gui::g_state.renderer.visible;
 
         // User edits all four resettable fields.
         gui::g_state.renderer.fov = 42.0f;
@@ -1960,7 +1971,7 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
         ctx->ItemClick("**/Reset##view");
         ctx->Yield(3);
 
-        const gui::ViewDefaults def = gui::DefaultViewParamsFor(lens);
+        gui::ViewDefaults def = gui::DefaultViewParamsFor(lens);
         IM_CHECK_EQ(gui::g_state.renderer.fov, def.fov);
         IM_CHECK_EQ(gui::g_state.renderer.elevation, def.elevation);
         IM_CHECK_EQ(gui::g_state.renderer.azimuth, def.azimuth);

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1814,6 +1814,192 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // ===== task-tests-and-baseline (scrum-outside-in-globe-view 173.4) =====
+  // Globe lens (lens=10) GUI interaction coverage. Verifies the lens-type
+  // selection / per-lens view controls / trackball drag handler / unified
+  // Reset button / cross-lens roll preservation, all of which were exercised
+  // only by manual GUI in scrum 173.3 due to headless-runner limits.
+
+  // p2_render/lens_globe_selection — selecting Globe drives FOV max to 90
+  // (MaxFov(kGlobe) = 90, src/config/render_config.cpp:138).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_selection");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Start with Dual Fisheye EA (fov=360) to prove the subsequent clamp is real.
+      gui::g_state.renderer.lens_type = gui::kLensTypeDualFisheyeEqualArea;
+      gui::g_state.renderer.fov = 360.0f;
+      ctx->Yield(3);
+
+      // Switch to Globe (MaxFov=90). fov must drop to <= 90.
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      ctx->Yield(3);
+      IM_CHECK_LE(gui::g_state.renderer.fov, 90.0f);
+      IM_CHECK_GT(gui::g_state.renderer.fov, 0.0f);
+
+      // Push fov past the cap; the per-frame clamp pulls it back to <= 90.
+      gui::g_state.renderer.fov = 200.0f;
+      ctx->Yield(3);
+      IM_CHECK_LE(gui::g_state.renderer.fov, 90.0f);
+    };
+  }
+
+  // p2_render/lens_globe_view_controls — Globe is NOT in kFullSkyLensTypes,
+  // so elevation/azimuth must NOT be force-zeroed, the stored roll value
+  // must be preserved (Globe disables the roll slider via BeginDisabled
+  // without writing back), and the FOV cap (90) must hold.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_view_controls");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.elevation = 30.0f;
+      gui::g_state.renderer.azimuth = 45.0f;
+      // Guard: Globe activation must NOT reset stored roll field
+      // (EffectiveRollForLens reads it without writing back).
+      gui::g_state.renderer.roll = 10.0f;
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 30.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 45.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 10.0f);
+
+      // FOV slider in Globe mode caps at 90.
+      gui::g_state.renderer.fov = 80.0f;
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.fov, 80.0f);
+
+      gui::g_state.renderer.fov = 120.0f;
+      ctx->Yield(3);
+      IM_CHECK_LE(gui::g_state.renderer.fov, 90.0f);
+    };
+  }
+
+  // p2_render/lens_globe_trackball — DEGRADED (Path C per plan §3 Step 3
+  // decision tree). The main-viewport "##preview_interact" InvisibleButton is
+  // created only when g_preview.HasTexture() || g_preview.HasBackground() is
+  // true (app_panels.cpp:669); under ResetTestState (no simulation yet, no
+  // texture uploaded) the button is not rendered, so neither Path A
+  // (ItemDragWithDelta) nor Path B (ItemHold + IO MouseDelta injection) can
+  // address it — both depend on ItemExists succeeding.
+  // Falling back to Path C: assert the trackball-adjacent state-level
+  // invariants that DO hold without an active drag handler:
+  //   1) Globe lens preserves a non-zero pre-set roll across multiple frames
+  //      (no spurious zero-out from any per-frame Globe code path).
+  //   2) Globe lens does NOT auto-modify azimuth / elevation in the absence
+  //      of user input (proxy for "trackball is dormant unless dragged").
+  // Trackball math (drag → azimuth, clamp at ±89) is left to manual GUI
+  // verification; revisit with a follow-up task that either provides a
+  // texture upload helper for tests or refactors the drag handler into a
+  // testable pure function (see progress.md DECISION entry for context).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.azimuth = 12.0f;
+      gui::g_state.renderer.elevation = -8.0f;
+      // Pre-set non-zero roll: must stay 7.0 across yields under Globe lens.
+      gui::g_state.renderer.roll = 7.0f;
+      ctx->Yield(5);
+
+      // Trackball does not run (no drag input, no addressable preview button).
+      // State must be exactly what we wrote — Globe must not clobber any field.
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 12.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, -8.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 7.0f);
+
+      // Multiple additional yields: still unchanged (no drift).
+      ctx->Yield(5);
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 12.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, -8.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 7.0f);
+    };
+  }
+
+  // p2_render/view_reset_button — the unified View `Reset` button (added in
+  // scrum 173.3) must restore all four resettable fields to
+  // DefaultViewParamsFor(lens) for ANY current lens, while leaving lens_type
+  // and visible untouched. Two lenses cover both the 180° fov default
+  // (fisheye_equidist) and the Globe-specific 30° default + roll branch.
+  // Per issue.md AC: "至少 2 个 lens" — exhaustive enumeration is unnecessary
+  // since DefaultViewParamsFor coverage is already established at the unit
+  // level + reviewed in scrum 173.3.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "view_reset_button");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      // Sanity: the Reset button must be addressable on the default lens.
+      IM_CHECK(ctx->ItemExists("**/Reset##view"));
+
+      const int lens_set[] = { gui::kLensTypeFisheyeEquidist, gui::kLensTypeGlobe };
+      for (int lens : lens_set) {
+        ResetTestState();
+        ctx->Yield(2);
+
+        gui::g_state.renderer.lens_type = lens;
+        const int visible_before = gui::g_state.renderer.visible;
+        ctx->Yield(3);
+
+        // User edits all four resettable fields.
+        gui::g_state.renderer.fov = 42.0f;
+        gui::g_state.renderer.elevation = 33.0f;
+        gui::g_state.renderer.azimuth = -77.0f;
+        gui::g_state.renderer.roll = 11.0f;
+        ctx->Yield(3);
+
+        ctx->ItemClick("**/Reset##view");
+        ctx->Yield(3);
+
+        const gui::ViewDefaults def = gui::DefaultViewParamsFor(lens);
+        IM_CHECK_EQ(gui::g_state.renderer.fov, def.fov);
+        IM_CHECK_EQ(gui::g_state.renderer.elevation, def.elevation);
+        IM_CHECK_EQ(gui::g_state.renderer.azimuth, def.azimuth);
+        IM_CHECK_EQ(gui::g_state.renderer.roll, def.roll);
+        // Reset must NOT alter lens_type or the visibility mode.
+        IM_CHECK_EQ(gui::g_state.renderer.lens_type, lens);
+        IM_CHECK_EQ(gui::g_state.renderer.visible, visible_before);
+      }
+    };
+  }
+
+  // p2_render/lens_globe_roll_preserved_on_lens_switch — switching to Globe
+  // and back must preserve the stored RenderConfig.roll value: Globe forces
+  // roll=0 only at render time via EffectiveRollForLens (gui_state.hpp:199),
+  // never writing back to the stored field. Regression guard for the
+  // 173.3 SUMMARY §3 design contract.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_roll_preserved_on_lens_switch");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.roll = 15.0f;
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 15.0f);
+
+      // Switch to Globe — stored roll must remain 15° (display path masks it).
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 15.0f);
+
+      // Switch back — stored roll still 15°.
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.roll, 15.0f);
+    };
+  }
+
   // p2_render/modal_layout_toggle_bit — switching modal_layout_vertical is safe
   // (view preference state-level test; layout dispatch is exercised only indirectly
   // through subsequent modal open, which would require a live popup — omitted to

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1895,7 +1895,7 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
   // Trackball math (drag → azimuth, clamp at ±89) is left to manual GUI
   // verification; revisit with a follow-up task that either provides a
   // texture upload helper for tests or refactors the drag handler into a
-  // testable pure function (see SUMMARY backlog entry for context).
+  // testable pure function (see scratchpad/backlog.md for the tracked item).
   //
   // Difference vs lens_globe_view_controls (avoid being mistaken for a
   // duplicate when triaging coverage):

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -269,24 +269,38 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // overlay_labels/globe_label_visibility — Globe lens (lens=10) must produce
-  // a STRICT subset of the fisheye-equidistant grid label set under the same
-  // standard view (elev=0, az=0). Geometric reasoning: Globe applies a
-  // back-hemisphere cull (overlay_labels.cpp Globe branch, dz > 1/D
-  // visibility filter) on top of its 60° fov frustum, while
-  // fisheye-equidistant at fov=180° samples the entire visible hemisphere —
-  // n_globe < n_fisheye is guaranteed. If they ever match, Globe culling has
-  // failed. (Regression guard for 173.4 issue.md AC: "Globe ⊊ fisheye_equidist".)
+  // overlay_labels/globe_label_visibility — Globe lens (lens=10) at its
+  // MaxFov=90° produces strictly fewer grid labels than Fisheye Equidistant
+  // at fov=180° under the same view (elev=0, az=0).
+  //
+  // What this test actually verifies (honest scope):
+  //   1) Globe lens label generation is wired up (n_globe > 0).
+  //   2) Globe at its native MaxFov never produces more grid labels than a
+  //      full-hemisphere fisheye at fov=180° (regression guard against
+  //      Globe label sampling running away or duplicating across passes).
+  //
+  // What this test does NOT directly verify:
+  //   - Globe's back-hemisphere `dz > 1/kGlobeCameraD` cull at
+  //     overlay_labels.cpp:299. At fov=90°/el=0/az=0, the Globe frustum is
+  //     a 45°-half-angle cone around +Z, so all sampled directions satisfy
+  //     dz ≥ cos(45°) ≈ 0.707 — the dz cull is geometrically unreachable
+  //     with this config. The strict inequality below is therefore secured
+  //     by the fov-asymmetry (90° vs 180°) only, not by the dz cull.
+  // Direct dz-cull coverage requires either a tilted view (e.g. el ≈ 60°
+  // bringing the cone into the wz < 0.25 region) or a same-fov comparison;
+  // captured as a follow-up backlog item (see SUMMARY).
+  // 60° matches SingleOrthoLatTestFunc baseline above; 90° here equals
+  // MaxFov(Globe), so no extra clamp interaction.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "globe_label_visibility");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       IM_UNUSED(ctx);
-      // Globe at fov=60° — front hemisphere subject to dz > 0.25 culling.
+      // Globe at fov=90° — its full native field of view (MaxFov(Globe)=90°).
       auto in_globe = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeGlobe,
                                    /*elev*/ 0.0f, /*az*/ 0.0f);
-      in_globe.fov = 60.0f;
-      // Fisheye Equidistant at fov=180° — full hemisphere, ensures strict
-      // numerical gap with Globe's culled subset.
+      in_globe.fov = 90.0f;
+      // Fisheye Equidistant at fov=180° — full hemisphere, deliberately
+      // wider than Globe's 90° to keep n_fisheye > n_globe by a margin.
       auto in_fisheye = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
                                      /*elev*/ 0.0f, /*az*/ 0.0f);
       in_fisheye.fov = 180.0f;
@@ -296,12 +310,12 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       lumice::gui::ComputeOverlayLabels(in_globe, 0.0f, 0.0f, 200.0f, 200.0f, labels_globe);
       lumice::gui::ComputeOverlayLabels(in_fisheye, 0.0f, 0.0f, 200.0f, 200.0f, labels_fisheye);
 
-      const int n_globe = CountGridLabels(labels_globe);
-      const int n_fisheye = CountGridLabels(labels_fisheye);
+      int n_globe = CountGridLabels(labels_globe);
+      int n_fisheye = CountGridLabels(labels_fisheye);
 
-      // Front-hemisphere visibility: Globe must produce at least one label.
+      // Globe must produce at least one label.
       IM_CHECK_GT(n_globe, 0);
-      // Strict subset: matches issue.md AC "⊊" (Globe culled vs fisheye full).
+      // Globe (fov=90°) strictly fewer than fisheye (fov=180°) under the same view.
       IM_CHECK_LT(n_globe, n_fisheye);
     };
   }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -269,6 +269,43 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // overlay_labels/globe_label_visibility — Globe lens (lens=10) must produce
+  // a STRICT subset of the fisheye-equidistant grid label set under the same
+  // standard view (elev=0, az=0). Geometric reasoning: Globe applies a
+  // back-hemisphere cull (overlay_labels.cpp Globe branch, dz > 1/D
+  // visibility filter) on top of its 60° fov frustum, while
+  // fisheye-equidistant at fov=180° samples the entire visible hemisphere —
+  // n_globe < n_fisheye is guaranteed. If they ever match, Globe culling has
+  // failed. (Regression guard for 173.4 issue.md AC: "Globe ⊊ fisheye_equidist".)
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "globe_label_visibility");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      // Globe at fov=60° — front hemisphere subject to dz > 0.25 culling.
+      auto in_globe = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeGlobe,
+                                   /*elev*/ 0.0f, /*az*/ 0.0f);
+      in_globe.fov = 60.0f;
+      // Fisheye Equidistant at fov=180° — full hemisphere, ensures strict
+      // numerical gap with Globe's culled subset.
+      auto in_fisheye = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeFisheyeEquidist,
+                                     /*elev*/ 0.0f, /*az*/ 0.0f);
+      in_fisheye.fov = 180.0f;
+
+      std::vector<lumice::gui::OverlayLabel> labels_globe;
+      std::vector<lumice::gui::OverlayLabel> labels_fisheye;
+      lumice::gui::ComputeOverlayLabels(in_globe, 0.0f, 0.0f, 200.0f, 200.0f, labels_globe);
+      lumice::gui::ComputeOverlayLabels(in_fisheye, 0.0f, 0.0f, 200.0f, 200.0f, labels_fisheye);
+
+      const int n_globe = CountGridLabels(labels_globe);
+      const int n_fisheye = CountGridLabels(labels_fisheye);
+
+      // Front-hemisphere visibility: Globe must produce at least one label.
+      IM_CHECK_GT(n_globe, 0);
+      // Strict subset: matches issue.md AC "⊊" (Globe culled vs fisheye full).
+      IM_CHECK_LT(n_globe, n_fisheye);
+    };
+  }
+
   // Test F: Modal z-order regression — DrawOverlayLabels must target the current
   // window's draw list (not foreground), so modals correctly occlude labels.
   // F9: ImGui API calls must go through GuiFunc (main thread); TestFunc reads

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -373,7 +373,7 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       // "%.0f\xC2\xB0" format byte-for-byte without depending on
       // source-charset handling.
       constexpr int kGridGroup = 0;
-      auto has_label = [&labels](const char* text) {
+      auto has_label = [&labels, kGridGroup](const char* text) {
         for (const auto& l : labels) {
           if (l.group == kGridGroup && l.text == text) {
             return true;

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -287,10 +287,10 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
   //     with this config. The strict inequality below is therefore secured
   //     by the fov-asymmetry (90° vs 180°) only, not by the dz cull.
   // Direct dz-cull coverage requires either a tilted view (e.g. el ≈ 60°
-  // bringing the cone into the wz < 0.25 region) or a same-fov comparison;
-  // captured as a follow-up backlog item (see SUMMARY).
-  // 60° matches SingleOrthoLatTestFunc baseline above; 90° here equals
-  // MaxFov(Globe), so no extra clamp interaction.
+  // bringing the cone into the wz < 0.25 region) or a same-fov comparison
+  // that pulls the cone past the dz threshold; captured as a follow-up in
+  // scratchpad/backlog.md.
+  // fov=90° here equals MaxFov(Globe), so per-frame clamp does not interact.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "globe_label_visibility");
     t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -366,14 +366,16 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       std::vector<lumice::gui::OverlayLabel> labels;
       lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
 
-      // group filter mirrors CountGridLabels: altitude/azimuth grid labels are
-      // pushed with kGroupGrid (0); Source 4 specifically uses it at
-      // overlay_labels.cpp:730. Byte-literal "\xC2\xB0" (UTF-8 for °) matches
-      // AddLabel's "%.0f\xC2\xB0" format byte-for-byte without depending on
+      // Mirrors kGroupGrid in overlay_labels.cpp:346 — kept private to the
+      // test because the constant is in an anonymous namespace there. Source 4
+      // emits altitude labels with this group at overlay_labels.cpp:730.
+      // Byte-literal "\xC2\xB0" (UTF-8 for °) matches AddLabel's
+      // "%.0f\xC2\xB0" format byte-for-byte without depending on
       // source-charset handling.
+      constexpr int kGridGroup = 0;
       auto has_label = [&labels](const char* text) {
         for (const auto& l : labels) {
-          if (l.group == 0 && l.text == text) {
+          if (l.group == kGridGroup && l.text == text) {
             return true;
           }
         }

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -320,6 +320,82 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // overlay_labels/globe_label_dz_cull_active — directly pin the back-hemisphere
+  // dz cull at overlay_labels.cpp:299 (`if (dz <= 1.0f / kGlobeCameraD)`).
+  //
+  // Companion to globe_label_visibility above, which only verifies the loose
+  // n_globe < n_fisheye(fov=180°) inequality — that one passes even if the dz
+  // cull is removed (it's secured by fov-asymmetry alone). This test fails
+  // whenever the dz cull is removed, threshold flipped, or comparison reversed.
+  //
+  // Mechanism:
+  //   With Globe + fov=90° + elev=0 + az=0, all grid labels in the output come
+  //   from sample_interior_latitudes (Source 4 in overlay_labels.cpp's
+  //   sample-source dispatch comment). Source 1 (viewport edges) is empty here:
+  //   the visible-cone half-angle is asin(1/kGlobeCameraD) = asin(0.25) ≈ 14.5°,
+  //   so all viewport-edge rays at fov/2 = 45° miss the unit sphere
+  //   (PixelToWorldDir returns invalid). Source 2/3 are gated on visible≠Full,
+  //   Source 5 on show_sun_circles=true; both inactive here. So only Source 4
+  //   contributes, and Source 4's only forward-projection gate (besides
+  //   viewport-bound) is the dz cull itself — no other path can write the
+  //   altitude text labels we assert against.
+  //
+  // Geometric pin (with kGlobeCameraD=4 ⇒ threshold dz=0.25, view_matrix at
+  // elev=0/az=0 reduces to dz_eye = wx):
+  //   - alt=±70°: max wx across azimuths = cos(70°) ≈ 0.342 > 0.25 → some az
+  //     passes → "70°" / "-70°" labels MUST appear (positive control; guards
+  //     against threshold being raised to 1.0 which would silently pass the
+  //     negative assertion).
+  //   - alt=±80°: max wx across azimuths = cos(80°) ≈ 0.174 < 0.25 → ALL az
+  //     fail dz cull → "80°" / "-80°" labels MUST NOT appear (the only
+  //     observable consequence of the dz cull at this config). Removing the
+  //     cull would let alt=±80° through (denom=D-dz≈3.826, focal=100, projected
+  //     py ≈ sin(80°)·100/3.826 ≈ 25.7 < hh=100, well inside viewport).
+  //
+  // ±85° would also satisfy the math, but kAltitudeSteps in
+  // overlay_labels.cpp:694 currently runs ±10°…±80° — picking ±80° keeps the
+  // test resilient to step-set narrowing (only widening could miss it).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "globe_label_dz_cull_active");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto in = MakeGridOnly(lumice::gui::kVisibleFull, lumice::gui::kLensTypeGlobe,
+                             /*elev*/ 0.0f, /*az*/ 0.0f);
+      in.fov = 90.0f;
+
+      std::vector<lumice::gui::OverlayLabel> labels;
+      lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 200.0f, 200.0f, labels);
+
+      // group filter mirrors CountGridLabels: altitude/azimuth grid labels are
+      // pushed with kGroupGrid (0); Source 4 specifically uses it at
+      // overlay_labels.cpp:730. Byte-literal "\xC2\xB0" (UTF-8 for °) matches
+      // AddLabel's "%.0f\xC2\xB0" format byte-for-byte without depending on
+      // source-charset handling.
+      auto has_label = [&labels](const char* text) {
+        for (const auto& l : labels) {
+          if (l.group == 0 && l.text == text) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      // Sanity: generation path is alive.
+      IM_CHECK_GT(CountGridLabels(labels), 0);
+
+      // Positive control — ±70° passes dz cull (max wx = cos(70°) > 0.25).
+      // Without these the negative assertion below could silently pass by
+      // having the threshold raised to 1.0 (cull everything → 80° also absent).
+      IM_CHECK(has_label("70\xC2\xB0"));
+      IM_CHECK(has_label("-70\xC2\xB0"));
+
+      // The dz cull's only observable consequence at this config: ±80° MUST
+      // be culled (max wx = cos(80°) < 0.25, fails for all azimuths).
+      IM_CHECK(!has_label("80\xC2\xB0"));
+      IM_CHECK(!has_label("-80\xC2\xB0"));
+    };
+  }
+
   // Test F: Modal z-order regression — DrawOverlayLabels must target the current
   // window's draw list (not foreground), so modals correctly occlude labels.
   // F9: ImGui API calls must go through GuiFunc (main thread); TestFunc reads

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -470,4 +470,38 @@ TEST(LensConfigOrthographic, FCalcTooShortThrows) {
   EXPECT_THROW(j.get<LensParam>(), nlohmann::detail::out_of_range);
 }
 
+// =============== Lens Globe ===============
+
+TEST(LensConfigGlobe, MaxFovIs90) {
+  EXPECT_FLOAT_EQ(MaxFov(LensParam::kGlobe), 90.0f);
+}
+
+TEST(LensConfigGlobe, FovDirectRoundTrip) {
+  nlohmann::json j = { { "type", "globe" }, { "fov", 30.0f } };
+  auto l = j.get<LensParam>();
+  EXPECT_EQ(l.type_, LensParam::kGlobe);
+  EXPECT_NEAR(l.fov_, 30.0f, 1e-5f);
+
+  nlohmann::json out = l;
+  EXPECT_EQ(out["type"], "globe");
+  EXPECT_NEAR(out["fov"].get<float>(), 30.0f, 1e-5f);
+}
+
+TEST(LensConfigGlobe, FovDirectBoundary) {
+  nlohmann::json ok = { { "type", "globe" }, { "fov", 90.0f } };
+  EXPECT_NO_THROW(ok.get<LensParam>());
+
+  nlohmann::json over = { { "type", "globe" }, { "fov", 90.01f } };
+  EXPECT_THROW(over.get<LensParam>(), nlohmann::detail::out_of_range);
+
+  nlohmann::json zero = { { "type", "globe" }, { "fov", 0.0f } };
+  EXPECT_THROW(zero.get<LensParam>(), nlohmann::detail::out_of_range);
+}
+
+TEST(LensConfigGlobe, FFieldRejected) {
+  // Globe lens does not support f-derived fov.
+  nlohmann::json j = { { "type", "globe" }, { "f", 12.0f } };
+  EXPECT_THROW(j.get<LensParam>(), nlohmann::detail::out_of_range);
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary
- Add a new Globe lens type: enum + JSON mapping (core), shader branch and preview integration (gui), with documentation updates.
- Implement trackball-style drag interaction (with correct direction, azimuth wrap, FOV reset on lens switch, and azimuth defaulting to -180 to match other lenses' view direction) plus overlay labels with back-hemisphere depth culling.
- Add unit/GUI test coverage: JSON config tests, lens trackball drag tests (Path A), and overlay label cull tests pinning Globe back-hemisphere behavior.

## Test plan
- [ ] \`./scripts/build.sh -tj release\` (unit tests)
- [ ] \`./scripts/build.sh -gtj release\` (GUI tests, including \`globe_label_dz_cull_active\` and \`lens_*trackball\`)
- [ ] Manual GUI smoke: switch to Globe lens, drag to rotate, switch lenses to confirm FOV reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)