### PR TITLE
chore(gui): unify overlay sentinel and add review follow-up fixes

### DIFF
--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -712,7 +712,7 @@ void BuildViewMatrix(float elevation_deg, float azimuth_deg, float roll_deg, flo
 // Sentinel value indicating the world direction does not project to a renderable
 // screen position under the current lens / camera setup. Kept identical to the
 // magic shader value so the GPU distance test trivially rejects it.
-static constexpr std::array<float, 2> kProjectSentinel = { -9999.f, -9999.f };
+static constexpr std::array<float, 2> kProjectSentinel = { kOverlaySentinel, kOverlaySentinel };
 
 static bool IsInViewport(float px, float py, float vp_w, float vp_h) {
   // Half-pixel margin keeps points landing exactly on the viewport edge
@@ -844,6 +844,7 @@ static std::array<float, 2> ProjectRectangular(const float world_dir[3], float s
 }
 
 // See declaration in preview_renderer.hpp for contract.
+// NOTE: must be updated when adding a new kLensType* constant.
 std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const float world_dir[3], int vp_w, int vp_h) {
   constexpr float kPi = 3.14159265358979323846f;
   if (vp_w <= 0 || vp_h <= 0) {

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -9,6 +9,8 @@
 
 namespace lumice::gui {
 
+inline constexpr float kOverlaySentinel = -9999.f;
+
 // Source texture format. Dual-fisheye overlap parameters for sampling a
 // packed front/back hemisphere texture. Owned by the producer (GUI hard-codes
 // kDualFisheyeOverlap today; future: server/RawXyzResult may supply).
@@ -73,8 +75,8 @@ struct OverlayDecoration {
   // (-9999, -9999) when the direction is offscreen / behind the camera
   // / unsupported lens — shader compares distance and naturally skips it.
   bool show_zenith_nadir = false;
-  float zenith_screen_pos[2] = { -9999.f, -9999.f };
-  float nadir_screen_pos[2] = { -9999.f, -9999.f };
+  float zenith_screen_pos[2] = { kOverlaySentinel, kOverlaySentinel };
+  float nadir_screen_pos[2] = { kOverlaySentinel, kOverlaySentinel };
   float zenith_nadir_color[3] = { 0.8f, 0.2f, 0.2f };
   float zenith_nadir_alpha = 0.6f;
   float zenith_nadir_radius_px = 8.0f;

--- a/test/gui/test_gui_import_export.cpp
+++ b/test/gui/test_gui_import_export.cpp
@@ -569,6 +569,9 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       gui::GuiState legacy_loaded;
       IM_CHECK(gui::DeserializeGuiStateJson(legacy_json, legacy_loaded));
       IM_CHECK_EQ(legacy_loaded.show_zenith_nadir_line, false);
+      IM_CHECK_EQ(legacy_loaded.zenith_nadir_color[0], 0.8f);
+      IM_CHECK_EQ(legacy_loaded.zenith_nadir_color[1], 0.2f);
+      IM_CHECK_EQ(legacy_loaded.zenith_nadir_color[2], 0.2f);
       IM_CHECK_EQ(legacy_loaded.zenith_nadir_alpha, 0.6f);
       IM_CHECK_EQ(legacy_loaded.zenith_nadir_radius_px, 8.0f);
     };


### PR DESCRIPTION
## Summary
- Consolidate the `-9999.f` overlay sentinel into a single `kOverlaySentinel` constant in `preview_renderer.hpp`, referenced by `OverlayDecoration` default initializers and `kProjectSentinel`
- Add missing `zenith_nadir_color[3]` fallback assertions in the legacy `.lmc` import/export test
- Add a maintenance note on `ProjectWorldDirToScreen` for new lens types

Follow-up from task-224 (gui-zenith-nadir-marker) code-review items B, C, D.

## Test plan
- [x] Build passes (`./scripts/build.sh -j release`)
- [x] GUI tests pass (260/260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)