### PR TITLE
fix(simulator): prevent MS filter-leaked rays from reaching main output

### DIFF
--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -82,6 +82,12 @@ struct RaySeg {
   // exclusive with is_continue_: both are only meaningful when to_face_ ==
   // kInvalidId && w_ >= 0.
   bool is_filter_dropped_ = false;
+  // Cross-layer persistent flag: set when an outgoing candidate fails the
+  // per-crystal filter in any MS layer, propagated to child segments via
+  // TraceRayBasicInfo(). Rays carrying this flag route to the anchor lane
+  // (is_filter_dropped_) rather than the main outgoing buffer, even if they
+  // pass the current layer's filter.
+  bool is_prior_filter_failed_ = false;
   RaypathRecorder rp_;  // Raypath in **CURRENT** crystal.
 
   // Derived segment-kind helpers. Invariants (mutually exclusive, exhaustive):

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -141,6 +141,8 @@ void InitRay_rot(RandomNumberGenerator& rng, const AxisDistribution& crystal_axi
 }
 
 
+// Do NOT reset cross-layer fields (e.g., is_prior_filter_failed_);
+// they are propagated via TraceRayBasicInfo().
 void InitRay_other_info(const Crystal& curr_crystal, size_t curr_crystal_id, size_t all_data_idx,  // input
                         RayBuffer buffer_data[2]) {                                                // output
   for (auto& r : buffer_data[0]) {
@@ -171,6 +173,11 @@ void InitRayFirstMs(RandomNumberGenerator& rng, const SunParam& light_param, con
 
   // 1.3 init crystal_id, root_ray_idx, rp, state
   InitRay_other_info(curr_crystal, curr_crystal_id, all_data.size_, buffer_data);
+
+  // 1.4 reset cross-layer state (pool-reuse guard: Reset() may not zero memory)
+  for (auto& r : buffer_data[0]) {
+    r.is_prior_filter_failed_ = false;
+  }
 
   all_data.EmplaceBack(buffer_data[0]);
 }
@@ -370,6 +377,8 @@ void TraceRayBasicInfo(const Crystal& curr_crystal, float refractive_index, size
     // Each child segment's from_face_ = parent's to_face_ (the face just hit).
     buffer_data[1][i * 2 + 0].from_face_ = buffer_data[0][i].to_face_;
     buffer_data[1][i * 2 + 1].from_face_ = buffer_data[0][i].to_face_;
+    buffer_data[1][i * 2 + 0].is_prior_filter_failed_ = buffer_data[0][i].is_prior_filter_failed_;
+    buffer_data[1][i * 2 + 1].is_prior_filter_failed_ = buffer_data[0][i].is_prior_filter_failed_;
   }
 
   buffer_data[0].size_ = 0;
@@ -413,9 +422,11 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
   // and the path degenerates to the no-filter case at zero extra cost.
   //
   // Branch table for outgoing candidates (to_face_ == kInvalidId, w_ >= 0):
-  //   filter-pass + prob-pass → is_continue_ = true (next MS)
-  //   filter-pass + prob-fail → outgoing (no flag)
-  //   filter-fail + prob-pass → is_continue_ = true (next MS) — anchor lane bypass
+  //   filter-pass + !prior_failed + prob-pass → is_continue_ = true (next MS)
+  //   filter-pass + !prior_failed + prob-fail → outgoing (no flag)
+  //   filter-pass +  prior_failed + prob-pass → is_continue_ = true (anchor bypass continues)
+  //   filter-pass +  prior_failed + prob-fail → is_filter_dropped_ = true (anchor lane)
+  //   filter-fail + prob-pass → is_continue_ = true; is_prior_filter_failed_ = true
   //   filter-fail + prob-fail → is_filter_dropped_ = true (anchor lane)
   // is_continue_ and is_filter_dropped_ are mutually exclusive (only one is set).
   for (auto& r : buffer_data[1]) {
@@ -434,15 +445,18 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
       r.crystal_rot_.Apply(r.p_);
 
       bool filter_pass = (spec == nullptr) || spec->Check(r);
+      if (!filter_pass) {
+        r.is_prior_filter_failed_ = true;
+      }
       if (rng.GetUniform() < ms_info.prob_) {
-        // 1.1 prob-pass → continue regardless of filter result. Filter-fail rays still
-        //     propagate to the next MS level (anchor lane bypass for in-trajectory paths).
+        // 1.1 prob-pass → continue to next MS level. is_prior_filter_failed_ persists
+        //     so downstream layers route this ray to anchor lane, not main outgoing.
         r.is_continue_ = true;
-      } else if (!filter_pass) {
-        // 1.2 filter-fail + prob-fail → anchor lane (not visible in main outgoing).
+      } else if (r.is_prior_filter_failed_) {
+        // 1.2 prior or current filter failure + prob-fail → anchor lane only.
         r.is_filter_dropped_ = true;
       }
-      // 1.3 else: filter-pass + prob-fail → emit outgoing (no flag set).
+      // 1.3 else: filter-pass + no prior failure + prob-fail → emit outgoing (no flag set).
     }
     // 2. else: normal rays (to_face_ != kInvalidId && w_ >= 0) — IsNormal() derived; no state write.
 

--- a/test/e2e/configs/ms_filter_leak_baseline.json
+++ b/test/e2e/configs/ms_filter_leak_baseline.json
@@ -1,0 +1,74 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 90,
+          "std": 10
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0,
+          "std": 360
+        },
+        "roll": {
+          "type": "gauss",
+          "mean": 0,
+          "std": 0
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "raypath",
+      "action": "filter_in",
+      "raypath": [4, 6],
+      "symmetry": "BD"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "spectrum": "D65"
+    },
+    "ray_num": 500000,
+    "max_hits": 7,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 10,
+            "filter": 1
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "fisheye_equal_area",
+        "fov": 120
+      },
+      "resolution": [
+        128,
+        128
+      ],
+      "view": {
+        "elevation": 20
+      }
+    }
+  ]
+}

--- a/test/e2e/configs/ms_filter_leak_impossible.json
+++ b/test/e2e/configs/ms_filter_leak_impossible.json
@@ -1,0 +1,83 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 0,
+          "std": 180
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0,
+          "std": 360
+        },
+        "roll": {
+          "type": "gauss",
+          "mean": 0,
+          "std": 0
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "raypath",
+      "action": "filter_in",
+      "raypath": [1, 1],
+      "symmetry": "none"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "spectrum": "D65"
+    },
+    "ray_num": 100000,
+    "max_hits": 7,
+    "scattering": [
+      {
+        "prob": 0.5,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 10,
+            "filter": 1
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 10
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "fisheye_equal_area",
+        "fov": 120
+      },
+      "resolution": [
+        64,
+        64
+      ],
+      "view": {
+        "elevation": 20
+      }
+    }
+  ]
+}

--- a/test/e2e/configs/ms_filter_leak_repro.json
+++ b/test/e2e/configs/ms_filter_leak_repro.json
@@ -1,0 +1,110 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 90,
+          "std": 10
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0,
+          "std": 360
+        },
+        "roll": {
+          "type": "gauss",
+          "mean": 0,
+          "std": 0
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 90,
+          "std": 360
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0,
+          "std": 360
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "raypath",
+      "action": "filter_in",
+      "raypath": [4, 6],
+      "symmetry": "BD"
+    },
+    {
+      "id": 2,
+      "type": "raypath",
+      "action": "filter_in",
+      "raypath": [1, 2],
+      "symmetry": "PBD"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "spectrum": "D65"
+    },
+    "ray_num": 500000,
+    "max_hits": 7,
+    "scattering": [
+      {
+        "prob": 0.5,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 10,
+            "filter": 1
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 2,
+            "proportion": 10,
+            "filter": 2
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "fisheye_equal_area",
+        "fov": 120
+      },
+      "resolution": [
+        128,
+        128
+      ],
+      "view": {
+        "elevation": 20
+      }
+    }
+  ]
+}

--- a/test/e2e/test_ms_filter_leak.py
+++ b/test/e2e/test_ms_filter_leak.py
@@ -1,0 +1,107 @@
+"""End-to-end regression tests for the MS filter leak bug.
+
+The bug: in multi-scattering configs, outgoing candidates that fail a per-crystal
+filter in layer N but pass the probability check (anchor-lane bypass) carry no
+persistent flag. In layer N+1, these rays can reach IsOutgoing() and leak into the
+main output buffer, producing extra arcs/halos.
+
+Fix: ``RaySeg::is_prior_filter_failed_`` persists filter failure across MS layers.
+Rays carrying this flag route to the anchor lane even if they pass the current
+layer's filter.
+
+Two tests:
+1. ``test_impossible_filter_produces_zero_intensity`` — layer 1 uses an impossible
+   raypath filter [1,1] (cannot occur in a convex hexagonal prism); all rays fail
+   the filter. With the fix, no ray reaches the main output (snapshot_intensity == 0).
+
+2. ``test_repro_scenario_matches_single_layer`` — the issue's exact reproduction
+   config (lowitz + transparent-plate layer 2) compared against the single-layer
+   baseline. With the fix, the normalized images are visually identical (high PSNR).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from test.e2e.capi_runner import run_scene_capi, run_scene_capi_buffered
+
+CONFIGS_DIR = Path(__file__).parent / "configs"
+
+_K_NORM_SCALE = 0.08
+
+_REPRO_TEST_SEED = "42"
+
+_REPRO_PSNR_THRESHOLD = 25.0
+
+
+def _display_xyz(buf: np.ndarray, intensity: float, total_pix: int) -> np.ndarray:
+    if intensity <= 0.0:
+        return np.zeros_like(buf)
+    return buf * (_K_NORM_SCALE * total_pix / intensity)
+
+
+def _psnr(a: np.ndarray, b: np.ndarray) -> float:
+    mse = float(np.mean((a - b) ** 2))
+    if mse < 1e-12:
+        return float("inf")
+    peak = max(float(a.max()), float(b.max()), 1e-12)
+    return 10.0 * np.log10(peak**2 / mse)
+
+
+@pytest.mark.slow
+def test_impossible_filter_produces_zero_intensity():
+    """Layer 1 impossible filter [1,1] + layer 2 no filter → snapshot_intensity == 0.
+
+    Raypath [1,1] (face 1 to face 1 consecutively) is geometrically impossible in a
+    convex hexagonal prism: after hitting face 1, convexity guarantees the next face
+    hit is always different. All rays fail the filter, so with the fix none reach the
+    main output buffer.
+    """
+    result = run_scene_capi(str(CONFIGS_DIR / "ms_filter_leak_impossible.json"))
+    assert result.snapshot_intensity == pytest.approx(0.0, abs=1e-6), (
+        f"Expected zero snapshot_intensity (impossible filter blocks all rays), "
+        f"got {result.snapshot_intensity:.6g}"
+    )
+
+
+@pytest.mark.slow
+def test_repro_scenario_matches_single_layer():
+    """2-layer MS (lowitz + transparent plate) matches single-layer baseline.
+
+    Layer 2's filter [1,2] PBD selects basal-to-basal paths (parallel-surface
+    transmission — no refraction). With the fix, filter-failed rays from layer 1
+    do not leak through layer 2. The normalized output should closely match the
+    single-layer baseline.
+    """
+    old_seed = os.environ.get("LUMICE_SIM_SEED")
+    os.environ["LUMICE_SIM_SEED"] = _REPRO_TEST_SEED
+    try:
+        repro = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_repro.json"))
+        baseline = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_baseline.json"))
+    finally:
+        if old_seed is None:
+            os.environ.pop("LUMICE_SIM_SEED", None)
+        else:
+            os.environ["LUMICE_SIM_SEED"] = old_seed
+
+    assert baseline.snapshot_intensity > 0, "baseline snapshot_intensity is zero"
+    assert baseline.anchor_snapshot_intensity > 0, "baseline anchor is zero"
+
+    pix = baseline.img_width * baseline.img_height
+    norm_baseline = baseline.anchor_snapshot_intensity
+    norm_repro = repro.anchor_snapshot_intensity if repro.anchor_snapshot_intensity > 0 else repro.snapshot_intensity
+
+    disp_baseline = _display_xyz(baseline.flt_buf, norm_baseline, pix)
+    disp_repro = _display_xyz(repro.flt_buf, norm_repro, pix)
+
+    psnr_val = _psnr(disp_baseline, disp_repro)
+    assert psnr_val >= _REPRO_PSNR_THRESHOLD, (
+        f"Repro scenario PSNR too low: {psnr_val:.1f} dB < {_REPRO_PSNR_THRESHOLD} dB. "
+        f"Layer 2 transparent-plate filter may be leaking extra light paths. "
+        f"baseline_snap={baseline.snapshot_intensity:.6g}, "
+        f"repro_snap={repro.snapshot_intensity:.6g}"
+    )


### PR DESCRIPTION
## Summary

- Add `is_prior_filter_failed_` persistent flag to `RaySeg` to track rays that failed a filter in any prior MS layer
- Modify `CollectData()` branch table: tainted rays (prior filter failed) are routed to anchor lane on prob-fail, never to main outgoing output
- Propagate the flag via `TraceRayBasicInfo()` parent→child and explicitly reset in `InitRayFirstMs` (pool-reuse guard)
- Add two slow E2E regression tests:
  - Impossible-filter test (`snapshot_intensity == 0` for geometrically impossible raypath `[1,1]`)
  - **Reproduction scenario test**: lowitz layer 1 + transparent-plate layer 2 vs single-layer baseline, asserting PSNR ≥ 25 dB (measured: 31.8 dB)

## Test plan

- [x] `./scripts/build.sh -tj release` — unit tests pass
- [x] `pytest test/e2e/ -v -m "not slow"` — 22/22 fast E2E pass
- [x] `pytest test/e2e/test_ms_filter_leak.py -v -m slow` — 2/2 new regression tests pass
- [x] `pytest test/e2e/test_additivity.py -v -m slow` — partition-additivity invariants not regressed
- [x] Manual GUI verification: lowitz + transparent-plate layer 2 output matches single layer 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)