### PR TITLE
refactor: replace LUMICE_SIM_SEED env var with C API sim_seed parameter

### DIFF
--- a/doc/c_api.md
+++ b/doc/c_api.md
@@ -123,6 +123,22 @@ typedef struct LUMICE_StatsResult_ {
 **Notes**:
 - Sentinel marker: all zeros (`sim_ray_num == 0`)
 
+#### LUMICE_ServerConfig
+
+Server configuration structure for `LUMICE_CreateServerEx()`.
+
+```c
+typedef struct LUMICE_ServerConfig_ {
+  int num_workers;        // Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+  unsigned int sim_seed;  // Deterministic seed for worker RNGs. 0 = random (default).
+                          // Non-zero collapses to 1 worker for bit-stable results.
+} LUMICE_ServerConfig;
+```
+
+**Notes**:
+- Zero-initialized struct (`= {0}`) is equivalent to default behavior (auto worker count, random seed)
+- When `sim_seed != 0`, the server forces `num_workers = 1` to ensure deterministic ray tracing results
+
 ### Server Lifecycle
 
 #### LUMICE_CreateServer
@@ -139,6 +155,25 @@ LUMICE_Server* LUMICE_CreateServer(void);
 
 **Notes**:
 - The returned handle must be freed using `LUMICE_DestroyServer()`
+
+#### LUMICE_CreateServerEx
+
+Creates a server instance with custom configuration.
+
+```c
+LUMICE_Server* LUMICE_CreateServerEx(const LUMICE_ServerConfig* config);
+```
+
+**Parameters**:
+- `config`: pointer to a `LUMICE_ServerConfig` struct; passing `NULL` is equivalent to `LUMICE_CreateServer()`
+
+**Return value**:
+- On success: returns a server handle pointer
+- On failure: returns `NULL`
+
+**Notes**:
+- The returned handle must be freed using `LUMICE_DestroyServer()`
+- Use this instead of `LUMICE_CreateServer()` when you need to set a deterministic seed or control worker count
 
 #### LUMICE_DestroyServer
 

--- a/doc/c_api_zh.md
+++ b/doc/c_api_zh.md
@@ -123,6 +123,22 @@ typedef struct LUMICE_StatsResult_ {
 **注意**：
 - 哨兵标识：全零（`sim_ray_num == 0`）
 
+#### LUMICE_ServerConfig
+
+服务器配置结构体，用于 `LUMICE_CreateServerEx()`。
+
+```c
+typedef struct LUMICE_ServerConfig_ {
+  int num_workers;        // 模拟器工作线程数。0 = 默认（hardware_concurrency - 2）
+  unsigned int sim_seed;  // 确定性 RNG 种子。0 = 随机（默认）。
+                          // 非零时强制为单线程以确保结果可复现。
+} LUMICE_ServerConfig;
+```
+
+**注意**：
+- 零初始化的结构体（`= {0}`）等同于默认行为（自动线程数、随机种子）
+- 当 `sim_seed != 0` 时，服务器强制 `num_workers = 1` 以确保确定性光线追踪结果
+
 ### 服务器生命周期
 
 #### LUMICE_CreateServer
@@ -139,6 +155,25 @@ LUMICE_Server* LUMICE_CreateServer(void);
 
 **注意**：
 - 返回的句柄必须使用 `LUMICE_DestroyServer()` 释放
+
+#### LUMICE_CreateServerEx
+
+使用自定义配置创建服务器实例。
+
+```c
+LUMICE_Server* LUMICE_CreateServerEx(const LUMICE_ServerConfig* config);
+```
+
+**参数**：
+- `config`: 指向 `LUMICE_ServerConfig` 结构体的指针；传 `NULL` 等同于 `LUMICE_CreateServer()`
+
+**返回值**：
+- 成功：返回服务器句柄指针
+- 失败：返回 `NULL`
+
+**注意**：
+- 返回的句柄必须使用 `LUMICE_DestroyServer()` 释放
+- 当需要设置确定性种子或控制线程数时，使用此函数替代 `LUMICE_CreateServer()`
 
 #### LUMICE_DestroyServer
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -99,6 +99,18 @@ gdb ./build/cmake_build/Lumice
 (gdb) run -f examples/config_example.json
 ```
 
+### Environment Variables
+
+Lumice uses a small number of environment variables for build scripts and test tooling. The product code (C++ source under `src/`) does **not** read any environment variables at runtime.
+
+| Variable | Where | Purpose |
+|----------|-------|---------|
+| `LUMICE_SKIP_GUI_TESTS` | `scripts/build.sh` | Set to `1` to skip GUI test compilation and execution. CI auto-detects headless environments via the `CI` variable. |
+| `LUMICE_BIN` | `test/e2e/runner.py` | Override the CLI binary path for E2E subprocess tests. Defaults to `build/cmake_install/Lumice`. |
+| `LUMICE_LIB` | `test/e2e/capi_runner.py` | Override the shared library path for E2E C API tests. Defaults to `build/cmake_install/liblumice.dylib` (macOS) or `.so` (Linux). |
+
+**Design principle**: Deterministic simulation seeds are passed via the C API (`LUMICE_ServerConfig.sim_seed`) rather than environment variables, to keep program behavior explicit and reproducible. See the [C API documentation](c_api.md) for details.
+
 ## Code Style Guide
 
 ### General Principles

--- a/doc/developer-guide_zh.md
+++ b/doc/developer-guide_zh.md
@@ -99,6 +99,18 @@ gdb ./build/cmake_build/Lumice
 (gdb) run -f examples/config_example.json
 ```
 
+### 环境变量
+
+Lumice 仅在构建脚本和测试工具中使用少量环境变量。产品代码（`src/` 下的 C++ 源码）在运行时**不读取**任何环境变量。
+
+| 变量 | 位置 | 用途 |
+|------|------|------|
+| `LUMICE_SKIP_GUI_TESTS` | `scripts/build.sh` | 设为 `1` 可跳过 GUI 测试的编译和执行。CI 通过 `CI` 变量自动检测无头环境。 |
+| `LUMICE_BIN` | `test/e2e/runner.py` | 覆盖 E2E 子进程测试使用的 CLI 可执行文件路径。默认为 `build/cmake_install/Lumice`。 |
+| `LUMICE_LIB` | `test/e2e/capi_runner.py` | 覆盖 E2E C API 测试使用的共享库路径。默认为 `build/cmake_install/liblumice.dylib`（macOS）或 `.so`（Linux）。 |
+
+**设计原则**：确定性模拟种子通过 C API（`LUMICE_ServerConfig.sim_seed`）传递，而非环境变量，以确保程序行为显式且可复现。详见 [C 接口文档](c_api_zh.md)。
+
 ## 代码风格指南
 
 ### 总体原则

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -97,7 +97,9 @@ typedef struct LUMICE_StatsResult_ {
 
 // =============== Server Configuration ===============
 typedef struct LUMICE_ServerConfig_ {
-  int num_workers;  // Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+  int num_workers;        // Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+  unsigned int sim_seed;  // Deterministic seed for worker RNGs. 0 = random (default).
+                          // Non-zero collapses to 1 worker for bit-stable results.
 } LUMICE_ServerConfig;
 
 // =============== Server Lifecycle ===============

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -69,7 +69,8 @@ LUMICE_Server* LUMICE_CreateServer() {
 LUMICE_Server* LUMICE_CreateServerEx(const LUMICE_ServerConfig* config) {
   auto* s = new LUMICE_Server;
   int num_workers = (config != nullptr) ? config->num_workers : 0;
-  s->server_ = std::make_unique<ns::Server>(num_workers);
+  uint32_t sim_seed = (config != nullptr) ? config->sim_seed : 0;
+  s->server_ = std::make_unique<ns::Server>(num_workers, sim_seed);
   return s;
 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -54,7 +54,7 @@ class TicketMutex {
 // =============== ServerImpl ===============
 class ServerImpl {
  public:
-  explicit ServerImpl(int num_workers = 0);
+  explicit ServerImpl(int num_workers = 0, uint32_t sim_seed = 0);
   ~ServerImpl();
 
   Error CommitConfig(const nlohmann::json& config_json, bool* out_reused = nullptr);
@@ -163,31 +163,15 @@ void ServerImpl::RunPersistentLoop(F work_fn) {
 }
 
 
-ServerImpl::ServerImpl(int num_workers)
+ServerImpl::ServerImpl(int num_workers, uint32_t sim_seed)
     : config_manager_{}, scene_queue_(std::make_shared<Queue<SimBatch>>()),
       data_queue_(std::make_shared<Queue<SimData>>()), status_(ServerStatus::kIdle) {
   int worker_count = num_workers > 0 ? num_workers : kDefaultSimulatorCnt;
-  // LUMICE_SIM_SEED (internal-only, test-facing): when set, deterministically seed
-  // worker simulators as base_seed + worker_index. Multi-worker batch dispatch via
-  // scene_queue is racy (FIFO queue popped by competing threads), so a seeded run
-  // still produces non-deterministic batch→worker mappings and ~1-2% snapshot drift.
-  // To get bit-stable e2e comparisons (anchor-invariant partition test) we collapse
-  // to a single worker whenever a seed is supplied: one RNG, one consumer of a FIFO
-  // queue. Loses parallelism for the seeded test path only; production paths (no env
-  // var) keep their hardware_concurrency default.
-  uint32_t base_seed = 0;
-  if (const char* seed_env = std::getenv("LUMICE_SIM_SEED")) {
-    try {
-      base_seed = static_cast<uint32_t>(std::stoul(seed_env));
-    } catch (...) {
-      base_seed = 0;
-    }
-  }
-  if (base_seed != 0) {
+  if (sim_seed != 0) {
     worker_count = 1;
   }
   for (int i = 0; i < worker_count; i++) {
-    uint32_t worker_seed = base_seed != 0 ? base_seed + static_cast<uint32_t>(i) : 0;
+    uint32_t worker_seed = sim_seed != 0 ? sim_seed + static_cast<uint32_t>(i) : 0;
     simulators_.emplace_back(scene_queue_, data_queue_, worker_seed);
   }
 
@@ -708,7 +692,7 @@ void ServerImpl::SetLogLevel(LogLevel level) {
 // =============== Server ===============
 Server::Server() : impl_(std::make_shared<ServerImpl>()) {}
 
-Server::Server(int num_workers) : impl_(std::make_shared<ServerImpl>(num_workers)) {}
+Server::Server(int num_workers, uint32_t sim_seed) : impl_(std::make_shared<ServerImpl>(num_workers, sim_seed)) {}
 
 Error Server::CommitConfig(const nlohmann::json& config_json, bool* out_reused) {
   if (!impl_) {

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_SERVER_H_
 #define INCLUDE_SERVER_H_
 
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <nlohmann/json_fwd.hpp>
@@ -187,9 +188,10 @@ class Server {
   /**
    * @brief Construct a new Server with specified worker count
    * @param num_workers Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+   * @param sim_seed Deterministic RNG seed. 0 = random. Non-zero collapses to 1 worker.
    * @note The server starts running immediately after construction
    */
-  explicit Server(int num_workers);
+  explicit Server(int num_workers, uint32_t sim_seed = 0);
 
   /**
    * @brief Commit configuration from string

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -57,6 +57,18 @@ assert ctypes.sizeof(LUMICE_RawXyzResult) == 64, (
 )
 
 
+class LUMICE_ServerConfig(ctypes.Structure):
+    _fields_ = [
+        ("num_workers", ctypes.c_int),
+        ("sim_seed",    ctypes.c_uint),
+    ]
+
+
+assert ctypes.sizeof(LUMICE_ServerConfig) == 8, (
+    "LUMICE_ServerConfig size mismatch — verify lumice.h field layout"
+)
+
+
 # LUMICE_ServerState constants (lumice.h)
 _LUMICE_SERVER_IDLE = 0
 _LUMICE_SERVER_RUNNING = 1
@@ -147,6 +159,9 @@ def _load_lib() -> ctypes.CDLL:
     lib.LUMICE_CreateServer.restype = ctypes.c_void_p
     lib.LUMICE_CreateServer.argtypes = []
 
+    lib.LUMICE_CreateServerEx.restype = ctypes.c_void_p
+    lib.LUMICE_CreateServerEx.argtypes = [ctypes.POINTER(LUMICE_ServerConfig)]
+
     lib.LUMICE_DestroyServer.restype = None
     lib.LUMICE_DestroyServer.argtypes = [ctypes.c_void_p]
 
@@ -167,7 +182,7 @@ def _load_lib() -> ctypes.CDLL:
     return lib
 
 
-def run_scene_capi(config_path: str, timeout_sec: int = 180) -> SimResult:
+def run_scene_capi(config_path: str, sim_seed: int = 0, timeout_sec: int = 180) -> SimResult:
     """Run a single Lumice simulation via the C API and return scalar intensity.
 
     Spawns a fresh server, commits ``config_path``, polls until valid data is
@@ -176,6 +191,7 @@ def run_scene_capi(config_path: str, timeout_sec: int = 180) -> SimResult:
 
     Args:
         config_path: absolute or repo-relative path to a JSON config.
+        sim_seed: deterministic RNG seed (0 = random). Non-zero collapses to 1 worker.
         timeout_sec: maximum wall time to wait for the simulation.
 
     Raises:
@@ -184,7 +200,11 @@ def run_scene_capi(config_path: str, timeout_sec: int = 180) -> SimResult:
     """
     lib = _load_lib()
 
-    server = lib.LUMICE_CreateServer()
+    if sim_seed != 0:
+        cfg = LUMICE_ServerConfig(num_workers=0, sim_seed=sim_seed)
+        server = lib.LUMICE_CreateServerEx(ctypes.byref(cfg))
+    else:
+        server = lib.LUMICE_CreateServer()
     if not server:
         raise RuntimeError("LUMICE_CreateServer returned NULL")
 
@@ -234,7 +254,7 @@ def run_scene_capi(config_path: str, timeout_sec: int = 180) -> SimResult:
         lib.LUMICE_DestroyServer(server)
 
 
-def run_scene_capi_buffered(config_path: str, timeout_sec: int = 180) -> BufferedSimResult:
+def run_scene_capi_buffered(config_path: str, sim_seed: int = 0, timeout_sec: int = 180) -> BufferedSimResult:
     """Run a Lumice sim via the C API and copy out both XYZ buffers.
 
     Polling exits only after `has_valid_data AND IDLE` is observed on two
@@ -247,7 +267,11 @@ def run_scene_capi_buffered(config_path: str, timeout_sec: int = 180) -> Buffere
     """
     lib = _load_lib()
 
-    server = lib.LUMICE_CreateServer()
+    if sim_seed != 0:
+        cfg = LUMICE_ServerConfig(num_workers=0, sim_seed=sim_seed)
+        server = lib.LUMICE_CreateServerEx(ctypes.byref(cfg))
+    else:
+        server = lib.LUMICE_CreateServer()
     if not server:
         raise RuntimeError("LUMICE_CreateServer returned NULL")
 

--- a/test/e2e/test_additivity.py
+++ b/test/e2e/test_additivity.py
@@ -22,7 +22,6 @@ default CI pytest invocation.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -50,11 +49,11 @@ _K_NORM_SCALE = 0.08
 
 # ── thresholds ───────────────────────────────────────────────────────────────
 
-# Fixed seed for the partition-additivity fixture. Combined with
-# LUMICE_SIM_SEED's single-worker override (see src/server/server.cpp) this
-# makes two server lifecycles bit-stable: same RNG seed, FIFO scene_queue
-# consumed by one Simulator → identical ray paths and identical fp32 sums.
-_PARTITION_TEST_SEED = "42"
+# Fixed seed for the partition-additivity fixture. Passed via C API
+# LUMICE_ServerConfig.sim_seed which collapses to 1 worker for bit-stable
+# results: same RNG seed, FIFO scene_queue consumed by one Simulator →
+# identical ray paths and identical fp32 sums.
+_PARTITION_TEST_SEED = 42
 
 # Anchor buffer cross-filter invariance tolerance. Under LUMICE_SIM_SEED the
 # anchor is bit-identical across filter_in / filter_out runs, so 1e-4 is
@@ -132,22 +131,13 @@ def additivity_runs():
 def partition_pair(request):
     """Two same-seed runs (filter_in + filter_out) — F1 anchor lane invariant.
 
-    LUMICE_SIM_SEED is read by each fresh ServerImpl ctor
-    (capi_runner.py:186 CreateServer / capi_runner.py:234 DestroyServer) and
-    forces worker_count=1 — see src/server/server.cpp. The two runs therefore
-    share an identical RNG state machine and produce bit-stable anchors.
+    sim_seed is passed via LUMICE_ServerConfig.sim_seed (C API) which forces
+    worker_count=1 — see src/server/server.cpp. The two runs therefore share
+    an identical RNG state machine and produce bit-stable anchors.
     """
     in_cfg, out_cfg, _label = request.param
-    old_seed = os.environ.get("LUMICE_SIM_SEED")
-    os.environ["LUMICE_SIM_SEED"] = _PARTITION_TEST_SEED
-    try:
-        result_in = run_scene_capi(str(CONFIGS_DIR / in_cfg))
-        result_out = run_scene_capi(str(CONFIGS_DIR / out_cfg))
-    finally:
-        if old_seed is None:
-            os.environ.pop("LUMICE_SIM_SEED", None)
-        else:
-            os.environ["LUMICE_SIM_SEED"] = old_seed
+    result_in = run_scene_capi(str(CONFIGS_DIR / in_cfg), sim_seed=_PARTITION_TEST_SEED)
+    result_out = run_scene_capi(str(CONFIGS_DIR / out_cfg), sim_seed=_PARTITION_TEST_SEED)
     return result_in, result_out
 
 

--- a/test/e2e/test_ms_filter_leak.py
+++ b/test/e2e/test_ms_filter_leak.py
@@ -21,7 +21,6 @@ Two tests:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -33,7 +32,7 @@ CONFIGS_DIR = Path(__file__).parent / "configs"
 
 _K_NORM_SCALE = 0.08
 
-_REPRO_TEST_SEED = "42"
+_REPRO_TEST_SEED = 42
 
 _REPRO_PSNR_THRESHOLD = 25.0
 
@@ -77,16 +76,8 @@ def test_repro_scenario_matches_single_layer():
     do not leak through layer 2. The normalized output should closely match the
     single-layer baseline.
     """
-    old_seed = os.environ.get("LUMICE_SIM_SEED")
-    os.environ["LUMICE_SIM_SEED"] = _REPRO_TEST_SEED
-    try:
-        repro = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_repro.json"))
-        baseline = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_baseline.json"))
-    finally:
-        if old_seed is None:
-            os.environ.pop("LUMICE_SIM_SEED", None)
-        else:
-            os.environ["LUMICE_SIM_SEED"] = old_seed
+    repro = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_repro.json"), sim_seed=_REPRO_TEST_SEED)
+    baseline = run_scene_capi_buffered(str(CONFIGS_DIR / "ms_filter_leak_baseline.json"), sim_seed=_REPRO_TEST_SEED)
 
     assert baseline.snapshot_intensity > 0, "baseline snapshot_intensity is zero"
     assert baseline.anchor_snapshot_intensity > 0, "baseline anchor is zero"


### PR DESCRIPTION
## Summary
- Audit all environment variable usage across the codebase (5 call sites identified)
- Replace `LUMICE_SIM_SEED` with `LUMICE_ServerConfig.sim_seed` C API parameter — product code (`src/`) no longer reads any environment variables at runtime
- Retain 3 env vars for build/test tooling (`LUMICE_SKIP_GUI_TESTS`, `LUMICE_BIN`, `LUMICE_LIB`) with documented rationale
- Document `LUMICE_ServerConfig` and `LUMICE_CreateServerEx` in C API docs (en/zh) — previously undocumented
- Add "Environment Variables" section to developer guide (en/zh)

## Test plan
- [x] `grep -rn "LUMICE_SIM_SEED" src/` returns 0 results
- [x] `./scripts/build.sh -tj release` — unit tests pass
- [x] `pytest test/e2e/ -v` — fast E2E pass
- [x] `pytest test/e2e/ -v -m slow` — slow E2E pass (test_additivity + test_ms_filter_leak use `sim_seed=42` via C API)
- [x] `LUMICE_SKIP_GUI_TESTS=1 ./scripts/build.sh -gtj release` — GUI build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)