### PR TITLE
feat(gui): card-wide click and front-hemisphere checkbox

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -47,6 +47,7 @@ OverlayLabelInput BuildOverlayLabelInput(const GuiState& state, const RenderConf
   input.azimuth = rc.azimuth;
   input.roll = EffectiveRollForLens(rc.lens_type, rc.roll);
   input.visible = rc.visible;
+  input.front = rc.front;
   input.show_horizon = state.show_horizon_label;
   input.show_grid = state.show_grid_label;
   input.show_sun_circles = state.show_sun_circles_label;

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -365,9 +365,19 @@ void RenderLeftPanel(float window_height) {
     g_state.MarkDirty();
   }
 
-  // Process edit request: open modal if an edit button was clicked
+  // Process edit request: open modal if an edit button or card area was clicked
   if (GetEditRequest().target != EditTarget::kNone) {
-    OpenEditModal(GetEditRequest(), g_state);
+    const auto& req = GetEditRequest();
+    if (req.target == EditTarget::kCard) {
+      const auto modal_tgt = GetEditModalTarget();
+      if (!IsEditModalOpen() || modal_tgt.layer_idx != req.layer_idx || modal_tgt.entry_idx != req.entry_idx) {
+        EditRequest resolved = req;
+        resolved.target = IsEditModalOpen() ? GetActiveTabAsEditTarget() : EditTarget::kCrystal;
+        OpenEditModal(resolved, g_state);
+      }
+    } else {
+      OpenEditModal(req, g_state);
+    }
     ResetEditRequest();
   }
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -494,11 +494,11 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     ImGui::RadioButton("Full##visible", &r.visible, kVisibleFull);
     ImGui::SameLine();
     ImGui::RadioButton("Lower##visible", &r.visible, kVisibleLower);
-    ImGui::SameLine();
+    ImGui::SameLine(0, 20);
     if (!full_sky) {
       ImGui::BeginDisabled(is_globe);
     }
-    ImGui::RadioButton("Front##visible", &r.visible, kVisibleFront);
+    ImGui::Checkbox("Front##visible", &r.front);
     if (!full_sky) {
       ImGui::EndDisabled();
     }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -911,6 +911,18 @@ EditModalTarget GetEditModalTarget() {
   return { g_modal_layer_idx, g_modal_entry_idx };
 }
 
+EditTarget GetActiveTabAsEditTarget() {
+  switch (g_active_tab) {
+    case ActiveTab::kCrystal:
+      return EditTarget::kCrystal;
+    case ActiveTab::kAxis:
+      return EditTarget::kAxis;
+    case ActiveTab::kFilter:
+      return EditTarget::kFilter;
+  }
+  return EditTarget::kCrystal;
+}
+
 void ResetModalState() {
   g_active_modal = ActiveModal::kNone;
   g_active_tab = ActiveTab::kCrystal;

--- a/src/gui/edit_modals.hpp
+++ b/src/gui/edit_modals.hpp
@@ -7,6 +7,7 @@ namespace lumice::gui {
 
 struct GuiState;
 struct EditRequest;
+enum class EditTarget;
 
 // Process an edit request from the card UI. Must be called from the left panel
 // after detecting a non-None EditRequest (before ResetEditRequest).
@@ -37,6 +38,10 @@ struct EditModalTarget {
   int entry_idx;
 };
 EditModalTarget GetEditModalTarget();
+
+// Returns the EditTarget corresponding to the currently active tab. When
+// no modal is open, returns EditTarget::kCrystal as the default tab.
+EditTarget GetActiveTabAsEditTarget();
 
 // Reset all modal-internal static state (active modal, edit buffers, pending flags).
 // Called by test teardown (ResetTestState) to prevent state leakage between tests.

--- a/src/gui/edit_modals.hpp
+++ b/src/gui/edit_modals.hpp
@@ -39,8 +39,10 @@ struct EditModalTarget {
 };
 EditModalTarget GetEditModalTarget();
 
-// Returns the EditTarget corresponding to the currently active tab. When
-// no modal is open, returns EditTarget::kCrystal as the default tab.
+// Returns the EditTarget corresponding to the currently active tab. Returns
+// EditTarget::kCrystal when no modal is open because ResetModalState() resets
+// g_active_tab to kCrystal on close. Intended solely for resolving the tab in
+// kCard edit requests — do not use for other purposes.
 EditTarget GetActiveTabAsEditTarget();
 
 // Reset all modal-internal static state (active modal, edit buffers, pending flags).

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -51,7 +51,7 @@ static const char* kLensTypeJsonNames[] = { "linear",
                                             "dual_fisheye_stereographic",
                                             "rectangular" };
 
-static const char* kVisibleJsonNames[] = { "upper", "lower", "full", "front" };
+static const char* kVisibleJsonNames[] = { "upper", "lower", "full" };
 static_assert(sizeof(kVisibleJsonNames) / sizeof(kVisibleJsonNames[0]) == kVisibleCount,
               "kVisibleJsonNames must match kVisibleCount");
 static const char* kAspectPresetJsonNames[] = { "free", "16:9", "3:2", "4:3", "1:1", "2:1", "match_background" };
@@ -499,6 +499,7 @@ static json SerializeRendererForGui(const RenderConfig& r) {
   jr["roll"] = r.roll;
   jr["sim_resolution"] = kSimResolutions[r.sim_resolution_index];
   jr["visible"] = kVisibleJsonNames[r.visible];
+  jr["front"] = r.front;
   jr["background"] = { r.background[0], r.background[1], r.background[2] };
   jr["ray_color"] = { r.ray_color[0], r.ray_color[1], r.ray_color[2] };
   jr["opacity"] = r.opacity;
@@ -514,7 +515,14 @@ static RenderConfig ParseRendererFromGuiJson(const json& jr) {
   r.azimuth = jr.value("azimuth", RenderConfig{}.azimuth);
   r.roll = jr.value("roll", RenderConfig{}.roll);
   r.sim_resolution_index = SimResolutionIndexFromValue(jr.value("sim_resolution", 1024));
-  r.visible = VisibleFromString(jr.value("visible", "full"));
+  std::string vis_str = jr.value("visible", "full");
+  if (vis_str == "front") {
+    r.visible = kVisibleFull;
+    r.front = true;
+  } else {
+    r.visible = VisibleFromString(vis_str);
+    r.front = jr.value("front", false);
+  }
   if (jr.contains("background") && jr["background"].is_array() && jr["background"].size() == 3) {
     for (int i = 0; i < 3; i++)
       r.background[i] = jr["background"][i].get<float>();
@@ -1027,7 +1035,14 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
       r.roll = jr["view"].value("roll", 0.0f);
     }
 
-    r.visible = VisibleFromString(jr.value("visible", "upper"));
+    std::string vis_str = jr.value("visible", "upper");
+    if (vis_str == "front") {
+      r.visible = kVisibleFull;
+      r.front = true;
+    } else {
+      r.visible = VisibleFromString(vis_str);
+      r.front = jr.value("front", false);
+    }
 
     if (jr.contains("background") && jr["background"].is_array() && jr["background"].size() == 3) {
       for (int i = 0; i < 3; i++)

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -172,12 +172,12 @@ inline constexpr bool LensIsFov180(int lens_type) {
 // shader string).
 inline constexpr float kGlobeCameraD = 4.0f;
 
-// Visible region selector. Order must match kVisibleNames in gui_state.hpp.
+// Visible region selector (base hemisphere). Order must match kVisibleNames in gui_state.hpp.
+// Front-hemisphere clipping is an independent flag (RenderConfig::front), not an enum value.
 enum Visible : int {
   kVisibleUpper = 0,
   kVisibleLower = 1,
   kVisibleFull = 2,
-  kVisibleFront = 3,
 };
 
 }  // namespace lumice::gui

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -137,11 +137,10 @@ constexpr float kDualFisheyeOverlap = 0.0872f;
 inline const char* const kSpectrumNames[] = { "D50", "D55", "D65", "D75", "A", "E" };
 constexpr int kSpectrumCount = 6;
 
-inline const char* const kVisibleNames[] = { "Upper", "Lower", "Full", "Front" };
-constexpr int kVisibleCount = 4;  // must stay in sync with fragment shader u_visible range
+inline const char* const kVisibleNames[] = { "Upper", "Lower", "Full" };
+constexpr int kVisibleCount = 3;  // must stay in sync with fragment shader u_visible range (0-2)
 static_assert(sizeof(kVisibleNames) / sizeof(*kVisibleNames) == kVisibleCount,
               "kVisibleNames length must match kVisibleCount");
-static_assert(kVisibleFront == kVisibleCount - 1, "Visible enum terminal value must match kVisibleCount - 1");
 
 inline const int kSimResolutions[] = { 512, 1024, 2048, 4096 };
 constexpr int kSimResolutionCount = 4;
@@ -153,7 +152,8 @@ struct RenderConfig {
   float azimuth = 0.0f;
   float roll = 0.0f;
   int sim_resolution_index = 1;  // Index into kSimResolutions (default 1024)
-  int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full, 3=front)
+  int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full)
+  bool front = false;            // Independent front-hemisphere clip flag (AND with base)
   float background[3] = { 0.0f, 0.0f, 0.0f };
   float ray_color[3] = { 1.0f, 1.0f, 1.0f };
   float opacity = 1.0f;
@@ -162,8 +162,9 @@ struct RenderConfig {
   bool operator==(const RenderConfig& o) const {
     return lens_type == o.lens_type && fov == o.fov && elevation == o.elevation && azimuth == o.azimuth &&
            roll == o.roll && sim_resolution_index == o.sim_resolution_index && visible == o.visible &&
-           std::equal(background, background + 3, o.background) && std::equal(ray_color, ray_color + 3, o.ray_color) &&
-           opacity == o.opacity && exposure_offset == o.exposure_offset;
+           front == o.front && std::equal(background, background + 3, o.background) &&
+           std::equal(ray_color, ray_color + 3, o.ray_color) && opacity == o.opacity &&
+           exposure_offset == o.exposure_offset;
   }
   bool operator!=(const RenderConfig& o) const { return !(*this == o); }
 };

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -420,15 +420,15 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   };
 
   // Hemisphere visibility check used by edge-crossing label paths.
-  // visible: 0=upper (alt>=0), 1=lower (alt<=0), 2=full, 3=front.
+  // visible: 0=upper (alt>=0), 1=lower (alt<=0), 2=full. front: independent AND clip.
   auto is_visible = [&](float alt, float wx, float wy, float wz) -> bool {
-    if (input.visible == 0)
-      return alt >= -0.5f;  // small tolerance for edge labels
-    if (input.visible == 1)
-      return alt <= 0.5f;
-    if (input.visible == 3)
-      return front_facing(wx, wy, wz);
-    return true;  // full(2)
+    if (input.visible == 0 && alt < -0.5f)
+      return false;
+    if (input.visible == 1 && alt > 0.5f)
+      return false;
+    if (input.front && !front_facing(wx, wy, wz))
+      return false;
+    return true;
   };
 
   // Front-only visibility check used by sun-circle interior label placement.
@@ -436,7 +436,7 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
   // Upper/Lower branches — the interior block historically did no is_visible
   // filtering, so other modes must continue to return true unconditionally.
   auto is_visible_front = [&](float wx, float wy, float wz) -> bool {
-    if (input.visible != 3)
+    if (!input.front)
       return true;
     return front_facing(wx, wy, wz);
   };
@@ -825,7 +825,7 @@ void ComputeOverlayLabels(const OverlayLabelInput& input, float vp_screen_x, flo
       sample_hemisphere_equator(-1.0f);
     if (input.visible == kVisibleLower)
       sample_hemisphere_equator(+1.0f);
-    if (input.visible == kVisibleFront)
+    if (input.front)
       sample_front_great_circle();
     if (input.lens_type != kLensTypeLinear)
       sample_interior_latitudes();

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -29,7 +29,7 @@ struct OverlayLabelInput {
   int lens_type;
   float fov, elevation, azimuth, roll;
   int visible;  // 0=upper, 1=lower, 2=full (base hemisphere)
-  bool front;
+  bool front = false;
   bool show_horizon, show_grid, show_sun_circles;
   float sun_dir[3];
   int sun_circle_count;

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -28,7 +28,8 @@ struct OverlayLabel {
 struct OverlayLabelInput {
   int lens_type;
   float fov, elevation, azimuth, roll;
-  int visible;  // 0=upper, 1=lower, 2=full
+  int visible;  // 0=upper, 1=lower, 2=full (base hemisphere)
+  bool front;
   bool show_horizon, show_grid, show_sun_circles;
   float sun_dir[3];
   int sun_circle_count;

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -696,7 +696,7 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     }
   }
 
-  // ---- Pick-mode hit-test ----
+  // ---- Card-area click handling ----
   // Detect a click anywhere inside the card area via a non-layout-affecting
   // rect query. We previously used SetCursorScreenPos(card_win_pos) +
   // InvisibleButton(card_win_sz), but that combination drives an AutoResizeY
@@ -709,27 +709,35 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // (Edit / Duplicate / Delete): when one of them is hovered, the click is
   // routed to it and pick-mode cancellation runs via the blank-area handler
   // in app_panels.cpp instead.
-  if (pick_active && !pick_target_disabled) {
+  if (pick_active) {
+    if (!pick_target_disabled) {
+      const ImVec2 card_max(card_win_pos.x + card_win_sz.x, card_win_pos.y + card_win_sz.y);
+      if (ImGui::IsMouseHoveringRect(card_win_pos, card_max) && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
+          !ImGui::IsAnyItemHovered()) {
+        // "Link A to B" semantics: A (the entry whose modal opened the picker —
+        // pick_link_source) adopts B's (the clicked card's) crystal/filter ids.
+        // So in ApplyPickLink(source, target) the *clicked card* is the source
+        // (model) and pick_link_source is the target (modified).
+        const auto pick_source_ref = *state.pick_link_source;
+        const auto& editing_entry = state.layers[pick_source_ref.layer_idx].entries[pick_source_ref.entry_idx];
+        const std::optional<int> old_filter_id = editing_entry.filter_id;
+        ApplyPickLink(state, GuiState::EntryRef{ layer_idx, entry_idx }, pick_source_ref);
+        state.pick_link_source.reset();
+        state.MarkDirty();
+        // Re-read editing entry after pool re-bind to compare filter existence.
+        const auto& editing_after = state.layers[pick_source_ref.layer_idx].entries[pick_source_ref.entry_idx];
+        if (old_filter_id.has_value() != editing_after.filter_id.has_value()) {
+          state.MarkFilterDirty();
+        }
+        // No explicit Invalidate: editing entry now shares clicked card's
+        // crystal_id; that crystal already has a cache entry from this frame.
+      }
+    }
+  } else {
     const ImVec2 card_max(card_win_pos.x + card_win_sz.x, card_win_pos.y + card_win_sz.y);
     if (ImGui::IsMouseHoveringRect(card_win_pos, card_max) && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
         !ImGui::IsAnyItemHovered()) {
-      // "Link A to B" semantics: A (the entry whose modal opened the picker —
-      // pick_link_source) adopts B's (the clicked card's) crystal/filter ids.
-      // So in ApplyPickLink(source, target) the *clicked card* is the source
-      // (model) and pick_link_source is the target (modified).
-      const auto pick_source_ref = *state.pick_link_source;
-      const auto& editing_entry = state.layers[pick_source_ref.layer_idx].entries[pick_source_ref.entry_idx];
-      const std::optional<int> old_filter_id = editing_entry.filter_id;
-      ApplyPickLink(state, GuiState::EntryRef{ layer_idx, entry_idx }, pick_source_ref);
-      state.pick_link_source.reset();
-      state.MarkDirty();
-      // Re-read editing entry after pool re-bind to compare filter existence.
-      const auto& editing_after = state.layers[pick_source_ref.layer_idx].entries[pick_source_ref.entry_idx];
-      if (old_filter_id.has_value() != editing_after.filter_id.has_value()) {
-        state.MarkFilterDirty();
-      }
-      // No explicit Invalidate: editing entry now shares clicked card's
-      // crystal_id; that crystal already has a cache entry from this frame.
+      g_edit_request = { EditTarget::kCard, layer_idx, entry_idx };
     }
   }
 

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -17,7 +17,7 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
                      SliderScale scale = SliderScale::kLinear);
 
 // ---- Edit request (shared between panels.cpp and app_panels.cpp) ----
-enum class EditTarget { kNone, kCrystal, kAxis, kFilter };
+enum class EditTarget { kNone, kCrystal, kAxis, kFilter, kCard };
 
 struct EditRequest {
   EditTarget target = EditTarget::kNone;

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -33,6 +33,7 @@ uniform int u_lens_type;     // 0=linear, 1-3=fisheye, 4-6=dual fisheye, 7=recta
 uniform float u_fov;         // full FOV in degrees
 uniform mat3 u_view_matrix;  // view-to-world rotation (inverse view)
 uniform int u_visible;       // 0=upper, 1=lower, 2=full
+uniform int u_front;         // 1=discard back hemisphere
 uniform float u_intensity_scale;  // = intensity_factor / per_pixel_intensity (0 = RGB mode)
 uniform int u_xyz_mode;           // 1 = XYZ float texture, 0 = sRGB uint8 texture
 uniform sampler2D u_bg_texture;
@@ -413,9 +414,9 @@ void main() {
     pixel_visible = true;
     if (u_visible == 0 && lat < 0.0) pixel_visible = false;   // upper: discard lower hemisphere
     if (u_visible == 1 && lat > 0.0) pixel_visible = false;   // lower: discard upper hemisphere
-    // 3=front: discard back hemisphere. u_view_matrix[2] = -forward (see BuildViewMatrix),
-    // so dot(world_dir, u_view_matrix[2]) > 0 means world_dir is behind the camera.
-    if (u_visible == 3 && dot(world_dir, u_view_matrix[2]) > 0.0) pixel_visible = false;
+    // u_front: discard back hemisphere (AND with base). u_view_matrix[2] = -forward
+    // (see BuildViewMatrix), so dot > 0 means world_dir is behind the camera.
+    if (u_front == 1 && dot(world_dir, u_view_matrix[2]) > 0.0) pixel_visible = false;
 
     if (pixel_visible) {
       vec3 tex_color = sampleDualFisheye(world_dir);
@@ -925,6 +926,7 @@ void PreviewRenderer::Render(int vp_x, int vp_y, int vp_w, int vp_h, const Previ
   glUniform1i(glGetUniformLocation(shader_program_, "u_lens_type"), params.view_proj.lens_type);
   glUniform1f(glGetUniformLocation(shader_program_, "u_fov"), params.view_proj.fov);
   glUniform1i(glGetUniformLocation(shader_program_, "u_visible"), params.view_proj.visible);
+  glUniform1i(glGetUniformLocation(shader_program_, "u_front"), params.view_proj.front ? 1 : 0);
   glUniform1i(glGetUniformLocation(shader_program_, "u_xyz_mode"), xyz_mode_ ? 1 : 0);
   glUniform1f(glGetUniformLocation(shader_program_, "u_intensity_scale"), params.exposure.intensity_scale);
   glUniform1f(glGetUniformLocation(shader_program_, "u_max_abs_dz"), params.source.max_abs_dz);

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -28,16 +28,17 @@ struct ViewProjection {
   float azimuth = 0.0f;             // Degrees
   float roll = 0.0f;                // Degrees
   int visible = kVisibleFull;       // Index into kVisibleNames (int for shader uniform)
+  bool front = false;               // Independent front-hemisphere clip flag
 };
 
 // Canonical ViewProjection values for export code paths. Kept adjacent to
 // ViewProjection so aggregate-initializer field order can be verified at a
 // glance. Field order, top-to-bottom: lens_type, fov, elevation, azimuth, roll, visible.
 inline constexpr ViewProjection kDualFisheyeExportViewProj = {
-  kLensTypeDualFisheyeEqualArea, 180.0f, 0.0f, 0.0f, 0.0f, kVisibleFull,
+  kLensTypeDualFisheyeEqualArea, 180.0f, 0.0f, 0.0f, 0.0f, kVisibleFull, false,
 };
 inline constexpr ViewProjection kEquirectExportViewProj = {
-  kLensTypeRectangular, 180.0f, 0.0f, 0.0f, 0.0f, kVisibleFull,
+  kLensTypeRectangular, 180.0f, 0.0f, 0.0f, 0.0f, kVisibleFull, false,
 };
 
 struct Exposure {
@@ -171,6 +172,7 @@ inline ViewProjection BuildPreviewViewProjFromRenderer(const RenderConfig& rc) {
   vp.azimuth = rc.azimuth;
   vp.roll = EffectiveRollForLens(rc.lens_type, rc.roll);
   vp.visible = rc.visible;
+  vp.front = rc.front;
   return vp;
 }
 

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -33,7 +33,7 @@ struct ViewProjection {
 
 // Canonical ViewProjection values for export code paths. Kept adjacent to
 // ViewProjection so aggregate-initializer field order can be verified at a
-// glance. Field order, top-to-bottom: lens_type, fov, elevation, azimuth, roll, visible.
+// glance. Field order, top-to-bottom: lens_type, fov, elevation, azimuth, roll, visible, front.
 inline constexpr ViewProjection kDualFisheyeExportViewProj = {
   kLensTypeDualFisheyeEqualArea, 180.0f, 0.0f, 0.0f, 0.0f, kVisibleFull, false,
 };

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -391,6 +391,36 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // Test 4f: legacy "visible": "front" in core-JSON format (DeserializeFromJson path)
+  // Covers the root["render"][0]["visible"]=="front" branch at file_io.cpp:1038-1041,
+  // which is distinct from the GUI-JSON "renderer" object path tested by renderer_legacy_front_compat.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "core_json_legacy_front_compat");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      std::string json = R"({
+        "crystal": [],
+        "filter": [],
+        "scene": {"scattering": [], "ray_num": 1000, "max_hits": 4,
+                   "light_source": {"altitude": 20.0, "diameter": 0.5, "spectrum": "D65"}},
+        "render": [
+          {
+            "lens": {"type": "fisheye_equal_area", "fov": 180.0},
+            "visible": "front"
+          }
+        ]
+      })";
+
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeFromJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.renderer.visible, gui::kVisibleFull);
+      IM_CHECK_EQ(loaded.renderer.front, true);
+    };
+  }
+
   // Test 4d: legacy format with multiple renderers — GUI now single-renderer, take first.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "renderer_legacy_multi_takes_first");

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -244,6 +244,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       r.roll = 7.5f;
       r.sim_resolution_index = 2;
       r.visible = 1;
+      r.front = true;
       r.background[0] = 0.1f;
       r.background[1] = 0.2f;
       r.background[2] = 0.3f;
@@ -267,6 +268,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(loaded.renderer.roll, 7.5f);
       IM_CHECK_EQ(loaded.renderer.sim_resolution_index, 2);
       IM_CHECK_EQ(loaded.renderer.visible, 1);
+      IM_CHECK_EQ(loaded.renderer.front, true);
       IM_CHECK_EQ(loaded.renderer.background[0], 0.1f);
       IM_CHECK_EQ(loaded.renderer.background[1], 0.2f);
       IM_CHECK_EQ(loaded.renderer.background[2], 0.3f);
@@ -323,6 +325,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(loaded.renderer.roll, 3.5f);
       IM_CHECK_EQ(loaded.renderer.sim_resolution_index, 2);  // 2048 → index 2 in kSimResolutions={512,1024,2048,4096}
       IM_CHECK_EQ(loaded.renderer.visible, 1);               // "lower" → 1
+      IM_CHECK_EQ(loaded.renderer.front, false);             // no "front" key → default false
       IM_CHECK(std::abs(loaded.renderer.background[0] - 0.11f) < 1e-5f);
       IM_CHECK(std::abs(loaded.renderer.background[1] - 0.22f) < 1e-5f);
       IM_CHECK(std::abs(loaded.renderer.background[2] - 0.33f) < 1e-5f);
@@ -359,7 +362,32 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(loaded.renderer.fov, 90.0f);
       IM_CHECK_EQ(loaded.renderer.sim_resolution_index, 1);
       IM_CHECK_EQ(loaded.renderer.visible, 2);
+      IM_CHECK_EQ(loaded.renderer.front, false);
       IM_CHECK_EQ(loaded.renderer.opacity, 1.0f);
+    };
+  }
+
+  // Test 4e: legacy "visible": "front" maps to base=full + front=true
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "renderer_legacy_front_compat");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      std::string json = R"({
+        "layers": [],
+        "renderer": {
+          "lens_type": "fisheye_equal_area",
+          "fov": 180.0,
+          "visible": "front"
+        }
+      })";
+
+      gui::GuiState loaded;
+      bool ok = gui::DeserializeGuiStateJson(json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(loaded.renderer.visible, gui::kVisibleFull);
+      IM_CHECK_EQ(loaded.renderer.front, true);
     };
   }
 

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1568,6 +1568,83 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::g_state.dirty, true);
     };
   }
+
+  // p1_card/card_wide_click_opens_modal — clicking card blank area opens the edit modal
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_card", "card_wide_click_opens_modal");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      IM_CHECK_EQ(gui::IsEditModalOpen(), false);
+
+      // Locate the Edit##cr button on the first card to derive the card's thumbnail area.
+      // The thumbnail occupies the left portion of the card; clicking there hits no ImGui item.
+      auto edit_info = ctx->ItemInfo("**/Edit##cr");
+      IM_CHECK(edit_info.ID != 0);
+      float card_left = edit_info.RectFull.Min.x - 200.0f;
+      float card_top = edit_info.RectFull.Min.y;
+      ImVec2 thumb_center(card_left + 30.0f, card_top + 20.0f);
+
+      ctx->MouseMoveToPos(thumb_center);
+      ctx->MouseClick(0);
+      ctx->Yield(4);
+
+      IM_CHECK_EQ(gui::IsEditModalOpen(), true);
+      auto tgt = gui::GetEditModalTarget();
+      IM_CHECK_EQ(tgt.layer_idx, 0);
+      IM_CHECK_EQ(tgt.entry_idx, 0);
+
+      // Cleanup: close modal
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
+  // p1_card/card_wide_click_noop_same_card — card click on already-open card is no-op
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_card", "card_wide_click_noop_same_card");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Open modal on entry 0 via Edit button
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      IM_CHECK_EQ(gui::IsEditModalOpen(), true);
+      auto tgt_before = gui::GetEditModalTarget();
+      IM_CHECK_EQ(tgt_before.layer_idx, 0);
+      IM_CHECK_EQ(tgt_before.entry_idx, 0);
+
+      // Modify a crystal param to detect if OpenEditModal resets buffers
+      gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].prism_h = 7.77f;
+      ctx->Yield();
+
+      // Click the thumbnail area of the same card
+      auto edit_info = ctx->ItemInfo("**/Edit##cr");
+      IM_CHECK(edit_info.ID != 0);
+      float card_left = edit_info.RectFull.Min.x - 200.0f;
+      float card_top = edit_info.RectFull.Min.y;
+      ImVec2 thumb_center(card_left + 30.0f, card_top + 20.0f);
+
+      ctx->MouseMoveToPos(thumb_center);
+      ctx->MouseClick(0);
+      ctx->Yield(4);
+
+      // Modal still open on same card — no-op
+      IM_CHECK_EQ(gui::IsEditModalOpen(), true);
+      auto tgt_after = gui::GetEditModalTarget();
+      IM_CHECK_EQ(tgt_after.layer_idx, 0);
+      IM_CHECK_EQ(tgt_after.entry_idx, 0);
+
+      // Crystal param was NOT reset by a spurious OpenEditModal call
+      IM_CHECK_EQ(gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].prism_h, 7.77f);
+
+      // Cleanup: close modal
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
 }
 
 // ========== task-test-gui-interaction: P1 Slider boundary tests ==========

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1578,8 +1578,11 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
 
       IM_CHECK_EQ(gui::IsEditModalOpen(), false);
 
-      // Locate the Edit##cr button on the first card to derive the card's thumbnail area.
-      // The thumbnail occupies the left portion of the card; clicking there hits no ImGui item.
+      // Derive a thumbnail click position from the Edit##cr button anchor.
+      // The Edit button sits in the right column at thumb_display_size + text_w + 2*spacing from
+      // card left (~200 px in the default test window). The thumbnail occupies the leftmost
+      // ~88 px (4 * frame_height_with_spacing − spacing_y), so card_left + 30 stays in the
+      // thumbnail and is clear of every ImGui item (IsAnyItemHovered == false).
       auto edit_info = ctx->ItemInfo("**/Edit##cr");
       IM_CHECK(edit_info.ID != 0);
       float card_left = edit_info.RectFull.Min.x - 200.0f;
@@ -1616,11 +1619,13 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(tgt_before.layer_idx, 0);
       IM_CHECK_EQ(tgt_before.entry_idx, 0);
 
-      // Modify a crystal param to detect if OpenEditModal resets buffers
-      gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].prism_h = 7.77f;
+      // Set the Height field through the modal UI — the buffer now differs from g_state.
+      // If a spurious OpenEditModal call resets the buffer, the field reverts to g_state.height.
+      const float orig_h = gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height;
+      ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h + 33.0f);
       ctx->Yield();
 
-      // Click the thumbnail area of the same card
+      // Click the thumbnail area of the same card (same anchor logic as card_wide_click_opens_modal)
       auto edit_info = ctx->ItemInfo("**/Edit##cr");
       IM_CHECK(edit_info.ID != 0);
       float card_left = edit_info.RectFull.Min.x - 200.0f;
@@ -1637,12 +1642,12 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(tgt_after.layer_idx, 0);
       IM_CHECK_EQ(tgt_after.entry_idx, 0);
 
-      // Crystal param was NOT reset by a spurious OpenEditModal call
-      IM_CHECK_EQ(gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].prism_h, 7.77f);
-
-      // Cleanup: close modal
-      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      // Commit buffer via OK: if no-op held, g_state.height becomes orig_h + 33.0f;
+      // if OpenEditModal was spuriously called, buffer was reset to orig_h.
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
       ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height,
+                  orig_h + 33.0f);
     };
   }
 }

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -1646,8 +1646,7 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
       // if OpenEditModal was spuriously called, buffer was reset to orig_h.
       ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
       ctx->Yield(2);
-      IM_CHECK_EQ(gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height,
-                  orig_h + 33.0f);
+      IM_CHECK_EQ(gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height, orig_h + 33.0f);
     };
   }
 }
@@ -2618,13 +2617,13 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // ===== task-visibility-radio-layout (scrum-gui-polish-v18 180.1) =====
-  // Verify the 1×4 horizontal layout: click hit and same-row geometry.
+  // ===== task-visible-hemisphere-combo =====
+  // Verify visibility controls: radio buttons (base hemisphere) + checkbox (front).
 
-  // p2_render/visibility_horizontal_layout_click_hit — fisheye lens (all 4 buttons
-  // enabled); ItemClick on Lower and Front commits the correct value.
+  // p2_render/visibility_click_hit — fisheye lens; ItemClick on Lower radio and Front
+  // checkbox commits the correct values.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_horizontal_layout_click_hit");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_click_hit");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);
@@ -2633,16 +2632,21 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       ctx->ItemClick("**/Lower##visible");
       ctx->Yield(2);
       IM_CHECK_EQ(gui::g_state.renderer.visible, gui::kVisibleLower);
+      IM_CHECK_EQ(gui::g_state.renderer.front, false);
       ctx->ItemClick("**/Front##visible");
       ctx->Yield(2);
-      IM_CHECK_EQ(gui::g_state.renderer.visible, gui::kVisibleFront);
+      IM_CHECK_EQ(gui::g_state.renderer.visible, gui::kVisibleLower);
+      IM_CHECK_EQ(gui::g_state.renderer.front, true);
+      ctx->ItemClick("**/Front##visible");
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.renderer.front, false);
     };
   }
 
-  // p2_render/visibility_horizontal_layout_same_row — fisheye lens; Upper and Front
-  // must share the same screen row (RectFull.Min.y equal, confirming 1×4 layout).
+  // p2_render/visibility_same_row — fisheye lens; Upper radio and Front checkbox
+  // must share the same screen row.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_horizontal_layout_same_row");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_same_row");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);
@@ -2652,6 +2656,19 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       auto info_front = ctx->ItemInfo("**/Front##visible");
       IM_CHECK_EQ(info_upper.RectFull.Min.y, info_front.RectFull.Min.y);
       IM_CHECK(info_front.RectFull.Min.x > info_upper.RectFull.Min.x);
+    };
+  }
+
+  // p2_render/visibility_globe_disables_front — Globe lens disables the Front checkbox.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_globe_disables_front");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kLensTypeGlobe;
+      ctx->Yield(3);
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK(info_front.ItemFlags & ImGuiItemFlags_Disabled);
     };
   }
 }

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -2671,6 +2671,22 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       IM_CHECK(info_front.ItemFlags & ImGuiItemFlags_Disabled);
     };
   }
+
+  // p2_render/visibility_full_sky_disables_all — Full-sky lens disables the radio buttons
+  // and Front checkbox (outer BeginDisabled path, acceptance criterion #5).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "visibility_full_sky_disables_all");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.renderer.lens_type = gui::kFullSkyLensTypes[0];
+      ctx->Yield(3);
+      auto info_upper = ctx->ItemInfo("**/Upper##visible");
+      auto info_front = ctx->ItemInfo("**/Front##visible");
+      IM_CHECK(info_upper.ItemFlags & ImGuiItemFlags_Disabled);
+      IM_CHECK(info_front.ItemFlags & ImGuiItemFlags_Disabled);
+    };
+  }
 }
 
 // ========== task-test-gui-interaction: P1 Running simulation restart tests ==========

--- a/test/gui/test_gui_overlay_labels.cpp
+++ b/test/gui/test_gui_overlay_labels.cpp
@@ -15,7 +15,8 @@
 namespace {
 
 // Convenience: build an OverlayLabelInput with grid enabled, sun circles disabled.
-lumice::gui::OverlayLabelInput MakeGridOnly(int visible, int lens_type, float elevation, float azimuth) {
+lumice::gui::OverlayLabelInput MakeGridOnly(int visible, int lens_type, float elevation, float azimuth,
+                                            bool front = false) {
   lumice::gui::OverlayLabelInput in{};
   in.lens_type = lens_type;
   in.fov = 120.0f;
@@ -23,6 +24,7 @@ lumice::gui::OverlayLabelInput MakeGridOnly(int visible, int lens_type, float el
   in.azimuth = azimuth;
   in.roll = 0.0f;
   in.visible = visible;
+  in.front = front;
   in.show_horizon = false;
   in.show_grid = true;
   in.show_sun_circles = false;
@@ -46,8 +48,10 @@ lumice::gui::OverlayLabelInput MakeGridOnly(int visible, int lens_type, float el
 // viewport bounds — the viewport bound check would then mask is_visible_front, making
 // "back labels suppressed" tests vacuously true. With this setup, is_visible_front is the
 // sole gate for sun-circle interior labels in the back hemisphere.
-lumice::gui::OverlayLabelInput MakeSunOnly(int visible, const float sun_dir[3], const float* circle_angles, int count) {
-  lumice::gui::OverlayLabelInput in = MakeGridOnly(visible, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
+lumice::gui::OverlayLabelInput MakeSunOnly(int visible, const float sun_dir[3], const float* circle_angles, int count,
+                                           bool front = false) {
+  lumice::gui::OverlayLabelInput in =
+      MakeGridOnly(visible, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f, front);
   in.fov = 360.0f;
   in.show_grid = false;
   in.show_sun_circles = true;
@@ -162,7 +166,7 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     t->TestFunc = [](ImGuiTestContext* ctx) {
       IM_UNUSED(ctx);
       auto in_full = MakeGridOnly(/*visible=*/2, /*lens=Rectangular*/ 7, /*elev*/ 0.0f, /*az*/ 0.0f);
-      auto in_front = MakeGridOnly(/*visible=*/3, /*lens=Rectangular*/ 7, /*elev*/ 0.0f, /*az*/ 0.0f);
+      auto in_front = MakeGridOnly(/*visible=*/2, /*lens=Rectangular*/ 7, /*elev*/ 0.0f, /*az*/ 0.0f, /*front=*/true);
 
       std::vector<lumice::gui::OverlayLabel> labels_full;
       std::vector<lumice::gui::OverlayLabel> labels_front;
@@ -185,7 +189,7 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       // forward (elev=0,az=0,roll=0) = (-1,0,0); sun_dir=(1,0,0) places the sun directly behind.
       const float sun_back[3] = { 1.0f, 0.0f, 0.0f };
       const float angle = 5.0f;  // small circle stays inside the viewport (interior labels path)
-      auto in = MakeSunOnly(/*visible=*/3, sun_back, &angle, 1);
+      auto in = MakeSunOnly(/*visible=*/2, sun_back, &angle, 1, /*front=*/true);
 
       std::vector<lumice::gui::OverlayLabel> labels;
       lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 800.0f, 600.0f, labels);
@@ -203,7 +207,7 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
       // sun_dir = forward = (-1,0,0); 4 interior labels all in front hemisphere.
       const float sun_front[3] = { -1.0f, 0.0f, 0.0f };
       const float angle = 5.0f;
-      auto in = MakeSunOnly(/*visible=*/3, sun_front, &angle, 1);
+      auto in = MakeSunOnly(/*visible=*/2, sun_front, &angle, 1, /*front=*/true);
 
       std::vector<lumice::gui::OverlayLabel> labels;
       lumice::gui::ComputeOverlayLabels(in, 0.0f, 0.0f, 800.0f, 600.0f, labels);
@@ -227,7 +231,8 @@ void RegisterOverlayLabelTests(ImGuiTestEngine* engine) {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_labels", "front_fisheye_boundary_labels");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       IM_UNUSED(ctx);
-      auto in_front = MakeGridOnly(/*visible=*/3, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
+      auto in_front =
+          MakeGridOnly(/*visible=*/2, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f, /*front=*/true);
       auto in_full = MakeGridOnly(/*visible=*/2, /*lens=Fisheye Equidistant*/ 2, /*elev*/ 0.0f, /*az*/ 0.0f);
       in_front.fov = 280.0f;
       in_full.fov = 280.0f;


### PR DESCRIPTION
## Summary
- **Card-wide click**: clicking anywhere on an entry card's blank area opens the edit modal (defaulting to the Crystal tab, or preserving the active tab if the modal is already open on a different card). Clicking the same card is a no-op to avoid resetting unsaved edits.
- **Front-hemisphere checkbox**: the `Front` visibility option is now an independent checkbox (combinable with Upper/Lower/Full) instead of a radio button. The `kVisibleFront` enum value is removed; front clipping is driven by `RenderConfig::front` and a dedicated `u_front` shader uniform. Legacy `"visible": "front"` JSON files are migrated to `visible=full + front=true` on load.
- Code-review follow-ups: spacing tweak for the checkbox gap, clarified API comments.

## Test plan
- [x] New GUI tests: `card_wide_click_opens_modal`, `card_wide_click_noop_same_card`
- [x] Updated tests: `visibility_click_hit`, `visibility_same_row`, new `visibility_globe_disables_front`, `visibility_full_sky_disables_all`
- [x] Import/export tests: `renderer_legacy_front_compat`, `core_json_legacy_front_compat` cover the old `"front"` value migration
- [x] Overlay label tests updated for `front` flag API (`MakeGridOnly`, `MakeSunOnly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)