### PR TITLE
feat(gui): zenith/nadir ring marker overlay

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -832,6 +832,22 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
       pp.overlay.sun_circle_angles[i] = g_state.sun_circle_angles[i];
     }
 
+    // Zenith / Nadir pixel-space marker. zenith world dir = (0,0,-1), nadir = (0,0,+1)
+    // (see preview_renderer.cpp:overlayAuxLines altitude convention).
+    pp.overlay.show_zenith_nadir = g_state.show_zenith_nadir_line;
+    std::copy(std::begin(g_state.zenith_nadir_color), std::end(g_state.zenith_nadir_color),
+              std::begin(pp.overlay.zenith_nadir_color));
+    pp.overlay.zenith_nadir_alpha = g_state.zenith_nadir_alpha;
+    pp.overlay.zenith_nadir_radius_px = g_state.zenith_nadir_radius_px;
+    constexpr float kZenithWorldDir[3] = { 0.f, 0.f, -1.f };
+    constexpr float kNadirWorldDir[3] = { 0.f, 0.f, 1.f };
+    auto zpos = ProjectWorldDirToScreen(pp.view_proj, kZenithWorldDir, g_preview_vp.vp_w, g_preview_vp.vp_h);
+    auto npos = ProjectWorldDirToScreen(pp.view_proj, kNadirWorldDir, g_preview_vp.vp_w, g_preview_vp.vp_h);
+    pp.overlay.zenith_screen_pos[0] = zpos[0];
+    pp.overlay.zenith_screen_pos[1] = zpos[1];
+    pp.overlay.nadir_screen_pos[0] = npos[0];
+    pp.overlay.nadir_screen_pos[1] = npos[1];
+
     // Overlay labels at viewport edges (drawn on the preview window's draw list so
     // modals correctly occlude them). BuildOverlayLabelInput is shared with
     // DoExportPreviewPng (off-screen FBO path) so both call sites produce

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -665,6 +665,16 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
                 &g_state.show_sun_circles_line, "Label##sun_circles", &g_state.show_sun_circles_label);
     SliderWithInput("Alpha##sun_circles", &g_state.sun_circles_alpha, 0.0f, 1.0f, "%.2f");
 
+    // Zenith / Nadir pixel-space marker. Single line toggle (no label column —
+    // markers don't carry text); radius slider mirrors the per-overlay alpha row.
+    ImGui::ColorEdit3("##zenith_nadir_color", g_state.zenith_nadir_color, ImGuiColorEditFlags_NoInputs);
+    ImGui::SameLine();
+    ImGui::TextUnformatted("Zenith/Nadir");
+    ImGui::SameLine(line_col_x);
+    ImGui::Checkbox("##zenith_nadir_line", &g_state.show_zenith_nadir_line);
+    SliderWithInput("Alpha##zenith_nadir", &g_state.zenith_nadir_alpha, 0.0f, 1.0f, "%.2f");
+    SliderWithInput("Radius##zenith_nadir", &g_state.zenith_nadir_radius_px, 2.0f, 20.0f, "%.1f px");
+
     if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {
       if (ImGui::Button("Edit Angles...##overlay")) {
         ImGui::OpenPopup("SunCirclesEdit");

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1126,6 +1126,11 @@ std::string SerializeGuiStateJson(const GuiState& state) {
   root["overlay_horizon_alpha"] = state.horizon_alpha;
   root["overlay_grid_alpha"] = state.grid_alpha;
   root["overlay_sun_circles_alpha"] = state.sun_circles_alpha;
+  root["overlay_zenith_nadir_line"] = state.show_zenith_nadir_line;
+  root["overlay_zenith_nadir_color"] = { state.zenith_nadir_color[0], state.zenith_nadir_color[1],
+                                         state.zenith_nadir_color[2] };
+  root["overlay_zenith_nadir_alpha"] = state.zenith_nadir_alpha;
+  root["overlay_zenith_nadir_radius_px"] = state.zenith_nadir_radius_px;
 
   // Panel state
   root["right_panel_collapsed"] = state.right_panel_collapsed;
@@ -1320,6 +1325,10 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   state.horizon_alpha = root.value("overlay_horizon_alpha", 0.6f);
   state.grid_alpha = root.value("overlay_grid_alpha", 0.3f);
   state.sun_circles_alpha = root.value("overlay_sun_circles_alpha", 0.5f);
+  state.show_zenith_nadir_line = root.value("overlay_zenith_nadir_line", false);
+  read_color3("overlay_zenith_nadir_color", state.zenith_nadir_color);
+  state.zenith_nadir_alpha = root.value("overlay_zenith_nadir_alpha", 0.6f);
+  state.zenith_nadir_radius_px = root.value("overlay_zenith_nadir_radius_px", 8.0f);
 
   // Panel state
   state.right_panel_collapsed = root.value("right_panel_collapsed", false);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -437,6 +437,14 @@ struct GuiState {
   float grid_alpha = 0.3f;
   float sun_circles_alpha = 0.5f;
 
+  // Zenith / Nadir pixel-space ring marker (see task-gui-zenith-nadir-marker).
+  // Single toggle controls both zenith and nadir; radius is in pixels and stays
+  // visually constant across lens / FOV / zoom changes.
+  bool show_zenith_nadir_line = false;
+  float zenith_nadir_color[3] = { 0.8f, 0.2f, 0.2f };
+  float zenith_nadir_alpha = 0.6f;
+  float zenith_nadir_radius_px = 8.0f;
+
   // File management
   std::filesystem::path current_file_path;
   bool dirty = false;

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -257,7 +257,8 @@ vec4 dualFisheyeInverse(vec2 pos, int type) {
 
   return vec4(d, 1.0);
 }
-
+)glsl"
+R"glsl(
 // Rectangular (equirectangular): always full-sky, returns world-space direction.
 // Matches Core: scale = min(width/2, height) / PI
 vec4 rectangularInverse(vec2 pos) {

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -1,5 +1,8 @@
 #include "gui/preview_renderer.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 
@@ -674,6 +677,201 @@ void BuildViewMatrix(float elevation_deg, float azimuth_deg, float roll_deg, flo
   out[6] = ce * ca;
   out[7] = ce * sa;
   out[8] = se;
+}
+
+// Sentinel value indicating the world direction does not project to a renderable
+// screen position under the current lens / camera setup. Kept identical to the
+// magic shader value so the GPU distance test trivially rejects it.
+static constexpr std::array<float, 2> kProjectSentinel = { -9999.f, -9999.f };
+
+static bool IsInViewport(float px, float py, float vp_w, float vp_h) {
+  // Half-pixel margin keeps points landing exactly on the viewport edge
+  // (e.g. fisheye r = img_radius for the equator) inside the visible region
+  // — the shader naturally clips anything truly outside.
+  constexpr float kEdgeMargin = 0.5f;
+  return std::abs(px) <= vp_w * 0.5f + kEdgeMargin && std::abs(py) <= vp_h * 0.5f + kEdgeMargin;
+}
+
+// Apply transpose(view_matrix) * world_dir. Column-major view-to-world.
+static void WorldToView(const ViewProjection& vp, const float world_dir[3], float out_view[3]) {
+  float vm[9];
+  BuildViewMatrix(vp.elevation, vp.azimuth, vp.roll, vm);
+  for (int c = 0; c < 3; ++c) {
+    out_view[c] = vm[c * 3 + 0] * world_dir[0] + vm[c * 3 + 1] * world_dir[1] + vm[c * 3 + 2] * world_dir[2];
+  }
+}
+
+// Small epsilon absorbs single-precision noise from BuildViewMatrix (e.g.
+// cos(π/2) ≈ -4.37e-8 leaks into view_dir.z when the camera is tilted to
+// elevation 90°), so directions right on the horizon still classify as
+// "in front" instead of being rejected by the behind-camera guard.
+constexpr float kBehindCameraEps = 1e-5f;
+
+// Linear pinhole: behind-camera ⇒ sentinel; otherwise standard perspective divide.
+static std::array<float, 2> ProjectLinear(const float view_dir[3], float half_fov, float img_radius) {
+  if (view_dir[2] >= -kBehindCameraEps) {
+    return kProjectSentinel;
+  }
+  float focal = img_radius / std::tan(half_fov);
+  float px = focal * view_dir[0] / (-view_dir[2]);
+  float py = focal * view_dir[1] / (-view_dir[2]);
+  return { px, py };
+}
+
+// Forward equation for the single-hemisphere fisheye family (lens=1..3, 8).
+// fisheye_type matches the shader's `fisheyeInverse(... int type)` switch:
+// 0=equal_area, 1=equidistant, 2=stereographic, 3=orthographic.
+static std::array<float, 2> ProjectFisheye(const float view_dir[3], float half_fov, float img_radius,
+                                           int fisheye_type) {
+  if (view_dir[2] > kBehindCameraEps) {
+    return kProjectSentinel;
+  }
+  float theta = std::acos(std::clamp(-view_dir[2], -1.0f, 1.0f));
+  float r_norm = 0.0f;
+  if (fisheye_type == 0) {
+    float denom = std::sin(half_fov * 0.5f);
+    if (denom <= 0.0f) {
+      return kProjectSentinel;
+    }
+    r_norm = std::sin(theta * 0.5f) / denom;
+  } else if (fisheye_type == 1) {
+    if (half_fov <= 0.0f) {
+      return kProjectSentinel;
+    }
+    r_norm = theta / half_fov;
+  } else if (fisheye_type == 2) {
+    float denom = std::tan(half_fov * 0.5f);
+    if (denom <= 0.0f) {
+      return kProjectSentinel;
+    }
+    r_norm = std::tan(theta * 0.5f) / denom;
+  } else {  // orthographic
+    float denom = std::sin(half_fov);
+    if (denom <= 0.0f) {
+      return kProjectSentinel;
+    }
+    r_norm = std::sin(theta) / denom;
+  }
+  float r = r_norm * img_radius;
+  float phi = std::atan2(view_dir[1], view_dir[0]);
+  return { r * std::cos(phi), r * std::sin(phi) };
+}
+
+// Compute r_norm for a dual-fisheye projection (theta in [0, pi/2]).
+// fisheye_type semantics match ProjectFisheye but the field of view is fixed
+// at half_pi per hemisphere (matches shader dualFisheyeInverse()).
+static float DualFisheyeRNorm(float theta, int fisheye_type) {
+  constexpr float kHalfPi = 1.57079632679489661923f;
+  if (fisheye_type == 0) {
+    return std::sin(theta * 0.5f) / std::sin(kHalfPi * 0.5f);
+  }
+  if (fisheye_type == 1) {
+    return theta / kHalfPi;
+  }
+  if (fisheye_type == 2) {
+    return std::tan(theta * 0.5f) / std::tan(kHalfPi * 0.5f);
+  }
+  // orthographic: r_norm = sin(theta)
+  return std::sin(theta);
+}
+
+// Forward for dual-fisheye family (lens=4..6, 9). world_dir.z<0 ⇒ left (upper)
+// circle, world_dir.z>0 ⇒ right (lower) circle. The phi solve mirrors the
+// hemisphere case split in shader dualFisheyeInverse().
+static std::array<float, 2> ProjectDualFisheye(const float world_dir[3], float short_res_dual, int fisheye_type) {
+  float circle_radius = short_res_dual * 0.5f;
+  bool is_upper = world_dir[2] < 0.0f;
+  float cx = is_upper ? -circle_radius : circle_radius;
+  float z_abs = std::abs(world_dir[2]);
+  float theta = std::acos(std::clamp(z_abs, -1.0f, 1.0f));
+  float r = DualFisheyeRNorm(theta, fisheye_type) * circle_radius;
+  // theta=0 (zenith / nadir) ⇒ sin(theta)=0, phi is irrelevant and the marker
+  // lands exactly at the circle center — the common case for this helper's caller.
+  float phi = 0.0f;
+  float sin_theta = std::sin(theta);
+  if (sin_theta > 1e-6f) {
+    // Shader: upper d = (-st*sin(phi),  st*cos(phi), -ct)
+    //         lower d = (-st*sin(phi), -st*cos(phi), +ct)
+    float sx = -world_dir[0] / sin_theta;                              // = sin(phi)
+    float cy = (is_upper ? world_dir[1] : -world_dir[1]) / sin_theta;  // = cos(phi)
+    phi = std::atan2(sx, cy);
+  }
+  return { cx + r * std::cos(phi), r * std::sin(phi) };
+}
+
+// Equirectangular forward: inverse of shader rectangularInverse().
+// At the poles (|lat|=π/2) world_dir.xy ≈ 0 and atan2 is singular — anchor
+// lon=0 so zenith/nadir project to the column directly in front of the
+// camera (mid-column of the viewport), not to the φ=±π edge.
+static std::array<float, 2> ProjectRectangular(const float world_dir[3], float short_res_dual) {
+  constexpr float kPi = 3.14159265358979323846f;
+  constexpr float kPoleEps = 1e-6f;
+  float scale = short_res_dual / kPi;
+  float lat = std::asin(std::clamp(-world_dir[2], -1.0f, 1.0f));
+  float xy_norm_sq = world_dir[0] * world_dir[0] + world_dir[1] * world_dir[1];
+  float lon = (xy_norm_sq < kPoleEps) ? 0.0f : std::atan2(-world_dir[1], -world_dir[0]);
+  return { lon * scale, -lat * scale };
+}
+
+// See declaration in preview_renderer.hpp for contract.
+std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const float world_dir[3], int vp_w, int vp_h) {
+  constexpr float kPi = 3.14159265358979323846f;
+  if (vp_w <= 0 || vp_h <= 0) {
+    return kProjectSentinel;
+  }
+
+  float half_fov = vp.fov * 0.5f * kPi / 180.0f;
+  auto vp_w_f = static_cast<float>(vp_w);
+  auto vp_h_f = static_cast<float>(vp_h);
+  float img_radius = std::min(vp_w_f, vp_h_f) * 0.5f;
+  float short_res_dual = std::min(vp_w_f * 0.5f, vp_h_f);
+
+  int lt = vp.lens_type;
+  bool needs_view_transform = (lt == kLensTypeLinear) ||
+                              (lt >= kLensTypeFisheyeEqualArea && lt <= kLensTypeFisheyeStereographic) ||
+                              (lt == kLensTypeFisheyeOrthographic);
+
+  float local_dir[3];
+  if (needs_view_transform) {
+    WorldToView(vp, world_dir, local_dir);
+  } else {
+    local_dir[0] = world_dir[0];
+    local_dir[1] = world_dir[1];
+    local_dir[2] = world_dir[2];
+  }
+
+  std::array<float, 2> out = kProjectSentinel;
+  if (lt == kLensTypeLinear) {
+    out = ProjectLinear(local_dir, half_fov, img_radius);
+  } else if (lt == kLensTypeFisheyeEqualArea) {
+    out = ProjectFisheye(local_dir, half_fov, img_radius, 0);
+  } else if (lt == kLensTypeFisheyeEquidist) {
+    out = ProjectFisheye(local_dir, half_fov, img_radius, 1);
+  } else if (lt == kLensTypeFisheyeStereographic) {
+    out = ProjectFisheye(local_dir, half_fov, img_radius, 2);
+  } else if (lt == kLensTypeFisheyeOrthographic) {
+    out = ProjectFisheye(local_dir, half_fov, img_radius, 3);
+  } else if (lt == kLensTypeDualFisheyeEqualArea) {
+    out = ProjectDualFisheye(local_dir, short_res_dual, 0);
+  } else if (lt == kLensTypeDualFisheyeEquidist) {
+    out = ProjectDualFisheye(local_dir, short_res_dual, 1);
+  } else if (lt == kLensTypeDualFisheyeStereographic) {
+    out = ProjectDualFisheye(local_dir, short_res_dual, 2);
+  } else if (lt == kLensTypeDualFisheyeOrthographic) {
+    out = ProjectDualFisheye(local_dir, short_res_dual, 3);
+  } else if (lt == kLensTypeRectangular) {
+    out = ProjectRectangular(local_dir, short_res_dual);
+  } else if (lt == kLensTypeGlobe) {
+    return kProjectSentinel;  // out of scope for this task
+  } else {
+    assert(false && "ProjectWorldDirToScreen: unhandled lens type");
+    return kProjectSentinel;
+  }
+
+  if (out == kProjectSentinel || !IsInViewport(out[0], out[1], vp_w_f, vp_h_f)) {
+    return kProjectSentinel;
+  }
+  return out;
 }
 
 void PreviewRenderer::Render(int vp_x, int vp_y, int vp_w, int vp_h, const PreviewParams& params) {

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -57,6 +57,17 @@ uniform float u_horizon_alpha;
 uniform float u_grid_alpha;
 uniform float u_sun_circles_alpha;
 
+// Zenith / Nadir pixel-space ring marker uniforms (task-gui-zenith-nadir-marker).
+// Screen positions are center-origin, y-up, in pixels — same convention as
+// `pos = v_ndc * u_resolution * 0.5` (see main()). Sentinel (-9999, -9999)
+// trivially fails the distance test so the ring is skipped.
+uniform int u_show_zenith_nadir;
+uniform vec2 u_zenith_screen_pos;
+uniform vec2 u_nadir_screen_pos;
+uniform float u_zenith_nadir_radius_px;
+uniform vec3 u_zenith_nadir_color;
+uniform float u_zenith_nadir_alpha;
+
 const float PI = 3.14159265358979323846;
 
 // Algorithm synced with CPU: src/util/color_space.hpp (GamutClipXyz + XyzToLinearRgb + LinearToSrgb)
@@ -293,7 +304,9 @@ vec4 globeInverse(vec2 pos, float half_fov) {
 
 // Overlay auxiliary lines on top of final_color.
 // world_dir must be a valid world-space direction.
-vec3 overlayAuxLines(vec3 world_dir, vec3 color) {
+// pos_pix: pixel-space position of the current fragment, center-origin (0,0),
+// y-up. Matches the CPU helper ProjectWorldDirToScreen for marker overlays.
+vec3 overlayAuxLines(vec3 world_dir, vec3 color, vec2 pos_pix) {
   float DEG = 180.0 / PI;
   float altitude_deg = asin(clamp(-world_dir.z, -1.0, 1.0)) * DEG;
   float azimuth_deg = atan(-world_dir.y, -world_dir.x) * DEG;  // [-180, 180]
@@ -335,6 +348,21 @@ vec3 overlayAuxLines(vec3 world_dir, vec3 color) {
     float d = abs(altitude_deg);
     float t = 1.0 - smoothstep(0.0, fw_alt * 1.5, d);
     color = mix(color, u_horizon_color, t * u_horizon_alpha);
+  }
+
+  // Zenith / Nadir pixel-space ring markers — drawn last so they sit on top
+  // of all other overlays. CPU passes sentinel (-9999, -9999) when the marker
+  // is offscreen / behind the camera; the distance test rejects it naturally.
+  if (u_show_zenith_nadir != 0) {
+    const float kRingHalfWidthPx = 1.5;
+    float dz = length(pos_pix - u_zenith_screen_pos);
+    float tz = 1.0 - smoothstep(0.0, kRingHalfWidthPx,
+                                abs(dz - u_zenith_nadir_radius_px));
+    color = mix(color, u_zenith_nadir_color, tz * u_zenith_nadir_alpha);
+    float dn = length(pos_pix - u_nadir_screen_pos);
+    float tn = 1.0 - smoothstep(0.0, kRingHalfWidthPx,
+                                abs(dn - u_zenith_nadir_radius_px));
+    color = mix(color, u_zenith_nadir_color, tn * u_zenith_nadir_alpha);
   }
 
   return color;
@@ -409,7 +437,7 @@ void main() {
 
   // Auxiliary line overlay (on top of everything, only in visible region)
   if (result.w >= 0.5 && pixel_visible) {
-    final_color = overlayAuxLines(world_dir, final_color);
+    final_color = overlayAuxLines(world_dir, final_color, pos);
   }
 
   frag_color = vec4(final_color, 1.0);
@@ -960,6 +988,16 @@ void PreviewRenderer::Render(int vp_x, int vp_y, int vp_w, int vp_h, const Previ
   glUniform1f(glGetUniformLocation(shader_program_, "u_horizon_alpha"), ov.horizon_alpha);
   glUniform1f(glGetUniformLocation(shader_program_, "u_grid_alpha"), ov.grid_alpha);
   glUniform1f(glGetUniformLocation(shader_program_, "u_sun_circles_alpha"), ov.sun_circles_alpha);
+
+  glUniform1i(glGetUniformLocation(shader_program_, "u_show_zenith_nadir"), ov.show_zenith_nadir ? 1 : 0);
+  glUniform2f(glGetUniformLocation(shader_program_, "u_zenith_screen_pos"), ov.zenith_screen_pos[0],
+              ov.zenith_screen_pos[1]);
+  glUniform2f(glGetUniformLocation(shader_program_, "u_nadir_screen_pos"), ov.nadir_screen_pos[0],
+              ov.nadir_screen_pos[1]);
+  glUniform1f(glGetUniformLocation(shader_program_, "u_zenith_nadir_radius_px"), ov.zenith_nadir_radius_px);
+  glUniform3f(glGetUniformLocation(shader_program_, "u_zenith_nadir_color"), ov.zenith_nadir_color[0],
+              ov.zenith_nadir_color[1], ov.zenith_nadir_color[2]);
+  glUniform1f(glGetUniformLocation(shader_program_, "u_zenith_nadir_alpha"), ov.zenith_nadir_alpha);
 
   // Draw fullscreen quad
   glBindVertexArray(vao_);

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -1,6 +1,7 @@
 #ifndef LUMICE_GUI_PREVIEW_RENDERER_HPP
 #define LUMICE_GUI_PREVIEW_RENDERER_HPP
 
+#include <array>
 #include <vector>
 
 #include "gui/gui_constants.hpp"
@@ -64,6 +65,18 @@ struct OverlayDecoration {
   float horizon_alpha = 0.6f;
   float grid_alpha = 0.3f;
   float sun_circles_alpha = 0.5f;
+
+  // Zenith / Nadir pixel-space ring marker.
+  // *_screen_pos: CPU-precomputed; center-origin pixel coords, y-up
+  // (matches shader's `pos = v_ndc * u_resolution * 0.5`). Sentinel
+  // (-9999, -9999) when the direction is offscreen / behind the camera
+  // / unsupported lens — shader compares distance and naturally skips it.
+  bool show_zenith_nadir = false;
+  float zenith_screen_pos[2] = { -9999.f, -9999.f };
+  float nadir_screen_pos[2] = { -9999.f, -9999.f };
+  float zenith_nadir_color[3] = { 0.8f, 0.2f, 0.2f };
+  float zenith_nadir_alpha = 0.6f;
+  float zenith_nadir_radius_px = 8.0f;
 
   static OverlayDecoration Disabled() { return {}; }
 };
@@ -137,6 +150,15 @@ class PreviewRenderer {
 // OpenGL column-major layout: out[col*3 + row].
 // Synced with shader u_view_matrix usage (preview_renderer.cpp).
 void BuildViewMatrix(float elevation_deg, float azimuth_deg, float roll_deg, float out[9]);
+
+// Project a unit world-space direction to screen pixel coordinates matching the
+// fragment shader's coordinate system: origin at viewport center, x right, y up,
+// units = pixels (i.e. `pos = v_ndc * resolution * 0.5`). Returns sentinel
+// {-9999.f, -9999.f} if the direction is behind the camera, outside the viewport,
+// or the lens is unsupported (e.g. kLensTypeGlobe). Synced with the shader's
+// inverse projection helpers (linearInverse / fisheyeInverse / dualFisheyeInverse
+// / rectangularInverse) in preview_renderer.cpp.
+std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const float world_dir[3], int vp_w, int vp_h);
 
 // Build a ViewProjection from the renderer sub-state of GuiState.
 // roll is wrapped through EffectiveRollForLens so that lens types that ignore

--- a/test/gui/CMakeLists.txt
+++ b/test/gui/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(LumiceGUITests
     test_gui_face_number_overlay.cpp
     test_gui_crystal_renderer.cpp
     test_gui_auto_ev.cpp
+    test_project_world_dir.cpp
     test_screenshot.cpp
     ${IMGUI_TE_DIR}/imgui_te_engine.cpp
     ${IMGUI_TE_DIR}/imgui_te_context.cpp

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -473,6 +473,49 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // task-gui-zenith-nadir-marker: zenith/nadir overlay round-trip — 4 new fields
+  // (line toggle, color[3], alpha, radius_px) preserved through Serialize → Deserialize.
+  // Missing-key fallback covered separately by overlay_legacy_key_fallback.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "zenith_nadir_roundtrip");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      gui::g_state.show_zenith_nadir_line = true;
+      gui::g_state.zenith_nadir_color[0] = 0.1f;
+      gui::g_state.zenith_nadir_color[1] = 0.5f;
+      gui::g_state.zenith_nadir_color[2] = 0.9f;
+      gui::g_state.zenith_nadir_alpha = 0.42f;
+      gui::g_state.zenith_nadir_radius_px = 12.5f;
+
+      std::string json = gui::SerializeGuiStateJson(gui::g_state);
+      IM_CHECK(!json.empty());
+
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeGuiStateJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.show_zenith_nadir_line, true);
+      IM_CHECK_EQ(loaded.zenith_nadir_color[0], 0.1f);
+      IM_CHECK_EQ(loaded.zenith_nadir_color[1], 0.5f);
+      IM_CHECK_EQ(loaded.zenith_nadir_color[2], 0.9f);
+      IM_CHECK_EQ(loaded.zenith_nadir_alpha, 0.42f);
+      IM_CHECK_EQ(loaded.zenith_nadir_radius_px, 12.5f);
+
+      // Legacy file (without these keys) must fall back to defaults — verifies
+      // no exception and no spurious enabled state for users on older .lmc files.
+      std::string legacy_json = R"({
+        "layers": [],
+        "renderer": {"lens_type": "linear", "fov": 90.0}
+      })";
+      gui::GuiState legacy_loaded;
+      IM_CHECK(gui::DeserializeGuiStateJson(legacy_json, legacy_loaded));
+      IM_CHECK_EQ(legacy_loaded.show_zenith_nadir_line, false);
+      IM_CHECK_EQ(legacy_loaded.zenith_nadir_alpha, 0.6f);
+      IM_CHECK_EQ(legacy_loaded.zenith_nadir_radius_px, 8.0f);
+    };
+  }
+
   // task-data-model-and-serialization: AC #7 — multi-raypath OR end-to-end.
   // GUI raypath_text "3-5; 1-3" → SerializeCoreConfig → ConfigManager parses
   // out 3 filters: 2 simple raypaths (ids 1, 2) + 1 complex (id 3) referencing

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -307,6 +307,7 @@ int main(int argc, char** argv) {
   RegisterCrystalRendererTests(engine);
   RegisterAutoEvRegressionTests(engine);
   RegisterLinkedEntriesTests(engine);
+  RegisterProjectWorldDirTests(engine);
   ImGuiTestEngine_QueueTests(engine, ImGuiTestGroup_Tests, test_filter);
 
   // Main loop — runs until all tests complete

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -167,5 +167,6 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine);
 void RegisterCrystalRendererTests(ImGuiTestEngine* engine);
 void RegisterAutoEvRegressionTests(ImGuiTestEngine* engine);
 void RegisterLinkedEntriesTests(ImGuiTestEngine* engine);
+void RegisterProjectWorldDirTests(ImGuiTestEngine* engine);
 
 #endif  // LUMICE_TEST_GUI_SHARED_HPP

--- a/test/gui/test_project_world_dir.cpp
+++ b/test/gui/test_project_world_dir.cpp
@@ -1,0 +1,143 @@
+#include <array>
+#include <cmath>
+
+#include "gui/gui_constants.hpp"
+#include "gui/preview_renderer.hpp"
+#include "test_gui_shared.hpp"
+
+namespace {
+
+constexpr float kSentinel = -9000.f;  // any helper output ≤ this is treated as the sentinel
+constexpr float kEps = 1.0f;          // ± 1 px tolerance vs. analytic expectation
+
+bool IsSentinel(const std::array<float, 2>& p) {
+  return p[0] <= kSentinel && p[1] <= kSentinel;
+}
+
+lumice::gui::ViewProjection MakeVp(int lens_type, float fov, float elev, float az, float roll) {
+  lumice::gui::ViewProjection vp;
+  vp.lens_type = lens_type;
+  vp.fov = fov;
+  vp.elevation = elev;
+  vp.azimuth = az;
+  vp.roll = roll;
+  vp.visible = lumice::gui::kVisibleFull;
+  return vp;
+}
+
+}  // namespace
+
+// Pure-CPU unit tests for ProjectWorldDirToScreen. Validate analytic expectations
+// against the shader's inverse projection formulas — see plan.md Step 3 / F14.
+void RegisterProjectWorldDirTests(ImGuiTestEngine* engine) {
+  // Case 1: Linear pinhole. Front direction (-1,0,0) at elevation=0, azimuth=0
+  // lands at viewport center; zenith (0,0,-1) is at exactly view_dir.z=0 — perspective
+  // singularity — and must return sentinel.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "project_world_dir", "linear");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto vp = MakeVp(lumice::gui::kLensTypeLinear, 90.0f, 0.0f, 0.0f, 0.0f);
+      const float front[3] = { -1.0f, 0.0f, 0.0f };
+      auto p = lumice::gui::ProjectWorldDirToScreen(vp, front, 800, 600);
+      IM_CHECK(!IsSentinel(p));
+      IM_CHECK(std::abs(p[0]) <= kEps);
+      IM_CHECK(std::abs(p[1]) <= kEps);
+
+      const float zenith[3] = { 0.0f, 0.0f, -1.0f };
+      auto pz = lumice::gui::ProjectWorldDirToScreen(vp, zenith, 800, 600);
+      IM_CHECK(IsSentinel(pz));  // view_dir.z = 0 ⇒ behind-or-on-camera-plane sentinel
+    };
+  }
+
+  // Case 2: Fisheye equal area, camera tilted to look at zenith (elevation=90°).
+  // img_radius = min(800,800)/2 = 400.
+  // Zenith (0,0,-1) ⇒ view_dir = (0,0,-1) ⇒ theta=0 ⇒ (0,0).
+  // Front world (-1,0,0) maps to view_dir = (0,-1,0) (col0=(0,-1,0), col1=(1,0,0)
+  // when elevation=90°,az=0,roll=0; transpose·world_dir gives view_dir). Then
+  // theta=π/2, r_norm = sin(π/4)/sin(π/4) = 1, r = 400, phi = atan2(-1, 0) = -π/2,
+  // ⇒ pixel (0, -400) (image bottom-center).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "project_world_dir", "fisheye_ea");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto vp = MakeVp(lumice::gui::kLensTypeFisheyeEqualArea, 180.0f, 90.0f, 0.0f, 0.0f);
+      const float zenith[3] = { 0.0f, 0.0f, -1.0f };
+      auto pz = lumice::gui::ProjectWorldDirToScreen(vp, zenith, 800, 800);
+      IM_CHECK(!IsSentinel(pz));
+      IM_CHECK(std::abs(pz[0]) <= kEps);
+      IM_CHECK(std::abs(pz[1]) <= kEps);
+
+      const float front[3] = { -1.0f, 0.0f, 0.0f };
+      auto pf = lumice::gui::ProjectWorldDirToScreen(vp, front, 800, 800);
+      IM_CHECK(!IsSentinel(pf));
+      IM_CHECK(std::abs(pf[0]) <= kEps);
+      IM_CHECK(std::abs(pf[1] - (-400.0f)) <= kEps);
+    };
+  }
+
+  // Case 3: Rectangular (equirectangular). vp = 800×400 ⇒
+  // short_res_dual = min(400, 400) = 400, scale = 400/π.
+  // Zenith (0,0,-1) ⇒ lat = π/2, py = -(π/2) * 400/π = -200.
+  // Nadir (0,0,+1)  ⇒ py = +200.
+  // Equator front (-1,0,0) ⇒ lat=0, lon=0 ⇒ (0,0).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "project_world_dir", "rectangular");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto vp = MakeVp(lumice::gui::kLensTypeRectangular, 180.0f, 0.0f, 0.0f, 0.0f);
+      const float zenith[3] = { 0.0f, 0.0f, -1.0f };
+      auto pz = lumice::gui::ProjectWorldDirToScreen(vp, zenith, 800, 400);
+      IM_CHECK(!IsSentinel(pz));
+      IM_CHECK(std::abs(pz[0]) <= kEps);
+      IM_CHECK(std::abs(pz[1] - (-200.0f)) <= kEps);
+
+      const float nadir[3] = { 0.0f, 0.0f, 1.0f };
+      auto pn = lumice::gui::ProjectWorldDirToScreen(vp, nadir, 800, 400);
+      IM_CHECK(!IsSentinel(pn));
+      IM_CHECK(std::abs(pn[0]) <= kEps);
+      IM_CHECK(std::abs(pn[1] - 200.0f) <= kEps);
+
+      const float front[3] = { -1.0f, 0.0f, 0.0f };
+      auto pf = lumice::gui::ProjectWorldDirToScreen(vp, front, 800, 400);
+      IM_CHECK(!IsSentinel(pf));
+      IM_CHECK(std::abs(pf[0]) <= kEps);
+      IM_CHECK(std::abs(pf[1]) <= kEps);
+    };
+  }
+
+  // Case 4: Dual fisheye equal area. vp = 800×400 ⇒
+  // short_res_dual = min(400, 400) = 400, circle_radius = 200.
+  // Zenith (0,0,-1) lands at left-circle center  (-200, 0).
+  // Nadir  (0,0,+1) lands at right-circle center (+200, 0).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "project_world_dir", "dual_fisheye_ea");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto vp = MakeVp(lumice::gui::kLensTypeDualFisheyeEqualArea, 180.0f, 0.0f, 0.0f, 0.0f);
+      const float zenith[3] = { 0.0f, 0.0f, -1.0f };
+      auto pz = lumice::gui::ProjectWorldDirToScreen(vp, zenith, 800, 400);
+      IM_CHECK(!IsSentinel(pz));
+      IM_CHECK(std::abs(pz[0] - (-200.0f)) <= kEps);
+      IM_CHECK(std::abs(pz[1]) <= kEps);
+
+      const float nadir[3] = { 0.0f, 0.0f, 1.0f };
+      auto pn = lumice::gui::ProjectWorldDirToScreen(vp, nadir, 800, 400);
+      IM_CHECK(!IsSentinel(pn));
+      IM_CHECK(std::abs(pn[0] - 200.0f) <= kEps);
+      IM_CHECK(std::abs(pn[1]) <= kEps);
+    };
+  }
+
+  // Case 5: Globe lens is out-of-scope — must return sentinel.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "project_world_dir", "globe_sentinel");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      auto vp = MakeVp(lumice::gui::kLensTypeGlobe, 30.0f, 0.0f, 0.0f, 0.0f);
+      const float zenith[3] = { 0.0f, 0.0f, -1.0f };
+      auto p = lumice::gui::ProjectWorldDirToScreen(vp, zenith, 800, 800);
+      IM_CHECK(IsSentinel(p));
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a screen-space ring marker overlay for the zenith and nadir directions in the GUI preview, with constant pixel size across lens types and zoom levels.

- New CPU helper `ProjectWorldDirToScreen` projects a world-space direction to screen pixels per lens type (Linear / Fisheye family / Dual Fisheye family / Rectangular; Globe returns a sentinel).
- Fragment shader gains 6 uniforms and a double-ring smoothstep block; sentinel screen coordinates make the marker auto-hide when off-screen or behind the camera.
- Overlay panel gets a new UI row (color picker, on/off toggle, alpha, pixel-radius slider 2–20 px).
- `.lmc` round-trip adds 4 new `overlay_zenith_nadir_*` JSON keys; legacy files without the keys fall back to defaults.
- 252/252 GUI tests pass, including 5 new analytic projection cases and a `zenith_nadir_roundtrip` serialization case.

## Notes

- Last commit splits the fragment shader raw-string literal in two adjacent `R\"glsl(...)\"` pieces. The marker code pushed the shader over MSVC's ~16380-byte per-literal limit and the Windows MSVC x86_64 job failed with `C2026: string too big, trailing characters truncated`. Adjacent-literal concatenation keeps the shader source byte-identical; clang/gcc are unaffected.
- Visual regression reference images for the new marker are deferred (requires a non-headless display server). Tracked as backlog in `scratchpad/task-gui-zenith-nadir-marker/SUMMARY.md`.

## Test plan

- [x] Local macOS GUI build (`./scripts/build.sh -gj release`)
- [x] Unit tests + GUI tests 252/252 locally
- [ ] CI: all platforms green (Ubuntu x86_64 / ARM64, macOS ARM64, Windows MSVC x86_64)
- [ ] Manual visual check of zenith/nadir ring across lens types

🤖 Generated with [Claude Code](https://claude.com/claude-code)