### PR TITLE
feat(gui-polish-v18): visibility row, drop Direction filter, EE align Raypath

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -419,6 +419,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::RadioButton("Upper##visible", &r.visible, kVisibleUpper);
     ImGui::SameLine();
     ImGui::RadioButton("Full##visible", &r.visible, kVisibleFull);
+    ImGui::SameLine();
     ImGui::RadioButton("Lower##visible", &r.visible, kVisibleLower);
     ImGui::SameLine();
     if (!full_sky) {

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -132,6 +132,7 @@ static char g_raypath_buf[256];
 // raypath → nullopt" commit rule this also closes the "Remove button" path
 // without a separate state bit.
 static bool g_filter_initial_present = false;
+static bool g_ee_remove_intent = false;
 
 // Snapshots captured on OpenEditModal for per-tab dirty-mark computation.
 // Filter already has its own snapshot above (used for a separate purpose in
@@ -647,6 +648,18 @@ namespace {
 lumice::CrystalKind CurrentValidationKind();
 }
 
+static ImVec4 ValidationFrameBgColor(RaypathValidation state) {
+  switch (state) {
+    case RaypathValidation::kValid:
+      return ImVec4(0.06f, 0.24f, 0.06f, 0.5f);
+    case RaypathValidation::kIncomplete:
+      return ImVec4(0.27f, 0.24f, 0.03f, 0.5f);
+    case RaypathValidation::kInvalid:
+      return ImVec4(0.27f, 0.06f, 0.06f, 0.5f);
+  }
+  return ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+}
+
 static void RenderRaypathSubpanel() {
   // Sync InputText backing buffer into the raypath sub-buffer before validation
   // so the displayed hint reflects the current edit state.
@@ -654,22 +667,8 @@ static void RenderRaypathSubpanel() {
   const auto result = ValidateRaypathTextMultiSegment(g_raypath_params.raypath_text, CurrentValidationKind());
   const auto validation = result.state;
 
-  ImVec4 border_color;
-  switch (validation) {
-    case RaypathValidation::kValid:
-      border_color = ImVec4(0.2f, 0.8f, 0.2f, 1.0f);
-      break;
-    case RaypathValidation::kIncomplete:
-      border_color = ImVec4(0.9f, 0.8f, 0.1f, 1.0f);
-      break;
-    case RaypathValidation::kInvalid:
-      border_color = ImVec4(0.9f, 0.2f, 0.2f, 1.0f);
-      break;
-  }
-
   // Row 1: Raypath text input (top-emphasized).
-  ImGui::PushStyleColor(ImGuiCol_FrameBg,
-                        ImVec4(border_color.x * 0.3f, border_color.y * 0.3f, border_color.z * 0.3f, 0.5f));
+  ImGui::PushStyleColor(ImGuiCol_FrameBg, ValidationFrameBgColor(validation));
   ImGui::InputText("Raypath##filter_modal", g_raypath_buf, sizeof(g_raypath_buf));
   ImGui::PopStyleColor();
 
@@ -717,27 +716,14 @@ static void RenderEntryExitSubpanel() {
   const auto v_entry = ValidateFaceNumberText(g_ee_entry_buf, kind);
   const auto v_exit = ValidateFaceNumberText(g_ee_exit_buf, kind);
 
-  // Border colour: kInvalid → red, kIncomplete → yellow, kValid → default.
-  auto push_state_color = [](RaypathValidation s) {
-    if (s == RaypathValidation::kInvalid) {
-      ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(220, 60, 60, 255));
-    } else if (s == RaypathValidation::kIncomplete) {
-      ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(220, 180, 60, 255));
-    }
-  };
-  auto pop_state_color = [](RaypathValidation s) {
-    if (s != RaypathValidation::kValid) {
-      ImGui::PopStyleColor();
-    }
-  };
+  // FrameBg tint mirrors RenderRaypathSubpanel (same helper).
+  ImGui::PushStyleColor(ImGuiCol_FrameBg, ValidationFrameBgColor(v_entry.state));
+  ImGui::InputText("Entry##filter_ee_entry", g_ee_entry_buf, sizeof(g_ee_entry_buf));
+  ImGui::PopStyleColor();
 
-  push_state_color(v_entry.state);
-  ImGui::InputText("Entry face number##filter_modal", g_ee_entry_buf, sizeof(g_ee_entry_buf));
-  pop_state_color(v_entry.state);
-
-  push_state_color(v_exit.state);
-  ImGui::InputText("Exit face number##filter_modal", g_ee_exit_buf, sizeof(g_ee_exit_buf));
-  pop_state_color(v_exit.state);
+  ImGui::PushStyleColor(ImGuiCol_FrameBg, ValidationFrameBgColor(v_exit.state));
+  ImGui::InputText("Exit##filter_ee_exit", g_ee_exit_buf, sizeof(g_ee_exit_buf));
+  ImGui::PopStyleColor();
 
   // Combined validation message (first non-valid wins, matching raypath).
   if (!v_entry.message.empty()) {
@@ -745,6 +731,9 @@ static void RenderEntryExitSubpanel() {
   } else if (!v_exit.message.empty()) {
     ImGui::TextColored(ImVec4(0.86f, 0.24f, 0.24f, 1.0f), "Exit: %s", v_exit.message.c_str());
   }
+
+  // Shared hint — single value syntax, consistent with EE single-value semantic.
+  ImGui::TextDisabled("e.g. 3");
 }
 
 // Shared filter controls (Action radio + P/B/D), rendered after the
@@ -791,6 +780,19 @@ static void RenderRemoveFilterButton() {
   ImGui::EndDisabled();
 }
 
+// Remove Filter for Entry-Exit: always enabled (carries "delete filter data"
+// semantics — sets g_ee_remove_intent so ApplyBuffersToEntry bypasses kValid
+// gate and resets entry.filter to nullopt on OK).
+static void RenderRemoveEEFilterButton() {
+  if (ImGui::Button("Remove Filter##filter_ee", ImVec2(120, 0))) {
+    g_ee_entry_buf[0] = '\0';
+    g_ee_exit_buf[0] = '\0';
+    g_ee_params.entry_text.clear();
+    g_ee_params.exit_text.clear();
+    g_ee_remove_intent = true;
+  }
+}
+
 static void RenderFilterModal() {
   // Type radio — 3 options, SameLine horizontal (style-aligned with Crystal
   // tab's Prism/Pyramid radios). Boolean form (RadioButton(label, active))
@@ -829,11 +831,11 @@ static void RenderFilterModal() {
 
   ImGui::Spacing();
 
-  // Remove Filter — raypath-only shortcut. The "empty raypath ≡ no filter"
-  // shortcut only applies to Raypath; EE each has a legal "default" state
-  // and requires switching back to Raypath + clearing to obtain "no filter".
+  // Remove Filter — type-specific shortcut.
   if (g_filter_active_type == FilterEditType::kRaypath) {
     RenderRemoveFilterButton();
+  } else if (g_filter_active_type == FilterEditType::kEntryExit) {
+    RenderRemoveEEFilterButton();
   }
 
   // OK / Cancel handled at modal level (RenderEditModals).
@@ -883,6 +885,7 @@ void ResetModalState() {
   g_raypath_params_snapshot = {};
   g_ee_params_snapshot = {};
   g_filter_initial_present = false;
+  g_ee_remove_intent = false;
   g_raypath_buf[0] = '\0';
   g_ee_entry_buf[0] = '\0';
   g_ee_exit_buf[0] = '\0';
@@ -979,6 +982,12 @@ ApplyBuffersResult ApplyBuffersToEntry(GuiState& state) {
   // and skip the commit — consistent with raypath's "empty ≡ no filter"
   // semantic at the UI layer.
   if (g_filter_active_type == FilterEditType::kEntryExit) {
+    // Remove intent: bypass kValid gate, reset filter to nullopt.
+    if (g_ee_remove_intent) {
+      entry.filter = std::nullopt;
+      g_ee_remove_intent = false;
+      return { true, entry != old_entry, entry.filter != old_entry.filter };
+    }
     const bool buf_changed = IsFilterDirty();
     const auto kind = CurrentValidationKind();
     const auto v_entry = ValidateFaceNumberText(g_ee_params.entry_text, kind);
@@ -1440,17 +1449,22 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       // tab-label dirty mark) sees the live value.
       g_ee_params.entry_text = g_ee_entry_buf;
       g_ee_params.exit_text = g_ee_exit_buf;
-      const auto kind = CurrentValidationKind();
-      const auto ve = ValidateFaceNumberText(g_ee_entry_buf, kind);
-      const auto vx = ValidateFaceNumberText(g_ee_exit_buf, kind);
-      const bool incomplete = ve.state == RaypathValidation::kIncomplete || vx.state == RaypathValidation::kIncomplete;
-      const bool invalid = ve.state == RaypathValidation::kInvalid || vx.state == RaypathValidation::kInvalid;
-      if (invalid) {
-        ok_disabled = true;
-        ok_tooltip = "Filter face number invalid — fix it in the Filter tab";
-      } else if (incomplete) {
-        ok_disabled = true;
-        ok_tooltip = "Enter entry and exit face numbers";
+      // Remove intent bypasses the incomplete/invalid gate — OK is always
+      // enabled when the user has clicked Remove Filter.
+      if (!g_ee_remove_intent) {
+        const auto kind = CurrentValidationKind();
+        const auto ve = ValidateFaceNumberText(g_ee_entry_buf, kind);
+        const auto vx = ValidateFaceNumberText(g_ee_exit_buf, kind);
+        const bool incomplete =
+            ve.state == RaypathValidation::kIncomplete || vx.state == RaypathValidation::kIncomplete;
+        const bool invalid = ve.state == RaypathValidation::kInvalid || vx.state == RaypathValidation::kInvalid;
+        if (invalid) {
+          ok_disabled = true;
+          ok_tooltip = "Filter face number invalid — fix it in the Filter tab";
+        } else if (incomplete) {
+          ok_disabled = true;
+          ok_tooltip = "Enter entry and exit face numbers";
+        }
       }
     }
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -89,7 +89,7 @@ static AxisDist g_axis_buf[3];  // zenith, azimuth, roll
 // Each FilterEditType keeps its own sub-buffer so switching type is non-destructive
 // (T6 contract: "切到 EE 再切回 raypath, 之前输入仍在"). Commit assembles a
 // FilterConfig from g_filter_top (shared fields) + active type's sub-buffer.
-enum class FilterEditType { kRaypath = 0, kEntryExit = 1, kDirection = 2 };
+enum class FilterEditType { kRaypath = 0, kEntryExit = 1 };
 static FilterEditType g_filter_active_type = FilterEditType::kRaypath;
 static FilterEditType g_filter_active_type_snapshot = FilterEditType::kRaypath;
 
@@ -111,10 +111,8 @@ static FilterConfig g_filter_top_snapshot;
 // Per-type sub-buffers — switching type is non-destructive (each retains state).
 static RaypathParams g_raypath_params;
 static EntryExitParams g_ee_params;
-static DirectionParams g_dir_params;
 static RaypathParams g_raypath_params_snapshot;
 static EntryExitParams g_ee_params_snapshot;
-static DirectionParams g_dir_params_snapshot;
 
 // Entry-Exit InputText backing buffers. ImGui needs persistent char arrays
 // for InputText; we mirror them with g_ee_params.{entry,exit}_text on
@@ -276,7 +274,6 @@ void SnapshotAllBuffers(const GuiState& state) {
   g_filter_top_snapshot = g_filter_top;
   g_raypath_params_snapshot = g_raypath_params;
   g_ee_params_snapshot = g_ee_params;
-  g_dir_params_snapshot = g_dir_params;
   g_filter_active_type_snapshot = g_filter_active_type;
   g_crystal_buf_snapshot = g_crystal_buf;
   g_axis_buf_snapshot[0] = g_axis_buf[0];
@@ -371,7 +368,6 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   // safe state rather than carrying over the previous session's discriminator.
   g_raypath_params = {};
   g_ee_params = {};
-  g_dir_params = {};
   g_filter_active_type = FilterEditType::kRaypath;
   if (std::holds_alternative<RaypathParams>(src.param)) {
     g_raypath_params = std::get<RaypathParams>(src.param);
@@ -379,9 +375,6 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   } else if (std::holds_alternative<EntryExitParams>(src.param)) {
     g_ee_params = std::get<EntryExitParams>(src.param);
     g_filter_active_type = FilterEditType::kEntryExit;
-  } else if (std::holds_alternative<DirectionParams>(src.param)) {
-    g_dir_params = std::get<DirectionParams>(src.param);
-    g_filter_active_type = FilterEditType::kDirection;
   }
   snprintf(g_raypath_buf, sizeof(g_raypath_buf), "%s", g_raypath_params.raypath_text.c_str());
   snprintf(g_ee_entry_buf, sizeof(g_ee_entry_buf), "%s", g_ee_params.entry_text.c_str());
@@ -754,33 +747,6 @@ static void RenderEntryExitSubpanel() {
   }
 }
 
-// 角度指光线传播方向 d（非视线方向 -d）；视位置筛选需取相反向量。
-static constexpr const char* kDirectionAngleTooltip =
-    "Angle specifies the ray's propagation direction\n"
-    "(the direction light travels from sun -> crystal -> observer).\n"
-    "To filter halos that appear at a sky position, use the opposite direction.";
-
-// Direction sub-panel: two SliderWithInput controls (azimuth, elevation)
-// in degrees, matching the right-side Camera section style. Values
-// written directly into g_dir_params; commit/dirty tracking handled by
-// ApplyBuffersToEntry / IsFilterDirty just like the raypath/EE paths.
-// The cone half-angle (core's DirectionFilterParam.radii_) is a fixed
-// default injected at GUI→core serialization (file_io.cpp::
-// kDirectionDefaultRadiiDeg). Slider ranges follow the geometric
-// principal interval; out-of-range values still construct valid cos/sin
-// (DirectionFilter, src/core/filter.cpp:81-98) but the slider clamp keeps
-// UX unambiguous.
-static void RenderDirectionSubpanel() {
-  SliderWithInput("Azimuth\xc2\xb0##filter_modal", &g_dir_params.az, -180.0f, 180.0f, "%.2f", SliderScale::kLinear);
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetTooltip("%s", kDirectionAngleTooltip);
-  }
-  SliderWithInput("Elevation\xc2\xb0##filter_modal", &g_dir_params.el, -90.0f, 90.0f, "%.2f", SliderScale::kLinear);
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetTooltip("%s", kDirectionAngleTooltip);
-  }
-}
-
 // Shared filter controls (Action radio + P/B/D), rendered after the
 // type-specific dispatch. Always uses g_filter_top so type switches don't
 // reset shared user preferences.
@@ -837,10 +803,6 @@ static void RenderFilterModal() {
   if (ImGui::RadioButton("Entry-Exit##filter_type", g_filter_active_type == FilterEditType::kEntryExit)) {
     g_filter_active_type = FilterEditType::kEntryExit;
   }
-  ImGui::SameLine();
-  if (ImGui::RadioButton("Direction##filter_type", g_filter_active_type == FilterEditType::kDirection)) {
-    g_filter_active_type = FilterEditType::kDirection;
-  }
 
   ImGui::Spacing();
 
@@ -855,9 +817,6 @@ static void RenderFilterModal() {
     case FilterEditType::kEntryExit:
       RenderEntryExitSubpanel();
       break;
-    case FilterEditType::kDirection:
-      RenderDirectionSubpanel();
-      break;
     default:
       assert(false && "unhandled FilterEditType in RenderFilterModal dispatch");
       break;
@@ -871,9 +830,8 @@ static void RenderFilterModal() {
   ImGui::Spacing();
 
   // Remove Filter — raypath-only shortcut. The "empty raypath ≡ no filter"
-  // shortcut only applies to Raypath; EE / Direction / Crystal each have a
-  // legal "default" state (entry=0/exit=0 / az=el=radii=0 / crystal_id=0)
-  // and require switching back to Raypath + clearing to obtain "no filter".
+  // shortcut only applies to Raypath; EE each has a legal "default" state
+  // and requires switching back to Raypath + clearing to obtain "no filter".
   if (g_filter_active_type == FilterEditType::kRaypath) {
     RenderRemoveFilterButton();
   }
@@ -922,10 +880,8 @@ void ResetModalState() {
   g_filter_active_type_snapshot = FilterEditType::kRaypath;
   g_raypath_params = {};
   g_ee_params = {};
-  g_dir_params = {};
   g_raypath_params_snapshot = {};
   g_ee_params_snapshot = {};
-  g_dir_params_snapshot = {};
   g_filter_initial_present = false;
   g_raypath_buf[0] = '\0';
   g_ee_entry_buf[0] = '\0';
@@ -969,8 +925,6 @@ bool IsFilterDirty() {
       return g_raypath_params != g_raypath_params_snapshot;
     case FilterEditType::kEntryExit:
       return g_ee_params != g_ee_params_snapshot;
-    case FilterEditType::kDirection:
-      return g_dir_params != g_dir_params_snapshot;
     default:
       assert(false && "unhandled FilterEditType in IsFilterDirty");
       return false;
@@ -1038,30 +992,6 @@ ApplyBuffersResult ApplyBuffersToEntry(GuiState& state) {
       out.sym_b = g_filter_top.sym_b;
       out.sym_d = g_filter_top.sym_d;
       out.param = g_ee_params;
-      entry.filter = out;
-    }
-    return { true, entry != old_entry, entry.filter != old_entry.filter };
-  }
-
-  // Direction commit branch (#178.5). Mirrors the EE branch above; gated on
-  // `g_filter_initial_present || buf_changed`. NOTE: switching to the
-  // Direction RadioButton already sets buf_changed=true (active_type !=
-  // snapshot inside IsFilterDirty), so the path "open a filterless entry →
-  // switch to Direction → OK without typing" always commits a default-zero
-  // Direction filter; the guard's actual function is to suppress a re-commit
-  // when the user reopens an existing Direction entry and presses OK without
-  // modifying any field. P/B/D fields stay in g_filter_top per the H4
-  // contract — UI hides the Checkboxes but the data round-trips unchanged.
-  if (g_filter_active_type == FilterEditType::kDirection) {
-    const bool buf_changed = IsFilterDirty();
-    if (g_filter_initial_present || buf_changed) {
-      FilterConfig out;
-      out.name = g_filter_top.name;
-      out.action = g_filter_top.action;
-      out.sym_p = g_filter_top.sym_p;
-      out.sym_b = g_filter_top.sym_b;
-      out.sym_d = g_filter_top.sym_d;
-      out.param = g_dir_params;
       entry.filter = out;
     }
     return { true, entry != old_entry, entry.filter != old_entry.filter };

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -32,14 +32,6 @@ namespace lumice::gui {
 
 using json = nlohmann::json;
 
-// Default Direction filter cone half-angle (deg) — GUI no longer exposes
-// this field (task-filter-modal-polish-v1, plan §3 D-Assume-1). Single
-// injection point: GUI→core / GUI→.lmc serialization fills this constant
-// when constructing core DirectionFilterParam. core JSON read-back
-// preserves whatever value config.json holds (direct-edit users keep
-// full control); .lmc read-back discards any radii field it encounters.
-static constexpr float kDirectionDefaultRadiiDeg = 5.0f;
-
 // Convert Miller index (i1, i4) to wedge angle in degrees. Returns default (28.0) if i1 == 0.
 static float MillerToAlpha(int i1, int i4) {
   constexpr float kSqrt3_2 = 0.866025403784f;
@@ -223,11 +215,6 @@ static json SerializeFilterForGui(const FilterConfig& f, int id) {
           j["type"] = "entry_exit";
           j["entry_text"] = p.entry_text;
           j["exit_text"] = p.exit_text;
-        } else if constexpr (std::is_same_v<T, DirectionParams>) {
-          // .lmc no longer persists radii (GUI uses default at commit time).
-          j["type"] = "direction";
-          j["az"] = p.az;
-          j["el"] = p.el;
         }
       },
       f.param);
@@ -246,7 +233,7 @@ struct FilterCoreResult {
   std::vector<json> filters;
 };
 
-// Build a single simple-filter JSON entry (any of raypath/entry_exit/direction/crystal).
+// Build a single simple-filter JSON entry (any of raypath/entry_exit).
 template <class FillFn>
 static json BuildCoreSimpleFilterJson(const FilterConfig& f, int id, const char* type_name, FillFn fill) {
   json j;
@@ -363,16 +350,6 @@ static FilterCoreResult SerializeFilterForCore(const FilterConfig& f, int next_f
           result.filters.push_back(BuildCoreSimpleFilterJson(f, id, "entry_exit", [&](json& j) {
             j["entry"] = ClampIdValue(entry_int, "entry");
             j["exit"] = ClampIdValue(exit_int, "exit");
-          }));
-          result.main_id = id;
-        } else if constexpr (std::is_same_v<T, DirectionParams>) {
-          // GUI struct lost radii — inject the fixed default so core's
-          // DirectionFilter still sees a sensible cone half-angle.
-          int id = next_filter_id_base;
-          result.filters.push_back(BuildCoreSimpleFilterJson(f, id, "direction", [&](json& j) {
-            j["az"] = p.az;
-            j["el"] = p.el;
-            j["radii"] = kDirectionDefaultRadiiDeg;
           }));
           result.main_id = id;
         }
@@ -590,13 +567,6 @@ static FilterConfig ParseFilterFromGuiJson(const json& jf) {
       int v = jf.value("exit", 0);
       p.exit_text = (v == 0) ? std::string{} : std::to_string(v);
     }
-    f.param = p;
-  } else if (type == "direction") {
-    // Older .lmc files (v2) may include "radii" — read-and-discard
-    // (jf.value() with default keeps the call no-op when absent).
-    DirectionParams p;
-    p.az = jf.value("az", 0.0f);
-    p.el = jf.value("el", 0.0f);
     f.param = p;
   } else {
     GUI_LOG_WARNING("[FileIO] Unknown filter type '{}', defaulting to raypath", type);
@@ -907,14 +877,6 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
         int exit_int = jf.value("exit", 0);
         p.entry_text = (entry_int == 0) ? std::string{} : std::to_string(entry_int);
         p.exit_text = (exit_int == 0) ? std::string{} : std::to_string(exit_int);
-        f.param = p;
-      } else if (type_str == "direction") {
-        // core JSON's "radii" is core-only (cone half-angle); GUI
-        // representation drops it and re-injects kDirectionDefaultRadiiDeg
-        // on the next commit.
-        DirectionParams p;
-        p.az = jf.value("az", 0.0f);
-        p.el = jf.value("el", 0.0f);
         f.param = p;
       } else {
         GUI_LOG_WARNING("[FileIO] Unknown filter type '{}' on core JSON import, defaulting to empty raypath", type_str);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -243,18 +243,7 @@ struct EntryExitParams {
   friend bool operator!=(const EntryExitParams& a, const EntryExitParams& b) { return !(a == b); }
 };
 
-struct DirectionParams {
-  // Maps to core DirectionFilterParam.lon_/lat_ (azimuth/elevation, degrees).
-  // Cone half-angle radii_ is core-only — GUI commits a fixed default
-  // (kDirectionDefaultRadiiDeg, see edit_modals.cpp / file_io.cpp).
-  float az = 0.0f;
-  float el = 0.0f;
-
-  friend bool operator==(const DirectionParams& a, const DirectionParams& b) { return a.az == b.az && a.el == b.el; }
-  friend bool operator!=(const DirectionParams& a, const DirectionParams& b) { return !(a == b); }
-};
-
-using FilterParamVariant = std::variant<RaypathParams, EntryExitParams, DirectionParams>;
+using FilterParamVariant = std::variant<RaypathParams, EntryExitParams>;
 
 // GUI-only data structure: filter configuration.
 //

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -93,7 +93,7 @@ std::string FilterSummarySuffix(const FilterConfig& fc) {
 //
 // Format dispatched by FilterParamVariant alternative:
 //   - Raypath:    "<raypath_text or *> <In|Out>[ <sym>]"        (e.g. "3-1-5 In PBD")
-//   - EntryExit:  "EE:<entry>→<exit> <In|Out>[ <sym>]"
+//   - EntryExit:  "EE:<entry>-><exit> <In|Out>[ <sym>]"
 //
 // 12-character truncation is preserved for the raypath body so the existing
 // test_gui_interaction "1-2-3-4-5-6-..." case stays bit-exact. Other types
@@ -127,7 +127,7 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
           // renders something readable in the entry card summary.
           const char* e = p.entry_text.empty() ? "?" : p.entry_text.c_str();
           const char* x = p.exit_text.empty() ? "?" : p.exit_text.c_str();
-          return std::string("EE:") + e + "\xe2\x86\x92" + x;
+          return std::string("EE:") + e + "->" + x;
         } else {
           return "*";
         }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -94,8 +94,6 @@ std::string FilterSummarySuffix(const FilterConfig& fc) {
 // Format dispatched by FilterParamVariant alternative:
 //   - Raypath:    "<raypath_text or *> <In|Out>[ <sym>]"        (e.g. "3-1-5 In PBD")
 //   - EntryExit:  "EE:<entry>→<exit> <In|Out>[ <sym>]"
-//   - Direction:  "DIR:<az>°/<el>° r=<radii>° <In|Out>[ <sym>]"
-//   - Crystal:    "CR:#<id> <In|Out>[ <sym>]"
 //
 // 12-character truncation is preserved for the raypath body so the existing
 // test_gui_interaction "1-2-3-4-5-6-..." case stays bit-exact. Other types
@@ -130,10 +128,6 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
           const char* e = p.entry_text.empty() ? "?" : p.entry_text.c_str();
           const char* x = p.exit_text.empty() ? "?" : p.exit_text.c_str();
           return std::string("EE:") + e + "\xe2\x86\x92" + x;
-        } else if constexpr (std::is_same_v<T, DirectionParams>) {
-          char buf[64];
-          snprintf(buf, sizeof(buf), "DIR:%g\xc2\xb0/%g\xc2\xb0", p.az, p.el);
-          return buf;
         } else {
           return "*";
         }

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -821,4 +821,51 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_STR_EQ(jf["exit_text"].get<std::string>().c_str(), "4");
     };
   }
+
+  // T13 — AC7 serialization equivalence: Remove EE Filter via GUI → OK →
+  // entry.filter == nullopt → SerializeCoreConfig emits no "filter" field.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "entry_exit_remove_ok_no_filter_in_json");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Pre-populate entry.filter with an EE filter.
+      {
+        gui::FilterConfig fc;
+        fc.action = 0;
+        fc.sym_p = true;
+        fc.sym_b = true;
+        fc.sym_d = true;
+        gui::EntryExitParams ee;
+        ee.entry_text = "3";
+        ee.exit_text = "6";
+        fc.param = ee;
+        gui::g_state.layers[0].entries[0].filter = fc;
+      }
+      ctx->Yield(2);
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Entry-Exit##filter_type");
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Remove Filter##filter_ee");
+      ctx->Yield(2);
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // filter must be nullopt after Remove + OK.
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
+
+      // SerializeCoreConfig must not emit any "filter" field (no EE residue).
+      const std::string core_json = gui::SerializeCoreConfig(gui::g_state);
+      IM_CHECK(!core_json.empty());
+      const auto j = nlohmann::json::parse(core_json);
+      // No top-level "filter" array, or it's empty.
+      const bool no_filter = !j.contains("filter") || j["filter"].empty();
+      IM_CHECK(no_filter);
+    };
+  }
 }

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -611,9 +611,9 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         return e;
       };
 
+      // Build one entry per remaining filter type (raypath, entry_exit).
       layer.entries.push_back(make_entry(gui::RaypathParams{ "3-1-5" }));
       layer.entries.push_back(make_entry(gui::EntryExitParams{ "7", "4" }));
-      layer.entries.push_back(make_entry(gui::DirectionParams{ 30.0f, -10.0f }));
       gui::g_state.layers.push_back(layer);
 
       const char* tmp_path = "/tmp/lumice_per_type_roundtrip.lmc";
@@ -627,7 +627,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       bool load_ok = gui::LoadLmcFile(tmp_path, gui::g_state, tex_data, tex_w, tex_h);
       IM_CHECK(load_ok);
 
-      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 3);
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
 
       const auto& f0 = *gui::g_state.layers[0].entries[0].filter;
       IM_CHECK(std::holds_alternative<gui::RaypathParams>(f0.param));
@@ -638,12 +638,6 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       const auto& ee = std::get<gui::EntryExitParams>(f1.param);
       IM_CHECK_EQ(ee.entry_text, std::string("7"));
       IM_CHECK_EQ(ee.exit_text, std::string("4"));
-
-      const auto& f2 = *gui::g_state.layers[0].entries[2].filter;
-      IM_CHECK(std::holds_alternative<gui::DirectionParams>(f2.param));
-      const auto& dp = std::get<gui::DirectionParams>(f2.param);
-      IM_CHECK_EQ(dp.az, 30.0f);
-      IM_CHECK_EQ(dp.el, -10.0f);
 
       std::remove(tmp_path);
     };
@@ -744,79 +738,11 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // task-per-type-direction (issue 178.5): end-to-end equivalence between
-  // GUI Direction filter → SerializeCoreConfig output and a hand-crafted
-  // reference core JSON object. Validates AC-7 (`type` / `action` /
-  // `symmetry` / `az` / `el` / `radii` / `id` field-by-field equality
-  // regardless of insertion order via nlohmann::json::operator==).
+  // filter-direction-hide (issue 180.2): .lmc with type="direction" filter
+  // must degrade to empty RaypathParams after the Direction type is removed
+  // from the GUI. Mirrors Crystal's unknown-type fallback path (#179).
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "direction_serialize_core_equivalent");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      IM_UNUSED(ctx);
-      ResetTestState();
-
-      // Build a single-entry GuiState carrying a DirectionParams filter.
-      gui::g_state.layers.clear();
-      gui::Layer layer;
-      layer.probability = 1.0f;
-
-      gui::EntryCard e;
-      e.crystal.type = gui::CrystalType::kPrism;
-      e.crystal.height = 1.0f;
-      for (int i = 0; i < 6; ++i) {
-        e.crystal.face_distance[i] = 1.0f;
-      }
-      e.proportion = 100.0f;
-
-      gui::FilterConfig fc;
-      fc.action = 1;     // filter_out
-      fc.sym_p = true;   // → "P" in symmetry suffix
-      fc.sym_b = false;  // omitted
-      fc.sym_d = true;   // → "D"
-      fc.param = gui::DirectionParams{ /*az=*/30.0f, /*el=*/45.0f };
-      e.filter = fc;
-
-      layer.entries.push_back(e);
-      gui::g_state.layers.push_back(layer);
-
-      const std::string s = gui::SerializeCoreConfig(gui::g_state);
-      IM_CHECK(!s.empty());
-
-      const auto j = nlohmann::json::parse(s);
-      IM_CHECK(j.contains("filter"));
-      IM_CHECK(j["filter"].is_array());
-      IM_CHECK_EQ(static_cast<int>(j["filter"].size()), 1);
-
-      // Field-level assertions (also catches symmetry string ordering bugs).
-      // Note: `symmetry` field is still serialized for Direction filters even
-      // though the GUI hides the P/B/D Checkboxes (H4 contract — UI hides
-      // controls but data round-trips unchanged for cross-type compatibility).
-      const auto& jf = j["filter"][0];
-      IM_CHECK_STR_EQ(jf["type"].get<std::string>().c_str(), "direction");
-      IM_CHECK_STR_EQ(jf["action"].get<std::string>().c_str(), "filter_out");
-      IM_CHECK_STR_EQ(jf["symmetry"].get<std::string>().c_str(), "PD");
-      IM_CHECK_EQ(jf["az"].get<float>(), 30.0f);
-      IM_CHECK_EQ(jf["el"].get<float>(), 45.0f);
-      // GUI no longer owns radii; serialization layer injects the fixed
-      // default (kDirectionDefaultRadiiDeg, file_io.cpp).
-      IM_CHECK_EQ(jf["radii"].get<float>(), 5.0f);
-      IM_CHECK_EQ(jf["id"].get<int>(), 1);
-
-      // Whole-object equivalence with hand-crafted reference.
-      const nlohmann::json expected = {
-        { "id", 1 },     { "type", "direction" }, { "action", "filter_out" }, { "symmetry", "PD" },
-        { "az", 30.0f }, { "el", 45.0f },         { "radii", 5.0f },
-      };
-      IM_CHECK(jf == expected);
-    };
-  }
-
-  // task-filter-modal-polish-v1: v2 .lmc-style Direction filter JSON
-  // (with explicit radii) must load successfully into a v3 DirectionParams
-  // (radii silently dropped — GUI struct lacks the field). Re-serializing
-  // (SerializeGuiStateJson) must omit "radii" from the filter object.
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "direction_v2_radii_dropped_on_load");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "direction_lmc_degrades_to_raypath");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       IM_UNUSED(ctx);
       ResetTestState();
@@ -831,7 +757,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
             "filter": {
               "type": "direction",
               "action": "filter_in",
-              "az": 22.0, "el": 5.0, "radii": 7.5
+              "az": 30.0, "el": 15.0
             }
           }]
         }]
@@ -840,22 +766,13 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       gui::GuiState restored;
       bool ok = gui::DeserializeGuiStateJson(v2_lmc, restored);
       IM_CHECK(ok);
+      IM_CHECK_EQ(static_cast<int>(restored.layers[0].entries.size()), 1);
+
+      // direction type → unknown-type fallback → empty RaypathParams
       IM_CHECK(restored.layers[0].entries[0].filter.has_value());
       const auto& f = *restored.layers[0].entries[0].filter;
-      IM_CHECK(std::holds_alternative<gui::DirectionParams>(f.param));
-      const auto& dp = std::get<gui::DirectionParams>(f.param);
-      IM_CHECK_EQ(dp.az, 22.0f);
-      IM_CHECK_EQ(dp.el, 5.0f);
-      // radii silently discarded — DirectionParams no longer has the field.
-
-      // Re-serializing must omit "radii" from the .lmc filter object.
-      const std::string written = gui::SerializeGuiStateJson(restored);
-      const auto j = nlohmann::json::parse(written);
-      const auto& jf = j["layers"][0]["entries"][0]["filter"];
-      IM_CHECK_STR_EQ(jf["type"].get<std::string>().c_str(), "direction");
-      IM_CHECK(!jf.contains("radii"));
-      IM_CHECK_EQ(jf["az"].get<float>(), 22.0f);
-      IM_CHECK_EQ(jf["el"].get<float>(), 5.0f);
+      IM_CHECK(std::holds_alternative<gui::RaypathParams>(f.param));
+      IM_CHECK(std::get<gui::RaypathParams>(f.param).raypath_text.empty());
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2418,6 +2418,43 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       IM_CHECK((info_front.ItemFlags & ImGuiItemFlags_Disabled) == 0);
     };
   }
+
+  // ===== task-visibility-radio-layout (scrum-gui-polish-v18 180.1) =====
+  // Verify the 1×4 horizontal layout: click hit and same-row geometry.
+
+  // p2_render/visibility_horizontal_layout_click_hit — fisheye lens (all 4 buttons
+  // enabled); ItemClick on Lower and Front commits the correct value.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_horizontal_layout_click_hit");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEqualArea;
+      ctx->Yield(3);
+      ctx->ItemClick("**/Lower##visible");
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.renderer.visible, gui::kVisibleLower);
+      ctx->ItemClick("**/Front##visible");
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.renderer.visible, gui::kVisibleFront);
+    };
+  }
+
+  // p2_render/visibility_horizontal_layout_same_row — fisheye lens; Upper and Front
+  // must share the same screen row (RectFull.Min.y equal, confirming 1×4 layout).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_horizontal_layout_same_row");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEqualArea;
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK_EQ(info_upper.RectFull.Min.y, info_front.RectFull.Min.y);
+      IM_CHECK(info_front.RectFull.Min.x > info_upper.RectFull.Min.x);
+    };
+  }
 }
 
 // ========== task-test-gui-interaction: P1 Running simulation restart tests ==========

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -3520,12 +3520,12 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(f.sym_b);
       IM_CHECK(f.sym_d);
 
-      // FilterSummary EE format: "EE:<entry>→<exit> <In|Out>[ <sym>]" —
+      // FilterSummary EE format: "EE:<entry>-><exit> <In|Out>[ <sym>]" —
       // entry/exit now render the raw text buffer (kept as-is so partial
-      // input stays visible). The "→" is UTF-8 U+2192 ("\xe2\x86\x92").
+      // input stays visible). ASCII "->" is used so the bundled font always
+      // renders it (U+2192 fell back to "?" glyph on user's machine).
       IM_CHECK_STR_EQ(gui::FilterSummary(gui::g_state.layers[0].entries[0].filter).c_str(),
-                      "EE:2\xe2\x86\x92"
-                      "5 Out PBD");
+                      "EE:2->5 Out PBD");
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -3265,9 +3265,9 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
   // the Action control switched from Combo to two RadioButtons.
   // ============================================================
 
-  // T1 — type radio is visible: all 3 type RadioButtons exist after opening
-  // the Filter tab. Crystal radio was removed in task-filter-modal-polish-v1
-  // (zero external .lmc files contain crystal filter; core path retained).
+  // T1 — type radio is visible: 2 type RadioButtons (Raypath, Entry-Exit) exist
+  // after opening the Filter tab. Direction was removed in filter-direction-hide
+  // (issue 180.2); Crystal was removed in task-filter-modal-polish-v1.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "filter_type_radio_visible");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -3279,7 +3279,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
 
       IM_CHECK(ctx->ItemExists("**/Raypath##filter_type"));
       IM_CHECK(ctx->ItemExists("**/Entry-Exit##filter_type"));
-      IM_CHECK(ctx->ItemExists("**/Direction##filter_type"));
+      IM_CHECK(!ctx->ItemExists("**/Direction##filter_type"));
       IM_CHECK(!ctx->ItemExists("**/Crystal##filter_type"));
 
       ctx->ItemClick("**/Cancel##edit_modal");
@@ -3459,13 +3459,10 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       auto info_typed = ctx->ItemInfo("**/OK##edit_modal");
       IM_CHECK((info_typed.ItemFlags & ImGuiItemFlags_Disabled) == 0);
 
-      // Switch to Direction: EE inputs un-render, OK stays enabled
-      // (Direction has no per-field gate).
-      ctx->ItemClick("**/Direction##filter_type");
+      // Switch to Raypath: EE inputs un-render.
+      ctx->ItemClick("**/Raypath##filter_type");
       ctx->Yield(2);
       IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
-      auto info_dir = ctx->ItemInfo("**/OK##edit_modal");
-      IM_CHECK((info_dir.ItemFlags & ImGuiItemFlags_Disabled) == 0);
 
       // Switch back to Entry-Exit: inputs reappear; the typed-and-valid
       // values are still in the buffers so OK stays enabled.
@@ -3534,12 +3531,9 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // T10 — per-type buffer isolation extends to EE ↔ Direction switch:
-  // type-in EE values, switch to Direction, switch back, OK → EE values
-  // preserved. Validates that #178.3 T6 guarantee (per-type buffer survives
-  // switches) holds for the newly-interactive EE type. Post-#178.5 Direction
-  // is also interactive — EE buffer must remain untouched while Direction
-  // sub-panel renders, since each type owns a separate sub-buffer.
+  // T10 — per-type buffer isolation: EE ↔ Raypath switch preserves EE values.
+  // Validates that T6 guarantee (per-type buffer survives switches) holds;
+  // each type owns a separate sub-buffer so switching away must not corrupt EE.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_per_type_buffer_isolated");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -3554,12 +3548,10 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->ItemInputValue("**/Exit face number##filter_modal", "7");
       ctx->Yield(2);
 
-      // Switch away — Direction owns a separate sub-buffer (g_dir_params),
-      // so it cannot be touched by EE inputs even now that Direction is
-      // interactive (#178.5).
-      ctx->ItemClick("**/Direction##filter_type");
+      // Switch away to Raypath — EE sub-buffer must remain untouched.
+      ctx->ItemClick("**/Raypath##filter_type");
       ctx->Yield(2);
-      // Verify EE inputs un-rendered while Direction is active.
+      // Verify EE inputs un-rendered while Raypath is active.
       IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
 
       // Switch back to Entry-Exit; per-type buffer must have retained values.
@@ -3576,191 +3568,6 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       const auto& ee = std::get<gui::EntryExitParams>(f.param);
       IM_CHECK_EQ(ee.entry_text, std::string("3"));
       IM_CHECK_EQ(ee.exit_text, std::string("7"));
-    };
-  }
-
-  // ============================================================
-  // p2_filter_type — task-per-type-direction (issue 178.5)
-  //
-  // Direction type renders 2 angle controls (Azimuth°/Elevation°). The
-  // cone half-angle (radii) was removed from the GUI in
-  // task-filter-modal-polish-v1 — the serialization layer injects a
-  // fixed default. H4 修正：P/B/D Checkbox 隐藏 for Direction (its core
-  // filter does not consume crystal symmetry); raypath / EE keep P/B/D.
-  // ============================================================
-
-  // T11 — Direction subpanel renders 2 angle inputs when Direction type
-  // is active; switching to other types hides them. With SliderWithInput
-  // (post-task-filter-modal-polish-v1) the matching ID is the input child
-  // widget "##<label>_input" — see panels.cpp::PrepareSliderLayout.
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "direction_subpanel_inputs_visible");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      ResetTestState();
-      ctx->Yield(2);
-
-      ctx->ItemClick("**/Edit##fi");
-      ctx->Yield(4);
-
-      // Default = Raypath: Direction inputs not present.
-      IM_CHECK(!ctx->ItemExists("**/##Azimuth\xc2\xb0##filter_modal_input"));
-
-      // Switch to Direction: az/el items appear; radii (removed) MUST not;
-      // raypath / EE inputs disappear.
-      ctx->ItemClick("**/Direction##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/##Azimuth\xc2\xb0##filter_modal_input"));
-      IM_CHECK(ctx->ItemExists("**/##Elevation\xc2\xb0##filter_modal_input"));
-      IM_CHECK(!ctx->ItemExists("**/##Radii\xc2\xb0##filter_modal_input"));
-      IM_CHECK(!ctx->ItemExists("**/Raypath##filter_modal"));
-      IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
-
-      // OK button is enabled on Direction (no validation gate, no stub disable).
-      auto info_ok = ctx->ItemInfo("**/OK##edit_modal");
-      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
-
-      // Switch back to Raypath: Direction inputs un-render.
-      ctx->ItemClick("**/Raypath##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(!ctx->ItemExists("**/##Azimuth\xc2\xb0##filter_modal_input"));
-
-      ctx->ItemClick("**/Cancel##edit_modal");
-      ctx->Yield(2);
-    };
-  }
-
-  // T12 — Direction OK commits filter end-to-end: fill az/el/radii, set
-  // Action=Filter Out, OK → entry.filter holds DirectionParams with the
-  // typed values + action=1. The "PBD" suffix in the asserted FilterSummary
-  // string relies on g_filter_top.sym_p/b/d defaulting to true — see
-  // gui_state.hpp:271-273. Note: H4 hides the P/B/D Checkbox for Direction
-  // so the test cannot toggle sym via UI; the default-true values are the
-  // single source for the asserted suffix.
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "direction_ok_commits_filter");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      ResetTestState();
-      ctx->Yield(2);
-
-      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
-
-      ctx->ItemClick("**/Edit##fi");
-      ctx->Yield(4);
-      ctx->ItemClick("**/Direction##filter_type");
-      ctx->Yield(2);
-
-      // ItemInputValue targets the input child of SliderWithInput.
-      ctx->ItemInputValue("**/##Azimuth\xc2\xb0##filter_modal_input", 30.0f);
-      ctx->ItemInputValue("**/##Elevation\xc2\xb0##filter_modal_input", 45.0f);
-      ctx->Yield(2);
-      ctx->ItemClick("**/Filter Out##filter_action");
-      ctx->Yield(2);
-
-      // OK must be enabled on Direction.
-      auto info_ok = ctx->ItemInfo("**/OK##edit_modal");
-      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
-
-      ctx->ItemClick("**/OK##edit_modal");
-      ctx->Yield(2);
-
-      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
-      const auto& f = *gui::g_state.layers[0].entries[0].filter;
-      IM_CHECK(std::holds_alternative<gui::DirectionParams>(f.param));
-      const auto& d = std::get<gui::DirectionParams>(f.param);
-      IM_CHECK_EQ(d.az, 30.0f);
-      IM_CHECK_EQ(d.el, 45.0f);
-      IM_CHECK_EQ(f.action, 1);
-      // Default sym_p/b/d = true (gui_state.hpp:271-273) → "PBD" suffix.
-      IM_CHECK(f.sym_p);
-      IM_CHECK(f.sym_b);
-      IM_CHECK(f.sym_d);
-
-      // FilterSummary Direction format is "DIR:<az>°/<el>° <In|Out>[ <sym>]"
-      // (panels.cpp Direction branch — radii dropped in
-      // task-filter-modal-polish-v1). The sym suffix is still emitted
-      // even though the P/B/D Checkbox is hidden — the underlying field
-      // values round-trip unchanged. The "°" is UTF-8 U+00B0 (\xc2\xb0).
-      IM_CHECK_STR_EQ(gui::FilterSummary(gui::g_state.layers[0].entries[0].filter).c_str(),
-                      "DIR:30\xc2\xb0/45\xc2\xb0 Out PBD");
-    };
-  }
-
-  // T13 — per-type buffer isolation extends to Direction ↔ Entry-Exit switch:
-  // type-in Direction values, switch to Entry-Exit, switch back, OK →
-  // Direction values preserved. Verifies the per-type buffer is not clobbered
-  // when transiting through another type's sub-panel.
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "direction_per_type_buffer_isolated");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      ResetTestState();
-      ctx->Yield(2);
-
-      ctx->ItemClick("**/Edit##fi");
-      ctx->Yield(4);
-      ctx->ItemClick("**/Direction##filter_type");
-      ctx->Yield(2);
-      ctx->ItemInputValue("**/##Azimuth\xc2\xb0##filter_modal_input", 10.0f);
-      ctx->ItemInputValue("**/##Elevation\xc2\xb0##filter_modal_input", 20.0f);
-      ctx->Yield(2);
-
-      // Switch away (Entry-Exit's sub-buffer should not be touched by
-      // Direction inputs).
-      ctx->ItemClick("**/Entry-Exit##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(!ctx->ItemExists("**/##Azimuth\xc2\xb0##filter_modal_input"));
-
-      // Switch back to Direction; per-type buffer must have retained values.
-      ctx->ItemClick("**/Direction##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/##Azimuth\xc2\xb0##filter_modal_input"));
-
-      ctx->ItemClick("**/OK##edit_modal");
-      ctx->Yield(2);
-
-      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
-      const auto& f = *gui::g_state.layers[0].entries[0].filter;
-      IM_CHECK(std::holds_alternative<gui::DirectionParams>(f.param));
-      const auto& d = std::get<gui::DirectionParams>(f.param);
-      IM_CHECK_EQ(d.az, 10.0f);
-      IM_CHECK_EQ(d.el, 20.0f);
-    };
-  }
-
-  // T14 — H4 修正：P/B/D Checkbox is hidden when active type is Direction
-  // (DirectionFilter does not consume crystal symmetry); P/B/D is rendered
-  // when active type is Raypath or EntryExit. Reverse-direction assertion
-  // in raypath / EE branches guards against an accidental "hide P/B/D in
-  // all types" regression.
-  {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "direction_hides_pbd_checkboxes");
-    t->TestFunc = [](ImGuiTestContext* ctx) {
-      ResetTestState();
-      ctx->Yield(2);
-
-      ctx->ItemClick("**/Edit##fi");
-      ctx->Yield(4);
-
-      // Default = Raypath: P/B/D rendered (forward assertion).
-      IM_CHECK(ctx->ItemExists("**/P##filter_modal"));
-      IM_CHECK(ctx->ItemExists("**/B##filter_modal"));
-      IM_CHECK(ctx->ItemExists("**/D##filter_modal"));
-
-      // Direction: P/B/D hidden (H4 gate).
-      ctx->ItemClick("**/Direction##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(!ctx->ItemExists("**/P##filter_modal"));
-      IM_CHECK(!ctx->ItemExists("**/B##filter_modal"));
-      IM_CHECK(!ctx->ItemExists("**/D##filter_modal"));
-
-      // EntryExit: P/B/D rendered (forward assertion — EE consumes sym).
-      ctx->ItemClick("**/Entry-Exit##filter_type");
-      ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/P##filter_modal"));
-      IM_CHECK(ctx->ItemExists("**/B##filter_modal"));
-      IM_CHECK(ctx->ItemExists("**/D##filter_modal"));
-
-      ctx->ItemClick("**/Cancel##edit_modal");
-      ctx->Yield(2);
     };
   }
 }

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -3524,8 +3524,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       // entry/exit now render the raw text buffer (kept as-is so partial
       // input stays visible). ASCII "->" is used so the bundled font always
       // renders it (U+2192 fell back to "?" glyph on user's machine).
-      IM_CHECK_STR_EQ(gui::FilterSummary(gui::g_state.layers[0].entries[0].filter).c_str(),
-                      "EE:2->5 Out PBD");
+      IM_CHECK_STR_EQ(gui::FilterSummary(gui::g_state.layers[0].entries[0].filter).c_str(), "EE:2->5 Out PBD");
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -3437,13 +3437,13 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(4);
 
       // Default = Raypath: EE inputs not present.
-      IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
+      IM_CHECK(!ctx->ItemExists("**/Entry##filter_ee_entry"));
 
       // Switch to Entry-Exit: both InputText items appear, raypath InputText disappears.
       ctx->ItemClick("**/Entry-Exit##filter_type");
       ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/Entry face number##filter_modal"));
-      IM_CHECK(ctx->ItemExists("**/Exit face number##filter_modal"));
+      IM_CHECK(ctx->ItemExists("**/Entry##filter_ee_entry"));
+      IM_CHECK(ctx->ItemExists("**/Exit##filter_ee_exit"));
       IM_CHECK(!ctx->ItemExists("**/Raypath##filter_modal"));
 
       // OK is disabled while EE fields are empty (kIncomplete, not kValid).
@@ -3453,8 +3453,8 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) != 0);
 
       // Type valid face numbers → OK enables.
-      ctx->ItemInputValue("**/Entry face number##filter_modal", "1");
-      ctx->ItemInputValue("**/Exit face number##filter_modal", "2");
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "1");
+      ctx->ItemInputValue("**/Exit##filter_ee_exit", "2");
       ctx->Yield(2);
       auto info_typed = ctx->ItemInfo("**/OK##edit_modal");
       IM_CHECK((info_typed.ItemFlags & ImGuiItemFlags_Disabled) == 0);
@@ -3462,13 +3462,13 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       // Switch to Raypath: EE inputs un-render.
       ctx->ItemClick("**/Raypath##filter_type");
       ctx->Yield(2);
-      IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
+      IM_CHECK(!ctx->ItemExists("**/Entry##filter_ee_entry"));
 
       // Switch back to Entry-Exit: inputs reappear; the typed-and-valid
       // values are still in the buffers so OK stays enabled.
       ctx->ItemClick("**/Entry-Exit##filter_type");
       ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/Entry face number##filter_modal"));
+      IM_CHECK(ctx->ItemExists("**/Entry##filter_ee_entry"));
       auto info_back = ctx->ItemInfo("**/OK##edit_modal");
       IM_CHECK((info_back.ItemFlags & ImGuiItemFlags_Disabled) == 0);
 
@@ -3495,10 +3495,8 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->ItemClick("**/Entry-Exit##filter_type");
       ctx->Yield(2);
 
-      // post-task-filter-modal-polish-v1: InputText (text), labels read
-      // "face number" not "face id".
-      ctx->ItemInputValue("**/Entry face number##filter_modal", "2");
-      ctx->ItemInputValue("**/Exit face number##filter_modal", "5");
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "2");
+      ctx->ItemInputValue("**/Exit##filter_ee_exit", "5");
       ctx->Yield(2);
       ctx->ItemClick("**/Filter Out##filter_action");
       ctx->Yield(2);
@@ -3544,20 +3542,20 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(4);
       ctx->ItemClick("**/Entry-Exit##filter_type");
       ctx->Yield(2);
-      ctx->ItemInputValue("**/Entry face number##filter_modal", "3");
-      ctx->ItemInputValue("**/Exit face number##filter_modal", "7");
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "3");
+      ctx->ItemInputValue("**/Exit##filter_ee_exit", "7");
       ctx->Yield(2);
 
       // Switch away to Raypath — EE sub-buffer must remain untouched.
       ctx->ItemClick("**/Raypath##filter_type");
       ctx->Yield(2);
       // Verify EE inputs un-rendered while Raypath is active.
-      IM_CHECK(!ctx->ItemExists("**/Entry face number##filter_modal"));
+      IM_CHECK(!ctx->ItemExists("**/Entry##filter_ee_entry"));
 
       // Switch back to Entry-Exit; per-type buffer must have retained values.
       ctx->ItemClick("**/Entry-Exit##filter_type");
       ctx->Yield(2);
-      IM_CHECK(ctx->ItemExists("**/Entry face number##filter_modal"));
+      IM_CHECK(ctx->ItemExists("**/Entry##filter_ee_entry"));
 
       ctx->ItemClick("**/OK##edit_modal");
       ctx->Yield(2);
@@ -3568,6 +3566,85 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       const auto& ee = std::get<gui::EntryExitParams>(f.param);
       IM_CHECK_EQ(ee.entry_text, std::string("3"));
       IM_CHECK_EQ(ee.exit_text, std::string("7"));
+    };
+  }
+
+  // T11 — Remove Filter (EE): button always enabled, clears fields, OK enabled
+  // (intent bypasses incomplete gate), and OK → entry.filter == nullopt even
+  // if user re-types values after Remove (session-level single direction).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_remove_clears_and_ok_enabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Entry-Exit##filter_type");
+      ctx->Yield(2);
+
+      // Remove Filter button must exist and be enabled even with empty fields.
+      IM_CHECK(ctx->ItemExists("**/Remove Filter##filter_ee"));
+      auto info_remove_empty = ctx->ItemInfo("**/Remove Filter##filter_ee");
+      IM_CHECK((info_remove_empty.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      // Type valid face numbers.
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "2");
+      ctx->ItemInputValue("**/Exit##filter_ee_exit", "5");
+      ctx->Yield(2);
+
+      // Remove Filter clears the fields.
+      ctx->ItemClick("**/Remove Filter##filter_ee");
+      ctx->Yield(2);
+
+      // After Remove: OK is enabled (intent bypasses incomplete gate).
+      auto info_ok = ctx->ItemInfo("**/OK##edit_modal");
+      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      // Re-type entry=1 after Remove (intent still set — session-level single direction).
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "1");
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // Remove intent takes precedence: filter must be nullopt regardless of re-typed value.
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
+    };
+  }
+
+  // T12 — Remove Filter (EE) followed by OK: pre-existing EE filter is cleared.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_remove_ok_clears_filter");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Pre-populate entry.filter with an EE filter.
+      {
+        gui::FilterConfig fc;
+        fc.action = 0;
+        gui::EntryExitParams ee;
+        ee.entry_text = "2";
+        ee.exit_text = "5";
+        fc.param = ee;
+        gui::g_state.layers[0].entries[0].filter = fc;
+      }
+      ctx->Yield(2);
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter.has_value());
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Entry-Exit##filter_type");
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Remove Filter##filter_ee");
+      ctx->Yield(2);
+      ctx->ItemClick("**/OK##edit_modal");
+      ctx->Yield(2);
+
+      // After Remove + OK, filter must be nullopt.
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter.has_value());
     };
   }
 }


### PR DESCRIPTION
## Summary

GUI polish round v18 — addresses three pieces of feedback collected on 2026-05-07 from self-testing and a small internal beta:

- **Visibility row layout** (`1180c81`): 4 RadioButtons rearranged from 2×2 to a single horizontal row. Verified ~35px of margin remains in the fixed 300px right panel.
- **Drop Direction filter from GUI** (`7e13b71`): mirrors the #179 Crystal removal route — Direction is removed from the filter type radio, variant alternative, and editor subpanel. The core JSON path is unchanged; loading an old `.lmc` containing `type: direction` falls back to an empty Raypath filter with a warning.
- **EE subpanel aligned to Raypath** (`3204cb5`): validation frame coloring, simplified labels, shared `e.g.` hint, and a Remove Filter button (uses `g_ee_remove_intent` to bypass the `kValid` gate and reset `entry.filter` to `std::nullopt`). Multi-value OR / wildcard expansion is out of scope and tracked in backlog.
- **EE summary ASCII arrow** (`4a0b270`): the EE crystal-card summary previously used `→` (U+2192), which the bundled font does not cover and was rendered as `?`. Replaced with ASCII `->`.

All four commits went through the full plan → plan-review → implement → code-review → closeout cycle (180.3 took two plan-review rounds; the others one). 220/220 GUI tests + 19/19 E2E pass on macOS.

## Test plan

- [x] `./scripts/build.sh -gtj release` — 220/220 GUI tests pass
- [x] User manual smoke test on macOS confirmed the four UI changes
- [x] Confirm EE crystal-card summary now shows `EE:2->5 ...` instead of `EE:2?5 ...`
- [x] Open a pre-existing `.lmc` containing `type: direction` and verify the entry degrades to empty Raypath with a warning toast/log
- [x] Verify the CLI core JSON path still loads `"type": "direction"` filters and produces correct halo output

🤖 Generated with [Claude Code](https://claude.com/claude-code)