### PR TITLE
feat: Globe↔other lens combo transform, visibility radio buttons, View panel regroup

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -368,7 +368,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
   // ---- View Group ----
   if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
-    ImGui::SeparatorText("Projection");
+    ImGui::SeparatorText("Lens");
     // Use BeginCombo + Selectable to honour kLensTypePresentationOrder (gui_state.hpp).
     // The enum value (r.lens_type) is preserved unchanged; only the display order differs.
     if (ImGui::BeginCombo("Lens Type##view", kLensTypeNames[r.lens_type])) {
@@ -403,10 +403,16 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::BeginDisabled(full_sky);
     SliderWithInput("FOV##view", &r.fov, 1.0f, max_fov, "%.0f");
     ImGui::EndDisabled();
-    ImGui::Combo("Visible##view", &r.visible, kVisibleNames, kVisibleCount);
+    ImGui::SeparatorText("Visibility");
+    ImGui::RadioButton("Upper##visible", &r.visible, kVisibleUpper);
+    ImGui::SameLine();
+    ImGui::RadioButton("Full##visible", &r.visible, kVisibleFull);
+    ImGui::RadioButton("Lower##visible", &r.visible, kVisibleLower);
+    ImGui::SameLine();
+    ImGui::RadioButton("Front##visible", &r.visible, kVisibleFront);
 
     bool is_globe = (r.lens_type == kLensTypeGlobe);
-    ImGui::SeparatorText("Camera");
+    ImGui::SeparatorText("Pose");
     if (is_globe) {
       ImGui::TextDisabled("(?)");
       if (ImGui::IsItemHovered()) {

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -403,15 +403,26 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::BeginDisabled(full_sky);
     SliderWithInput("FOV##view", &r.fov, 1.0f, max_fov, "%.0f");
     ImGui::EndDisabled();
+    bool is_globe = (r.lens_type == kLensTypeGlobe);
     ImGui::SeparatorText("Visibility");
+    if (full_sky) {
+      ImGui::BeginDisabled();
+    }
     ImGui::RadioButton("Upper##visible", &r.visible, kVisibleUpper);
     ImGui::SameLine();
     ImGui::RadioButton("Full##visible", &r.visible, kVisibleFull);
     ImGui::RadioButton("Lower##visible", &r.visible, kVisibleLower);
     ImGui::SameLine();
+    if (!full_sky) {
+      ImGui::BeginDisabled(is_globe);
+    }
     ImGui::RadioButton("Front##visible", &r.visible, kVisibleFront);
-
-    bool is_globe = (r.lens_type == kLensTypeGlobe);
+    if (!full_sky) {
+      ImGui::EndDisabled();
+    }
+    if (full_sky) {
+      ImGui::EndDisabled();
+    }
     ImGui::SeparatorText("Pose");
     if (is_globe) {
       ImGui::TextDisabled("(?)");

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -385,11 +385,19 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
             // and tests bypass this combo by writing lens_type directly, so
             // they keep their fov.
             r.fov = d.fov;
-            // Crossing the Globe boundary inverts the view direction (Globe is
-            // outside-in), so reset az to the target lens' default. el/roll
-            // are preserved — only az has the inversion semantics.
             if (was_globe != now_globe) {
-              r.azimuth = d.azimuth;
+              // Globe is outside-in: crossing the boundary inverts both az and el.
+              // az: add 180 (mod 360) — self-inverse, same formula both directions.
+              r.azimuth += 180.0f;
+              if (r.azimuth > 180.0f) {
+                r.azimuth -= 360.0f;
+              }
+              // el: negate — self-inverse, same formula both directions.
+              r.elevation = -r.elevation;
+              // Globe el is limited to ±89° to avoid view-matrix degeneracy.
+              if (now_globe) {
+                r.elevation = std::max(-89.0f, std::min(89.0f, r.elevation));
+              }
             }
           }
         }

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -190,9 +190,10 @@ inline ViewDefaults DefaultViewParamsFor(int lens_type) {
     fov = 180.0f;
   } else if (lens_type == kLensTypeGlobe) {
     fov = 30.0f;
-    // Globe is outside-in: az=0 puts the camera behind the sphere, opposite to
-    // every inside-out lens. Default az=-180 so first-time entry / Reset shows
-    // the same direction users see in non-Globe projections at az=0.
+    // Globe is outside-in: az=0 puts the camera behind the sphere. Default az=-180
+    // so View Reset shows the same forward direction as non-Globe lenses at az=0.
+    // Lens-combo direction continuity is handled separately by the transform formula
+    // in RenderRightPanel (app_panels.cpp), not by this default.
     azimuth = -180.0f;
   }
   // Orthographic single + dual already fall through to 90; no extra branch.

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2189,6 +2189,55 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_render/lens_globe_switch_transform_az180_wrap — az=180 switching to Globe
+  // applies az+180=360, which is > 180 and wraps to 0 (not staying at 360).
+  // Regression guard for the strict "> 180.0f" wrap condition.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_az180_wrap");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.azimuth = 180.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      ctx->Yield(3);
+
+      ctx->SetRef("//##RightPanel");
+      ctx->ComboClick("Lens Type##view/Globe");
+      ctx->SetRef("");
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 0.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 0.0f);
+    };
+  }
+
+  // p2_render/lens_globe_switch_transform_el_clamp — el=91° switching to Globe
+  // negates to -91°, then clamps to -89° (Globe el limit).
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_el_clamp");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 91.0f;
+      ctx->Yield(3);
+
+      ctx->SetRef("//##RightPanel");
+      ctx->ComboClick("Lens Type##view/Globe");
+      ctx->SetRef("");
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 180.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, -89.0f);
+    };
+  }
+
   // p2_render/modal_layout_toggle_bit — switching modal_layout_vertical is safe
   // (view preference state-level test; layout dispatch is exercised only indirectly
   // through subsequent modal open, which would require a live popup — omitted to

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2193,8 +2193,7 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
   // applies az+180=360, which is > 180 and wraps to 0 (not staying at 360).
   // Regression guard for the strict "> 180.0f" wrap condition.
   {
-    ImGuiTest* t =
-        IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_az180_wrap");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_az180_wrap");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);
@@ -2217,8 +2216,7 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
   // p2_render/lens_globe_switch_transform_el_clamp — el=91° switching to Globe
   // negates to -91°, then clamps to -89° (Globe el limit).
   {
-    ImGuiTest* t =
-        IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_el_clamp");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_el_clamp");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2172,6 +2172,131 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::g_state.show_sun_circles_label, true);
     };
   }
+
+  // ===== task-visible-lens-adapt (scrum-globe-view-v3 176.2) =====
+  // lens × visibility adapter matrix: full-sky lenses disable the entire
+  // Visibility section; Globe disables only the Front radio button.
+
+  // p2_render/visibility_globe_front_disabled — Globe lens: Upper/Lower/Full
+  // remain interactive, Front is greyed out (no 2-hemisphere symmetry).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_globe_front_disabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+    };
+  }
+
+  // p2_render/visibility_dual_fisheye_all_disabled — dual-fisheye (full-sky)
+  // disables all four Visibility radio buttons.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_dual_fisheye_all_disabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeDualFisheyeEqualArea;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+    };
+  }
+
+  // p2_render/visibility_rectangular_all_disabled — rectangular (full-sky)
+  // disables all four Visibility radio buttons.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_rectangular_all_disabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeRectangular;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+    };
+  }
+
+  // p2_render/visibility_dual_ortho_all_disabled — dual orthographic (full-sky)
+  // disables all four Visibility radio buttons.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_dual_ortho_all_disabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeDualFisheyeOrthographic;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+    };
+  }
+
+  // p2_render/visibility_fisheye_all_enabled — single fisheye (baseline):
+  // all four Visibility radio buttons remain interactive.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_fisheye_all_enabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEqualArea;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
+
+  // p2_render/visibility_fisheye_ortho_all_enabled — single orthographic fisheye
+  // (kLensTypeFisheyeOrthographic, enum 8) is NOT in kFullSkyLensTypes: all four
+  // Visibility radio buttons remain interactive (orthographic research conclusion).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_fisheye_ortho_all_enabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeOrthographic;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      IM_CHECK((info_upper.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_full = ctx->ItemInfo("**/Full##visible");
+      IM_CHECK((info_full.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_lower = ctx->ItemInfo("**/Lower##visible");
+      IM_CHECK((info_lower.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
 }
 
 // ========== task-test-gui-interaction: P1 Running simulation restart tests ==========

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2115,6 +2115,80 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_render/lens_globe_switch_transform_other_to_globe — switching to Globe via
+  // UI combo applies az+180 / el-negate transform (supersedes ba841e4 az-reset).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_other_to_globe");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.azimuth = 90.0f;
+      gui::g_state.renderer.elevation = 20.0f;
+      ctx->Yield(3);
+
+      // BeginCombo doesn't call IMGUI_TEST_ENGINE_ITEM_INFO so wildcard search fails for
+      // the combo button; use SetRef + ComboClick which finds the button by ID and the
+      // popup item via a window-scoped wildcard that scrolls to reveal clipped items.
+      // Globe is item 11/11 in kLensTypePresentationOrder; the default popup height is 8,
+      // so Globe is initially clipped and only reachable after popup scroll.
+      ctx->SetRef("//##RightPanel");
+      ctx->ComboClick("Lens Type##view/Globe");
+      ctx->SetRef("");
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, -90.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, -20.0f);
+    };
+  }
+
+  // p2_render/lens_globe_switch_transform_globe_to_other — switching from Globe via
+  // UI combo applies the same self-inverse transform (az+180 / el-negate).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_globe_to_other");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      gui::g_state.renderer.azimuth = -90.0f;
+      gui::g_state.renderer.elevation = -20.0f;
+      ctx->Yield(3);
+
+      ctx->SetRef("//##RightPanel");
+      ctx->ComboClick("Lens Type##view/Fisheye Equidistant");
+      ctx->SetRef("");
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 90.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 20.0f);
+    };
+  }
+
+  // p2_render/lens_globe_switch_transform_az_zero_boundary — az=0 wraps to 180
+  // (not -180): the condition is "> 180.0f" (strict), so 0+180=180 is not reduced.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_switch_transform_az_zero_boundary");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
+      gui::g_state.renderer.azimuth = 0.0f;
+      gui::g_state.renderer.elevation = 0.0f;
+      ctx->Yield(3);
+
+      ctx->SetRef("//##RightPanel");
+      ctx->ComboClick("Lens Type##view/Globe");
+      ctx->SetRef("");
+      ctx->Yield(3);
+
+      IM_CHECK_EQ(gui::g_state.renderer.azimuth, 180.0f);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 0.0f);
+    };
+  }
+
   // p2_render/modal_layout_toggle_bit — switching modal_layout_vertical is safe
   // (view preference state-level test; layout dispatch is exercised only indirectly
   // through subsequent modal open, which would require a live popup — omitted to


### PR DESCRIPTION
## Summary

- **Regroup View panel** (`task-visible-control-regroup`): split the old "Projection"/"Camera" sections into three named subsections — **Lens**, **Visibility**, and **Pose** — to mirror the logical grouping of controls.
- **Lens×Visibility adapter matrix** (`task-visible-lens-adapt`): replace the Visible combo box with radio buttons; disable the *Front* option when Globe lens is active (Globe has no front/back distinction); disable all visibility controls when Full-Sky mode is on. Covered by 6 new GUI tests.
- **Globe↔other lens combo transform** (`task-lens-switch-transform`): when crossing the Globe/non-Globe boundary, apply a mathematically self-inverse direction transform — az += 180° (mod ±180°) and el = −el — so the camera stays pointed at the same real-world direction instead of jumping. El is clamped to ±89° on Globe entry to avoid view-matrix degeneracy.
- **Boundary tests** (`chore-drag-and-test-realign`): add az=180° wrap and el=±90° clamp edge-case tests.

## Test plan

- [ ] Build release and run all GUI tests: `./scripts/build.sh -gtj release`
- [ ] Manually switch lens types in the GUI and verify the view direction is preserved across the Globe↔non-Globe boundary
- [ ] Verify *Front* radio button is disabled when Globe lens is selected
- [ ] Verify all visibility controls are disabled in Full-Sky mode
- [ ] Check az=180° wrap and el-clamp boundary cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)