### PR TITLE
refactor: redesign RaySeg state + sentinel (scrum-206)

### DIFF
--- a/doc/adaptive-brightness.md
+++ b/doc/adaptive-brightness.md
@@ -177,14 +177,15 @@ Contributors who need the technical specification should consult this document a
 ## 5b. Behavior Change Notice (task-query-filter-uplift-v2)
 
 Prior to this change, the simulator marked any ray that failed a configured
-`scattering.entries[].filter` as `kStopped`, so it never reached the consumer's
+`scattering.entries[].filter` as stopped (the pre-T2 `kStopped` state, since
+folded into the `IsTir()` predicate), so it never reached the consumer's
 "unfiltered" accumulator. As a result, `unfiltered_xyz_buffer` was actually
 *post-filter*, and Off-mode EV was indirectly sensitive to the filter — violating
 the additivity invariant described in §4.
 
 The fix demotes the simulator-side filter to a pure branch gate (controlling
-multi-scatter `kContinue` only), so filter-fail rays are emitted as `kOutgoing`
-and the consumer's Path B accumulates the true unfiltered set.
+the multi-scatter `IsContinue()` bit only), so filter-fail rays are emitted as
+`IsOutgoing()` and the consumer's Path B accumulates the true unfiltered set.
 
 **User-visible consequence**:
 

--- a/doc/adaptive-brightness.zh.md
+++ b/doc/adaptive-brightness.zh.md
@@ -146,12 +146,12 @@ GUI tooltip 文案为：
 ## 5b. 行为变更说明（task-query-filter-uplift-v2）
 
 在本次改动之前，simulator 端会把任何未通过 `scattering.entries[].filter`
-的光线标记为 `kStopped`，这些光线无法抵达 consumer 的 unfiltered accumulator，
-导致 `unfiltered_xyz_buffer` 实际上是 *post-filter* 的，Off 模式 EV 因而间接受
-filter 影响，违反 §4 的可加性不变量。
+的光线标记为已停止（即 T2 前的 `kStopped` 状态，现已并入 `IsTir()` 派生谓词），
+这些光线无法抵达 consumer 的 unfiltered accumulator，导致 `unfiltered_xyz_buffer`
+实际上是 *post-filter* 的，Off 模式 EV 因而间接受 filter 影响，违反 §4 的可加性不变量。
 
 修复将 simulator 端 filter 降级为纯 branch gate（仅控制 multi-scatter 的
-`kContinue` 展开），filter-fail 光线统一作为 `kOutgoing` 释放，consumer 的
+`IsContinue()` 位翻转），filter-fail 光线统一作为 `IsOutgoing()` 释放，consumer 的
 Path B 现在累积真正的 unfiltered 全集。
 
 **用户可见影响**：

--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -1,5 +1,6 @@
 #include "config/sim_data.hpp"
 
+#include <cassert>
 #include <cstddef>
 #include <cstring>
 
@@ -30,6 +31,8 @@ bool RayBuffer::Empty() const {
 }
 
 void RayBuffer::EmplaceBack(RaySeg r) {
+  // N4 construction-time invariant gate. Debug only; noop in Release (NDEBUG).
+  assert(r.IsValidComplete());
   if (size_ + 1 < capacity_) {
     rays_[size_++] = r;
   }

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -19,6 +19,10 @@ struct RayBuffer {
 
   void Reset(size_t capacity);
   bool Empty() const;
+  // Single-RaySeg entry point. Asserts RaySeg::IsValidComplete() at entry
+  // to gate the N4 construction-time invariants (Debug only; noop in Release).
+  // Buffer-to-buffer overload below is internal data movement and skips this
+  // gate — its inputs were already validated when first emplaced.
   void EmplaceBack(RaySeg r);
   void EmplaceBack(const RayBuffer& buffer, size_t start = 0, size_t len = kInfSize);
 

--- a/src/core/buffer.hpp
+++ b/src/core/buffer.hpp
@@ -4,6 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "core/def.hpp"
+
 namespace lumice {
 
 template <class T>
@@ -21,6 +23,7 @@ struct BufferWrapper {
 
 using float_bf_t = BufferWrapper<float>;
 using int_bf_t = BufferWrapper<int>;
+using id_bf_t = BufferWrapper<IdType>;
 
 }  // namespace lumice
 

--- a/src/core/crystal.cpp
+++ b/src/core/crystal.cpp
@@ -193,10 +193,7 @@ Crystal::Crystal(const Crystal& other)
     poly_face_tri_id_ = reinterpret_cast<int*>(poly_face_data_.get() + poly_face_cnt_ * 4);
     std::memcpy(poly_face_data_.get(), other.poly_face_data_.get(), poly_face_cnt_ * 5 * sizeof(float));
   }
-  if (other.tri_to_poly_) {
-    tri_to_poly_ = std::make_unique<int[]>(tri_cnt);
-    std::memcpy(tri_to_poly_.get(), other.tri_to_poly_.get(), tri_cnt * sizeof(int));
-  }
+  (void)tri_cnt;
 }
 
 Crystal::Crystal(Crystal&& other) noexcept
@@ -206,7 +203,7 @@ Crystal::Crystal(Crystal&& other) noexcept
       face_area_(cache_data_.get() + mesh_.GetTriangleCnt() * CrystalCachOffset::kArea),
       face_coord_tf_(cache_data_.get() + mesh_.GetTriangleCnt() * CrystalCachOffset::kTf),
       fn_map_(std::move(other.fn_map_)), fn_period_(other.fn_period_), poly_face_cnt_(other.poly_face_cnt_),
-      poly_face_data_(std::move(other.poly_face_data_)), tri_to_poly_(std::move(other.tri_to_poly_)) {
+      poly_face_data_(std::move(other.poly_face_data_)) {
   other.face_v_ = nullptr;
   other.face_n_ = nullptr;
   other.face_area_ = nullptr;
@@ -257,13 +254,6 @@ Crystal& Crystal::operator=(const Crystal& other) {
     poly_face_d_ = nullptr;
     poly_face_tri_id_ = nullptr;
   }
-  if (other.tri_to_poly_) {
-    tri_to_poly_ = std::make_unique<int[]>(n);
-    std::memcpy(tri_to_poly_.get(), other.tri_to_poly_.get(), n * sizeof(int));
-  } else {
-    tri_to_poly_.reset();
-  }
-
   return *this;
 }
 
@@ -304,8 +294,6 @@ Crystal& Crystal::operator=(Crystal&& other) noexcept {
   other.poly_face_n_ = nullptr;
   other.poly_face_d_ = nullptr;
   other.poly_face_tri_id_ = nullptr;
-
-  tri_to_poly_ = std::move(other.tri_to_poly_);
 
   return *this;
 }
@@ -384,6 +372,13 @@ IdType Crystal::GetFn(int fid) const {
   } else {
     return fn_map_[fid];
   }
+}
+
+IdType Crystal::GetFn(IdType poly_idx) const {
+  if (poly_idx == kInvalidId || poly_idx >= poly_face_cnt_) {
+    return kInvalidId;
+  }
+  return fn_map_[poly_face_tri_id_[poly_idx]];
 }
 
 Crystal& Crystal::Rotate(const Rotation& r) {
@@ -610,8 +605,6 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
     poly_face_n_ = nullptr;
     poly_face_d_ = nullptr;
     poly_face_tri_id_ = nullptr;
-    tri_to_poly_ = std::make_unique<int[]>(tri_cnt);
-    std::fill(tri_to_poly_.get(), tri_to_poly_.get() + tri_cnt, -1);
     return;
   }
 
@@ -654,29 +647,6 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
     poly_face_tri_id_[idx] = best_tri;
     idx++;
   }
-
-  // Reverse mapping: triangle id → polygon face index.
-  // For each triangle, find the polygon face whose unit normal best matches.
-  tri_to_poly_ = std::make_unique<int[]>(tri_cnt);
-  for (size_t t = 0; t < tri_cnt; t++) {
-    float best_dot = -1.0f;
-    int best_poly = -1;
-    for (size_t p = 0; p < poly_face_cnt_; p++) {
-      float dot = Dot3(face_n_ + t * 3, poly_face_n_ + p * 3);
-      if (dot > best_dot) {
-        best_dot = dot;
-        best_poly = static_cast<int>(p);
-      }
-    }
-    tri_to_poly_[t] = (best_dot > 1.0f - 1e-3f) ? best_poly : -1;
-  }
-}
-
-int Crystal::GetTriangleToPolygonFace(int tri_id) const {
-  if (tri_id < 0 || tri_to_poly_ == nullptr || static_cast<size_t>(tri_id) >= TotalTriangles()) {
-    return -1;
-  }
-  return tri_to_poly_[tri_id];
 }
 
 float Crystal::GetRefractiveIndex(float wl) const {

--- a/src/core/crystal.cpp
+++ b/src/core/crystal.cpp
@@ -193,7 +193,6 @@ Crystal::Crystal(const Crystal& other)
     poly_face_tri_id_ = reinterpret_cast<int*>(poly_face_data_.get() + poly_face_cnt_ * 4);
     std::memcpy(poly_face_data_.get(), other.poly_face_data_.get(), poly_face_cnt_ * 5 * sizeof(float));
   }
-  (void)tri_cnt;
 }
 
 Crystal::Crystal(Crystal&& other) noexcept

--- a/src/core/crystal.hpp
+++ b/src/core/crystal.hpp
@@ -207,11 +207,18 @@ class Crystal {
   const float* GetTriangleCoordTf() const;
 
   /**
-   * @brief Get face number for a given face index
-   * @param fid Face index
-   * @return Face number (for raypath symmetry)
+   * @brief Get face number for a given triangle face index
+   * @param fid Triangle face index
+   * @return Face number (for raypath symmetry); kInvalidId if @p fid is out of range
    */
   IdType GetFn(int fid) const;
+
+  /**
+   * @brief Get face number for a given polygon face index
+   * @param poly_idx Polygon face index (0..PolygonFaceCount()-1)
+   * @return Face number (for raypath symmetry); kInvalidId if @p poly_idx is out of range
+   */
+  IdType GetFn(IdType poly_idx) const;
 
   /**
    * @brief Rotate the crystal
@@ -270,10 +277,6 @@ class Crystal {
   const float* GetPolygonFaceDist() const;
   const int* GetPolygonFaceTriId() const;
 
-  // Returns the polygon face index (0..PolygonFaceCount()-1) for a given triangle id.
-  // Returns -1 if tri_id is out of range or no matching polygon face was found.
-  int GetTriangleToPolygonFace(int tri_id) const;
-
   IdType config_id_ = kInvalidId;
 
  private:
@@ -297,8 +300,6 @@ class Crystal {
   float* poly_face_n_ = nullptr;             // unit normals, 3 * poly_face_cnt_
   float* poly_face_d_ = nullptr;             // plane distances, poly_face_cnt_
   int* poly_face_tri_id_ = nullptr;          // representative triangle ID, poly_face_cnt_
-
-  std::unique_ptr<int[]> tri_to_poly_;  // triangle id → polygon face index, size = TotalTriangles()
 };
 
 

--- a/src/core/optics.cpp
+++ b/src/core/optics.cpp
@@ -20,14 +20,16 @@ float GetReflectRatio(float delta, float rr) {
 }
 
 // NOLINTNEXTLINE(readability-function-size)
-void HitSurface(const Crystal& crystal, float n, size_t num,                          // input
-                const float_bf_t d_in, const float_bf_t w_in, const int_bf_t fid_in,  // input
-                float_bf_t d_out, float_bf_t w_out) {                                 // output
-  const auto* face_norm = crystal.GetTriangleNormal();
+void HitSurface(const Crystal& crystal, float n, size_t num,                             // input
+                const float_bf_t d_in, const float_bf_t w_in, const id_bf_t to_face_in,  // input
+                float_bf_t d_out, float_bf_t w_out) {                                    // output
+  // Polygon-face normals are equivalent to per-triangle normals (Build matches
+  // by dot > 1 - 1e-3) but indexed by polygon face — matches RaySeg::to_face_.
+  const auto* poly_norm = crystal.GetPolygonFaceNormal();
 
   for (size_t i = 0; i < num; i++) {
     const float* tmp_dir = d_in.Ptr(i);
-    const float* tmp_norm = face_norm + fid_in[i] * 3;
+    const float* tmp_norm = poly_norm + to_face_in[i] * 3;
 
     float cos_theta = Dot3(tmp_dir, tmp_norm);
     float rr = cos_theta > 0 ? n : 1.0f / n;
@@ -59,11 +61,10 @@ static_assert(kMaxSlabRays % 2 == 0, "kMaxSlabRays must be even for step=2 chunk
 // Per-polygon-face half-space interval method with face-outer/ray-inner SoA loop.
 // NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
 static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const float_bf_t d_in, const float_bf_t p_in,
-                          const float_bf_t w_in, const int_bf_t fid_in_src, float_bf_t p_out, int_bf_t fid_out) {
+                          const float_bf_t w_in, const id_bf_t from_face_in, float_bf_t p_out, id_bf_t to_face_out) {
   auto poly_cnt = crystal.PolygonFaceCount();
   const auto* pn = crystal.GetPolygonFaceNormal();
   const auto* pd = crystal.GetPolygonFaceDist();
-  const auto* tri_id = crystal.GetPolygonFaceTriId();
 
   // Gather strided BufferWrapper data into contiguous SoA arrays
   alignas(64) float dx[kMaxSlabRays], dy[kMaxSlabRays], dz[kMaxSlabRays];
@@ -83,8 +84,8 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
     pz[i] = p[2];
     t_far[i] = 1e30f;
     far_face[i] = -1;
-    int src_tri = fid_in_src[i / step];
-    src_poly[i] = (src_tri >= 0) ? crystal.GetTriangleToPolygonFace(src_tri) : -1;
+    IdType src_id = from_face_in[i / step];
+    src_poly[i] = (src_id != kInvalidId) ? static_cast<int>(src_id) : -1;
   }
 
   // Face-outer, ray-inner: find minimum t among exit faces (denom > eps)
@@ -111,7 +112,7 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
     }
 
     float* out_pt = p_out.Ptr(i);
-    int* out_fid = fid_out.Ptr(i);
+    IdType* out_face = to_face_out.Ptr(i);
 
     // Use relaxed threshold for non-source faces to accept t≈0 TIR-edge hits.
     // Source face keeps +kFloatEps to prevent self-selection.
@@ -121,12 +122,12 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
       out_pt[0] = px[i] + t * dx[i];
       out_pt[1] = py[i] + t * dy[i];
       out_pt[2] = pz[i] + t * dz[i];
-      *out_fid = tri_id[far_face[i]];
+      *out_face = static_cast<IdType>(far_face[i]);
     } else {
       out_pt[0] = px[i];
       out_pt[1] = py[i];
       out_pt[2] = pz[i];
-      *out_fid = -1;
+      *out_face = kInvalidId;
     }
   }
 }
@@ -136,17 +137,17 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
 // NOLINTNEXTLINE(readability-function-size)
 void Propagate(const Crystal& crystal, size_t num, size_t step,                      // input
                const float_bf_t d_in, const float_bf_t p_in, const float_bf_t w_in,  // input, d, p, w
-               const int_bf_t fid_in_src,                                            // source face ids
-               float_bf_t p_out, int_bf_t fid_out) {                                 // output, p, fid
+               const id_bf_t from_face_in,                                           // source polygon face ids
+               float_bf_t p_out, id_bf_t to_face_out) {                              // output, p, to_face
   for (size_t offset = 0; offset < num; offset += kMaxSlabRays) {
     size_t chunk = std::min(num - offset, kMaxSlabRays);
-    PropagateSlab(crystal, chunk, step,                                       //
-                  float_bf_t(d_in.Ptr(offset), d_in.step_),                   //
-                  float_bf_t(p_in.Ptr(offset / step), p_in.step_),            //
-                  float_bf_t(w_in.Ptr(offset), w_in.step_),                   //
-                  int_bf_t(fid_in_src.Ptr(offset / step), fid_in_src.step_),  //
-                  float_bf_t(p_out.Ptr(offset), p_out.step_),                 //
-                  int_bf_t(fid_out.Ptr(offset), fid_out.step_));
+    PropagateSlab(crystal, chunk, step,                                          //
+                  float_bf_t(d_in.Ptr(offset), d_in.step_),                      //
+                  float_bf_t(p_in.Ptr(offset / step), p_in.step_),               //
+                  float_bf_t(w_in.Ptr(offset), w_in.step_),                      //
+                  id_bf_t(from_face_in.Ptr(offset / step), from_face_in.step_),  //
+                  float_bf_t(p_out.Ptr(offset), p_out.step_),                    //
+                  id_bf_t(to_face_out.Ptr(offset), to_face_out.step_));
   }
 }
 

--- a/src/core/optics.cpp
+++ b/src/core/optics.cpp
@@ -28,6 +28,12 @@ void HitSurface(const Crystal& crystal, float n, size_t num,                    
   const auto* poly_norm = crystal.GetPolygonFaceNormal();
 
   for (size_t i = 0; i < num; i++) {
+    if (to_face_in[i] == kInvalidId) {
+      // No valid hit face — zero both output weights (and leave directions unchanged).
+      w_out[2 * i + 0] = 0.0f;
+      w_out[2 * i + 1] = 0.0f;
+      continue;
+    }
     const float* tmp_dir = d_in.Ptr(i);
     const float* tmp_norm = poly_norm + to_face_in[i] * 3;
 

--- a/src/core/optics.hpp
+++ b/src/core/optics.hpp
@@ -32,14 +32,14 @@ class IceRefractiveIndex {
 };
 
 
-void HitSurface(const Crystal& crystal, float n, size_t num,                          // input
-                const float_bf_t d_in, const float_bf_t w_in, const int_bf_t fid_in,  // input
-                float_bf_t d_out, float_bf_t w_out);                                  // output
+void HitSurface(const Crystal& crystal, float n, size_t num,                             // input
+                const float_bf_t d_in, const float_bf_t w_in, const id_bf_t to_face_in,  // input
+                float_bf_t d_out, float_bf_t w_out);                                     // output
 
 void Propagate(const Crystal& crystal, size_t num, size_t step,                      // input
                const float_bf_t d_in, const float_bf_t p_in, const float_bf_t w_in,  // input
-               const int_bf_t fid_in_src,            // source face ids (-1 = no constraint)
-               float_bf_t p_out, int_bf_t fid_out);  // output
+               const id_bf_t from_face_in,              // source polygon face ids (kInvalidId = no constraint)
+               float_bf_t p_out, id_bf_t to_face_out);  // output
 
 }  // namespace lumice
 

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -34,14 +34,7 @@ struct RaypathHash {
 
 
 struct RaySeg {
-  enum State {
-    kNormal,
-    kOutgoing,
-    kContinue,  // continue to next crystal, on multi-scattering situation
-    kStopped,   // exceed max_hits, or total internal reflection
-  };
-
-  // NOTE: if state == kNormal, d and p are in crystal-local coordinates; otherwise
+  // NOTE: if IsNormal(), d and p are in crystal-local coordinates; otherwise
   // d and p are in world coordinates.
   float d_[3];
   float p_[3];  // Generally it is for end point, **NOT** for start point.
@@ -65,8 +58,21 @@ struct RaySeg {
   IdType crystal_config_id_;
   Rotation crystal_rot_;
 
-  State state_;
+  // 1-bit run-time decision: whether this segment continues into the next
+  // crystal (multi-scattering). Other segment kinds (Normal / Outgoing / Tir)
+  // are pure derivations of to_face_ and w_; see helpers below.
+  bool is_continue_ = false;
   RaypathRecorder rp_;  // Raypath in **CURRENT** crystal.
+
+  // Derived segment-kind helpers. Invariants (mutually exclusive, exhaustive):
+  //   IsTir()      <=> w_ < 0
+  //   IsNormal()   <=> to_face_ != kInvalidId && w_ >= 0
+  //   IsOutgoing() <=> to_face_ == kInvalidId && w_ >= 0 && !is_continue_
+  //   IsContinue() <=> is_continue_ (only set when to_face_ == kInvalidId && w_ >= 0)
+  bool IsTir() const { return w_ < 0; }
+  bool IsNormal() const { return to_face_ != kInvalidId && w_ >= 0; }
+  bool IsContinue() const { return is_continue_; }
+  bool IsOutgoing() const { return to_face_ == kInvalidId && w_ >= 0 && !is_continue_; }
 };
 
 }  // namespace lumice

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -46,7 +46,16 @@ struct RaySeg {
   float d_[3];
   float p_[3];  // Generally it is for end point, **NOT** for start point.
   float w_;
-  int fid_;
+  // Polygon-face index this segment originated from (i.e. the previous segment's
+  // to_face_). Used by Propagate as a source-face guard so the ray does not
+  // immediately re-select its own face. kInvalidId means no source face — set on
+  // the very first segment of a tracing chain after surface sampling.
+  IdType from_face_;
+  // Polygon-face index this segment hit / currently rests on. Updated by
+  // Propagate at exit; consumed by HitSurface (Fresnel normal lookup) and the
+  // raypath recorder. kInvalidId marks "no hit": either an outgoing candidate
+  // (no further face intersected) or a TIR-stopped segment.
+  IdType to_face_;
 
   size_t prev_ray_idx_;
   size_t root_ray_idx_;

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -2,6 +2,7 @@
 #define CORE_RAYPATH_H_
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <vector>
 
@@ -73,6 +74,41 @@ struct RaySeg {
   bool IsNormal() const { return to_face_ != kInvalidId && w_ >= 0; }
   bool IsContinue() const { return is_continue_; }
   bool IsOutgoing() const { return to_face_ == kInvalidId && w_ >= 0 && !is_continue_; }
+
+  // --- Construction-time invariant validation (for assert only) ---
+  // N4 invariants checked at RayBuffer::EmplaceBack(RaySeg) entry. Debug only;
+  // Release builds compile this to noop via assert(). NOT for business-logic
+  // queries — use IsNormal()/IsTir()/etc. for state inspection.
+  //
+  // N4-1 (to_face_ < poly_count) is intentionally omitted: it requires
+  // external crystal context not carried by RaySeg. If needed in the future,
+  // expose as a separate IsValidWithCrystal(const Crystal&) overload.
+  //
+  // Per-field helpers below are column-friendly: an SoA migration can reuse
+  // each predicate against a single column without re-deriving the formula.
+  static bool IsValidW(float w) {
+    // N4-2: weight is non-negative or the TIR sentinel exactly.
+    return w >= 0.0f || w == -1.0f;
+  }
+  static bool IsValidContinueFace(bool is_continue, IdType to_face) {
+    // N4-3: is_continue_ implies no outgoing face (continue rays do not hit).
+    return !is_continue || to_face == kInvalidId;
+  }
+  static bool IsValidCrystalIdx(IdType crystal_idx) {
+    // N4-4: crystal_idx_ in [0, kMaxCrystalNum) or the init sentinel.
+    return crystal_idx == kInvalidId || crystal_idx < static_cast<IdType>(kMaxCrystalNum);
+  }
+  static bool IsValidVec3Finite(const float v[3]) {
+    // N4-5: vector components must be finite (no NaN / Inf).
+    return std::isfinite(v[0]) && std::isfinite(v[1]) && std::isfinite(v[2]);
+  }
+
+  bool IsValidComplete() const {
+    return IsValidW(w_) &&                                 //
+           IsValidContinueFace(is_continue_, to_face_) &&  //
+           IsValidCrystalIdx(crystal_idx_) &&              //
+           IsValidVec3Finite(d_) && IsValidVec3Finite(p_);
+  }
 };
 
 }  // namespace lumice

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -46,10 +46,11 @@ struct RaySeg {
   float d_[3];
   float p_[3];  // Generally it is for end point, **NOT** for start point.
   float w_;
-  // Polygon-face index this segment originated from (i.e. the previous segment's
-  // to_face_). Used by Propagate as a source-face guard so the ray does not
-  // immediately re-select its own face. kInvalidId means no source face — set on
-  // the very first segment of a tracing chain after surface sampling.
+  // Polygon-face index this segment originated from (i.e. the parent segment's
+  // to_face_). Records the face the ray just exited; used for show_rays logging
+  // and as a SoA-ready bookkeeping field. The actual source-face guard passed to
+  // Propagate is the *current* segment's to_face_ via BufferWrapper — not this
+  // field directly. kInvalidId means no source face (first segment of a chain).
   IdType from_face_;
   // Polygon-face index this segment hit / currently rests on. Updated by
   // Propagate at exit; consumed by HitSurface (Fresnel normal lookup) and the

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -147,7 +147,6 @@ void InitRay_other_info(const Crystal& curr_crystal, size_t curr_crystal_id, siz
     r.crystal_idx_ = curr_crystal_id;
     r.crystal_config_id_ = curr_crystal.config_id_;
     r.root_ray_idx_ = all_data_idx++;
-    r.state_ = RaySeg::kNormal;
     r.rp_.Clear();
     r.rp_ << curr_crystal.GetFn(r.to_face_);
   }
@@ -407,9 +406,13 @@ void FillRayOtherInfo(size_t curr_ray_num, size_t i,                           /
 void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter* filter,  // input
                  RayBuffer* buffer_data, RayBuffer* init_data) {                           // output
   for (auto& r : buffer_data[1]) {
+    // Default: not continuing. The branch-gate below may override for outgoing
+    // candidates that pass filter+prob. TIR / Normal / unselected-Outgoing all
+    // stay false; the buffer slot may carry a stale `true` from a prior round.
+    r.is_continue_ = false;
+
     if (r.w_ < 0) {
-      // 0. Total reflection.
-      r.state_ = RaySeg::kStopped;
+      // 0. Total reflection — derived via IsTir() (w_ < 0); no state write needed.
     } else if (r.to_face_ == kInvalidId) {
       // 1. Outgoing candidates. Apply rotation first so filter operates in world-space.
       // (w_ < 0 is already handled above, so to_face_==kInvalidId implies w_ >= 0 — no double-rotation risk.)
@@ -422,16 +425,12 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
       // not preserved across this change.
       if (rng.GetUniform() < ms_info.prob_ && filter->Check(r)) {
         // 1.1 Branch gate: filter+prob both pass → continue to next ms scatter level.
-        r.state_ = RaySeg::kContinue;
-      } else {
-        // 1.2 Emit outgoing: both filter-fail and prob-fail rays go here.
-        //     Query filter is now applied downstream by RenderConsumer.
-        r.state_ = RaySeg::kOutgoing;
+        r.is_continue_ = true;
       }
-    } else {
-      // 2. Normal rays. Squeeze (or better swap?) buffers.
-      r.state_ = RaySeg::kNormal;
+      // 1.2 else: emit outgoing — both filter-fail and prob-fail rays stay
+      //     is_continue_ = false. Query filter is applied downstream by RenderConsumer.
     }
+    // 2. else: normal rays (to_face_ != kInvalidId && w_ >= 0) — IsNormal() derived; no state write.
 
     // Tail rotation: only for total reflection (w_ < 0). Outgoing candidates (to_face_==kInvalidId) are
     // already rotated above; normal rays (to_face_!=kInvalidId) stay in crystal-local coordinates.
@@ -440,10 +439,10 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
       r.crystal_rot_.Apply(r.p_);
     }
 
-    if (r.state_ == RaySeg::kNormal) {
+    if (r.IsNormal()) {
       buffer_data[0].EmplaceBack(r);
     }
-    if (r.state_ == RaySeg::kContinue) {
+    if (r.IsContinue()) {
       init_data[1].EmplaceBack(r);
     }
   }
@@ -670,7 +669,7 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
           size_t base_index = all_data.size_;
           all_data.EmplaceBack(buffer_data[1]);
           for (size_t j = 0; j < buffer_data[1].size_; j++) {
-            if (buffer_data[1][j].state_ == RaySeg::kOutgoing) {
+            if (buffer_data[1][j].IsOutgoing()) {
               outgoing_indices.push_back(base_index + j);
               const auto& r = buffer_data[1][j];
               outgoing_d.push_back(r.d_[0]);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -24,8 +24,24 @@
 
 namespace lumice {
 
+// Maps a triangle id to its polygon-face index by matching unit normals
+// (BuildPolygonFaceData uses the same dot>1-1e-3 criterion). Returns kInvalidId
+// if no polygon face matches. Used only by InitRay_p_fid below — keeping it
+// file-local avoids reintroducing a Crystal-level reverse mapping that is
+// otherwise unneeded after the from_face_/to_face_ split.
+static IdType PolygonFaceOfTri(const Crystal& crystal, int tri_id) {
+  const float* tn = crystal.GetTriangleNormal() + tri_id * 3;
+  const float* pn = crystal.GetPolygonFaceNormal();
+  for (size_t p = 0; p < crystal.PolygonFaceCount(); p++) {
+    if (Dot3(tn, pn + p * 3) > 1.0f - 1e-3f) {
+      return static_cast<IdType>(p);
+    }
+  }
+  return kInvalidId;
+}
+
 /**
- * @brief Sample on crystal & init origin (p & fid) of rays.
+ * @brief Sample on crystal & init origin (p, from_face_, to_face_) of rays.
  *        NOTE: direction of rays should be given.
  */
 void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
@@ -34,7 +50,7 @@ void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
   }
 
   RayBuffer& ray_buf = *ray_buf_ptr;
-  // p & fid: sample on crystal faces
+  // p & to_face_: sample on crystal triangles (area-weighted), then map to polygon face.
   auto total_faces = curr_crystal.TotalTriangles();
   const auto* face_area = curr_crystal.GetTirangleArea();
   const auto* face_norm = curr_crystal.GetTriangleNormal();
@@ -53,10 +69,12 @@ void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
     for (size_t j = 0; j < total_faces; j++) {
       proj_prob[j] = std::max(-Dot3(d, face_norm + j * 3) * face_area[j], 0.0f);
     }
-    // fid
-    RandomSample(total_faces, proj_prob, &r.fid_);
-    // p
-    SampleTrianglePoint(face_vtx + r.fid_ * 9, r.p_);
+    int tri_id = 0;
+    RandomSample(total_faces, proj_prob, &tri_id);
+    SampleTrianglePoint(face_vtx + tri_id * 9, r.p_);
+    // Initial entry segment: no source face, hit face = the sampled one's polygon.
+    r.from_face_ = kInvalidId;
+    r.to_face_ = PolygonFaceOfTri(curr_crystal, tri_id);
   }
 }
 
@@ -124,7 +142,7 @@ void InitRay_other_info(const Crystal& curr_crystal, size_t curr_crystal_id, siz
     r.root_ray_idx_ = all_data_idx++;
     r.state_ = RaySeg::kNormal;
     r.rp_.Clear();
-    r.rp_ << curr_crystal.GetFn(r.fid_);
+    r.rp_ << curr_crystal.GetFn(r.to_face_);
   }
 }
 
@@ -315,31 +333,37 @@ void TraceRayBasicInfo(const Crystal& curr_crystal, float refractive_index, size
   {
     float_bf_t d_in{ buffer_data[0][0].d_, sizeof(RaySeg) };
     float_bf_t w_in{ &buffer_data[0][0].w_, sizeof(RaySeg) };
-    int_bf_t fid_in{ &buffer_data[0][0].fid_, sizeof(RaySeg) };
+    id_bf_t to_face_in{ &buffer_data[0][0].to_face_, sizeof(RaySeg) };
     float_bf_t d_out{ buffer_data[1][0].d_, sizeof(RaySeg) };
     float_bf_t w_out{ &buffer_data[1][0].w_, sizeof(RaySeg) };
     HitSurface(curr_crystal, refractive_index, curr_ray_num,  // Input
-               d_in, w_in, fid_in,                            // Input, d, w, fid
+               d_in, w_in, to_face_in,                        // Input, d, w, to_face
                d_out, w_out);                                 // Output, d, w
   }
 
   // 2 Propagate.
+  // Source-face guard reuses the input segment's to_face_ as the next segment's
+  // from_face_ (the face the ray just hit). step=2 is shared by reflect+refract
+  // (both children have the same source face).
   {
     float_bf_t d_in{ buffer_data[1][0].d_, sizeof(RaySeg) };
     float_bf_t w_in{ &buffer_data[1][0].w_, sizeof(RaySeg) };
     float_bf_t p_in{ buffer_data[0][0].p_, sizeof(RaySeg) };
-    int_bf_t fid_src_in{ &buffer_data[0][0].fid_, sizeof(RaySeg) };
+    id_bf_t from_face_in{ &buffer_data[0][0].to_face_, sizeof(RaySeg) };
     float_bf_t p_out{ buffer_data[1][0].p_, sizeof(RaySeg) };
-    int_bf_t fid_out{ &buffer_data[1][0].fid_, sizeof(RaySeg) };
+    id_bf_t to_face_out{ &buffer_data[1][0].to_face_, sizeof(RaySeg) };
     Propagate(curr_crystal, curr_ray_num * 2, 2,  // Input
               d_in, p_in, w_in,                   // Input, d, w, p(1/2)
-              fid_src_in,                         // Source face ids (step=2, shared by reflect+refract pair)
-              p_out, fid_out);                    // Output, p, fid
+              from_face_in,                       // Source face ids (step=2, shared by reflect+refract pair)
+              p_out, to_face_out);                // Output, p, to_face
   }
 
   for (size_t i = 0; i < curr_ray_num; i++) {
     buffer_data[1][i * 2 + 0].rp_ = buffer_data[0][i].rp_;
     buffer_data[1][i * 2 + 1].rp_ = buffer_data[0][i].rp_;
+    // Each child segment's from_face_ = parent's to_face_ (the face just hit).
+    buffer_data[1][i * 2 + 0].from_face_ = buffer_data[0][i].to_face_;
+    buffer_data[1][i * 2 + 1].from_face_ = buffer_data[0][i].to_face_;
   }
 
   buffer_data[0].size_ = 0;
@@ -353,8 +377,8 @@ void FillRayOtherInfo(size_t curr_ray_num, size_t i,                           /
   size_t ray_id_offset = all_data.size_;
   for (size_t j = 0; j < buffer_data[1].size_; j++) {
     auto& r = buffer_data[1][j];
-    if (r.fid_ >= 0) {
-      r.rp_ << curr_crystal.GetFn(r.fid_);
+    if (r.to_face_ != kInvalidId) {
+      r.rp_ << curr_crystal.GetFn(r.to_face_);
     }
 
     if (i == 0) {
@@ -379,9 +403,9 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
     if (r.w_ < 0) {
       // 0. Total reflection.
       r.state_ = RaySeg::kStopped;
-    } else if (r.fid_ < 0) {
+    } else if (r.to_face_ == kInvalidId) {
       // 1. Outgoing candidates. Apply rotation first so filter operates in world-space.
-      // (w_ < 0 is already handled above, so fid_ < 0 implies w_ >= 0 — no double-rotation risk.)
+      // (w_ < 0 is already handled above, so to_face_==kInvalidId implies w_ >= 0 — no double-rotation risk.)
       r.crystal_rot_.Apply(r.d_);
       r.crystal_rot_.Apply(r.p_);
 
@@ -402,8 +426,8 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
       r.state_ = RaySeg::kNormal;
     }
 
-    // Tail rotation: only for total reflection (w_ < 0). Outgoing candidates (fid_ < 0) are
-    // already rotated above; normal rays (fid_ >= 0) stay in crystal-local coordinates.
+    // Tail rotation: only for total reflection (w_ < 0). Outgoing candidates (to_face_==kInvalidId) are
+    // already rotated above; normal rays (to_face_!=kInvalidId) stay in crystal-local coordinates.
     if (r.w_ < 0) {
       r.crystal_rot_.Apply(r.d_);
       r.crystal_rot_.Apply(r.p_);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -75,6 +75,13 @@ void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
     // Initial entry segment: no source face, hit face = the sampled one's polygon.
     r.from_face_ = kInvalidId;
     r.to_face_ = PolygonFaceOfTri(curr_crystal, tri_id);
+    if (r.to_face_ == kInvalidId) {
+      // Triangle has no matching polygon face — should not happen for a valid crystal.
+      // Zero weight so this ray is silently discarded downstream instead of causing UB
+      // in HitSurface (which would index poly_norm + 0xffff*3).
+      LOG_WARNING("PolygonFaceOfTri: tri {} has no matching polygon face; zeroing ray weight", tri_id);
+      r.w_ = 0.0f;
+    }
   }
 }
 

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -77,8 +77,8 @@ void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
     r.to_face_ = PolygonFaceOfTri(curr_crystal, tri_id);
     if (r.to_face_ == kInvalidId) {
       // Triangle has no matching polygon face — should not happen for a valid crystal.
-      // Zero weight so this ray is silently discarded downstream instead of causing UB
-      // in HitSurface (which would index poly_norm + 0xffff*3).
+      // Zero weight to suppress downstream contribution; HitSurface also guards
+      // kInvalidId at loop entry, preventing any OOB access.
       LOG_WARNING("PolygonFaceOfTri: tri {} has no matching polygon face; zeroing ray weight", tri_id);
       r.w_ = 0.0f;
     }

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -80,12 +80,15 @@ class Simulator {
 std::unique_ptr<size_t[]> PartitionCrystalRayNum(const std::vector<float>& proportions, size_t ray_num,
                                                  std::vector<double>& carry);
 
-// Per-batch ray dispatcher: decides each ray's final state (kNormal / kOutgoing /
-// kContinue / kStopped) and routes kContinue rays into the next ms init buffer.
+// Per-batch ray dispatcher: classifies each ray via derived predicates
+// (IsNormal() / IsOutgoing() / IsContinue() / IsTir()) and routes IsContinue()
+// rays into the next ms init buffer. Segment kind is derived from (to_face_,
+// w_, is_continue_); only the IsContinue() bit is written here.
 //
-// Filter semantics (post task-query-filter-uplift-v2): the filter acts only as a
-// branch gate controlling kContinue. Filter-fail rays are emitted as kOutgoing so
-// that the consumer-side query filter sees the full unfiltered ray set.
+// Filter semantics (post task-query-filter-uplift-v2): the filter acts only as
+// a branch gate controlling IsContinue(). Filter-fail rays are emitted as
+// IsOutgoing() so that the consumer-side query filter sees the full unfiltered
+// ray set.
 //
 // Internal: exposed for unit testing; not part of the public C API.
 void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter* filter,  // input

--- a/src/server/show_rays.cpp
+++ b/src/server/show_rays.cpp
@@ -7,16 +7,17 @@
 namespace lumice {
 
 void ShowRayInfoConsumer::Consume(const SimData& data) {
-  LOG_INFO("(id) p  d  w fid prev_id");
+  LOG_INFO("(id) p  d  w from_face to_face prev_id");
   for (size_t i = 0; i < data.rays_.size_; i++) {
     const auto& r = data.rays_[i];
-    LOG_INFO("({:02}) {:+9.6f},{:+9.6f},{:+9.6f}  {:+9.6f},{:+9.6f},{:+9.6f}  {:.6f}  {}  {}",  //
-             i,                                                                                 // id
-             r.p_[0], r.p_[1], r.p_[2],                                                         // p
-             r.d_[0], r.d_[1], r.d_[2],                                                         // d
-             r.w_,                                                                              // w
-             r.fid_,                                                                            // fid
-             r.prev_ray_idx_);                                                                  // prev_ray_id
+    LOG_INFO("({:02}) {:+9.6f},{:+9.6f},{:+9.6f}  {:+9.6f},{:+9.6f},{:+9.6f}  {:.6f}  {}  {}  {}",  //
+             i,                                                                                     // id
+             r.p_[0], r.p_[1], r.p_[2],                                                             // p
+             r.d_[0], r.d_[1], r.d_[2],                                                             // d
+             r.w_,                                                                                  // w
+             r.from_face_,                                                                          // from_face
+             r.to_face_,                                                                            // to_face
+             r.prev_ray_idx_);                                                                      // prev_ray_id
   }
 }
 

--- a/test/test_crystal.cpp
+++ b/test/test_crystal.cpp
@@ -471,6 +471,29 @@ TEST(DetailIsDApplicable, Conditions) {
   EXPECT_FALSE(lumice::detail::IsDApplicable(d));
 }
 
+// D4 invariant: every triangle's normal must align with at least one polygon-face
+// normal (dot > 1-1e-3), ensuring PolygonFaceOfTri always finds a match on valid
+// crystals and HitSurface's polygon-face normal equals the per-triangle normal.
+TEST_F(V3TestCrystal, EveryTriangleMapsToCoplanarPolygon) {
+  auto prism = Crystal::CreatePrism(1.3);
+  auto pyramid = Crystal::CreatePyramid(0.3f, 1.0f, 0.3f);
+
+  for (const auto* crystal : { &prism, &pyramid }) {
+    const float* tn = crystal->GetTriangleNormal();
+    const float* pn = crystal->GetPolygonFaceNormal();
+    for (size_t t = 0; t < crystal->TotalTriangles(); t++) {
+      bool found = false;
+      for (size_t p = 0; p < crystal->PolygonFaceCount(); p++) {
+        if (Dot3(tn + t * 3, pn + p * 3) > 1.0f - 1e-3f) {
+          found = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(found) << "triangle " << t << " has no coplanar polygon face";
+    }
+  }
+}
+
 // AC-5: GetFn(IdType poly_idx) returns the same fn that GetFn(int tri_id) gives
 // for the polygon's representative triangle, and yields kInvalidId on out-of-range
 // or kInvalidId input. Covers the new polygon-face overload used by simulator

--- a/test/test_crystal.cpp
+++ b/test/test_crystal.cpp
@@ -471,64 +471,26 @@ TEST(DetailIsDApplicable, Conditions) {
   EXPECT_FALSE(lumice::detail::IsDApplicable(d));
 }
 
-// ============================================================================
-// Crystal::GetTriangleToPolygonFace (task-raypath-1-3-fix AC-8)
-//
-// The triangle→polygon reverse mapping is the basis that PropagateTriangle
-// uses to compare face identities polygon-wise (preventing one polygon's
-// triangles from masking each other in the source-face guard). Test the
-// contract directly so future Crystal refactors can't silently break it.
-// ============================================================================
-
-TEST(CrystalTriangleToPolygonFace, OutOfRangeReturnsMinusOne) {
-  auto crystal = Crystal::CreatePrism(1.3);
-  int total = static_cast<int>(crystal.TotalTriangles());
-
-  EXPECT_EQ(crystal.GetTriangleToPolygonFace(-1), -1);
-  EXPECT_EQ(crystal.GetTriangleToPolygonFace(total), -1);
-  EXPECT_EQ(crystal.GetTriangleToPolygonFace(total + 100), -1);
-  EXPECT_EQ(crystal.GetTriangleToPolygonFace(-1000), -1);
-}
-
-TEST(CrystalTriangleToPolygonFace, EveryTriangleMapsToCoplanarPolygon) {
-  // Contract: every triangle maps to a polygon face whose plane normal
-  // aligns with the triangle's own normal (BuildPolygonFaceData is the
-  // single source of truth for both arrays).
-  auto crystal = Crystal::CreatePrism(1.3);
+// AC-5: GetFn(IdType poly_idx) returns the same fn that GetFn(int tri_id) gives
+// for the polygon's representative triangle, and yields kInvalidId on out-of-range
+// or kInvalidId input. Covers the new polygon-face overload used by simulator
+// after the from_face_/to_face_ split.
+TEST(CrystalGetFnByPolygonFace, MatchesTriangleOverloadAndBoundaries) {
+  auto crystal = Crystal::CreatePrism(1.0f);
   ASSERT_GT(crystal.PolygonFaceCount(), 0u);
 
-  const float* tri_n = crystal.GetTriangleNormal();
-  const float* poly_n = crystal.GetPolygonFaceNormal();
-
-  for (size_t t = 0; t < crystal.TotalTriangles(); t++) {
-    int p = crystal.GetTriangleToPolygonFace(static_cast<int>(t));
-    ASSERT_GE(p, 0) << "triangle " << t << " has no polygon mapping";
-    ASSERT_LT(static_cast<size_t>(p), crystal.PolygonFaceCount()) << "triangle " << t << " maps out of range";
-    float dot =
-        tri_n[t * 3] * poly_n[p * 3] + tri_n[t * 3 + 1] * poly_n[p * 3 + 1] + tri_n[t * 3 + 2] * poly_n[p * 3 + 2];
-    EXPECT_NEAR(dot, 1.0f, 1e-4f) << "triangle " << t << " normal does not align with polygon " << p;
+  const int* poly_tri = crystal.GetPolygonFaceTriId();
+  for (size_t p = 0; p < crystal.PolygonFaceCount(); p++) {
+    IdType fn_poly = crystal.GetFn(static_cast<IdType>(p));
+    IdType fn_tri = crystal.GetFn(poly_tri[p]);
+    EXPECT_EQ(fn_poly, fn_tri) << "polygon " << p << " fn mismatch vs tri " << poly_tri[p];
+    EXPECT_NE(fn_poly, kInvalidId) << "polygon " << p << " should resolve to a known fn";
   }
-}
 
-TEST(CrystalTriangleToPolygonFace, CoplanarTrianglesShareSamePolygon) {
-  // Stronger structural check: triangles whose normals are parallel must
-  // map to the same polygon index. Catches mappings that are individually
-  // plausible but inconsistent across triangles of the same physical face.
-  auto crystal = Crystal::CreatePrism(1.3);
-  const float* tri_n = crystal.GetTriangleNormal();
-  size_t n = crystal.TotalTriangles();
-
-  for (size_t a = 0; a < n; a++) {
-    for (size_t b = a + 1; b < n; b++) {
-      float dot =
-          tri_n[a * 3] * tri_n[b * 3] + tri_n[a * 3 + 1] * tri_n[b * 3 + 1] + tri_n[a * 3 + 2] * tri_n[b * 3 + 2];
-      if (dot > 0.9999f) {
-        int pa = crystal.GetTriangleToPolygonFace(static_cast<int>(a));
-        int pb = crystal.GetTriangleToPolygonFace(static_cast<int>(b));
-        EXPECT_EQ(pa, pb) << "coplanar triangles " << a << " and " << b << " map to different polygons";
-      }
-    }
-  }
+  // Out-of-range polygon index returns kInvalidId.
+  EXPECT_EQ(crystal.GetFn(static_cast<IdType>(crystal.PolygonFaceCount())), kInvalidId);
+  // kInvalidId input returns kInvalidId.
+  EXPECT_EQ(crystal.GetFn(kInvalidId), kInvalidId);
 }
 
 }  // namespace

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -27,7 +27,6 @@ class FilterTest : public ::testing::Test {
     for (auto fn : rp_vec) {
       r.rp_ << fn;
     }
-    r.state_ = RaySeg::kOutgoing;
     r.from_face_ = kInvalidId;
     r.to_face_ = kInvalidId;
     r.w_ = 1.0f;
@@ -233,7 +232,6 @@ TEST_F(FilterTest, DirectionFilter_BasicMatch) {
   r1.d_[0] = 1.0f;
   r1.d_[1] = 0.0f;
   r1.d_[2] = 0.0f;
-  r1.state_ = RaySeg::kOutgoing;
   EXPECT_TRUE(filter->Check(r1));
 
   // Ray along (0, 1, 0) — 90° away, should fail
@@ -241,12 +239,15 @@ TEST_F(FilterTest, DirectionFilter_BasicMatch) {
   r2.d_[0] = 0.0f;
   r2.d_[1] = 1.0f;
   r2.d_[2] = 0.0f;
-  r2.state_ = RaySeg::kOutgoing;
   EXPECT_FALSE(filter->Check(r2));
 }
 
 
-// DirectionFilter: no state guard — works regardless of state_
+// DirectionFilter: state-agnostic by construction. Post task-state-derive,
+// `state_` no longer exists — Filter::Check reads only d_/rp_/crystal_config_id_,
+// so the pre-uplift "no state guard" invariant is enforced structurally rather
+// than per-case. Test retained as a smoke check that the filter accepts any
+// matching direction regardless of bookkeeping fields.
 TEST_F(FilterTest, DirectionFilter_NoStateGuard) {
   DirectionFilterParam dp{};
   dp.lon_ = 0.0f;
@@ -260,19 +261,20 @@ TEST_F(FilterTest, DirectionFilter_NoStateGuard) {
 
   auto filter = Filter::Create(config);
 
-  // Matching direction with various non-kOutgoing states
   RaySeg r{};
   r.d_[0] = 1.0f;
   r.d_[1] = 0.0f;
   r.d_[2] = 0.0f;
 
-  r.state_ = RaySeg::kNormal;
+  // Toggle is_continue_ and w_ sign to exercise both branch-gate and TIR cases.
+  r.is_continue_ = false;
+  r.w_ = 1.0f;
   EXPECT_TRUE(filter->Check(r));
 
-  r.state_ = RaySeg::kContinue;
+  r.is_continue_ = true;
   EXPECT_TRUE(filter->Check(r));
 
-  r.state_ = RaySeg::kStopped;
+  r.w_ = -1.0f;  // TIR
   EXPECT_TRUE(filter->Check(r));
 }
 
@@ -296,7 +298,6 @@ TEST_F(FilterTest, DirectionFilter_FilterOut) {
   r1.d_[0] = 1.0f;
   r1.d_[1] = 0.0f;
   r1.d_[2] = 0.0f;
-  r1.state_ = RaySeg::kOutgoing;
   EXPECT_FALSE(filter->Check(r1));
 
   // Non-matching direction → should pass (Check returns true)
@@ -304,15 +305,15 @@ TEST_F(FilterTest, DirectionFilter_FilterOut) {
   r2.d_[0] = 0.0f;
   r2.d_[1] = 1.0f;
   r2.d_[2] = 0.0f;
-  r2.state_ = RaySeg::kOutgoing;
   EXPECT_TRUE(filter->Check(r2));
 
-  // kFilterOut + non-kOutgoing state + matching direction → should be excluded
+  // kFilterOut + is_continue_ ray (branch-gate path) + matching direction →
+  // still excluded (filter is state-agnostic; structural invariant).
   RaySeg r3{};
   r3.d_[0] = 1.0f;
   r3.d_[1] = 0.0f;
   r3.d_[2] = 0.0f;
-  r3.state_ = RaySeg::kContinue;
+  r3.is_continue_ = true;
   EXPECT_FALSE(filter->Check(r3));
 }
 
@@ -729,7 +730,6 @@ static RaySeg MakeFilterTestRay(const std::vector<IdType>& rp_vec) {
   for (auto fn : rp_vec) {
     r.rp_ << fn;
   }
-  r.state_ = RaySeg::kOutgoing;
   r.from_face_ = kInvalidId;
   r.to_face_ = kInvalidId;
   r.w_ = 1.0f;

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -28,7 +28,8 @@ class FilterTest : public ::testing::Test {
       r.rp_ << fn;
     }
     r.state_ = RaySeg::kOutgoing;
-    r.fid_ = -1;
+    r.from_face_ = kInvalidId;
+    r.to_face_ = kInvalidId;
     r.w_ = 1.0f;
     return r;
   }
@@ -729,7 +730,8 @@ static RaySeg MakeFilterTestRay(const std::vector<IdType>& rp_vec) {
     r.rp_ << fn;
   }
   r.state_ = RaySeg::kOutgoing;
-  r.fid_ = -1;
+  r.from_face_ = kInvalidId;
+  r.to_face_ = kInvalidId;
   r.w_ = 1.0f;
   return r;
 }

--- a/test/test_optics.cpp
+++ b/test/test_optics.cpp
@@ -107,16 +107,16 @@ class HitSurfaceTest : public ::testing::Test {
     float refract_weight;
   };
 
-  HitResult HitSingle(const float* dir, float weight, int fid) {
+  HitResult HitSingle(const float* dir, float weight, IdType to_face) {
     float dir_in[3] = { dir[0], dir[1], dir[2] };
     float w_in[1] = { weight };
-    int fid_in[1] = { fid };
+    IdType to_face_in[1] = { to_face };
     float dir_out[6] = {};
     float w_out[2] = {};
 
     float_bf_t d_in(dir_in, 3 * sizeof(float));
     float_bf_t wt_in(w_in, sizeof(float));
-    int_bf_t fi_in(fid_in, sizeof(int));
+    id_bf_t fi_in(to_face_in, sizeof(IdType));
     float_bf_t d_out(dir_out, 3 * sizeof(float));
     float_bf_t wt_out(w_out, sizeof(float));
 
@@ -136,8 +136,9 @@ class HitSurfaceTest : public ::testing::Test {
 
 TEST_F(HitSurfaceTest, AirToIceNormalIncidence) {
   // Find a face normal and shoot a ray along -normal (air -> ice, cos_theta < 0)
-  const float* norms = crystal_.GetTriangleNormal();
-  int fid = 0;
+  // HitSurface looks up the polygon-face normal indexed by RaySeg::to_face_.
+  const float* norms = crystal_.GetPolygonFaceNormal();
+  IdType fid = 0;
   float norm[3] = { norms[0], norms[1], norms[2] };
 
   // Ray direction = -normal (shooting into the crystal)
@@ -168,8 +169,9 @@ TEST_F(HitSurfaceTest, AirToIceNormalIncidence) {
 
 TEST_F(HitSurfaceTest, SnellsLaw30Degrees) {
   // Construct a ray at 30° to a face normal (air -> ice)
-  const float* norms = crystal_.GetTriangleNormal();
-  int fid = 0;
+  // HitSurface looks up the polygon-face normal indexed by RaySeg::to_face_.
+  const float* norms = crystal_.GetPolygonFaceNormal();
+  IdType fid = 0;
   float norm[3] = { norms[0], norms[1], norms[2] };
 
   // Build a tangent vector perpendicular to norm
@@ -217,8 +219,9 @@ TEST_F(HitSurfaceTest, SnellsLaw30Degrees) {
 
 TEST_F(HitSurfaceTest, TotalInternalReflection) {
   // Ice -> air (cos_theta > 0), angle > critical angle (~49.8°)
-  const float* norms = crystal_.GetTriangleNormal();
-  int fid = 0;
+  // HitSurface looks up the polygon-face normal indexed by RaySeg::to_face_.
+  const float* norms = crystal_.GetPolygonFaceNormal();
+  IdType fid = 0;
   float norm[3] = { norms[0], norms[1], norms[2] };
 
   // Build tangent
@@ -258,8 +261,9 @@ TEST_F(HitSurfaceTest, TotalInternalReflection) {
 
 TEST_F(HitSurfaceTest, EnergyConservation) {
   // Non-total-reflection case: reflect_weight + refract_weight ≈ input_weight
-  const float* norms = crystal_.GetTriangleNormal();
-  int fid = 0;
+  // HitSurface looks up the polygon-face normal indexed by RaySeg::to_face_.
+  const float* norms = crystal_.GetPolygonFaceNormal();
+  IdType fid = 0;
   float norm[3] = { norms[0], norms[1], norms[2] };
 
   // Air -> ice, 20° incidence
@@ -297,8 +301,9 @@ TEST_F(HitSurfaceTest, EnergyConservation) {
 
 TEST_F(HitSurfaceTest, DirectionSwitchAirVsIce) {
   // Same face, same angle, but from air side (cos < 0) vs ice side (cos > 0)
-  const float* norms = crystal_.GetTriangleNormal();
-  int fid = 0;
+  // HitSurface looks up the polygon-face normal indexed by RaySeg::to_face_.
+  const float* norms = crystal_.GetPolygonFaceNormal();
+  IdType fid = 0;
   float norm[3] = { norms[0], norms[1], norms[2] };
 
   float tangent[3];
@@ -363,21 +368,21 @@ TEST_F(PropagateTest, HorizontalRayHitsSideFace) {
   float pos[3] = { 0.0f, 0.0f, 0.0f };
   float w[1] = { 1.0f };
   float pos_out[3] = {};
-  int fid_out[1] = { -1 };
-  int src_fid[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(src_fid, sizeof(int));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
-  // Should hit some face (fid >= 0)
-  EXPECT_GE(fid_out[0], 0);
-  EXPECT_LT(fid_out[0], static_cast<int>(crystal_.TotalTriangles()));
+  // Should hit some polygon face (fid != kInvalidId)
+  EXPECT_NE(fid_out[0], kInvalidId);
+  EXPECT_LT(fid_out[0], crystal_.PolygonFaceCount());
 
   // Output position should be different from input (ray traveled)
   float dist = DiffNorm3(pos_out, pos);
@@ -391,19 +396,19 @@ TEST_F(PropagateTest, VerticalRayHitsTopFace) {
   float pos[3] = { 0.0f, 0.0f, 0.0f };
   float w[1] = { 1.0f };
   float pos_out[3] = {};
-  int fid_out[1] = { -1 };
-  int src_fid[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(src_fid, sizeof(int));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
-  EXPECT_GE(fid_out[0], 0);
+  EXPECT_NE(fid_out[0], kInvalidId);
 
   // Output z should be positive (hit top face)
   EXPECT_GT(pos_out[2], 0.0f);
@@ -418,22 +423,22 @@ TEST_F(PropagateTest, NegativeWeightSkipped) {
   float pos[3] = { 0.0f, 0.0f, 0.0f };
   float w[1] = { -1.0f };
   float pos_out[3] = { -999.0f, -999.0f, -999.0f };
-  int fid_out[1] = { -1 };
-  int src_fid[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(src_fid, sizeof(int));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
-  // PropagateSlab skips w<0 rays: output position = input position, fid = -1
+  // PropagateSlab skips w<0 rays: output position = input position, fid = kInvalidId
   // (The skip preserves the initialized values from the gather phase in PropagateSlab,
   //  but for the original position since w<0 is skipped in the scatter phase)
-  EXPECT_EQ(fid_out[0], -1);
+  EXPECT_EQ(fid_out[0], kInvalidId);
 }
 
 TEST_F(PropagateTest, Step2SharedPosition) {
@@ -451,21 +456,21 @@ TEST_F(PropagateTest, Step2SharedPosition) {
   };
   float weights[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
   float pos_out[12] = {};
-  int fid_out[4] = { -1, -1, -1, -1 };
-  int src_fids[2] = { -1, -1 };
+  IdType fid_out[4] = { kInvalidId, kInvalidId, kInvalidId, kInvalidId };
+  IdType src_fids[2] = { kInvalidId, kInvalidId };
 
   float_bf_t d_in(dirs, 3 * sizeof(float));
   float_bf_t p_in(positions, 3 * sizeof(float));
   float_bf_t wt_in(weights, sizeof(float));
-  int_bf_t fi_src(src_fids, sizeof(int));
+  id_bf_t fi_src(src_fids, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 4, 2, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
   // All rays should hit something (from center, any direction hits a face)
   for (int i = 0; i < 4; i++) {
-    EXPECT_GE(fid_out[i], 0) << "Ray " << i << " missed";
+    EXPECT_NE(fid_out[i], kInvalidId) << "Ray " << i << " missed";
   }
 
   // Rays with same direction and same position should produce same results
@@ -487,15 +492,15 @@ TEST_F(PropagateTest, ChunkBoundaryConsistency) {
 
   // Single-chunk reference (num=1)
   float pos_out_ref[3] = {};
-  int fid_ref[1] = { -1 };
-  int src_fid_ref[1] = { -1 };
+  IdType fid_ref[1] = { kInvalidId };
+  IdType src_fid_ref[1] = { kInvalidId };
   {
     float_bf_t d_in(dir, 3 * sizeof(float));
     float_bf_t p_in(pos, 3 * sizeof(float));
     float_bf_t wt_in(w, sizeof(float));
-    int_bf_t fi_src(src_fid_ref, sizeof(int));
+    id_bf_t fi_src(src_fid_ref, sizeof(IdType));
     float_bf_t p_out(pos_out_ref, 3 * sizeof(float));
-    int_bf_t fi_out(fid_ref, sizeof(int));
+    id_bf_t fi_out(fid_ref, sizeof(IdType));
     Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
   }
 
@@ -506,8 +511,8 @@ TEST_F(PropagateTest, ChunkBoundaryConsistency) {
   std::vector<float> positions(kNum * 3, 0.0f);
   std::vector<float> weights(kNum, -1.0f);
   std::vector<float> pos_out_chunk(kNum * 3, 0.0f);
-  std::vector<int> fid_chunk(kNum, -1);
-  std::vector<int> src_fid_chunk(kNum, -1);
+  std::vector<IdType> fid_chunk(kNum, kInvalidId);
+  std::vector<IdType> src_fid_chunk(kNum, kInvalidId);
 
   dirs[0] = dir[0];
   dirs[1] = dir[1];
@@ -518,13 +523,13 @@ TEST_F(PropagateTest, ChunkBoundaryConsistency) {
     float_bf_t d_in(dirs.data(), 3 * sizeof(float));
     float_bf_t p_in(positions.data(), 3 * sizeof(float));
     float_bf_t wt_in(weights.data(), sizeof(float));
-    int_bf_t fi_src(src_fid_chunk.data(), sizeof(int));
+    id_bf_t fi_src(src_fid_chunk.data(), sizeof(IdType));
     float_bf_t p_out(pos_out_chunk.data(), 3 * sizeof(float));
-    int_bf_t fi_out(fid_chunk.data(), sizeof(int));
+    id_bf_t fi_out(fid_chunk.data(), sizeof(IdType));
     Propagate(crystal_, kNum, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
   }
 
-  EXPECT_GE(fid_ref[0], 0);
+  EXPECT_NE(fid_ref[0], kInvalidId);
   EXPECT_EQ(fid_ref[0], fid_chunk[0]);
   for (int j = 0; j < 3; j++) {
     EXPECT_NEAR(pos_out_ref[j], pos_out_chunk[j], 1e-5f);
@@ -538,15 +543,15 @@ TEST_F(PropagateTest, NoIntersection) {
   float pos[3] = { 100.0f, 100.0f, 100.0f };
   float w[1] = { 1.0f };
   float pos_out[3] = {};
-  int fid_out[1] = { -1 };
-  int src_fid[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(src_fid, sizeof(int));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
@@ -558,8 +563,20 @@ TEST_F(PropagateTest, NoIntersection) {
   EXPECT_TRUE(true);  // No crash is the test
 }
 
+// Find the polygon face whose normal aligns with target_n (dot > 0.99).
+// Returns kInvalidId if no polygon face matches.
+static IdType FindPolygonFaceByNormal(const Crystal& crystal, const float* target_n) {
+  const float* pn = crystal.GetPolygonFaceNormal();
+  for (size_t p = 0; p < crystal.PolygonFaceCount(); p++) {
+    if (Dot3(target_n, pn + p * 3) > 0.99f) {
+      return static_cast<IdType>(p);
+    }
+  }
+  return kInvalidId;
+}
+
 // AC-1: TIR on fn=3 (x=√3/4), ray starts at shared edge with fn=4 (0.5x+√3/2·y=√3/4).
-// fid_in_src = a triangle of fn=3 (TIR source); adjacent fn=4 should be hit.
+// from_face_in = polygon face of fn=3 (TIR source); adjacent fn=4 should be hit.
 //
 // Geometry note: pos.x is shifted inward by δ = 3e-6 (well below kFloatEps=1e-5)
 // so t_fn4 = δ is reliably positive across platforms while still less than the
@@ -573,31 +590,25 @@ TEST_F(PropagateTest, TIREdgeAdjacentFaceHit) {
   float dir[3] = { -0.5f, kSqrt3 / 2.0f, 0.0f };
   float w[1] = { 1.0f };
   float pos_out[3] = {};
-  int fid_out[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
 
-  // Find a triangle whose normal is fn=3 (normal ≈ (1, 0, 0)) to use as source face
-  int src_tri = -1;
-  for (int t = 0; t < static_cast<int>(crystal_.TotalTriangles()); t++) {
-    const float* tn = crystal_.GetTriangleNormal() + t * 3;
-    if (tn[0] > 0.99f && std::abs(tn[1]) < 0.01f) {
-      src_tri = t;
-      break;
-    }
-  }
-  ASSERT_GE(src_tri, 0) << "Could not find fn=3 triangle";
+  // Use the polygon face whose normal is fn=3 (normal ≈ (1, 0, 0)).
+  const float kFn3Norm[3] = { 1.0f, 0.0f, 0.0f };
+  IdType src_poly = FindPolygonFaceByNormal(crystal_, kFn3Norm);
+  ASSERT_NE(src_poly, kInvalidId) << "Could not find fn=3 polygon face";
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(&src_tri, sizeof(int));
+  id_bf_t fi_src(&src_poly, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
   // Should hit fn=4 (normal ≈ (0.5, √3/2, 0)); verify via dot product
-  ASSERT_GE(fid_out[0], 0) << "Expected adjacent face hit, got no intersection";
-  const float* norm_out = crystal_.GetTriangleNormal() + fid_out[0] * 3;
+  ASSERT_NE(fid_out[0], kInvalidId) << "Expected adjacent face hit, got no intersection";
+  const float* norm_out = crystal_.GetPolygonFaceNormal() + fid_out[0] * 3;
   float dot = norm_out[0] * 0.5f + norm_out[1] * (kSqrt3 / 2.0f);
   EXPECT_NEAR(dot, 1.0f, 1e-3f);
 }
@@ -615,8 +626,8 @@ TEST_F(PropagateTest, TIREdgeAdjacentFaceHit_LargeNum) {
   std::vector<float> positions(kNum * 3, 0.0f);
   std::vector<float> weights(kNum, -1.0f);
   std::vector<float> pos_out(kNum * 3, 0.0f);
-  std::vector<int> fid_out(kNum, -1);
-  std::vector<int> src_fids(kNum, -1);
+  std::vector<IdType> fid_out(kNum, kInvalidId);
+  std::vector<IdType> src_fids(kNum, kInvalidId);
 
   dirs[0] = -0.5f;
   dirs[1] = kSqrt3 / 2.0f;
@@ -626,28 +637,23 @@ TEST_F(PropagateTest, TIREdgeAdjacentFaceHit_LargeNum) {
   positions[2] = 0.0f;
   weights[0] = 1.0f;
 
-  // Find fn=3 triangle for source face
-  for (int t = 0; t < static_cast<int>(crystal_.TotalTriangles()); t++) {
-    const float* tn = crystal_.GetTriangleNormal() + t * 3;
-    if (tn[0] > 0.99f && std::abs(tn[1]) < 0.01f) {
-      src_fids[0] = t;
-      break;
-    }
-  }
-  ASSERT_GE(src_fids[0], 0) << "Could not find fn=3 triangle";
+  // Polygon face for fn=3 (normal ≈ (1, 0, 0)) as source face.
+  const float kFn3Norm[3] = { 1.0f, 0.0f, 0.0f };
+  src_fids[0] = FindPolygonFaceByNormal(crystal_, kFn3Norm);
+  ASSERT_NE(src_fids[0], kInvalidId) << "Could not find fn=3 polygon face";
 
   float_bf_t d_in(dirs.data(), 3 * sizeof(float));
   float_bf_t p_in(positions.data(), 3 * sizeof(float));
   float_bf_t wt_in(weights.data(), sizeof(float));
-  int_bf_t fi_src(src_fids.data(), sizeof(int));
+  id_bf_t fi_src(src_fids.data(), sizeof(IdType));
   float_bf_t p_out(pos_out.data(), 3 * sizeof(float));
-  int_bf_t fi_out(fid_out.data(), sizeof(int));
+  id_bf_t fi_out(fid_out.data(), sizeof(IdType));
 
   Propagate(crystal_, kNum, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
   // Should hit fn=4 (normal ≈ (0.5, √3/2, 0))
-  ASSERT_GE(fid_out[0], 0) << "Expected adjacent face hit, got no intersection";
-  const float* norm_out = crystal_.GetTriangleNormal() + fid_out[0] * 3;
+  ASSERT_NE(fid_out[0], kInvalidId) << "Expected adjacent face hit, got no intersection";
+  const float* norm_out = crystal_.GetPolygonFaceNormal() + fid_out[0] * 3;
   float dot = norm_out[0] * 0.5f + norm_out[1] * (kSqrt3 / 2.0f);
   EXPECT_NEAR(dot, 1.0f, 1e-3f);
 }
@@ -658,48 +664,42 @@ TEST_F(PropagateTest, TIREdgeAdjacentFaceHit_LargeNum) {
 TEST_F(PropagateTest, PropagateSourceFaceNotSelected) {
   const float kSqrt3 = std::sqrt(3.0f);
 
-  // Find fn=3 triangle (normal ≈ (1, 0, 0))
-  int src_tri = -1;
-  for (int t = 0; t < static_cast<int>(crystal_.TotalTriangles()); t++) {
-    const float* tn = crystal_.GetTriangleNormal() + t * 3;
-    if (tn[0] > 0.99f && std::abs(tn[1]) < 0.01f) {
-      src_tri = t;
-      break;
-    }
-  }
-  ASSERT_GE(src_tri, 0) << "Could not find fn=3 triangle";
+  // Polygon face for fn=3 (normal ≈ (1, 0, 0)) as source face.
+  const float kFn3Norm[3] = { 1.0f, 0.0f, 0.0f };
+  IdType src_poly = FindPolygonFaceByNormal(crystal_, kFn3Norm);
+  ASSERT_NE(src_poly, kInvalidId) << "Could not find fn=3 polygon face";
 
   // Place ray half-epsilon inside fn=3 (pos.x = √3/4 - kFloatEps/2), direction +x (outward).
   // t_fn3 = (kFloatEps/2) / 1.0 ∈ (0, kFloatEps): in the guard zone.
-  //   - Correct code (source face uses +kFloatEps): t_fn3 < kFloatEps → fn=3 rejected → fid_out = -1.
-  //   - Regressed code (all faces use -kFloatEps): t_fn3 > -kFloatEps → fn=3 accepted → fid_out = fn=3 tri.
+  //   - Correct code (source face uses +kFloatEps): t_fn3 < kFloatEps → fn=3 rejected → fid_out = kInvalidId.
+  //   - Regressed code (all faces use -kFloatEps): t_fn3 > -kFloatEps → fn=3 accepted → fid_out = fn=3 poly.
   float pos[3] = { kSqrt3 / 4.0f - math::kFloatEps * 0.5f, 0.0f, 0.0f };
   float dir[3] = { 1.0f, 0.0f, 0.0f };
 
   float w[1] = { 1.0f };
   float pos_out[3] = {};
-  int fid_out[1] = { -1 };
+  IdType fid_out[1] = { kInvalidId };
 
   float_bf_t d_in(dir, 3 * sizeof(float));
   float_bf_t p_in(pos, 3 * sizeof(float));
   float_bf_t wt_in(w, sizeof(float));
-  int_bf_t fi_src(&src_tri, sizeof(int));
+  id_bf_t fi_src(&src_poly, sizeof(IdType));
   float_bf_t p_out(pos_out, 3 * sizeof(float));
-  int_bf_t fi_out(fid_out, sizeof(int));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
 
   Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
   // With dir=(+1,0,0) from a point ε/2 inside fn=3, the only face geometrically
   // reachable in the forward direction is fn=3 itself. A correctly-functioning
-  // source-face guard must reject it, leaving fid_out=-1. Asserting "-1" is
-  // strictly stronger than "not fn=3": it also catches regressions where some
-  // unrelated face is spuriously selected (e.g. PropagateSlab returning a
-  // stale far_face), which the earlier `if (fid_out>=0)` wrapping would miss.
-  EXPECT_EQ(fid_out[0], -1) << "guard zone must produce no hit; "
-                               "non-negative fid_out (="
-                            << fid_out[0]
-                            << ") means either "
-                               "source face fn=3 was wrongly selected or some unreachable face was returned";
+  // source-face guard must reject it, leaving fid_out=kInvalidId. Asserting
+  // "kInvalidId" is strictly stronger than "not fn=3": it also catches regressions
+  // where some unrelated face is spuriously selected (e.g. PropagateSlab returning
+  // a stale far_face), which the earlier `if (fid_out>=0)` wrapping would miss.
+  EXPECT_EQ(fid_out[0], kInvalidId) << "guard zone must produce no hit; "
+                                       "fid_out (="
+                                    << fid_out[0]
+                                    << ") means either "
+                                       "source face fn=3 was wrongly selected or some unreachable face was returned";
 }
 
 // AC-3 (a): polygon-only equivalence on a regular hexagonal prism.
@@ -725,20 +725,20 @@ TEST_F(PropagateTest, PolygonOnlyPrism6SideFaces) {
     float pos[3] = { 0.0f, 0.0f, 0.0f };
     float w[1] = { 1.0f };
     float pos_out[3] = {};
-    int fid_out[1] = { -1 };
-    int src_fid[1] = { -1 };
+    IdType fid_out[1] = { kInvalidId };
+    IdType src_fid[1] = { kInvalidId };
 
     float_bf_t d_in(dir, 3 * sizeof(float));
     float_bf_t p_in(pos, 3 * sizeof(float));
     float_bf_t wt_in(w, sizeof(float));
-    int_bf_t fi_src(src_fid, sizeof(int));
+    id_bf_t fi_src(src_fid, sizeof(IdType));
     float_bf_t p_out(pos_out, 3 * sizeof(float));
-    int_bf_t fi_out(fid_out, sizeof(int));
+    id_bf_t fi_out(fid_out, sizeof(IdType));
 
     Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
-    ASSERT_GE(fid_out[0], 0) << "Ray " << i << " missed all faces";
-    const float* norm = crystal_.GetTriangleNormal() + fid_out[0] * 3;
+    ASSERT_NE(fid_out[0], kInvalidId) << "Ray " << i << " missed all faces";
+    const float* norm = crystal_.GetPolygonFaceNormal() + fid_out[0] * 3;
     // Hit a side face (z-component of normal ≈ 0).
     EXPECT_NEAR(norm[2], 0.0f, 1e-4f) << "Ray " << i << " hit non-side face (norm.z=" << norm[2] << ")";
     // Outward normal aligns with the ray direction.
@@ -771,22 +771,70 @@ TEST_F(PropagateTest, PolygonOnlyPyramidConeFaces) {
     float pos[3] = { 0.0f, 0.0f, 0.0f };
     float w[1] = { 1.0f };
     float pos_out[3] = {};
-    int fid_out[1] = { -1 };
-    int src_fid[1] = { -1 };
+    IdType fid_out[1] = { kInvalidId };
+    IdType src_fid[1] = { kInvalidId };
 
     float_bf_t d_in(dir, 3 * sizeof(float));
     float_bf_t p_in(pos, 3 * sizeof(float));
     float_bf_t wt_in(w, sizeof(float));
-    int_bf_t fi_src(src_fid, sizeof(int));
+    id_bf_t fi_src(src_fid, sizeof(IdType));
     float_bf_t p_out(pos_out, 3 * sizeof(float));
-    int_bf_t fi_out(fid_out, sizeof(int));
+    id_bf_t fi_out(fid_out, sizeof(IdType));
 
     Propagate(pyramid, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
 
-    ASSERT_GE(fid_out[0], 0) << c.label << ": ray missed all faces";
-    const float* norm = pyramid.GetTriangleNormal() + fid_out[0] * 3;
+    ASSERT_NE(fid_out[0], kInvalidId) << c.label << ": ray missed all faces";
+    const float* norm = pyramid.GetPolygonFaceNormal() + fid_out[0] * 3;
     // Hit face must belong to the expected cone segment (norm.z sign + magnitude > 0.5).
     EXPECT_GT(norm[2] * c.expected_norm_z_sign, 0.5f)
         << c.label << ": hit face norm.z=" << norm[2] << " (expected sign " << c.expected_norm_z_sign << ")";
   }
+}
+
+// AC-5: when from_face_in = kInvalidId (initial ray, no source face), Propagate
+// applies no source-face guard — equivalent to the legacy fid_in_src = -1 path.
+// The ray from the origin along +x must hit some polygon face.
+TEST_F(PropagateTest, FromFaceNotSelf_InitialRayNoSource) {
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { 1.0f };
+  float pos_out[3] = {};
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };  // no source — legacy "-1" sentinel
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
+
+  ASSERT_NE(fid_out[0], kInvalidId) << "kInvalidId source should not exclude any face";
+}
+
+// AC-5: to_face_out from Propagate is a polygon face index — i.e. always in
+// [0, PolygonFaceCount()), never a triangle id. Guarantees the new ABI invariant
+// downstream consumers (HitSurface normal lookup, raypath recorder) rely on.
+TEST_F(PropagateTest, ToFaceIsPolygonFaceIndex) {
+  float dir[3] = { 1.0f, 0.0f, 0.0f };
+  float pos[3] = { 0.0f, 0.0f, 0.0f };
+  float w[1] = { 1.0f };
+  float pos_out[3] = {};
+  IdType fid_out[1] = { kInvalidId };
+  IdType src_fid[1] = { kInvalidId };
+
+  float_bf_t d_in(dir, 3 * sizeof(float));
+  float_bf_t p_in(pos, 3 * sizeof(float));
+  float_bf_t wt_in(w, sizeof(float));
+  id_bf_t fi_src(src_fid, sizeof(IdType));
+  float_bf_t p_out(pos_out, 3 * sizeof(float));
+  id_bf_t fi_out(fid_out, sizeof(IdType));
+
+  Propagate(crystal_, 1, 1, d_in, p_in, wt_in, fi_src, p_out, fi_out);
+
+  ASSERT_NE(fid_out[0], kInvalidId);
+  EXPECT_LT(fid_out[0], crystal_.PolygonFaceCount()) << "fid_out must be a polygon-face index, got " << fid_out[0]
+                                                     << " (PolygonFaceCount=" << crystal_.PolygonFaceCount() << ")";
 }

--- a/test/test_proj.cpp
+++ b/test/test_proj.cpp
@@ -34,7 +34,7 @@ class CopyRayDataConsumer : public lumice::IConsume {
   void Consume(const lumice::SimData& data) override {
     int offset = 0;
     for (const auto& r : data.rays_) {
-      if (r.fid_ >= 0 || r.w_ < 0) {
+      if (r.to_face_ != lumice::kInvalidId || r.w_ < 0) {
         continue;
       }
       std::memcpy(output_data_ + offset * 7 + 0, r.p_, 3 * sizeof(float));

--- a/test/test_sim_data.cpp
+++ b/test/test_sim_data.cpp
@@ -42,7 +42,10 @@ static_assert(sizeof(SimData) == 168,
 RaySeg MakeRay(int marker) {
   RaySeg r{};
   r.w_ = static_cast<float>(marker);
-  r.fid_ = marker;
+  // No fid-equivalent in the new RaySeg; keep both polygon-face fields at
+  // kInvalidId. Test assertions only inspect w_, so this is sufficient.
+  r.from_face_ = lumice::kInvalidId;
+  r.to_face_ = lumice::kInvalidId;
   return r;
 }
 

--- a/test/test_simulator.cpp
+++ b/test/test_simulator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -571,6 +572,72 @@ TEST(RaySegDerivedKind, ContinueWhenOutgoingCandidateBranchGated) {
   EXPECT_FALSE(r.IsOutgoing());  // is_continue_ excludes IsOutgoing
   EXPECT_FALSE(r.IsNormal());
   EXPECT_FALSE(r.IsTir());
+}
+
+// ---- AC-3: RaySeg::IsValidComplete() — N4 construction-time invariants ----
+
+namespace {
+
+// Build a fully N4-compliant RaySeg as the positive baseline. Each negative
+// test below mutates one field to exercise a single invariant in isolation.
+RaySeg MakeValidRaySeg() {
+  RaySeg r = MakeRaySegBase();
+  r.w_ = 0.5f;
+  r.to_face_ = 3;
+  r.is_continue_ = false;
+  r.crystal_idx_ = 0;
+  return r;
+}
+
+}  // namespace
+
+TEST(RaySegValidate, ValidRayPassesAllChecks) {
+  RaySeg r = MakeValidRaySeg();
+  EXPECT_TRUE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, TirSentinelWeightPasses) {
+  // w_ == -1.0f exactly is the TIR sentinel and must be accepted by N4-2.
+  RaySeg r = MakeValidRaySeg();
+  r.w_ = -1.0f;
+  r.to_face_ = kInvalidId;
+  EXPECT_TRUE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, InvalidWeightNotMinusOne) {
+  // N4-2 violation: negative weight other than the TIR sentinel.
+  RaySeg r = MakeValidRaySeg();
+  r.w_ = -0.5f;
+  EXPECT_FALSE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, ContinueWithValidFace) {
+  // N4-3 violation: is_continue_ ray must have to_face_ == kInvalidId.
+  RaySeg r = MakeValidRaySeg();
+  r.is_continue_ = true;
+  r.to_face_ = 3;
+  EXPECT_FALSE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, CrystalIdxOutOfRange) {
+  // N4-4 violation: crystal_idx_ must be < kMaxCrystalNum or == kInvalidId.
+  RaySeg r = MakeValidRaySeg();
+  r.crystal_idx_ = static_cast<IdType>(kMaxCrystalNum);  // == 16, out of [0, 15]
+  EXPECT_FALSE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, DirectionNaN) {
+  // N4-5 violation: direction component is NaN.
+  RaySeg r = MakeValidRaySeg();
+  r.d_[0] = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_FALSE(r.IsValidComplete());
+}
+
+TEST(RaySegValidate, PositionInf) {
+  // N4-5 violation: position component is Inf.
+  RaySeg r = MakeValidRaySeg();
+  r.p_[1] = std::numeric_limits<float>::infinity();
+  EXPECT_FALSE(r.IsValidComplete());
 }
 
 }  // namespace

--- a/test/test_simulator.cpp
+++ b/test/test_simulator.cpp
@@ -400,7 +400,8 @@ RaySeg MakeOutgoingCandidate() {
   r.p_[1] = 0.0f;
   r.p_[2] = 0.0f;
   r.w_ = 0.5f;  // positive (not TIR)
-  r.fid_ = -1;  // outgoing candidate marker
+  r.from_face_ = kInvalidId;
+  r.to_face_ = kInvalidId;  // outgoing candidate marker
   r.crystal_rot_ = Rotation{};
   return r;
 }

--- a/test/test_simulator.cpp
+++ b/test/test_simulator.cpp
@@ -429,15 +429,14 @@ TEST(CollectDataFilterDispatch, FilterFailBecomesOutgoing) {
   CollectData(rng, ms_info, &filter, buffer_data, init_data);
 
   ASSERT_EQ(buffer_data[1].size_, 1u);
-  EXPECT_EQ(buffer_data[1].rays_[0].state_, RaySeg::kOutgoing)
-      << "filter-fail ray must emit as kOutgoing (was " << buffer_data[1].rays_[0].state_ << ")";
+  EXPECT_TRUE(buffer_data[1].rays_[0].IsOutgoing()) << "filter-fail ray must emit as IsOutgoing()";
   // init_data must NOT contain the filter-fail ray.
   EXPECT_EQ(init_data[1].size_, 0u);
 }
 
 TEST(CollectDataFilterDispatch, FilterFailWithNonZeroProbEmitsOutgoing) {
   // prob_=1.0f: rng < prob is always true → filter->Check IS called and returns false.
-  // This is the direct AC-2 coverage: filter-fail ray must emit as kOutgoing.
+  // This is the direct AC-2 coverage: filter-fail ray must emit as IsOutgoing().
   RandomNumberGenerator rng(42);
   AlwaysRejectFilter filter;
   MsInfo ms_info;
@@ -455,8 +454,7 @@ TEST(CollectDataFilterDispatch, FilterFailWithNonZeroProbEmitsOutgoing) {
   CollectData(rng, ms_info, &filter, buffer_data, init_data);
 
   ASSERT_EQ(buffer_data[1].size_, 1u);
-  EXPECT_EQ(buffer_data[1].rays_[0].state_, RaySeg::kOutgoing)
-      << "filter-fail ray must emit as kOutgoing (was " << buffer_data[1].rays_[0].state_ << ")";
+  EXPECT_TRUE(buffer_data[1].rays_[0].IsOutgoing()) << "filter-fail ray must emit as IsOutgoing()";
   EXPECT_EQ(init_data[1].size_, 0u);
 }
 
@@ -478,7 +476,7 @@ TEST(CollectDataFilterDispatch, FilterPassWithProbContinues) {
   CollectData(rng, ms_info, &filter, buffer_data, init_data);
 
   ASSERT_EQ(buffer_data[1].size_, 1u);
-  EXPECT_EQ(buffer_data[1].rays_[0].state_, RaySeg::kContinue);
+  EXPECT_TRUE(buffer_data[1].rays_[0].IsContinue());
   EXPECT_EQ(init_data[1].size_, 1u);
 }
 
@@ -500,8 +498,79 @@ TEST(CollectDataFilterDispatch, FilterPassNoProbEmitsOutgoing) {
   CollectData(rng, ms_info, &filter, buffer_data, init_data);
 
   ASSERT_EQ(buffer_data[1].size_, 1u);
-  EXPECT_EQ(buffer_data[1].rays_[0].state_, RaySeg::kOutgoing);
+  EXPECT_TRUE(buffer_data[1].rays_[0].IsOutgoing());
   EXPECT_EQ(init_data[1].size_, 0u);
+}
+
+// ---- AC-5: derived-helper unit tests for RaySeg segment-kind predicates ----
+
+namespace {
+
+RaySeg MakeRaySegBase() {
+  RaySeg r{};
+  r.d_[0] = 1.0f;
+  r.d_[1] = 0.0f;
+  r.d_[2] = 0.0f;
+  r.p_[0] = 0.0f;
+  r.p_[1] = 0.0f;
+  r.p_[2] = 0.0f;
+  r.from_face_ = kInvalidId;
+  r.crystal_rot_ = Rotation{};
+  return r;
+}
+
+}  // namespace
+
+// TC-1: to_face_ != kInvalidId && w_ >= 0  →  IsNormal()
+TEST(RaySegDerivedKind, NormalWhenHasFaceAndPositiveWeight) {
+  RaySeg r = MakeRaySegBase();
+  r.w_ = 0.5f;
+  r.to_face_ = 3;  // any non-sentinel face id
+  r.is_continue_ = false;
+
+  EXPECT_TRUE(r.IsNormal());
+  EXPECT_FALSE(r.IsTir());
+  EXPECT_FALSE(r.IsOutgoing());
+  EXPECT_FALSE(r.IsContinue());
+}
+
+// TC-2: w_ < 0  →  IsTir()  (overrides to_face_ value)
+TEST(RaySegDerivedKind, TirWhenNegativeWeight) {
+  RaySeg r = MakeRaySegBase();
+  r.w_ = -1.0f;
+  r.to_face_ = kInvalidId;  // also exercises that w_<0 wins over to_face_ branches
+  r.is_continue_ = false;
+
+  EXPECT_TRUE(r.IsTir());
+  EXPECT_FALSE(r.IsNormal());
+  EXPECT_FALSE(r.IsOutgoing());
+  EXPECT_FALSE(r.IsContinue());
+}
+
+// TC-3: to_face_ == kInvalidId && w_ >= 0 && !is_continue_  →  IsOutgoing()
+TEST(RaySegDerivedKind, OutgoingWhenNoFaceAndNotContinue) {
+  RaySeg r = MakeRaySegBase();
+  r.w_ = 0.5f;
+  r.to_face_ = kInvalidId;
+  r.is_continue_ = false;
+
+  EXPECT_TRUE(r.IsOutgoing());
+  EXPECT_FALSE(r.IsNormal());
+  EXPECT_FALSE(r.IsTir());
+  EXPECT_FALSE(r.IsContinue());
+}
+
+// TC-4: to_face_ == kInvalidId && w_ >= 0 && is_continue_  →  IsContinue() (not IsOutgoing)
+TEST(RaySegDerivedKind, ContinueWhenOutgoingCandidateBranchGated) {
+  RaySeg r = MakeRaySegBase();
+  r.w_ = 0.5f;
+  r.to_face_ = kInvalidId;
+  r.is_continue_ = true;
+
+  EXPECT_TRUE(r.IsContinue());
+  EXPECT_FALSE(r.IsOutgoing());  // is_continue_ excludes IsOutgoing
+  EXPECT_FALSE(r.IsNormal());
+  EXPECT_FALSE(r.IsTir());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Carries scrum-rayseg-state-sentinel-redesign to completion on top of the post-scrum-193 baseline (task-199 / task-200 / task-205). Five commits land the full M1–M7b set from explore-195 stage-1, with one explore subtask + three task subtasks driven through plan → plan-review → implement → code-review → closeout.

- **T1 (M3 + M4)** — `5fa20fa` + `8e905ab` + `9371321`: split `RaySeg::fid_ (int, -1 sentinel)` into `from_face_` + `to_face_` (`IdType`, `kInvalidId` sentinel); collapse the `Propagate(..., fid_in_src, ...)` parameter introduced by task-199; remove `Crystal::GetTriangleToPolygonFace` + `tri_to_poly_` (no longer needed once we store polygon ids directly); add `kInvalidId` guards in `HitSurface` + a `D4` cross-check unit test.
- **T2 (M1 + M2)** — `d1d5b9b`: replace `RaySeg::State` 4-value enum with a single `bool is_continue_` bit; introduce derived helpers `IsTir() / IsOutgoing() / IsContinue() / IsNormal()`; tighten the crystal-local vs. world coordinate comment so the coordinate convention no longer rides on `state_ == kNormal`.
- **T3 (M7b)** — `14508e1`: `RaySeg::IsValidComplete()` plus four column-level static helpers (`IsValidW / IsValidContinueFace / IsValidCrystalIdx / IsValidVec3Finite`) and an `assert` at the `RayBuffer::EmplaceBack(RaySeg)` entry; 7 new `RaySegValidate` unit tests cover the legal baseline (incl. TIR sentinel) and five N4 violation classes.

Scope landed at ~335 lines, vs. the explore-195 stage-1 estimate of 1200–1500. Every change is at-least-neutral for the SoA / GPU migration backlog item; the four column-level validators in T3 are directly reusable as column-wise batch checks once SoA lands.

Closes the two conditional backlog items left behind when scrum-193 was unwound:
- *scrum-193 follow-ups §1* — `fid` sentinel three-way overloading.
- *scrum-193 follow-ups §2* — RaySeg state-machine split.

Detailed write-up: `scratchpad/scrum-rayseg-state-sentinel-redesign/SUMMARY.md`.

## Test plan

- [x] `./scripts/build.sh -tj release` — unit tests pass on every intermediate commit, final HEAD 1.51 s.
- [x] `pytest test/e2e/ -v` — fast e2e 25/25 PASS at the final HEAD (matches CI scope).
- [x] `./scripts/build.sh -sj release && pytest test/e2e/ -v -m slow` — `test_unfiltered_intensity_consistent` + `test_xyz_addition_beats_srgb` PASS; `test_partition_buffer_additivity` fluctuated to 11.615% on the first run (threshold 11.5%, `mean+3σ` from N=15) and PASSED on a single retry — consistent with explore-202's MC noise-floor characterisation and not a regression (scalar primary assertion passes either way).
- [x] `./scripts/format.sh` — clean.
- [ ] CI green on `dev/refactor_rayseg` push (waiting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)