### PR TITLE
feat(gui): edit modal UX polish (raypath buffer + pyramid slider alignment)

### DIFF
--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -168,6 +168,7 @@ struct ValuePreset {
   float value;
 };
 
+// Label precision must match the fmt passed to SliderWithPresetEdit (currently "%.3f").
 constexpr ValuePreset kWedgePresets[] = {
   { "{1,0,-1,1} 28.000\xc2\xb0", 28.0f },
   { "{2,0,-2,1} 47.300\xc2\xb0", 47.3f },
@@ -202,7 +203,7 @@ bool SliderWithPresetEdit(const char* label, float* value, float min_val, float 
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
-  float slider_w = avail_w - kInputWidth - kLabelColWidth - spacing * 2;
+  float slider_w = avail_w - kInputWidth - kLabelColWidth - spacing * 2;  // mirrors PrepareSliderLayout
   if (slider_w < 40.0f)
     slider_w = 40.0f;
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -123,7 +123,7 @@ static char g_ee_exit_buf[32];
 // ImGui InputText backing store for the raypath text input. The raypath
 // sub-buffer's raypath_text is synced FROM this char array (canonical source)
 // at every commit / dirty-compare site (mirrors the pre-task convention).
-static char g_raypath_buf[256];
+static char g_raypath_buf[4096];
 
 // Initial-present flag captured at modal open. Used by ApplyBuffersToEntry so
 // an untouched OK on a previously-empty filter does not silently materialize a
@@ -169,10 +169,10 @@ struct ValuePreset {
 };
 
 constexpr ValuePreset kWedgePresets[] = {
-  { "{1,0,-1,1} 28.0\xc2\xb0", 28.0f },
-  { "{2,0,-2,1} 47.3\xc2\xb0", 47.3f },
-  { "{1,0,-1,0} 90.0\xc2\xb0", 90.0f },
-  { "{1,0,-1,2} 14.7\xc2\xb0", 14.7f },
+  { "{1,0,-1,1} 28.000\xc2\xb0", 28.0f },
+  { "{2,0,-2,1} 47.300\xc2\xb0", 47.3f },
+  { "{1,0,-1,0} 90.000\xc2\xb0", 90.0f },
+  { "{1,0,-1,2} 14.700\xc2\xb0", 14.7f },
 };
 constexpr int kWedgePresetCount = 4;
 
@@ -202,7 +202,7 @@ bool SliderWithPresetEdit(const char* label, float* value, float min_val, float 
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
-  float slider_w = avail_w - kInputWidth - kArrowBtnWidth - kLabelColWidth - spacing * 3;
+  float slider_w = avail_w - kInputWidth - kLabelColWidth - spacing * 2;
   if (slider_w < 40.0f)
     slider_w = 40.0f;
 
@@ -520,9 +520,9 @@ static void RenderCrystalModal(GuiState& /*state*/) {
     SliderWithInput("Prism H##modal_cr", &cr.prism_h, 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear);
     SliderWithInput("Upper H##modal_cr", &cr.upper_h, 0.0f, 1.0f, "%.3f", SliderScale::kLinear);
     SliderWithInput("Lower H##modal_cr", &cr.lower_h, 0.0f, 1.0f, "%.3f", SliderScale::kLinear);
-    SliderWithPresetEdit("Upper A##modal_cr", &cr.upper_alpha, 0.1f, 90.0f, "%.1f", SliderScale::kLinear, kWedgePresets,
+    SliderWithPresetEdit("Upper A##modal_cr", &cr.upper_alpha, 0.1f, 90.0f, "%.3f", SliderScale::kLinear, kWedgePresets,
                          kWedgePresetCount);
-    SliderWithPresetEdit("Lower A##modal_cr", &cr.lower_alpha, 0.1f, 90.0f, "%.1f", SliderScale::kLinear, kWedgePresets,
+    SliderWithPresetEdit("Lower A##modal_cr", &cr.lower_alpha, 0.1f, 90.0f, "%.3f", SliderScale::kLinear, kWedgePresets,
                          kWedgePresetCount);
   }
 


### PR DESCRIPTION
## Summary

Three lightweight UX improvements to the editor modal, picked from internal-tester feedback (backlog items 2026-05-10 / 2026-05-16 / 2026-05-17).

- **Raypath filter input buffer**: expand `g_raypath_buf` from 256 to 4096 bytes (`src/gui/edit_modals.cpp:126`) so users can OR-combine dozens of long raypaths in one expression. EE filter buffers (`g_ee_entry_buf[32]` / `g_ee_exit_buf[32]`) were audited and confirmed sufficient — single face IDs are at most two digits.
- **Pyramid Upper/Lower slider width alignment**: fix `SliderWithPresetEdit`'s `slider_w` formula — the old expression redundantly subtracted `kArrowBtnWidth + spacing`, making angle rows ~20 px narrower than height rows. New formula mirrors `panels.cpp::PrepareSliderLayout`.
- **Pyramid Upper/Lower combo precision**: bump preset format string from `%.1f` to `%.3f` and sync `kWedgePresets` preset labels (e.g. `28.0°` → `28.000°`). Added a coupling comment so future changes can't silently desync label and fmt.

Scope is strictly GUI-only; no `core/` or C API changes.

Tracking: scratchpad task #207 (`task-gui-modal-polish-v1`).

## Test plan

- [x] `./scripts/format.sh` — clean
- [x] `./scripts/build.sh -j release` — builds without warnings
- [x] `LUMICE_SKIP_GUI_TESTS=1 ./scripts/build.sh -tj release` — unit tests 1/1 pass
- [x] `./scripts/build.sh -gtj release` — 232/233 pass; the single failure (`filters` auto_ev) reproduces independently as random-render noise, no code-path overlap with this diff
- [ ] Visual sanity check: open Pyramid edit modal locally and confirm Upper/Lower rows visually align with H rows + combo presets show three decimal places (no pixel-level reference test covers modal interior — see backlog "GUI 截图回归覆盖补齐" branch B)

## Follow-ups (in backlog)

- `panels.cpp::SliderWithPreset` is dead code that still carries the pre-fix (broken) `slider_w` formula. Logged for future decision (delete vs. fix vs. annotate) so a re-activation can't silently re-introduce the width-skew bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)