### PR TITLE
feat(core): scrum-193 leftovers batch — per-face topology + polygon-only tracing

### DIFF
--- a/src/core/optics.cpp
+++ b/src/core/optics.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 
 #include "core/math.hpp"
 
@@ -52,6 +51,10 @@ void HitSurface(const Crystal& crystal, float n, size_t num,                    
 
 
 constexpr size_t kMaxSlabRays = 128;
+// Chunk boundary in Propagate() must be a multiple of the position-sharing
+// stride (step=1 or step=2 in practice). Keeping kMaxSlabRays even guarantees
+// `offset / step` stays integer-aligned across chunks.
+static_assert(kMaxSlabRays % 2 == 0, "kMaxSlabRays must be even for step=2 chunk alignment");
 
 // Per-polygon-face half-space interval method with face-outer/ray-inner SoA loop.
 // NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
@@ -128,95 +131,22 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
   }
 }
 
-// Per-triangle barycentric intersection (original algorithm, used as fallback).
-// NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
-static void PropagateTriangle(const Crystal& crystal, size_t num, size_t step, const float_bf_t d_in,
-                              const float_bf_t p_in, const float_bf_t w_in, const int_bf_t fid_in_src, float_bf_t p_out,
-                              int_bf_t fid_out) {
-  auto face_num = crystal.TotalTriangles();
-  const auto* face_transform = crystal.GetTriangleCoordTf();
-
-  for (size_t i = 0; i < num; i++) {
-    if (w_in[i] < 0) {  // Total reflection
-      continue;
-    }
-
-    // --- Inlined RayTriangleBW: find nearest triangle intersection ---
-    const float* ray_pt = p_in.Ptr(i / step);
-    const float* ray_dir = d_in.Ptr(i);
-    float* out_pt = p_out.Ptr(i);
-    int* out_face_id = fid_out.Ptr(i);
-
-    // Polygon-level source face for t≈0 TIR-edge handling.
-    int src_tri_i = fid_in_src[i / step];
-    int src_poly_i = (src_tri_i >= 0) ? crystal.GetTriangleToPolygonFace(src_tri_i) : -1;
-
-    float min_t = -1.0f;
-    *out_face_id = -1;
-    std::memcpy(out_pt, ray_pt, 3 * sizeof(float));
-
-    float d[3];
-    float p[3];
-
-    for (int fi = 0; fi < static_cast<int>(face_num); fi++) {
-      const float* tf = face_transform + fi * 12;
-      p[2] = Dot3(ray_pt, tf + 8) + tf[11];
-      d[2] = Dot3(ray_dir, tf + 8);
-
-      if (FloatEqualZero(d[2])) {
-        continue;  // Parallel to this triangle
-      }
-
-      auto t = -p[2] / d[2];
-      // fi ∈ [0, face_num-1] and tri_to_poly_ is always valid after BuildPolygonFaceData;
-      // the nullptr/bounds guards inside GetTriangleToPolygonFace are structurally redundant
-      // here but kept for safety.
-      int fi_poly = crystal.GetTriangleToPolygonFace(fi);
-      float eps_thr = (src_poly_i >= 0 && fi_poly != src_poly_i) ? -math::kFloatEps : math::kFloatEps;
-      if (t < eps_thr) {
-        continue;
-      }
-
-      p[0] = Dot3(ray_pt, tf + 0) + tf[3];
-      d[0] = Dot3(ray_dir, tf + 0);
-
-      auto u = p[0] + t * d[0];
-      if (u < -math::kFloatEps || u > 1.0f) {
-        continue;  // out of this triangle
-      }
-
-      p[1] = Dot3(ray_pt, tf + 4) + tf[7];
-      d[1] = Dot3(ray_dir, tf + 4);
-
-      auto v = p[1] + t * d[1];
-      if (v < -math::kFloatEps || v > 1.0f) {
-        continue;  // out of this triangle
-      }
-
-      if (u + v > 1.0f) {
-        continue;  // out of this triangle
-      }
-
-      if (min_t < -math::kFloatEps || (t < min_t && min_t > 0.0f)) {
-        min_t = t;
-        *out_face_id = fi;
-        for (int j = 0; j < 3; j++) {
-          out_pt[j] += t * ray_dir[j];
-        }
-      }
-    }
-  }
-}
-
+// Polygon-only tracing dispatcher. Chunks the ray batch so each PropagateSlab
+// invocation stays within its fixed-size scratch arrays (kMaxSlabRays).
 // NOLINTNEXTLINE(readability-function-size)
 void Propagate(const Crystal& crystal, size_t num, size_t step,                      // input
                const float_bf_t d_in, const float_bf_t p_in, const float_bf_t w_in,  // input, d, p, w
                const int_bf_t fid_in_src,                                            // source face ids
                float_bf_t p_out, int_bf_t fid_out) {                                 // output, p, fid
-  if (crystal.PolygonFaceCount() > 0 && num <= kMaxSlabRays) {
-    PropagateSlab(crystal, num, step, d_in, p_in, w_in, fid_in_src, p_out, fid_out);
-  } else {
-    PropagateTriangle(crystal, num, step, d_in, p_in, w_in, fid_in_src, p_out, fid_out);
+  for (size_t offset = 0; offset < num; offset += kMaxSlabRays) {
+    size_t chunk = std::min(num - offset, kMaxSlabRays);
+    PropagateSlab(crystal, chunk, step,                                       //
+                  float_bf_t(d_in.Ptr(offset), d_in.step_),                   //
+                  float_bf_t(p_in.Ptr(offset / step), p_in.step_),            //
+                  float_bf_t(w_in.Ptr(offset), w_in.step_),                   //
+                  int_bf_t(fid_in_src.Ptr(offset / step), fid_in_src.step_),  //
+                  float_bf_t(p_out.Ptr(offset), p_out.step_),                 //
+                  int_bf_t(fid_out.Ptr(offset), fid_out.step_));
   }
 }
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -468,8 +468,7 @@ static void RenderCrystalPreviewPane(GuiState& /*state*/) {
     float mvp[16];
     CrystalRenderer::ComputeMvp(g_crystal_rotation, g_crystal_zoom, static_cast<int>(kModalPreviewImageSize),
                                 static_cast<int>(kModalPreviewImageSize), mvp);
-    DrawFaceNumberOverlay(m->vertices, m->vertex_count, m->triangles, m->triangle_count, m->face_numbers,
-                          g_crystal_rotation, mvp, g_crystal_zoom, preview_pos,
+    DrawFaceNumberOverlay(m, g_crystal_rotation, mvp, g_crystal_zoom, preview_pos,
                           ImVec2(kModalPreviewImageSize, kModalPreviewImageSize), ImGui::GetWindowDrawList(),
                           crystal_style);
   }

--- a/src/gui/face_number_overlay.cpp
+++ b/src/gui/face_number_overlay.cpp
@@ -157,6 +157,82 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
   return label_count;
 }
 
+int AggregateFaceLabelsFromTopology(const float* vertices, int vertex_count, int face_count,
+                                    const int* face_numbers_by_face, const int* face_vtx_offsets,
+                                    const int* face_vtx_counts, const int* face_vtx_pool, FaceLabel* out_labels,
+                                    int max_labels) {
+  int label_count = 0;
+  for (int fi = 0; fi < face_count && label_count < max_labels; ++fi) {
+    int fn = face_numbers_by_face[fi];
+    if (fn <= 0) {
+      continue;
+    }
+    int offset = face_vtx_offsets[fi];
+    int count = face_vtx_counts[fi];
+    if (count < 3) {
+      continue;
+    }
+    int capped = (count < kMaxFacePolygonVerts) ? count : kMaxFacePolygonVerts;
+
+    FaceLabel& label = out_labels[label_count];
+    label.face_number = fn;
+    label.display_polygon_vertex_count = 0;
+    label.display_center[0] = 0.0f;
+    label.display_center[1] = 0.0f;
+    label.display_center[2] = 0.0f;
+
+    for (int k = 0; k < capped; ++k) {
+      int vi = face_vtx_pool[offset + k];
+      if (vi < 0 || vi >= vertex_count) {
+        continue;
+      }
+      const float* p = vertices + vi * 3;
+      label.display_center[0] += p[0];
+      label.display_center[1] += p[1];
+      label.display_center[2] += p[2];
+      label.display_polygon_verts[k * 3 + 0] = p[0];
+      label.display_polygon_verts[k * 3 + 1] = p[1];
+      label.display_polygon_verts[k * 3 + 2] = p[2];
+      ++label.display_polygon_vertex_count;
+    }
+
+    if (label.display_polygon_vertex_count > 0) {
+      float inv = 1.0f / static_cast<float>(label.display_polygon_vertex_count);
+      label.display_center[0] *= inv;
+      label.display_center[1] *= inv;
+      label.display_center[2] *= inv;
+    }
+
+    // Face normal from first 3 vertices (CCW-ordered by FillPerFaceTopology)
+    if (label.display_polygon_vertex_count >= 3) {
+      const float* p0 = label.display_polygon_verts;
+      const float* p1 = label.display_polygon_verts + 3;
+      const float* p2 = label.display_polygon_verts + 6;
+      float e1[3] = { p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2] };
+      float e2[3] = { p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2] };
+      float nx = e1[1] * e2[2] - e1[2] * e2[1];
+      float ny = e1[2] * e2[0] - e1[0] * e2[2];
+      float nz = e1[0] * e2[1] - e1[1] * e2[0];
+      float len = std::sqrt(nx * nx + ny * ny + nz * nz);
+      if (len > 1e-12f) {
+        nx /= len;
+        ny /= len;
+        nz /= len;
+      }
+      label.display_normal[0] = nx;
+      label.display_normal[1] = ny;
+      label.display_normal[2] = nz;
+    } else {
+      label.display_normal[0] = 0.0f;
+      label.display_normal[1] = 0.0f;
+      label.display_normal[2] = 0.0f;
+    }
+
+    ++label_count;
+  }
+  return label_count;
+}
+
 namespace detail {
 
 FaceLabelStyle ResolveFaceLabelStyle(CrystalStyle style) {
@@ -347,15 +423,22 @@ bool ProjectLabelToScreen(const FaceLabel* label, const float rotation[16], cons
   return true;
 }
 
-void DrawFaceNumberOverlay(const float* vertices, int vertex_count, const int* triangles, int triangle_count,
-                           const int* face_numbers, const float rotation[16], const float mvp[16], float zoom,
+void DrawFaceNumberOverlay(const LUMICE_CrystalMesh* mesh, const float rotation[16], const float mvp[16], float zoom,
                            ImVec2 image_pos, ImVec2 image_size, ImDrawList* draw_list, CrystalStyle style) {
-  if (triangle_count <= 0 || draw_list == nullptr) {
+  if (mesh == nullptr || mesh->triangle_count <= 0 || draw_list == nullptr) {
     return;
   }
 
   FaceLabel labels[kMaxFaceLabels];
-  int n = AggregateFaceLabels(vertices, vertex_count, triangles, triangle_count, face_numbers, labels, kMaxFaceLabels);
+  int n = 0;
+  if (mesh->face_count > 0) {
+    n = AggregateFaceLabelsFromTopology(mesh->vertices, mesh->vertex_count, mesh->face_count,
+                                        mesh->face_numbers_by_face, mesh->face_vtx_offsets, mesh->face_vtx_counts,
+                                        mesh->face_vtx_pool, labels, kMaxFaceLabels);
+  } else {
+    n = AggregateFaceLabels(mesh->vertices, mesh->vertex_count, mesh->triangles, mesh->triangle_count,
+                            mesh->face_numbers, labels, kMaxFaceLabels);
+  }
   if (n <= 0) {
     return;
   }

--- a/src/gui/face_number_overlay.hpp
+++ b/src/gui/face_number_overlay.hpp
@@ -3,6 +3,7 @@
 
 #include "gui/crystal_renderer.hpp"
 #include "imgui.h"
+#include "include/lumice.h"
 
 namespace lumice::gui {
 
@@ -35,6 +36,14 @@ struct FaceLabel {
 // Returns the number of labels written into out_labels (bounded by max_labels).
 int AggregateFaceLabels(const float* vertices, int vertex_count, const int* triangles, int triangle_count,
                         const int* face_numbers, FaceLabel* out_labels, int max_labels);
+
+// Aggregate per-face topology (from LUMICE_GetCrystalMesh new fields) into FaceLabel array.
+// Vertices are already CCW-ordered in face_vtx_pool; skips faces with face_numbers_by_face <= 0.
+// Returns the number of labels written.
+int AggregateFaceLabelsFromTopology(const float* vertices, int vertex_count, int face_count,
+                                    const int* face_numbers_by_face, const int* face_vtx_offsets,
+                                    const int* face_vtx_counts, const int* face_vtx_pool, FaceLabel* out_labels,
+                                    int max_labels);
 
 // Per-CrystalStyle face-number rendering policy.
 // `visible_*` colors apply to front-facing labels; `hidden_*` apply to back-
@@ -120,16 +129,16 @@ bool ProjectLabelToScreen(const FaceLabel* label, const float rotation[16], cons
 // same `rotation`, `zoom`, and image dimensions used for the current render pass;
 // otherwise overlay coordinates will misalign with GL-rendered pixels.
 //
-// `face_numbers` and `vertices` / `triangles` must come from the same
-// LUMICE_CrystalMesh in display space (Y-Z swapped + AABB normalized).
+// `mesh` must be in display space (Y-Z swapped + AABB normalized). If
+// `mesh->face_count > 0`, uses AggregateFaceLabelsFromTopology (new path);
+// otherwise falls back to AggregateFaceLabels via triangle data.
 //
 // `style` selects the per-mode policy from ResolveFaceLabelStyle: it controls
 // whether hidden (back-facing) faces get drawn (Wireframe / X-Ray do; Hidden
 // Line / Shaded skip them) and whether visible faces are filtered out when
 // their projected-polygon min-width ratio (see ComputeLabelMinWidthRatio)
 // drops below kFaceLabelMinViewportRatio.
-void DrawFaceNumberOverlay(const float* vertices, int vertex_count, const int* triangles, int triangle_count,
-                           const int* face_numbers, const float rotation[16], const float mvp[16], float zoom,
+void DrawFaceNumberOverlay(const LUMICE_CrystalMesh* mesh, const float rotation[16], const float mvp[16], float zoom,
                            ImVec2 image_pos, ImVec2 image_size, ImDrawList* draw_list, CrystalStyle style);
 
 }  // namespace lumice::gui

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -287,6 +287,8 @@ void LUMICE_StopServer(LUMICE_Server* server);
 #define LUMICE_MAX_CRYSTAL_VERTICES 128
 #define LUMICE_MAX_CRYSTAL_EDGES 256
 #define LUMICE_MAX_CRYSTAL_TRIANGLES 128
+#define LUMICE_MAX_CRYSTAL_FACES 24
+#define LUMICE_MAX_CRYSTAL_FACE_VTXPOOL 192
 
 typedef struct LUMICE_CrystalMesh_ {
   float vertices[LUMICE_MAX_CRYSTAL_VERTICES * 3];  // [x0,y0,z0, x1,y1,z1, ...]
@@ -303,6 +305,14 @@ typedef struct LUMICE_CrystalMesh_ {
   //   basal = 1/2; prism = 3..8; upper pyramidal = 13..18; lower = 23..28.
   // -1 for unrecognized orientations (kInvalidId in core).
   int face_numbers[LUMICE_MAX_CRYSTAL_TRIANGLES];
+  // Per-face polygon topology (CCW ordered vertex indices when viewed from outside).
+  // face_vtx_pool[face_vtx_offsets[i] .. face_vtx_offsets[i]+face_vtx_counts[i]-1]
+  // gives the CCW vertex indices for face i. face_count=0 means not populated.
+  int face_count;
+  int face_numbers_by_face[LUMICE_MAX_CRYSTAL_FACES];
+  int face_vtx_offsets[LUMICE_MAX_CRYSTAL_FACES];
+  int face_vtx_counts[LUMICE_MAX_CRYSTAL_FACES];
+  int face_vtx_pool[LUMICE_MAX_CRYSTAL_FACE_VTXPOOL];
 } LUMICE_CrystalMesh;
 
 LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* server, const char* crystal_json, LUMICE_CrystalMesh* out);

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -827,6 +827,154 @@ void LUMICE_StopServer(LUMICE_Server* server) {
 
 
 // =============== Crystal Mesh ===============
+
+// Compute per-face polygon topology from triangle data and face_numbers array.
+// Writes face_count, face_numbers_by_face, face_vtx_offsets, face_vtx_counts,
+// and face_vtx_pool into out. Skips face_numbers <= 0.
+static void FillPerFaceTopology(const int* tri, int tri_cnt, const float* vtx, const int* face_numbers_per_tri,
+                                LUMICE_CrystalMesh* out) {
+  // Collect distinct face numbers in sorted order (skip <= 0)
+  std::set<int> face_set;
+  for (int t = 0; t < tri_cnt; ++t) {
+    int fn = face_numbers_per_tri[t];
+    if (fn > 0) {
+      face_set.insert(fn);
+    }
+  }
+
+  int pool_offset = 0;
+  int fi = 0;
+
+  for (int fn : face_set) {
+    if (fi >= LUMICE_MAX_CRYSTAL_FACES) {
+      break;
+    }
+
+    // Gather unique vertex indices for this face_number
+    std::vector<int> unique_verts;
+    int first_tri = -1;
+    for (int t = 0; t < tri_cnt; ++t) {
+      if (face_numbers_per_tri[t] != fn) {
+        continue;
+      }
+      if (first_tri < 0) {
+        first_tri = t;
+      }
+      for (int k = 0; k < 3; ++k) {
+        int vi = tri[t * 3 + k];
+        bool found = false;
+        for (int x : unique_verts) {
+          if (x == vi) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          unique_verts.push_back(vi);
+        }
+      }
+    }
+
+    if (unique_verts.size() < 3 || first_tri < 0) {
+      continue;
+    }
+
+    // Check pool capacity
+    int count = static_cast<int>(unique_verts.size());
+    if (pool_offset + count > LUMICE_MAX_CRYSTAL_FACE_VTXPOOL) {
+      break;  // pool exhausted
+    }
+
+    // Compute face center
+    float fc[3] = { 0.0f, 0.0f, 0.0f };
+    for (int vi : unique_verts) {
+      fc[0] += vtx[vi * 3 + 0];
+      fc[1] += vtx[vi * 3 + 1];
+      fc[2] += vtx[vi * 3 + 2];
+    }
+    float inv_cnt = 1.0f / static_cast<float>(count);
+    fc[0] *= inv_cnt;
+    fc[1] *= inv_cnt;
+    fc[2] *= inv_cnt;
+
+    // Compute outward normal from first triangle's cross product
+    const float* a = vtx + tri[first_tri * 3 + 0] * 3;
+    const float* b = vtx + tri[first_tri * 3 + 1] * 3;
+    const float* c = vtx + tri[first_tri * 3 + 2] * 3;
+    float e1[3] = { b[0] - a[0], b[1] - a[1], b[2] - a[2] };
+    float e2[3] = { c[0] - a[0], c[1] - a[1], c[2] - a[2] };
+    float ref_n[3] = {
+      e1[1] * e2[2] - e1[2] * e2[1],
+      e1[2] * e2[0] - e1[0] * e2[2],
+      e1[0] * e2[1] - e1[1] * e2[0],
+    };
+    float nlen = std::sqrt(ref_n[0] * ref_n[0] + ref_n[1] * ref_n[1] + ref_n[2] * ref_n[2]);
+    if (nlen > 1e-6f) {
+      ref_n[0] /= nlen;
+      ref_n[1] /= nlen;
+      ref_n[2] /= nlen;
+    }
+
+    // Compute v0_dir: normalized vector from face center to first unique vertex
+    float v0_dir[3] = {
+      vtx[unique_verts[0] * 3 + 0] - fc[0],
+      vtx[unique_verts[0] * 3 + 1] - fc[1],
+      vtx[unique_verts[0] * 3 + 2] - fc[2],
+    };
+    float v0_len = std::sqrt(v0_dir[0] * v0_dir[0] + v0_dir[1] * v0_dir[1] + v0_dir[2] * v0_dir[2]);
+    if (v0_len > 1e-6f) {
+      v0_dir[0] /= v0_len;
+      v0_dir[1] /= v0_len;
+      v0_dir[2] /= v0_len;
+    }
+
+    // Sort vertices CCW around ref_n: atan2(dot(cross(v0,vi), ref_n), dot(v0,vi))
+    // Mirrors Triangulate() in math.cpp:920-938.
+    std::sort(unique_verts.begin(), unique_verts.end(), [&](int ia, int ib) {
+      float va[3] = { vtx[ia * 3] - fc[0], vtx[ia * 3 + 1] - fc[1], vtx[ia * 3 + 2] - fc[2] };
+      float vb[3] = { vtx[ib * 3] - fc[0], vtx[ib * 3 + 1] - fc[1], vtx[ib * 3 + 2] - fc[2] };
+      float la = std::sqrt(va[0] * va[0] + va[1] * va[1] + va[2] * va[2]);
+      float lb = std::sqrt(vb[0] * vb[0] + vb[1] * vb[1] + vb[2] * vb[2]);
+      if (la > 1e-6f) {
+        va[0] /= la;
+        va[1] /= la;
+        va[2] /= la;
+      }
+      if (lb > 1e-6f) {
+        vb[0] /= lb;
+        vb[1] /= lb;
+        vb[2] /= lb;
+      }
+      float na[3] = {
+        v0_dir[1] * va[2] - v0_dir[2] * va[1],
+        v0_dir[2] * va[0] - v0_dir[0] * va[2],
+        v0_dir[0] * va[1] - v0_dir[1] * va[0],
+      };
+      float nb[3] = {
+        v0_dir[1] * vb[2] - v0_dir[2] * vb[1],
+        v0_dir[2] * vb[0] - v0_dir[0] * vb[2],
+        v0_dir[0] * vb[1] - v0_dir[1] * vb[0],
+      };
+      float s1 = na[0] * ref_n[0] + na[1] * ref_n[1] + na[2] * ref_n[2];
+      float s2 = nb[0] * ref_n[0] + nb[1] * ref_n[1] + nb[2] * ref_n[2];
+      float c1 = v0_dir[0] * va[0] + v0_dir[1] * va[1] + v0_dir[2] * va[2];
+      float c2 = v0_dir[0] * vb[0] + v0_dir[1] * vb[1] + v0_dir[2] * vb[2];
+      return std::atan2(s1, c1) < std::atan2(s2, c2);
+    });
+
+    out->face_numbers_by_face[fi] = fn;
+    out->face_vtx_offsets[fi] = pool_offset;
+    out->face_vtx_counts[fi] = count;
+    for (int k = 0; k < count; ++k) {
+      out->face_vtx_pool[pool_offset + k] = unique_verts[k];
+    }
+    pool_offset += count;
+    ++fi;
+  }
+
+  out->face_count = fi;
+}
+
 LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* /*server*/, const char* crystal_json, LUMICE_CrystalMesh* out) {
   if (!crystal_json || !out) {
     return LUMICE_ERR_NULL_ARG;
@@ -994,6 +1142,8 @@ LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* /*server*/, const char* cr
     std::memcpy(&out->edge_face_normals[i * 6 + 0], edge_infos[i].n0, 3 * sizeof(float));
     std::memcpy(&out->edge_face_normals[i * 6 + 3], edge_infos[i].n1, 3 * sizeof(float));
   }
+
+  FillPerFaceTopology(tri, static_cast<int>(tri_cnt), vtx, out->face_numbers, out);
 
   return LUMICE_OK;
 }

--- a/test/gui/test_gui_face_number_overlay.cpp
+++ b/test/gui/test_gui_face_number_overlay.cpp
@@ -53,6 +53,7 @@ bool ReferenceFrontFacing(const float rotation[16], float zoom, const float cent
 
 void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
   using lumice::gui::AggregateFaceLabels;
+  using lumice::gui::AggregateFaceLabelsFromTopology;
   using lumice::gui::CrystalStyle;
   using lumice::gui::FaceLabel;
   using lumice::gui::kFaceLabelMinViewportRatio;
@@ -588,6 +589,14 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
         3, 4, 5,  // face 2 → reversed winding → -z normal → back
       };
       static int face_numbers[] = { 1, 2 };
+      // Build a minimal LUMICE_CrystalMesh (face_count=0 → fallback path)
+      LUMICE_CrystalMesh mesh{};
+      mesh.vertex_count = 6;
+      std::memcpy(mesh.vertices, verts, sizeof(verts));
+      mesh.triangle_count = 2;
+      std::memcpy(mesh.triangles, tris, sizeof(tris));
+      std::memcpy(mesh.face_numbers, face_numbers, sizeof(face_numbers));
+      mesh.face_count = 0;
 
       float rot[16];
       Identity4x4(rot);
@@ -635,8 +644,8 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
         if (ImGui::Begin(title, nullptr, ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoCollapse)) {
           ImDrawList* draw_list = ImGui::GetWindowDrawList();
           int before = draw_list->VtxBuffer.Size;
-          lumice::gui::DrawFaceNumberOverlay(verts, 6, tris, 2, face_numbers, rot, mvp, kZoom, ImVec2(0.0f, 0.0f),
-                                             ImVec2(320.0f, 320.0f), draw_list, styles[s]);
+          lumice::gui::DrawFaceNumberOverlay(&mesh, rot, mvp, kZoom, ImVec2(0.0f, 0.0f), ImVec2(320.0f, 320.0f),
+                                             draw_list, styles[s]);
           int after = draw_list->VtxBuffer.Size;
           g_capture.vertex_delta[s] = after - before;
         }
@@ -692,6 +701,47 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
                                     /*image_size*/ 320.0f, 320.0f, &sx, &sy, &front));
       IM_CHECK(std::abs(sx - (100.0f + 160.0f)) < 1e-3f);
       IM_CHECK(std::abs(sy - (200.0f + 160.0f)) < 1e-3f);
+    };
+  }
+
+  // AggregateFaceLabelsFromTopology vs AggregateFaceLabels: same face_number set,
+  // same vertex count per face. Uses a real prism mesh from LUMICE_GetCrystalMesh.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "unit", "face_number_aggregate_from_topology_parity");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::ResetLastCrystalMesh();
+
+      LUMICE_CrystalMesh mesh{};
+      const char* prism_json = R"({"type": "prism", "shape": {"height": 1.0}})";
+      IM_CHECK_EQ(LUMICE_GetCrystalMesh(nullptr, prism_json, &mesh), LUMICE_OK);
+      IM_CHECK_GT(mesh.face_count, 0);
+
+      FaceLabel labels_old[lumice::gui::kMaxFaceLabels] = {};
+      FaceLabel labels_new[lumice::gui::kMaxFaceLabels] = {};
+
+      int n_old = AggregateFaceLabels(mesh.vertices, mesh.vertex_count, mesh.triangles, mesh.triangle_count,
+                                      mesh.face_numbers, labels_old, lumice::gui::kMaxFaceLabels);
+      int n_new = lumice::gui::AggregateFaceLabelsFromTopology(
+          mesh.vertices, mesh.vertex_count, mesh.face_count, mesh.face_numbers_by_face, mesh.face_vtx_offsets,
+          mesh.face_vtx_counts, mesh.face_vtx_pool, labels_new, lumice::gui::kMaxFaceLabels);
+
+      IM_CHECK_EQ(n_old, n_new);
+      IM_CHECK_EQ(n_old, mesh.face_count);
+
+      // Both must produce the same set of face_numbers
+      for (int i = 0; i < n_new; ++i) {
+        bool found = false;
+        for (int j = 0; j < n_old; ++j) {
+          if (labels_new[i].face_number == labels_old[j].face_number) {
+            found = true;
+            // vertex count per face should match
+            IM_CHECK_EQ(labels_new[i].display_polygon_vertex_count, labels_old[j].display_polygon_vertex_count);
+            break;
+          }
+        }
+        IM_CHECK(found);
+      }
     };
   }
 }

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -118,6 +118,152 @@ TEST(CrystalMeshApi, FillHexFnMapInvalidNormalMapsToMinusOne) {
 }
 
 
+// =============== Per-face topology tests ===============
+
+TEST(CrystalMeshApi, PrismPerFaceTopology) {
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "prism", "shape": {"height": 1.0}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+
+  // Prism: 2 basal + 6 lateral faces
+  EXPECT_EQ(mesh.face_count, 8);
+  EXPECT_GT(mesh.face_count, 0);
+
+  int basal_count = 0;
+  int lateral_count = 0;
+  for (int i = 0; i < mesh.face_count; ++i) {
+    int fn = mesh.face_numbers_by_face[i];
+    EXPECT_GT(fn, 0) << "face " << i << " face_number should be > 0";
+    int vtx_cnt = mesh.face_vtx_counts[i];
+    if (fn == 1 || fn == 2) {
+      // Basal faces have 6 vertices (regular hexagon)
+      EXPECT_EQ(vtx_cnt, 6) << "basal face " << i << " (fn=" << fn << ") should have 6 vertices";
+      ++basal_count;
+    } else if (fn >= 3 && fn <= 8) {
+      // Lateral prism faces are quads
+      EXPECT_EQ(vtx_cnt, 4) << "prism face " << i << " (fn=" << fn << ") should have 4 vertices";
+      ++lateral_count;
+    }
+  }
+  EXPECT_EQ(basal_count, 2);
+  EXPECT_EQ(lateral_count, 6);
+}
+
+TEST(CrystalMeshApi, PyramidPerFaceTopology) {
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "pyramid", "shape": {"prism_h": 1.0, "upper_h": 0.5, "lower_h": 0.5}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+
+  EXPECT_GT(mesh.face_count, 0);
+  // Full pyramid: 2 basal + 6 prism + 6 upper + 6 lower = 20 faces
+  EXPECT_EQ(mesh.face_count, 20);
+
+  for (int i = 0; i < mesh.face_count; ++i) {
+    int fn = mesh.face_numbers_by_face[i];
+    bool legal = (fn == 1) || (fn == 2) || (fn >= 3 && fn <= 8) || (fn >= 13 && fn <= 18) || (fn >= 23 && fn <= 28);
+    EXPECT_TRUE(legal) << "face " << i << " face_number=" << fn << " is not in legal set";
+    EXPECT_GE(mesh.face_vtx_counts[i], 3) << "face " << i << " must have >= 3 vertices";
+  }
+}
+
+TEST(CrystalMeshApi, PerFaceVertexOrderCCW) {
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "prism", "shape": {"height": 1.0}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+  ASSERT_GT(mesh.face_count, 0);
+
+  // Find basal face (fn==1) and verify CCW winding
+  int basal_fi = -1;
+  for (int i = 0; i < mesh.face_count; ++i) {
+    if (mesh.face_numbers_by_face[i] == 1) {
+      basal_fi = i;
+      break;
+    }
+  }
+  ASSERT_GE(basal_fi, 0) << "no basal face 1 found";
+
+  int offset = mesh.face_vtx_offsets[basal_fi];
+  int count = mesh.face_vtx_counts[basal_fi];
+  ASSERT_GE(count, 3);
+
+  // Compute face normal from first triangle (v0, v1, v2)
+  const float* p0 = mesh.vertices + mesh.face_vtx_pool[offset + 0] * 3;
+  const float* p1 = mesh.vertices + mesh.face_vtx_pool[offset + 1] * 3;
+  const float* p2 = mesh.vertices + mesh.face_vtx_pool[offset + 2] * 3;
+  float e1[3] = { p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2] };
+  float e2[3] = { p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2] };
+  float nx = e1[1] * e2[2] - e1[2] * e2[1];
+  float ny = e1[2] * e2[0] - e1[0] * e2[2];
+  float nz = e1[0] * e2[1] - e1[1] * e2[0];
+  float nlen = std::sqrt(nx * nx + ny * ny + nz * nz);
+  ASSERT_GT(nlen, 1e-6f) << "degenerate face normal";
+  nx /= nlen;
+  ny /= nlen;
+  nz /= nlen;
+
+  // For CCW winding, each consecutive edge cross product should point along the face normal
+  for (int k = 0; k < count; ++k) {
+    const float* a = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+    const float* b = mesh.vertices + mesh.face_vtx_pool[offset + (k + 1) % count] * 3;
+    float ex = b[0] - a[0];
+    float ey = b[1] - a[1];
+    float ez = b[2] - a[2];
+    // Edge next_edge = b - a; for CCW the "winding cross" test uses consecutive edges.
+    // Simple check: cross of consecutive edge pairs projected onto face normal > 0 on average.
+    (void)ex;
+    (void)ey;
+    (void)ez;
+  }
+  // A simpler winding check: sum of cross products of (vi - center) × (v_{i+1} - center)
+  // projected onto the face normal should be positive for CCW.
+  float cx = 0.0f;
+  float cy = 0.0f;
+  float cz = 0.0f;
+  for (int k = 0; k < count; ++k) {
+    const float* v = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+    cx += v[0];
+    cy += v[1];
+    cz += v[2];
+  }
+  cx /= count;
+  cy /= count;
+  cz /= count;
+
+  float winding_sum = 0.0f;
+  for (int k = 0; k < count; ++k) {
+    const float* a = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+    const float* b = mesh.vertices + mesh.face_vtx_pool[offset + (k + 1) % count] * 3;
+    float ax = a[0] - cx, ay = a[1] - cy, az = a[2] - cz;
+    float bx = b[0] - cx, by = b[1] - cy, bz = b[2] - cz;
+    // cross(a, b) projected onto normal
+    float cross_x = ay * bz - az * by;
+    float cross_y = az * bx - ax * bz;
+    float cross_z = ax * by - ay * bx;
+    winding_sum += cross_x * nx + cross_y * ny + cross_z * nz;
+  }
+  EXPECT_GT(winding_sum, 0.0f) << "basal face vertices not in CCW order";
+}
+
+TEST(CrystalMeshApi, PerFacePoolBoundary) {
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "pyramid", "shape": {"prism_h": 1.0, "upper_h": 0.5, "lower_h": 0.5}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+
+  // Verify pool usage doesn't exceed the cap
+  int total_pool = 0;
+  for (int i = 0; i < mesh.face_count; ++i) {
+    int end = mesh.face_vtx_offsets[i] + mesh.face_vtx_counts[i];
+    if (end > total_pool) {
+      total_pool = end;
+    }
+    EXPECT_LE(end, LUMICE_MAX_CRYSTAL_FACE_VTXPOOL) << "face " << i << " exceeds pool cap";
+    // offsets and counts must be non-negative
+    EXPECT_GE(mesh.face_vtx_offsets[i], 0);
+    EXPECT_GT(mesh.face_vtx_counts[i], 0);
+  }
+  EXPECT_LE(total_pool, LUMICE_MAX_CRYSTAL_FACE_VTXPOOL);
+}
+
 // =============== ParseConfigApi Tests ===============
 
 // Helper: build a minimal valid JSON (ConfigToJson format) for testing.

--- a/test/test_optics.cpp
+++ b/test/test_optics.cpp
@@ -476,37 +476,39 @@ TEST_F(PropagateTest, Step2SharedPosition) {
   }
 }
 
-TEST_F(PropagateTest, SlabAndTrianglePathConsistency) {
-  // Compare PropagateSlab (num=1, <= 128) vs PropagateTriangle (num=129, > 128)
-  // Only compare face IDs (PropagateTriangle has known accumulation behavior for positions)
+TEST_F(PropagateTest, ChunkBoundaryConsistency) {
+  // Verify single-chunk (num=1) and multi-chunk (num=129 = 128+1) Propagate
+  // produce identical face IDs and exit positions for the same active ray.
+  // Replaces the pre-polygon-only SlabAndTrianglePathConsistency test (the two
+  // paths have been merged — only the chunk loop remains to be exercised).
   float dir[3] = { 1.0f, 0.0f, 0.0f };
   float pos[3] = { 0.0f, 0.0f, 0.0f };
   float w[1] = { 1.0f };
 
-  // PropagateSlab path (num=1)
-  float pos_out_slab[3] = {};
-  int fid_slab[1] = { -1 };
-  int src_fid_slab[1] = { -1 };
+  // Single-chunk reference (num=1)
+  float pos_out_ref[3] = {};
+  int fid_ref[1] = { -1 };
+  int src_fid_ref[1] = { -1 };
   {
     float_bf_t d_in(dir, 3 * sizeof(float));
     float_bf_t p_in(pos, 3 * sizeof(float));
     float_bf_t wt_in(w, sizeof(float));
-    int_bf_t fi_src(src_fid_slab, sizeof(int));
-    float_bf_t p_out(pos_out_slab, 3 * sizeof(float));
-    int_bf_t fi_out(fid_slab, sizeof(int));
+    int_bf_t fi_src(src_fid_ref, sizeof(int));
+    float_bf_t p_out(pos_out_ref, 3 * sizeof(float));
+    int_bf_t fi_out(fid_ref, sizeof(int));
     Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
   }
 
-  // PropagateTriangle path (num=129, only first ray matters, rest are padding)
+  // Multi-chunk path (num=129 → chunk1=128, chunk2=1); only first ray is
+  // active, the rest are padded with w=-1 so they get skipped in scatter.
   constexpr int kNum = 129;
   std::vector<float> dirs(kNum * 3, 0.0f);
   std::vector<float> positions(kNum * 3, 0.0f);
-  std::vector<float> weights(kNum, -1.0f);  // Mark all as skip
-  std::vector<float> pos_out_tri(kNum * 3, 0.0f);
-  std::vector<int> fid_tri(kNum, -1);
-  std::vector<int> src_fid_tri(kNum, -1);
+  std::vector<float> weights(kNum, -1.0f);
+  std::vector<float> pos_out_chunk(kNum * 3, 0.0f);
+  std::vector<int> fid_chunk(kNum, -1);
+  std::vector<int> src_fid_chunk(kNum, -1);
 
-  // Only first ray is active
   dirs[0] = dir[0];
   dirs[1] = dir[1];
   dirs[2] = dir[2];
@@ -516,15 +518,17 @@ TEST_F(PropagateTest, SlabAndTrianglePathConsistency) {
     float_bf_t d_in(dirs.data(), 3 * sizeof(float));
     float_bf_t p_in(positions.data(), 3 * sizeof(float));
     float_bf_t wt_in(weights.data(), sizeof(float));
-    int_bf_t fi_src(src_fid_tri.data(), sizeof(int));
-    float_bf_t p_out(pos_out_tri.data(), 3 * sizeof(float));
-    int_bf_t fi_out(fid_tri.data(), sizeof(int));
+    int_bf_t fi_src(src_fid_chunk.data(), sizeof(int));
+    float_bf_t p_out(pos_out_chunk.data(), 3 * sizeof(float));
+    int_bf_t fi_out(fid_chunk.data(), sizeof(int));
     Propagate(crystal_, kNum, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
   }
 
-  // Face IDs should match between the two paths
-  EXPECT_EQ(fid_slab[0], fid_tri[0]);
-  EXPECT_GE(fid_slab[0], 0);
+  EXPECT_GE(fid_ref[0], 0);
+  EXPECT_EQ(fid_ref[0], fid_chunk[0]);
+  for (int j = 0; j < 3; j++) {
+    EXPECT_NEAR(pos_out_ref[j], pos_out_chunk[j], 1e-5f);
+  }
 }
 
 TEST_F(PropagateTest, NoIntersection) {
@@ -598,10 +602,12 @@ TEST_F(PropagateTest, TIREdgeAdjacentFaceHit) {
   EXPECT_NEAR(dot, 1.0f, 1e-3f);
 }
 
-// AC-2: same geometry as AC-1 but num=129 forces PropagateTriangle path.
-// Same inward-shift rationale as AC-1: triangle path is more numerically
-// variant than slab path and was the failure site on x86_64 with δ=0.
-TEST_F(PropagateTest, TIREdgeAdjacentFaceHit_TrianglePath) {
+// AC-2: same geometry as AC-1 but num=129 crosses the chunk boundary
+// (chunk1=128, chunk2=1), exercising the per-chunk source-face exclusion
+// path. The inward-shift rationale from AC-1 still applies: with δ=0 the
+// computed t at the shared edge can land slightly negative on x86_64 and
+// trip the source-face guard spuriously.
+TEST_F(PropagateTest, TIREdgeAdjacentFaceHit_LargeNum) {
   const float kSqrt3 = std::sqrt(3.0f);
   constexpr float kInwardShift = 3e-6f;
   constexpr int kNum = 129;
@@ -694,4 +700,93 @@ TEST_F(PropagateTest, PropagateSourceFaceNotSelected) {
                             << fid_out[0]
                             << ") means either "
                                "source face fn=3 was wrongly selected or some unreachable face was returned";
+}
+
+// AC-3 (a): polygon-only equivalence on a regular hexagonal prism.
+// Six horizontal rays from the prism centre, each aimed along one of the
+// six side-face outward normals (60° apart, in the x-y plane). Each ray
+// must land on a side face whose outward normal aligns with the ray
+// direction (dot > 0.9), i.e. the ray exits through the polygon face it
+// is pointing at.
+TEST_F(PropagateTest, PolygonOnlyPrism6SideFaces) {
+  const float kSqrt3 = std::sqrt(3.0f);
+  // Outward normals of the 6 hexagonal side faces (unit vectors, z=0).
+  const float kDirs[6][3] = {
+    { 1.0f, 0.0f, 0.0f },             //
+    { 0.5f, kSqrt3 / 2.0f, 0.0f },    //
+    { -0.5f, kSqrt3 / 2.0f, 0.0f },   //
+    { -1.0f, 0.0f, 0.0f },            //
+    { -0.5f, -kSqrt3 / 2.0f, 0.0f },  //
+    { 0.5f, -kSqrt3 / 2.0f, 0.0f },   //
+  };
+
+  for (int i = 0; i < 6; i++) {
+    float dir[3] = { kDirs[i][0], kDirs[i][1], kDirs[i][2] };
+    float pos[3] = { 0.0f, 0.0f, 0.0f };
+    float w[1] = { 1.0f };
+    float pos_out[3] = {};
+    int fid_out[1] = { -1 };
+    int src_fid[1] = { -1 };
+
+    float_bf_t d_in(dir, 3 * sizeof(float));
+    float_bf_t p_in(pos, 3 * sizeof(float));
+    float_bf_t wt_in(w, sizeof(float));
+    int_bf_t fi_src(src_fid, sizeof(int));
+    float_bf_t p_out(pos_out, 3 * sizeof(float));
+    int_bf_t fi_out(fid_out, sizeof(int));
+
+    Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
+
+    ASSERT_GE(fid_out[0], 0) << "Ray " << i << " missed all faces";
+    const float* norm = crystal_.GetTriangleNormal() + fid_out[0] * 3;
+    // Hit a side face (z-component of normal ≈ 0).
+    EXPECT_NEAR(norm[2], 0.0f, 1e-4f) << "Ray " << i << " hit non-side face (norm.z=" << norm[2] << ")";
+    // Outward normal aligns with the ray direction.
+    float dot = norm[0] * dir[0] + norm[1] * dir[1] + norm[2] * dir[2];
+    EXPECT_GT(dot, 0.9f) << "Ray " << i << " hit wrong side face (dot=" << dot << ")";
+  }
+}
+
+// AC-3 (b): polygon-only equivalence on a hexagonal pyramid with both
+// cone segments present. Parameters chosen so that both the upper and
+// lower pyramid caps exist (h1=0.5, h3=0.5 are non-zero) and the prism
+// middle segment is non-degenerate (h2=1.0). Vertical rays from the
+// origin must hit a face on the corresponding cone (norm.z > 0.5 for
+// the upward ray, < -0.5 for the downward ray).
+TEST_F(PropagateTest, PolygonOnlyPyramidConeFaces) {
+  Crystal pyramid = Crystal::CreatePyramid(0.5f, 1.0f, 0.5f);
+
+  struct Case {
+    float dir_z;
+    float expected_norm_z_sign;
+    const char* label;
+  };
+  const Case kCases[] = {
+    { 1.0f, 1.0f, "up -> upper cone" },
+    { -1.0f, -1.0f, "down -> lower cone" },
+  };
+
+  for (const auto& c : kCases) {
+    float dir[3] = { 0.0f, 0.0f, c.dir_z };
+    float pos[3] = { 0.0f, 0.0f, 0.0f };
+    float w[1] = { 1.0f };
+    float pos_out[3] = {};
+    int fid_out[1] = { -1 };
+    int src_fid[1] = { -1 };
+
+    float_bf_t d_in(dir, 3 * sizeof(float));
+    float_bf_t p_in(pos, 3 * sizeof(float));
+    float_bf_t wt_in(w, sizeof(float));
+    int_bf_t fi_src(src_fid, sizeof(int));
+    float_bf_t p_out(pos_out, 3 * sizeof(float));
+    int_bf_t fi_out(fid_out, sizeof(int));
+
+    Propagate(pyramid, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
+
+    ASSERT_GE(fid_out[0], 0) << c.label << ": ray missed all faces";
+    const float* norm = pyramid.GetTriangleNormal() + fid_out[0] * 3;
+    // Hit face must belong to the expected cone segment (norm.z sign + magnitude > 0.5).
+    EXPECT_GT(norm[2] * c.expected_norm_z_sign, 0.5f)
+        << c.label << ": hit face norm.z=" << norm[2] << " (expected sign " << c.expected_norm_z_sign << ")";
+  }
 }


### PR DESCRIPTION
## Summary

Two scrum-193 leftover items, both pulled back to `main` after the scrum-193..198 chain was canceled. Logically coherent (mesh per-face topology data channel + simplified core tracing path), validated together end-to-end.

### Commit 1 — `5e08528` feat: per-face topology in `LUMICE_CrystalMesh` (task-204)
Cherry-pick of `1752ff8` (originally scrum-193.6, reverted with the scrum-193 chain).

- `LUMICE_CrystalMesh` gains 5 per-face fields (`face_count`, `face_numbers_by_face`, `face_vtx_offsets`, `face_vtx_counts`, `face_vtx_pool`) + `LUMICE_MAX_CRYSTAL_FACES` / `LUMICE_MAX_CRYSTAL_VTXPOOL` constants. Zero-count fallback path preserves old consumer behavior.
- `FillPerFaceTopology` (c_api) groups triangles by `face_number` and recovers CCW vertex order via `atan2` sort (mirrors `Triangulate`).
- GUI `DrawFaceNumberOverlay` signature collapses 5 scattered C-array parameters into a single `const LUMICE_CrystalMesh*`; new `AggregateFaceLabelsFromTopology` consumes per-face data when `face_count > 0`, otherwise falls back to legacy `AggregateFaceLabels`.

Design fit (atan2 vs `tri_to_poly_`, future polygon-only follow-up, API-boundary collapse) recorded in `scratchpad/task-mesh-per-face-cherry-pick/plan.md`.

### Commits 2-3 — `f58a3cc` + `4179f3e` polygon-only tracing (task-205)
Backlog item #4 from scrum-193 leftover list. Removes the `PropagateTriangle` fallback in `core::Propagate`, leaving polygon-plane–based `PropagateSlab` as the only tracing path.

- `src/core/optics.cpp`: delete `PropagateTriangle` (~79 lines); rewrite `Propagate` as a chunk loop dispatching to `PropagateSlab` in `kMaxSlabRays=128` batches using offset `BufferWrapper`s. `static_assert(kMaxSlabRays % 2 == 0, ...)` locks the chunk-alignment invariant.
- `test/test_optics.cpp`: rename `SlabAndTrianglePathConsistency` → `ChunkBoundaryConsistency` (verifies num=1 vs num=129 give identical output); rename `TIREdgeAdjacentFaceHit_TrianglePath` → `TIREdgeAdjacentFaceHit_LargeNum` (preserves TIR-edge coverage on the chunk path); add `PolygonOnlyPrism6SideFaces` and `PolygonOnlyPyramidConeFaces` for polygon-only equivalence.

Production hot path is unaffected: `num ≤ 64 < kMaxSlabRays`, so production was already on the polygon path. The fallback was dead code in practice, and removing it unblocks future SoA/GPU work on the tracing loop.

Plan / code-review records: `scratchpad/task-polygon-only-tracing/{plan,code-review}.md` (both APPROVE).

## Test plan

- [x] Static build + unit tests: `./scripts/build.sh -tj release` — 1/1 PASS (covers all 13 `PropagateTest` cases incl. 4 new ones)
- [x] Shared lib build + unit tests: `./scripts/build.sh -stj release` — 1/1 PASS
- [x] Fast e2e (static): `pytest test/e2e/ -v -m "not slow"` — 22/22 PASS (174.62s); covers smoke / CLI / errors / raypath equivalence / output format
- [x] Slow e2e (shared lib): `pytest test/e2e/ -v -m slow` — 3/3 PASS; key invariants `test_unfiltered_intensity_consistent`, `test_partition_buffer_additivity`, `test_xyz_addition_beats_srgb`
- [x] task-204 GUI parity test: `face_number_aggregate_from_topology_parity` PASS (new per-face path matches legacy path for all 8 faces)
- [x] Cherry-pick auto-merge: clean (no manual conflict resolution)

## Notes

- Found one pre-existing issue during this validation: `./scripts/build.sh -sgj release` (shared + GUI combined) fails to link `LumiceGUI.app` / `LumiceGUITests` because `src/gui/app.cpp` calls `lumice::XyzToSrgbUint8` directly and `test/gui/test_gui_import_export.cpp` uses `lumice::from_json(..., ConfigManager&)` — both violate the AGENTS.md GUI↔core API boundary. Unrelated to this PR; logged as a new backlog entry. Verification therefore split into two builds (static for fast e2e + GUI tests, shared for slow e2e).