### PR TITLE
fix(c-api): guard sentinel write past max_count + slow regression test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,9 @@ Release artifacts land in `build/cmake_install/`. Debug builds stay in `build/cm
 - GUI tests require a display server unless explicitly skipped with `LUMICE_SKIP_GUI_TESTS=1`.
 - E2E test split:
   - Default `pytest test/e2e/ -v` runs the fast subset — matches CI behavior (CI uses `-m "not slow"`).
-  - `@pytest.mark.slow` tests (e.g. `test_additivity.py`) require the shared-lib build (`./scripts/build.sh -sj release`) and are excluded from CI to keep PR feedback fast. Run them locally with `pytest test/e2e/ -v -m slow` before opening a PR that touches the simulator core, query filter, or C API surface.
+  - `@pytest.mark.slow` tests require the shared-lib build (`./scripts/build.sh -sj release`) and are excluded from CI to keep PR feedback fast. Run them locally with `pytest test/e2e/ -v -m slow` before opening a PR that touches the simulator core, query filter, or C API surface.
+    - `test_additivity.py` — partition-additivity and unfiltered-intensity invariants
+    - `test_capi_sentinel_overflow.py` — sentinel-overflow regression: 3-config × 12 rounds = 36 server lifecycles via `LUMICE_GetRawXyzResults(max_count=1)`; guards against reintroduction of the c_api.cpp off-by-one sentinel write (fix: 5287efe)
 - GUI screenshot references live under `test/gui/references/`.
 - Windows physical-desktop validation uses `scripts/win_remote_test.sh` together with `scripts/win_test_watcher.ps1`.
 - Performance diagnostics and workflows are documented in `doc/performance-testing.md`.

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -253,17 +253,21 @@ LUMICE_ErrorCode LUMICE_ParseConfigFile(const char* filename, LUMICE_Config* out
 
 // =============== Results ===============
 // Unified pattern: (server, out, max_count) -> LUMICE_ErrorCode, sentinel-terminated.
-// out array size must be at least max_count + 1 (for sentinel slot).
+// Sentinel is written at out[count] only when count < max_count.
+// When the array is full (count == max_count), no sentinel slot is written;
+// callers relying on sentinel iteration must value-initialize the array
+// (e.g., Type arr[N + 1]{}) and pass max_count = N. Minimum array size:
+// max_count + 1 for sentinel iteration, max_count for direct index access.
 
-// Fill render results into out array, sentinel-terminated (img_buffer == NULL).
+// Fill render results into out array (img_buffer == NULL sentinel when count < max_count).
 // Returns sRGB uint8 image data (CPU-converted from XYZ).
 LUMICE_ErrorCode LUMICE_GetRenderResults(LUMICE_Server* server, LUMICE_RenderResult* out, int max_count);
 
-// Fill raw XYZ results into out array, sentinel-terminated (xyz_buffer == NULL).
+// Fill raw XYZ results into out array (xyz_buffer == NULL sentinel when count < max_count).
 // Returns unconverted XYZ float data + intensity scalars for GPU-side conversion.
 LUMICE_ErrorCode LUMICE_GetRawXyzResults(LUMICE_Server* server, LUMICE_RawXyzResult* out, int max_count);
 
-// Fill stats results into out array, sentinel-terminated (sim_ray_num == 0).
+// Fill stats results into out array (sim_ray_num == 0 sentinel when count < max_count).
 // Note: triggers DoSnapshot internally (includes PostSnapshot XYZ→RGB conversion).
 LUMICE_ErrorCode LUMICE_GetStatsResults(LUMICE_Server* server, LUMICE_StatsResult* out, int max_count);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ std::filesystem::path FormatImagePath(const std::filesystem::path& output_dir, i
 
 void SaveRenderResults(LUMICE_Server* server, const std::filesystem::path& output_dir, std::string_view image_format,
                        int jpeg_quality) {
-  LUMICE_RenderResult renders[LUMICE_MAX_RENDER_RESULTS + 1];
+  LUMICE_RenderResult renders[LUMICE_MAX_RENDER_RESULTS + 1]{};
   if (LUMICE_GetRenderResults(server, renders, LUMICE_MAX_RENDER_RESULTS) != LUMICE_OK) {
     return;
   }
@@ -90,7 +90,7 @@ void SaveRenderResults(LUMICE_Server* server, const std::filesystem::path& outpu
 }
 
 void PrintStats(LUMICE_Server* server) {
-  LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1];
+  LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1]{};
   if (LUMICE_GetStatsResults(server, stats, LUMICE_MAX_STATS_RESULTS) != LUMICE_OK) {
     return;
   }
@@ -116,7 +116,7 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
   while (true) {
     std::this_thread::sleep_for(kBenchmarkPollInterval);
     LUMICE_ServerState state{};
-    LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1];
+    LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1]{};
     if (LUMICE_QueryServerState(server, &state) == LUMICE_OK && state == LUMICE_SERVER_IDLE) {
       if (LUMICE_GetStatsResults(server, stats, LUMICE_MAX_STATS_RESULTS) == LUMICE_OK && stats[0].sim_ray_num > 0) {
         auto t_end = std::chrono::steady_clock::now();
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
     PrintStats(server);
 
     LUMICE_ServerState state{};
-    LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1];
+    LUMICE_StatsResult stats[LUMICE_MAX_STATS_RESULTS + 1]{};
     if (LUMICE_QueryServerState(server, &state) == LUMICE_OK && state == LUMICE_SERVER_IDLE) {
       if (LUMICE_GetStatsResults(server, stats, LUMICE_MAX_STATS_RESULTS) == LUMICE_OK && stats[0].sim_ray_num > 0) {
         break;

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -721,8 +721,10 @@ LUMICE_ErrorCode LUMICE_GetRenderResults(LUMICE_Server* server, LUMICE_RenderRes
     out[i].img_buffer = render_results[i].img_buffer_;
   }
 
-  // Sentinel
-  std::memset(&out[count], 0, sizeof(LUMICE_RenderResult));
+  // Sentinel — only when caller provided an extra slot (count < max_count)
+  if (count < max_count) {
+    std::memset(&out[count], 0, sizeof(LUMICE_RenderResult));
+  }
 
   return LUMICE_OK;
 }
@@ -753,8 +755,10 @@ LUMICE_ErrorCode LUMICE_GetRawXyzResults(LUMICE_Server* server, LUMICE_RawXyzRes
     out[i].unfiltered_snapshot_intensity = results[i].unfiltered_snapshot_intensity_;
   }
 
-  // Sentinel
-  std::memset(&out[count], 0, sizeof(LUMICE_RawXyzResult));
+  // Sentinel — only when caller provided an extra slot (count < max_count)
+  if (count < max_count) {
+    std::memset(&out[count], 0, sizeof(LUMICE_RawXyzResult));
+  }
 
   return LUMICE_OK;
 }
@@ -776,8 +780,10 @@ LUMICE_ErrorCode LUMICE_GetStatsResults(LUMICE_Server* server, LUMICE_StatsResul
     }
   }
 
-  // Sentinel
-  std::memset(&out[count], 0, sizeof(LUMICE_StatsResult));
+  // Sentinel — only when caller provided an extra slot (count < max_count)
+  if (count < max_count) {
+    std::memset(&out[count], 0, sizeof(LUMICE_StatsResult));
+  }
 
   return LUMICE_OK;
 }

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -223,11 +223,10 @@ def run_scene_capi(config_path: str, timeout_sec: int = 180) -> SimResult:
 def run_scene_capi_buffered(config_path: str, timeout_sec: int = 180) -> BufferedSimResult:
     """Run a Lumice sim via the C API and copy out both XYZ buffers.
 
-    Polling exits only after `has_valid_data AND IDLE AND xyz_buffer != NULL
-    AND unfiltered_xyz_buffer != NULL` is observed on two consecutive samples,
-    mirroring the pattern validated in
-    scratchpad/explore-partition-buffer-additivity-root-cause/probe_e1_baseline.py
-    (single-sample exit hit a buffer-NULL race in ~5% of runs).
+    Polling exits only after `has_valid_data AND IDLE` is observed on two
+    consecutive samples. The two-sample check defends against the narrow window
+    where the server reports IDLE before the latest snapshot is fully visible
+    to the caller; it is independent of the c_api.cpp sentinel-overflow fix.
 
     Buffer contents are copied into owned numpy arrays before destroying the
     server; the returned object holds no references to server memory.
@@ -267,10 +266,7 @@ def run_scene_capi_buffered(config_path: str, timeout_sec: int = 180) -> Buffere
             if state == _LUMICE_SERVER_NOT_READY:
                 raise RuntimeError("Server NOT_READY")
 
-            xyz_addr = ctypes.cast(results[0].xyz_buffer, ctypes.c_void_p).value
-            unf_addr = ctypes.cast(results[0].unfiltered_xyz_buffer, ctypes.c_void_p).value
-            if (results[0].has_valid_data and state == _LUMICE_SERVER_IDLE
-                    and xyz_addr is not None and unf_addr is not None):
+            if results[0].has_valid_data and state == _LUMICE_SERVER_IDLE:
                 consecutive_ok += 1
                 if consecutive_ok >= 2:
                     break

--- a/test/e2e/test_capi_sentinel_overflow.py
+++ b/test/e2e/test_capi_sentinel_overflow.py
@@ -1,0 +1,62 @@
+"""Regression guard: sentinel-overflow in LUMICE_GetRawXyzResults.
+
+Fix commit: 5287efe (fix(capi-sentinel-overflow): guard sentinel write past max_count)
+
+Root cause: c_api.cpp wrote a sentinel at out[count] when count == max_count,
+overflowing the caller's buffer by one LUMICE_RawXyzResult (72 bytes). With
+3 distinct configs in rotation, the heap layout evolved such that the overflow
+hit a live allocation at approximately lifecycle 31, causing SIGSEGV.
+
+Trigger conditions:
+- max_count == 1 (caller passes a size-1 array, the common case via capi_runner)
+- ≥ 3 distinct configs alternated across lifecycles (single-config loops survived
+  because the heap layout remained stable across repeated same-config lifecycles)
+
+This test runs 3 configs × _REGRESSION_ROUNDS lifecycles (> 31 crash threshold)
+via the same C API path used by the bug. If the sentinel guard were removed,
+the process would SIGSEGV before the assertion on lifecycle ~31 completes.
+
+Requires shared-lib build: ./scripts/build.sh -sj release
+Run: pytest test/e2e/ -v -m slow
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from test.e2e.capi_runner import run_scene_capi
+
+_CONFIGS_DIR = Path(__file__).parent / "configs"
+
+_LIFECYCLE_CONFIGS = [
+    str(_CONFIGS_DIR / "rp46_additivity_in.json"),
+    str(_CONFIGS_DIR / "rp46_additivity_out.json"),
+    str(_CONFIGS_DIR / "rp46_additivity_nof.json"),
+]
+
+# 12 rounds × 3 configs = 36 lifecycles > 31 crash threshold
+_REGRESSION_ROUNDS = 12
+
+
+@pytest.mark.slow
+def test_capi_sentinel_overflow_regression():
+    """3-config rotation across 36 server lifecycles must not crash or produce invalid data.
+
+    Each lifecycle calls CreateServer / CommitConfigFromFile / poll-until-IDLE /
+    DestroyServer with a size-1 LUMICE_RawXyzResult array (max_count=1). Before
+    fix 5287efe the sentinel write at out[max_count] overflowed this array;
+    this test would have crashed around lifecycle 31 on all platforms.
+    """
+    n_configs = len(_LIFECYCLE_CONFIGS)
+    total = _REGRESSION_ROUNDS * n_configs
+    completed = 0
+    for _ in range(_REGRESSION_ROUNDS):
+        for cfg in _LIFECYCLE_CONFIGS:
+            result = run_scene_capi(cfg)
+            completed += 1
+            assert result.has_valid_data, (
+                f"lifecycle {completed}/{total}: no valid data ({cfg})"
+            )
+    assert completed == total


### PR DESCRIPTION
## Summary

- **Root cause**: three `LUMICE_Get*Results` functions in `src/server/c_api.cpp` (`Render`, `RawXyz`, `Stats`) wrote a sentinel at `out[count]` even when `count == max_count`, producing a one-`LUMICE_*Result`-element past-the-end OOB store. ASan caught it as `stack-buffer-overflow`; in production it manifested as a SIGSEGV after roughly 31 server lifecycles when three distinct configs alternated (heap layout evolved enough for the overflow to hit a live allocation).
- **Fix**: gate the sentinel write on `count < max_count` in `c_api.cpp`. Value-initialize the result arrays at the call sites in `src/main.cpp` so sentinel-iteration still terminates when the array is full. Update `src/include/lumice.h` to document the new contract. Drop the now-redundant `NULL`-buffer polling guards in `test/e2e/capi_runner.py` that were workarounds for the downstream symptom.
- **Regression test**: new slow e2e test `test/e2e/test_capi_sentinel_overflow.py` runs 3 configs × 12 rounds (36 lifecycles, well past the ~31 crash threshold) via `LUMICE_GetRawXyzResults(max_count=1)` — the exact path that originally crashed. Requires the shared-lib build (`./scripts/build.sh -sj release`); excluded from default CI to keep PR feedback fast. `AGENTS.md` updated to list both slow tests.

Trace: see `scratchpad/scrum-capi-server-lifecycle-stability/SUMMARY.md` (explore + fix + regression-test scrum).

## Test plan

- [x] `./scripts/build.sh -tj release` — unit tests pass on fixed build
- [x] `pytest test/e2e/ -v` — 25/25 fast e2e pass
- [x] `./scripts/build.sh -sj release && pytest test/e2e/ -v -m slow` — `test_additivity.py` + new `test_capi_sentinel_overflow.py` both pass (36 lifecycles complete cleanly)
- [x] ASan probe: 30 rounds × 3 lifecycles = 90 lifecycles clean, no ASan reports
- [x] Pre-fix regression: same slow test SIGSEGV at ~lifecycle 31 on `main` (confirms the test catches the bug it guards against)