### PR TITLE
Refactor: enforce GUI/core API boundary via 4 new C API entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ Release artifacts land in `build/cmake_install/`. Debug builds stay in `build/cm
 - Do not use raw `new` / `delete`.
 - Do not use `using namespace`.
 - Keep code comments in English.
+- Public API boundary: `src/gui/` code must only access core/config functionality
+  through the C API (`src/include/lumice.h`). Direct `#include` of `core/` or `config/`
+  headers from `src/gui/` is prohibited.
 
 ## Testing and Platform Notes
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <string>
 
-#include "config/render_config.hpp"
 #include "gui/app.hpp"
 #include "gui/edit_modals.hpp"
 #include "gui/gui_constants.hpp"
@@ -408,7 +407,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
       }
       ImGui::EndCombo();
     }
-    float max_fov = MaxFov(static_cast<LensParam::LensType>(r.lens_type));
+    float max_fov = LUMICE_MaxFov(static_cast<LUMICE_LensType>(r.lens_type));
     ImGui::BeginDisabled(full_sky);
     SliderWithInput("FOV##view", &r.fov, 1.0f, max_fov, "%.0f");
     ImGui::EndDisabled();
@@ -712,7 +711,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
   // Copy-model: GuiState always owns a single renderer, no vector/index bookkeeping needed.
   {
     auto& r = g_state.renderer;
-    float max_fov = MaxFov(static_cast<LensParam::LensType>(r.lens_type));
+    float max_fov = LUMICE_MaxFov(static_cast<LUMICE_LensType>(r.lens_type));
     r.fov = std::min(r.fov, max_fov);
     if (LensIsFullSky(r.lens_type)) {  // Full-sky lenses: force view angles to zero
       r.elevation = 0.0f;
@@ -842,7 +841,7 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
       }
 
       if (is_hovered && io.MouseWheel != 0.0f) {
-        float fov_max = MaxFov(static_cast<LensParam::LensType>(rc.lens_type));
+        float fov_max = LUMICE_MaxFov(static_cast<LUMICE_LensType>(rc.lens_type));
         rc.fov -= io.MouseWheel * 5.0f;
         rc.fov = std::max(1.0f, std::min(fov_max, rc.fov));
       }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -9,7 +9,6 @@
 #include <optional>
 #include <string>
 
-#include "config/raypath_validation.hpp"
 #include "gui/app.hpp"
 #include "gui/axis_presets.hpp"
 #include "gui/crystal_preview.hpp"
@@ -645,16 +644,16 @@ static void RenderAxisModal(GuiState& /*state*/) {
 // for "what crystal kind should the raypath validator use"; both this Filter
 // sub-panel and the modal-level OK gate consume it.
 namespace {
-lumice::CrystalKind CurrentValidationKind();
+LUMICE_CrystalKind CurrentValidationKind();
 }
 
-static ImVec4 ValidationFrameBgColor(RaypathValidation state) {
+static ImVec4 ValidationFrameBgColor(LUMICE_RaypathValidationState state) {
   switch (state) {
-    case RaypathValidation::kValid:
+    case LUMICE_RAYPATH_VALID:
       return ImVec4(0.06f, 0.24f, 0.06f, 0.5f);
-    case RaypathValidation::kIncomplete:
+    case LUMICE_RAYPATH_INCOMPLETE:
       return ImVec4(0.27f, 0.24f, 0.03f, 0.5f);
-    case RaypathValidation::kInvalid:
+    case LUMICE_RAYPATH_INVALID:
       return ImVec4(0.27f, 0.06f, 0.06f, 0.5f);
   }
   return ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -674,17 +673,17 @@ static void RenderRaypathSubpanel() {
 
   // Validation hint immediately under the InputText.
   switch (validation) {
-    case RaypathValidation::kValid:
+    case LUMICE_RAYPATH_VALID:
       if (g_raypath_params.raypath_text.empty()) {
         ImGui::TextDisabled("No raypath filter (match all)");
       } else {
         ImGui::TextColored(ImVec4(0.2f, 0.8f, 0.2f, 1.0f), "Valid");
       }
       break;
-    case RaypathValidation::kIncomplete:
+    case LUMICE_RAYPATH_INCOMPLETE:
       ImGui::TextColored(ImVec4(0.9f, 0.8f, 0.1f, 1.0f), "Incomplete (still typing?)");
       break;
-    case RaypathValidation::kInvalid: {
+    case LUMICE_RAYPATH_INVALID: {
       const char* msg = result.message.empty() ? "Invalid raypath" : result.message.c_str();
       // TextWrapped so multi-segment "Segment N: ..." messages don't overflow
       // the modal's narrow vertical layout.
@@ -713,8 +712,8 @@ static void RenderRaypathSubpanel() {
 // char arrays in place across frames.
 static void RenderEntryExitSubpanel() {
   const auto kind = CurrentValidationKind();
-  const auto v_entry = ValidateFaceNumberText(g_ee_entry_buf, kind);
-  const auto v_exit = ValidateFaceNumberText(g_ee_exit_buf, kind);
+  const auto v_entry = GuiValidateFaceNumberText(g_ee_entry_buf, kind);
+  const auto v_exit = GuiValidateFaceNumberText(g_ee_exit_buf, kind);
 
   // FrameBg tint mirrors RenderRaypathSubpanel (same helper).
   ImGui::PushStyleColor(ImGuiCol_FrameBg, ValidationFrameBgColor(v_entry.state));
@@ -955,8 +954,8 @@ namespace {
 // because the user may switch crystal type before committing — the validator
 // should match what will actually be written on OK. Single source of truth
 // for the Filter sub-panel and the modal-level OK gate.
-lumice::CrystalKind CurrentValidationKind() {
-  return (g_crystal_buf.type == CrystalType::kPrism) ? lumice::CrystalKind::kPrism : lumice::CrystalKind::kPyramid;
+LUMICE_CrystalKind CurrentValidationKind() {
+  return (g_crystal_buf.type == CrystalType::kPrism) ? LUMICE_CRYSTAL_PRISM : LUMICE_CRYSTAL_PYRAMID;
 }
 
 // Filter-tab dirty predicate. Active-type-guarded form per plan §7 risk 6:
@@ -1043,9 +1042,9 @@ ApplyBuffersResult ApplyBuffersToEntry(GuiState& state) {
     }
     const bool buf_changed = IsFilterDirty();
     const auto kind = CurrentValidationKind();
-    const auto v_entry = ValidateFaceNumberText(g_ee_params.entry_text, kind);
-    const auto v_exit = ValidateFaceNumberText(g_ee_params.exit_text, kind);
-    const bool both_valid = v_entry.state == RaypathValidation::kValid && v_exit.state == RaypathValidation::kValid;
+    const auto v_entry = GuiValidateFaceNumberText(g_ee_params.entry_text, kind);
+    const auto v_exit = GuiValidateFaceNumberText(g_ee_params.exit_text, kind);
+    const bool both_valid = v_entry.state == LUMICE_RAYPATH_VALID && v_exit.state == LUMICE_RAYPATH_VALID;
     if ((g_filter_initial_present || buf_changed) && both_valid) {
       FilterConfig out;
       out.name = g_filter_top.name;
@@ -1087,7 +1086,7 @@ ApplyBuffersResult ApplyBuffersToEntry(GuiState& state) {
       // preventing half-typed input from poisoning the renderer. Multi-segment
       // OR (";") is supported via ValidateRaypathTextMultiSegment.
       auto v = ValidateRaypathTextMultiSegment(g_raypath_params.raypath_text, CurrentValidationKind());
-      if (v.state == RaypathValidation::kValid) {
+      if (v.state == LUMICE_RAYPATH_VALID) {
         // Materialize FilterConfig from top fields + active raypath sub-buffer.
         FilterConfig out;
         out.name = g_filter_top.name;
@@ -1490,7 +1489,7 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       g_raypath_params.raypath_text = g_raypath_buf;
       if (!g_raypath_params.raypath_text.empty()) {
         const auto v = ValidateRaypathTextMultiSegment(g_raypath_params.raypath_text, CurrentValidationKind());
-        if (v.state != RaypathValidation::kValid) {
+        if (v.state != LUMICE_RAYPATH_VALID) {
           ok_disabled = true;
           ok_tooltip = "Filter raypath invalid — fix it in the Filter tab";
         }
@@ -1506,11 +1505,10 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       // enabled when the user has clicked Remove Filter.
       if (!g_ee_remove_intent) {
         const auto kind = CurrentValidationKind();
-        const auto ve = ValidateFaceNumberText(g_ee_entry_buf, kind);
-        const auto vx = ValidateFaceNumberText(g_ee_exit_buf, kind);
-        const bool incomplete =
-            ve.state == RaypathValidation::kIncomplete || vx.state == RaypathValidation::kIncomplete;
-        const bool invalid = ve.state == RaypathValidation::kInvalid || vx.state == RaypathValidation::kInvalid;
+        const auto ve = GuiValidateFaceNumberText(g_ee_entry_buf, kind);
+        const auto vx = GuiValidateFaceNumberText(g_ee_exit_buf, kind);
+        const bool incomplete = ve.state == LUMICE_RAYPATH_INCOMPLETE || vx.state == LUMICE_RAYPATH_INCOMPLETE;
+        const bool invalid = ve.state == LUMICE_RAYPATH_INVALID || vx.state == LUMICE_RAYPATH_INVALID;
         if (invalid) {
           ok_disabled = true;
           ok_tooltip = "Filter face number invalid — fix it in the Filter tab";

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -16,8 +16,6 @@
 #include <sstream>
 #include <vector>
 
-#include "config/raypath_validation.hpp"
-#include "core/def.hpp"
 #include "gui/app.hpp"
 #include "gui/export_fbo_renderer.hpp"
 #include "gui/gl_capture.hpp"
@@ -265,8 +263,8 @@ static int ParseFaceNumberOrZero(const std::string& text) {
   // faces — any text the syntax stage rejects (separators, non-digits,
   // overlong) bails to 0; only the kind-specific stage might "reject"
   // a legal-on-pyramid face we want to keep, which we tolerate here.
-  const auto v = ValidateFaceNumberText(text, CrystalKind::kPyramid);
-  if (v.state == RaypathValidation::kInvalid && v.message.find("not legal on this crystal type") == std::string::npos) {
+  const auto v = GuiValidateFaceNumberText(text, LUMICE_CRYSTAL_PYRAMID);
+  if (v.state == LUMICE_RAYPATH_INVALID && v.message.find("not legal on this crystal type") == std::string::npos) {
     return 0;
   }
   // Safe to parse: ValidateFaceNumberText caps digit count.
@@ -280,16 +278,15 @@ static int ParseFaceNumberOrZero(const std::string& text) {
   return value;
 }
 
-// Clamp a GUI int to the core IdType range and warn on overflow.
+// Clamp a GUI int to the C API ID range and warn on overflow.
 static int ClampIdValue(int v, const char* field_name) {
   if (v < 0) {
-    GUI_LOG_WARNING("[Filter] {} = {} clamped to 0 (IdType range [0, {}])", field_name, v,
-                    std::numeric_limits<IdType>::max());
+    GUI_LOG_WARNING("[Filter] {} = {} clamped to 0 (LUMICE_MAX_ID range [0, {}])", field_name, v, LUMICE_MAX_ID);
     return 0;
   }
-  int max_id = static_cast<int>(std::numeric_limits<IdType>::max());
+  constexpr int max_id = LUMICE_MAX_ID;
   if (v > max_id) {
-    GUI_LOG_WARNING("[Filter] {} = {} clamped to {} (IdType range [0, {}])", field_name, v, max_id, max_id);
+    GUI_LOG_WARNING("[Filter] {} = {} clamped to {} (LUMICE_MAX_ID range [0, {}])", field_name, v, max_id, max_id);
     return max_id;
   }
   return v;

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <string>
 
-#include "config/render_config.hpp"
 #include "gui/app.hpp"
 #include "gui/axis_presets.hpp"
 #include "gui/crystal_preview.hpp"

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -2,13 +2,19 @@
 #define LUMICE_GUI_RAYPATH_SEGMENTS_HPP
 
 #include <cctype>
+#include <cstdio>
 #include <string>
 #include <vector>
 
-#include "config/raypath_validation.hpp"
-#include "core/crystal_kind.hpp"
+#include "include/lumice.h"
 
 namespace lumice::gui {
+
+// Validation result for GUI raypath / face-number inputs.
+struct GuiValidationResult {
+  LUMICE_RaypathValidationState state;
+  std::string message;
+};
 
 // Trim ASCII whitespace from both ends of a string.
 inline std::string TrimRaypathSegment(const std::string& s) {
@@ -50,6 +56,44 @@ inline std::vector<std::string> SplitRaypathSegments(const std::string& text) {
   return out;
 }
 
+// Validate a single face-number text input. Unlike LUMICE_ValidateRaypathText,
+// rejects separators outright — entry/exit fields each take exactly one face number.
+// Message for kind-specific rejection contains "not legal on this crystal type"
+// so that ParseFaceNumberOrZero can distinguish it from a syntax error.
+inline GuiValidationResult GuiValidateFaceNumberText(const std::string& text, LUMICE_CrystalKind kind) {
+  GuiValidationResult r;
+  if (text.empty()) {
+    r.state = LUMICE_RAYPATH_INCOMPLETE;
+    return r;
+  }
+  if (text.size() > 3) {
+    r.state = LUMICE_RAYPATH_INVALID;
+    r.message = "face number out of range";
+    return r;
+  }
+  for (char c : text) {
+    if (c < '0' || c > '9') {
+      r.state = LUMICE_RAYPATH_INVALID;
+      r.message = "must be a single non-negative integer";
+      return r;
+    }
+  }
+  int face = std::stoi(text);
+  if (!LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, face)) {
+    r.state = LUMICE_RAYPATH_INVALID;
+    r.message = "Face " + std::to_string(face) + " is outside the legal range of any crystal";
+    return r;
+  }
+  if (!LUMICE_IsLegalFace(kind, face)) {
+    const char* kind_name = (kind == LUMICE_CRYSTAL_PRISM) ? "Prism" : "Pyramid";
+    r.state = LUMICE_RAYPATH_INVALID;
+    r.message = "Face " + std::to_string(face) + " is not legal on this crystal type (" + std::string(kind_name) + ")";
+    return r;
+  }
+  r.state = LUMICE_RAYPATH_VALID;
+  return r;
+}
+
 // Validate raypath text supporting the multi-segment ';' syntax.
 //
 // Job split (per plan):
@@ -59,23 +103,27 @@ inline std::vector<std::string> SplitRaypathSegments(const std::string& text) {
 //     trailing ';' or repeated ';' (with optional whitespace between) before
 //     calling the splitter, so inputs like ";3" / "3;" / "3;;5" are rejected
 //     up-front rather than relying on splitter output.
-//   - Each non-empty segment is then validated by the kind-aware single-segment
-//     validator from core (ValidateRaypathText overload).
+//   - Each non-empty segment is then validated by LUMICE_ValidateRaypathText.
 //   - Empty input → kValid (means "no filter").
 //   - Single-segment input (no ';') → delegates to the single-segment validator
 //     so existing behavior is preserved exactly (incl. kIncomplete states for
 //     trailing dashes / commas).
-inline RaypathValidationResult ValidateRaypathTextMultiSegment(const std::string& text, CrystalKind kind) {
-  RaypathValidationResult result;
+inline GuiValidationResult ValidateRaypathTextMultiSegment(const std::string& text, LUMICE_CrystalKind kind) {
+  GuiValidationResult result;
 
   if (text.empty()) {
-    result.state = RaypathValidation::kValid;
+    result.state = LUMICE_RAYPATH_VALID;
     return result;
   }
 
   // No ';' → preserve single-segment semantics.
   if (text.find(';') == std::string::npos) {
-    return ValidateRaypathText(text, kind);
+    char msg[256] = {};
+    LUMICE_RaypathValidationState seg_state = LUMICE_RAYPATH_VALID;
+    LUMICE_ValidateRaypathText(text.c_str(), kind, &seg_state, msg, sizeof(msg));
+    result.state = seg_state;
+    result.message = msg;
+    return result;
   }
 
   // Pre-flight: scan for leading / trailing / consecutive ';' (allowing
@@ -85,7 +133,7 @@ inline RaypathValidationResult ValidateRaypathTextMultiSegment(const std::string
   for (char c : text) {
     if (c == ';') {
       if (sep_pending) {
-        result.state = RaypathValidation::kInvalid;
+        result.state = LUMICE_RAYPATH_INVALID;
         result.message = "Empty raypath segment";
         return result;
       }
@@ -96,7 +144,7 @@ inline RaypathValidationResult ValidateRaypathTextMultiSegment(const std::string
   }
   // Trailing ';' (sep_pending still true after loop) or pure-whitespace input.
   if (sep_pending) {
-    result.state = RaypathValidation::kInvalid;
+    result.state = LUMICE_RAYPATH_INVALID;
     result.message = "Empty raypath segment";
     return result;
   }
@@ -108,19 +156,21 @@ inline RaypathValidationResult ValidateRaypathTextMultiSegment(const std::string
     ++idx;
     if (seg.empty()) {
       // Defensive — pre-flight should already have caught this.
-      result.state = RaypathValidation::kInvalid;
+      result.state = LUMICE_RAYPATH_INVALID;
       result.message = "Empty raypath segment " + std::to_string(idx);
       return result;
     }
-    auto r = ValidateRaypathText(seg, kind);
-    if (r.state != RaypathValidation::kValid) {
-      result.state = r.state;
-      result.message = "Segment " + std::to_string(idx) + ": " + r.message;
+    char msg[256] = {};
+    LUMICE_RaypathValidationState seg_state = LUMICE_RAYPATH_VALID;
+    LUMICE_ValidateRaypathText(seg.c_str(), kind, &seg_state, msg, sizeof(msg));
+    if (seg_state != LUMICE_RAYPATH_VALID) {
+      result.state = seg_state;
+      result.message = "Segment " + std::to_string(idx) + ": " + msg;
       return result;
     }
   }
 
-  result.state = RaypathValidation::kValid;
+  result.state = LUMICE_RAYPATH_VALID;
   return result;
 }
 

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -1,6 +1,8 @@
 #ifndef LUMICE_H_
 #define LUMICE_H_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,6 +32,7 @@ typedef enum LUMICE_ErrorCode_ {
   LUMICE_ERR_INVALID_VALUE,
   LUMICE_ERR_FILE_NOT_FOUND,
   LUMICE_ERR_SERVER,
+  LUMICE_ERR_UNKNOWN,
 } LUMICE_ErrorCode;
 
 // =============== Log Levels ===============
@@ -301,6 +304,61 @@ typedef struct LUMICE_CrystalMesh_ {
 } LUMICE_CrystalMesh;
 
 LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* server, const char* crystal_json, LUMICE_CrystalMesh* out);
+
+// =============== Config ID Range ===============
+// Maximum value for LUMICE config IDs (matches core IdType = uint16_t max).
+// GUI code should clamp user-editable IDs to [0, LUMICE_MAX_ID].
+#define LUMICE_MAX_ID 65535
+
+// =============== Crystal Kind ===============
+// Coarse crystal classification used for raypath face-number validation.
+// GUI uses this to determine which face numbers are legal for a given crystal.
+typedef enum LUMICE_CrystalKind_ {
+  LUMICE_CRYSTAL_PRISM,    // Basal + prism lateral faces (1,2,3-8)
+  LUMICE_CRYSTAL_PYRAMID,  // All faces including upper/lower pyramidal (1,2,3-8,13-18,23-28)
+} LUMICE_CrystalKind;
+
+// Returns non-zero if `face` is a legal face number for the given crystal kind.
+int LUMICE_IsLegalFace(LUMICE_CrystalKind kind, int face);
+
+// =============== Raypath Validation ===============
+// Validation state for raypath text input (GUI border color + OK gate).
+typedef enum LUMICE_RaypathValidationState_ {
+  LUMICE_RAYPATH_VALID,       // All tokens valid; safe to submit
+  LUMICE_RAYPATH_INCOMPLETE,  // Trailing/leading separator; user still typing
+  LUMICE_RAYPATH_INVALID,     // Non-numeric tokens or illegal face numbers
+} LUMICE_RaypathValidationState;
+
+// Validate a raypath text string (dash- or comma-separated face indices) against
+// both syntax rules and face-number legality for the given crystal kind.
+// Used by GUI for raypath filter input validation.
+// out_msg: human-readable error description (empty on kValid/kIncomplete).
+//          Caller provides buffer; recommended size = 256.
+// Returns LUMICE_ERR_NULL_ARG if text, out_state, or out_msg is NULL.
+LUMICE_ErrorCode LUMICE_ValidateRaypathText(const char* text, LUMICE_CrystalKind kind,
+                                            LUMICE_RaypathValidationState* out_state, char* out_msg,
+                                            size_t msg_buf_size);
+
+// =============== Lens Type ===============
+// Lens projection type. Values match Core's LensParam::LensType enum (index 0-10).
+// Used by GUI to look up per-lens FOV limits without including config/render_config.hpp.
+typedef enum LUMICE_LensType_ {
+  LUMICE_LENS_LINEAR = 0,
+  LUMICE_LENS_FISHEYE_EQUAL_AREA = 1,
+  LUMICE_LENS_FISHEYE_EQUIDISTANT = 2,
+  LUMICE_LENS_FISHEYE_STEREOGRAPHIC = 3,
+  LUMICE_LENS_DUAL_FISHEYE_EQUAL_AREA = 4,
+  LUMICE_LENS_DUAL_FISHEYE_EQUIDISTANT = 5,
+  LUMICE_LENS_DUAL_FISHEYE_STEREOGRAPHIC = 6,
+  LUMICE_LENS_RECTANGULAR = 7,
+  LUMICE_LENS_FISHEYE_ORTHOGRAPHIC = 8,
+  LUMICE_LENS_DUAL_FISHEYE_ORTHOGRAPHIC = 9,
+  LUMICE_LENS_GLOBE = 10,
+} LUMICE_LensType;
+
+// Returns the maximum valid FOV (degrees) for the given lens type.
+// Used by GUI to clamp the FOV slider upper bound when the user switches lens type.
+float LUMICE_MaxFov(LUMICE_LensType type);
 
 #if !defined(_MSC_VER)
 #pragma GCC visibility pop

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "config/raypath_validation.hpp"
+#include "config/render_config.hpp"
 #include "core/crystal.hpp"
 #include "core/geo3d.hpp"
 #include "include/lumice.h"
@@ -994,4 +996,50 @@ LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* /*server*/, const char* cr
   }
 
   return LUMICE_OK;
+}
+
+
+// =============== Crystal Kind ===============
+int LUMICE_IsLegalFace(LUMICE_CrystalKind kind, int face) {
+  // Two-value enum: extend to switch+assert when CrystalKind expands.
+  auto core_kind = (kind == LUMICE_CRYSTAL_PRISM) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
+  return ns::IsLegalFace(core_kind, face) ? 1 : 0;
+}
+
+
+// =============== Raypath Validation ===============
+LUMICE_ErrorCode LUMICE_ValidateRaypathText(const char* text, LUMICE_CrystalKind kind,
+                                            LUMICE_RaypathValidationState* out_state, char* out_msg,
+                                            size_t msg_buf_size) {
+  if (!text || !out_state || !out_msg) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  // Two-value enum: extend to switch+assert when CrystalKind expands.
+  auto core_kind = (kind == LUMICE_CRYSTAL_PRISM) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
+  auto r = ns::ValidateRaypathText(std::string(text), core_kind);
+  switch (r.state) {
+    case ns::RaypathValidation::kValid:
+      *out_state = LUMICE_RAYPATH_VALID;
+      break;
+    case ns::RaypathValidation::kIncomplete:
+      *out_state = LUMICE_RAYPATH_INCOMPLETE;
+      break;
+    case ns::RaypathValidation::kInvalid:
+      *out_state = LUMICE_RAYPATH_INVALID;
+      break;
+    default:
+      assert(false);
+      *out_state = LUMICE_RAYPATH_INVALID;
+      return LUMICE_ERR_UNKNOWN;
+  }
+  if (msg_buf_size > 0) {
+    std::snprintf(out_msg, msg_buf_size, "%s", r.message.c_str());
+  }
+  return LUMICE_OK;
+}
+
+
+// =============== Lens Type ===============
+float LUMICE_MaxFov(LUMICE_LensType type) {
+  return ns::MaxFov(static_cast<ns::LensParam::LensType>(type));
 }

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -691,3 +691,173 @@ TEST(ResultsApi, GetBeforeCommit) {
   LUMICE_StopServer(server);
   LUMICE_DestroyServer(server);
 }
+
+// ============================================================
+// LUMICE_MAX_ID
+// ============================================================
+
+TEST(MaxIdApi, ValueMatchesUint16Max) {
+  EXPECT_EQ(LUMICE_MAX_ID, 65535);
+}
+
+// ============================================================
+// LUMICE_IsLegalFace
+// ============================================================
+
+TEST(IsLegalFaceApi, PrismLegalFaces) {
+  // Basal faces: 1, 2; prism lateral faces: 3..8
+  EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, 1), 0);
+  EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, 2), 0);
+  for (int f = 3; f <= 8; ++f) {
+    EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, f), 0) << "face=" << f;
+  }
+}
+
+TEST(IsLegalFaceApi, PrismIllegalFaces) {
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, 0), 0);
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, 9), 0);
+  for (int f = 13; f <= 18; ++f) {
+    EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, f), 0) << "face=" << f;
+  }
+  for (int f = 23; f <= 28; ++f) {
+    EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PRISM, f), 0) << "face=" << f;
+  }
+}
+
+TEST(IsLegalFaceApi, PyramidLegalFaces) {
+  EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 1), 0);
+  EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 2), 0);
+  for (int f = 3; f <= 8; ++f) {
+    EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, f), 0) << "face=" << f;
+  }
+  for (int f = 13; f <= 18; ++f) {
+    EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, f), 0) << "face=" << f;
+  }
+  for (int f = 23; f <= 28; ++f) {
+    EXPECT_NE(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, f), 0) << "face=" << f;
+  }
+}
+
+TEST(IsLegalFaceApi, PyramidIllegalFaces) {
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 0), 0);
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 9), 0);
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 29), 0);
+  EXPECT_EQ(LUMICE_IsLegalFace(LUMICE_CRYSTAL_PYRAMID, 100), 0);
+}
+
+// ============================================================
+// LUMICE_ValidateRaypathText
+// ============================================================
+
+TEST(ValidateRaypathTextApi, NullArgs) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_VALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText(nullptr, LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3", LUMICE_CRYSTAL_PRISM, nullptr, msg, sizeof(msg)), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3", LUMICE_CRYSTAL_PRISM, &vstate, nullptr, sizeof(msg)), LUMICE_ERR_NULL_ARG);
+}
+
+TEST(ValidateRaypathTextApi, EmptyIsValid) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_INVALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_VALID);
+  EXPECT_EQ(std::string(msg), "");
+}
+
+TEST(ValidateRaypathTextApi, ValidSingleFace) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_INVALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_VALID);
+}
+
+TEST(ValidateRaypathTextApi, ValidMultiFace) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_INVALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3-5-8", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_VALID);
+}
+
+TEST(ValidateRaypathTextApi, TrailingSepIncomplete) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_VALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3-", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_INCOMPLETE);
+}
+
+TEST(ValidateRaypathTextApi, NonDigitInvalid) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_VALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3-x", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_INVALID);
+}
+
+TEST(ValidateRaypathTextApi, KindSpecificInvalid) {
+  // Face 13 is legal on pyramid but not prism
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_VALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("13", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_INVALID);
+  EXPECT_NE(std::string(msg).find("not legal on this crystal type"), std::string::npos);
+}
+
+TEST(ValidateRaypathTextApi, KindSpecificValidPyramid) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_INVALID;
+  char msg[256] = {};
+  EXPECT_EQ(LUMICE_ValidateRaypathText("13", LUMICE_CRYSTAL_PYRAMID, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(vstate, LUMICE_RAYPATH_VALID);
+}
+
+TEST(ValidateRaypathTextApi, MsgBufTruncation) {
+  LUMICE_RaypathValidationState vstate = LUMICE_RAYPATH_VALID;
+  char msg[4] = {};
+  // Should not crash; result must be null-terminated within 4 bytes
+  EXPECT_EQ(LUMICE_ValidateRaypathText("3-x-y", LUMICE_CRYSTAL_PRISM, &vstate, msg, sizeof(msg)), LUMICE_OK);
+  EXPECT_EQ(msg[3], '\0');
+}
+
+// ============================================================
+// GuiValidateFaceNumberText (via raypath_segments.hpp)
+// — validates the substring "not legal on this crystal type"
+//   that ParseFaceNumberOrZero relies on for kind-specific detection.
+// ============================================================
+
+#include "gui/raypath_segments.hpp"
+
+TEST(GuiValidateFaceNumberTextApi, KindSpecificMsgContainsExpectedSubstring) {
+  // Face 13 is legal on pyramid but not prism — kind-specific rejection
+  auto r = lumice::gui::GuiValidateFaceNumberText("13", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
+  EXPECT_NE(r.message.find("not legal on this crystal type"), std::string::npos);
+}
+
+// ============================================================
+// LUMICE_MaxFov
+// ============================================================
+
+TEST(MaxFovApi, LinearIs179) {
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_LINEAR), 179.0f, 0.01f);
+}
+
+TEST(MaxFovApi, StereographicIs359) {
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_FISHEYE_STEREOGRAPHIC), 359.0f, 0.01f);
+}
+
+TEST(MaxFovApi, OrthographicIs180) {
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_FISHEYE_ORTHOGRAPHIC), 180.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_DUAL_FISHEYE_ORTHOGRAPHIC), 180.0f, 0.01f);
+}
+
+TEST(MaxFovApi, GlobeIs90) {
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_GLOBE), 90.0f, 0.01f);
+}
+
+TEST(MaxFovApi, DefaultIs360) {
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_FISHEYE_EQUAL_AREA), 360.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_FISHEYE_EQUIDISTANT), 360.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_DUAL_FISHEYE_EQUAL_AREA), 360.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_DUAL_FISHEYE_EQUIDISTANT), 360.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_DUAL_FISHEYE_STEREOGRAPHIC), 360.0f, 0.01f);
+  EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_RECTANGULAR), 360.0f, 0.01f);
+}

--- a/test/test_raypath_segments.cpp
+++ b/test/test_raypath_segments.cpp
@@ -50,63 +50,63 @@ TEST(RaypathSegments, SplitLeadingTrailingSeparators) {
 // ---- ValidateRaypathTextMultiSegment ----
 
 TEST(RaypathSegments, ValidateEmptyIsValid) {
-  auto r = ValidateRaypathTextMultiSegment("", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kValid);
+  auto r = ValidateRaypathTextMultiSegment("", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_VALID);
 }
 
 TEST(RaypathSegments, ValidateSingleSegmentDelegates) {
   // No ';' → must behave exactly like single-segment validator.
-  auto r = ValidateRaypathTextMultiSegment("3-1-5", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kValid);
+  auto r = ValidateRaypathTextMultiSegment("3-1-5", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_VALID);
 
-  auto r2 = ValidateRaypathTextMultiSegment("3-5-", CrystalKind::kPrism);
-  EXPECT_EQ(r2.state, RaypathValidation::kIncomplete);
+  auto r2 = ValidateRaypathTextMultiSegment("3-5-", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r2.state, LUMICE_RAYPATH_INCOMPLETE);
 
-  auto r3 = ValidateRaypathTextMultiSegment("abc", CrystalKind::kPrism);
-  EXPECT_EQ(r3.state, RaypathValidation::kInvalid);
+  auto r3 = ValidateRaypathTextMultiSegment("abc", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r3.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateMultiSegmentValid) {
-  auto r = ValidateRaypathTextMultiSegment("3-5; 1-3", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kValid);
+  auto r = ValidateRaypathTextMultiSegment("3-5; 1-3", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_VALID);
 }
 
 TEST(RaypathSegments, ValidateLeadingSemicolonRejected) {
-  auto r = ValidateRaypathTextMultiSegment(";3", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment(";3", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateTrailingSemicolonRejected) {
-  auto r = ValidateRaypathTextMultiSegment("3-5;", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment("3-5;", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateConsecutiveSemicolonsRejected) {
-  auto r = ValidateRaypathTextMultiSegment("3;;5", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment("3;;5", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateConsecutiveSemicolonsWithWhitespaceRejected) {
   // "; ;" in a multi-segment context is still empty between separators.
-  auto r = ValidateRaypathTextMultiSegment("3 ; ; 5", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment("3 ; ; 5", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidatePureSemicolonRejected) {
-  auto r = ValidateRaypathTextMultiSegment(";", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment(";", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateOneInvalidSegmentRejected) {
   // Face 51 is outside any crystal's legal range.
-  auto r = ValidateRaypathTextMultiSegment("3-5; 51", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  auto r = ValidateRaypathTextMultiSegment("3-5; 51", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 TEST(RaypathSegments, ValidateSegmentMixedSeparators) {
   // Both '-' and ',' are accepted within a segment (legacy comma-as-dash).
-  auto r = ValidateRaypathTextMultiSegment("3,5; 1-3", CrystalKind::kPrism);
-  EXPECT_EQ(r.state, RaypathValidation::kValid);
+  auto r = ValidateRaypathTextMultiSegment("3,5; 1-3", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_VALID);
 }
 
 // ---- ParseRaypathTextMultiSegment ----


### PR DESCRIPTION
## Summary

- Adds 4 lightweight C API entries to `lumice.h` so `src/gui/` no longer needs to `#include` any `core/` or `config/` headers, landing the B-option from the `explore-gui-core-boundary` investigation.
- New API surface: `LUMICE_MAX_ID`, `LUMICE_CrystalKind` + `LUMICE_IsLegalFace`, `LUMICE_RaypathValidationState` + `LUMICE_ValidateRaypathText`, `LUMICE_LensType` + `LUMICE_MaxFov` (plus a new `LUMICE_ERR_UNKNOWN` error code required by the validator's `default` branch).
- Migrates `edit_modals.cpp`, `file_io.cpp`, `panels.cpp`, `app_panels.cpp`, and `raypath_segments.hpp` to the new API; documents the boundary rule in `AGENTS.md`.

## Changes

- `src/include/lumice.h`: new enums, constants, and 3 new function declarations.
- `src/server/c_api.cpp`: bridge implementations for `LUMICE_IsLegalFace`, `LUMICE_ValidateRaypathText`, `LUMICE_MaxFov`.
- `src/gui/raypath_segments.hpp`: inline `GuiValidateFaceNumberText` helper preserving the message text used by `ParseFaceNumberOrZero`.
- `src/gui/*.cpp`: drop direct `core/`/`config/` includes, switch to LUMICE API types.
- `test/test_c_api.cpp`: 20 new unit tests covering all 4 entries (happy path + edge cases).
- `test/test_raypath_segments.cpp`: adjust to migrated helper.
- `AGENTS.md`: codify the rule that `src/gui/` must access core/config functionality only via the C API.

## Verification

- `./scripts/build.sh -tj release` — 100% unit tests pass.
- `grep -r '^#include "(core|config)/' src/gui/` — empty (boundary clean).
- `./build/cmake_install/Lumice -f examples/config_example.json` — CLI smoke runs without errors.
- Local `LumiceGUITests` (release): raypath / filter / lens GUI tests pass; one pre-existing `auto_ev` PSNR flakiness near the 15.0 dB threshold is unrelated to this change and tracked in backlog.

## Test plan

- [x] Build + unit tests pass in CI
- [x] No `src/gui/` source includes `core/*` or `config/*` headers
- [x] CLI smoke run with the example config
- [ ] CI E2E and GUI tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)