### PR TITLE
chore: major audit — architecture docs, tooltips, and cross-ref comments

### DIFF
--- a/doc/accumulator-consumer-architecture.md
+++ b/doc/accumulator-consumer-architecture.md
@@ -1,0 +1,366 @@
+# Accumulator / Consumer Architecture
+
+This document describes the internal invariants of Lumice's accumulator/consumer
+subsystem — the bridge between the simulator's raw ray output and the rendering
+pipeline (GUI preview and CLI image export).
+
+**Target audience**: contributors who modify consumer lifecycle management,
+snapshot protocol, thread synchronization, or the `NeedsRebuild` / `ResetWith`
+reuse path.
+
+**Scope**: internal invariants and data-flow contracts. This document does **not**
+cover:
+
+- EV auto algorithm, P99.5 computation, or adaptive brightness
+  — see [`doc/ev-pipeline-architecture.md`](ev-pipeline-architecture.md).
+- Filter subsystem internals or Design A gate semantics
+  — see [`doc/filter-architecture.md`](filter-architecture.md).
+- C API lifecycle (server creation, config commit, result retrieval)
+  — covered by a separate audit.
+
+---
+
+## §1 Overview
+
+The accumulator/consumer subsystem sits between the simulator thread pool and the
+result-consumption paths (GUI `ServerPoller`, CLI `GetRenderResults`). Its
+responsibilities:
+
+1. **Accumulate** incoming ray data (`SimData`) into per-pixel XYZ buffers.
+2. **Snapshot** accumulated state for consumption without blocking the simulation.
+3. **Transform** XYZ data to sRGB for CLI image export (`PostSnapshot`).
+4. **Expose** raw XYZ data for GPU-side rendering in the GUI path.
+
+Key source files:
+
+| File | Role |
+|------|------|
+| `src/server/consumer.hpp` | `IConsume` interface |
+| `src/server/render.hpp` / `render.cpp` | `RenderConsumer` — projection, accumulation, snapshot |
+| `src/server/stats.hpp` / `stats.cpp` | `StatsConsumer` — ray/crystal counters |
+| `src/server/server.cpp` | `ServerImpl` — consumer orchestration, locking, snapshot protocol |
+| `src/config/render_config.hpp` / `.cpp` | `RenderConfig`, `NeedsRebuild()` |
+| `src/gui/server_poller.hpp` / `.cpp` | GUI consumption side |
+
+---
+
+## §2 IConsume Interface
+
+`IConsume` (`consumer.hpp:18`) defines the consumer contract:
+
+| Method | Called under | Purpose |
+|--------|-------------|---------|
+| `Consume(SimData)` | `consumer_mutex_` | Accumulate one batch of ray data |
+| `PrepareSnapshot()` | `consumer_mutex_` | `memcpy` internal → snapshot buffers |
+| `PostSnapshot()` | `snapshot_mutex_` | XYZ→RGB conversion (CLI path) |
+| `GetResult()` | `snapshot_mutex_` | Return typed result (`RenderResult` / `StatsResult`) |
+| `Reset()` | `consumer_mutex_` | Zero accumulators, preserve buffer allocations |
+
+Two concrete implementations:
+
+- **`RenderConsumer`**: projects rays through the lens model, accumulates into
+  `internal_xyz_`, snapshots to `snapshot_xyz_`, converts to sRGB in
+  `PostSnapshot()`. Also manages the anchor lane for filter-independent EV.
+- **`StatsConsumer`**: counts `total_rays_`, `sim_rays_`, `crystals_`.
+
+Both are held via `shared_ptr<IConsume>` in `ServerImpl::consumers_`.
+
+---
+
+## §3 Consumer State Machine
+
+### §3.1 Lifecycle Paths
+
+The consumer lifecycle has four entry points:
+
+```
+CommitConfig (full rebuild, NeedsRebuild=true or first commit):
+  Stop() → consumers_.clear() → new RenderConsumer(config) → new StatsConsumer → Start()
+
+CommitConfig (reuse path, NeedsRebuild=false):
+  Stop() → ResetWith(new_config) for RenderConsumers, Reset() for StatsConsumer → Start()
+
+Stop():
+  snapshot_dirty_ = false
+  has_ever_consumed_ = false          ← prevents stale snapshot reads
+  (consumers_ not cleared — CommitConfig decides rebuild vs. reuse)
+
+~ServerImpl():
+  Stop() → state_ = kTerminating → join threads → consumers_ destroyed with ServerImpl
+```
+
+### §3.2 State Transition Diagram
+
+Consumer state is implicit, encoded in flags rather than an explicit enum:
+
+```
+                    CommitConfig
+                   (full rebuild)        ConsumeData (under consumer_mutex_)
+  ┌──────────┐  ──────────────────►  ┌──────┐  ──────────────────────────►  ┌──────────────┐
+  │ Created  │                       │ Idle │                               │ Accumulating │
+  └──────────┘                       └──┬───┘  ◄────────────────────────── └──────────────┘
+                                        │         Stop() + CommitConfig
+                                        │         (rebuild or reuse)
+                                        │
+                              GetRawXyzResults /
+                                DoSnapshot
+                                        │
+                                        ▼
+                                  ┌──────────────┐
+                                  │ Snapshotted  │
+                                  │ (snapshot_xyz_│
+                                  │   valid)     │
+                                  └──────────────┘
+```
+
+State flags:
+
+| Flag | Set by | Cleared by | Meaning |
+|------|--------|------------|---------|
+| `has_ever_consumed_` | `ConsumeData` (`server.cpp:613`) | `Stop()` (`server.cpp:524`) | True after first batch consumed; gates `has_valid_data_` in results |
+| `snapshot_dirty_` | `ConsumeData` (`server.cpp:612`) | `PrepareSnapshot` in `DoSnapshot`/`GetRawXyzResults` (`server.cpp:350,398`) | Indicates new data since last snapshot |
+| `snapshot_generation_` | `GetRawXyzResults` (`server.cpp:399`) | Never reset (monotonic) | Poller detects new snapshots via generation comparison |
+
+---
+
+## §4 Thread Safety Model
+
+### §4.1 Two-Lock Design
+
+| Lock | Type | Guards | Writer thread | Reader thread |
+|------|------|--------|---------------|---------------|
+| `consumer_mutex_` | `TicketMutex` (FIFO) | `consumers_` list, all consumer mutable state (`internal_xyz_`, `total_intensity_`, anchor buffers) | `ConsumeData` thread (high frequency) | Poller → `GetRawXyzResults` (low frequency); `CommitConfig` caller (rebuild/reset) |
+| `snapshot_mutex_` | `std::mutex` | `cached_render_results_`, `cached_stats_result_` | `DoSnapshot` / `GetRawXyzResults` (after snapshot) | `Get*Results` callers |
+
+**Why TicketMutex**: on Windows, `std::mutex` uses SRWLOCK which provides no
+fairness guarantee. A high-frequency locker (`ConsumeData`, called per simulator
+batch) can starve a low-frequency waiter (`ServerPoller`, polling every
+~100ms). `TicketMutex` (`server.cpp:35`) assigns monotonic tickets and serves
+in FIFO order, guaranteeing bounded wait.
+
+### §4.2 Two-Phase Snapshot Protocol
+
+`DoSnapshot()` (`server.cpp:336`) and `GetRawXyzResults()` (`server.cpp:386`)
+use a two-phase protocol to minimize `consumer_mutex_` hold time:
+
+```
+Phase 1  (consumer_mutex_ held):
+  PrepareSnapshot() for each consumer    ← memcpy internal → snapshot buffers
+  snapshot_consumers = consumers_        ← shared_ptr copy keeps objects alive
+  snapshot_dirty_ = false
+
+Phase 1.5 (NO lock held):
+  CountEffectivePixels()                 ← O(W×H) scan of snapshot_xyz_
+
+Phase 2  (snapshot_mutex_ held):
+  PostSnapshot() for each consumer       ← XYZ→RGB (CLI path only)
+  Cache results
+```
+
+**Critical invariant**: `snapshot_xyz_` is stable between Phase 1 and the next
+`PrepareSnapshot()` call. `CountEffectivePixels()` (`render.cpp:596`) relies on
+this — it reads `snapshot_xyz_` outside `consumer_mutex_` but before any
+subsequent `PrepareSnapshot()` can overwrite it. This is safe because:
+
+1. `ConsumeData` only writes to `internal_xyz_` (never `snapshot_xyz_`).
+2. `PrepareSnapshot` is the sole writer of `snapshot_xyz_`, and it runs under
+   `consumer_mutex_` which the snapshot caller already released.
+3. The snapshot caller holds `snapshot_consumers` via `shared_ptr`, preventing
+   object destruction.
+
+### §4.3 Consumer Lifetime Safety
+
+`consumers_` is a `vector<shared_ptr<IConsume>>`. During `DoSnapshot` /
+`GetRawXyzResults`, the snapshot code copies the `shared_ptr` vector under
+`consumer_mutex_`, then operates on the copies outside the lock. Even if
+`CommitConfig` calls `consumers_.clear()` concurrently (under `consumer_mutex_`),
+the snapshot's `shared_ptr` copies keep the consumer objects alive until the
+snapshot operation completes.
+
+---
+
+## §5 NeedsRebuild / ResetWith
+
+### §5.1 NeedsRebuild Semantics
+
+`NeedsRebuild()` (`render_config.cpp:164`) compares layout-affecting fields
+between old and new `RenderConfig`:
+
+| Triggers rebuild (`true`) | Does NOT trigger rebuild (`false`) |
+|---------------------------|------------------------------------|
+| `resolution_` | `background_` |
+| `lens_` (type + fov) | `ray_color_` |
+| `lens_shift_` | `opacity_` |
+| `view_` | `intensity_factor_` |
+| `visible_` | `norm_mode_` |
+| `overlap_` | `central_grid_` / `elevation_grid_` / `celestial_outline_` |
+
+**Filter changes do not trigger NeedsRebuild.** Filter specs belong to
+`SceneConfig`, not `RenderConfig`. When a filter changes, consumers walk the
+reuse path: `Stop()` → `ResetWith()` → `Start()`. Accumulators are zeroed but
+buffer allocations are preserved.
+
+### §5.2 sizeof Sentinel
+
+```cpp
+static_assert(sizeof(RenderConfig) == 144,
+              "Update NeedsRebuild when RenderConfig fields change");
+```
+
+This sentinel (`render_config.cpp:166`) forces a compile error when any field is
+added to or removed from `RenderConfig`. The developer must then classify the
+new field as layout-affecting (add to `NeedsRebuild` comparisons) or
+appearance-only (no change needed). This prevents silent drift where a new
+layout field is added but `NeedsRebuild` is not updated.
+
+### §5.3 ResetWith Path
+
+`ResetWith(new_config)` (`render.cpp:715`):
+```cpp
+void RenderConsumer::ResetWith(const RenderConfig& new_config) {
+  config_ = new_config;
+  Reset();
+}
+```
+
+Because `NeedsRebuild` returned `false`, all layout fields are identical.
+Assigning the full config is safe — `rot_` and all buffer sizes remain valid.
+`Reset()` zeros the accumulation state without reallocating buffers.
+
+### §5.4 CommitConfig Reuse Logic
+
+`CommitConfig` (`server.cpp:273`) determines reuse eligibility:
+
+1. `consumers_` must be non-empty (first commit always rebuilds).
+2. Renderer count must match (same number of render configs).
+3. Renderer keys must match (same map ordering).
+4. `NeedsRebuild()` must return `false` for every renderer pair.
+
+If all conditions pass, the reuse path calls `ResetWith()` on each
+`RenderConsumer` and `Reset()` on `StatsConsumer`, avoiding the cost of
+destroying and reconstructing consumers (~0.5ms vs. ~30ms for full rebuild).
+
+---
+
+## §6 Data Integrity Invariants
+
+| Invariant | Location | Notes |
+|-----------|----------|-------|
+| `internal_xyz_` size = `W × H × 3` floats | `render.cpp:324` (constructor) | Allocated once, never resized |
+| `snapshot_xyz_` size = `W × H × 3` floats | `render.cpp:325` (constructor) | Same allocation as internal |
+| `snapshot_work_` size = `W × H × 3` floats | `render.cpp:326` (constructor) | Preserves `snapshot_xyz_` during `PostSnapshot` |
+| `snapshot_image_buffer_` size = `W × H × 3` bytes | `render.cpp:327` (constructor) | sRGB output for CLI |
+| Anchor buffers size = `W × H × 3` floats | `render.cpp:506–513` (lazy alloc) | Only allocated on first filter-fail emission |
+| `d_buf_`/`w_buf_`/`xy_buf_`/`overlap_w_buf_` capacity ≥ max(rays, outgoing) | `render.cpp:347–354` | Grow-only; never shrink |
+| `snapshot_xyz_` read-only between `PrepareSnapshot()` calls | `render.cpp:674` (`GetRawXyzResult` returns raw pointer) | Enables lock-free read in Phase 1.5 and result delivery |
+| `snapshot_image_buffer_` valid until next `GetRenderResults`/`CommitConfig` | `server.hpp` (`RenderResult` doc) | Pointer-based result; caller must consume before next snapshot |
+| StatsConsumer snapshot fields zeroed on `Reset()` | `stats.cpp:23–30` | Both accumulation and snapshot counters cleared |
+
+### §6.1 Anchor Buffer Lifecycle
+
+Anchor buffers (`anchor_internal_xyz_`, `anchor_snapshot_xyz_`) follow a lazy
+allocation pattern:
+
+1. **Constructor**: not allocated (null). Zero cost when no filter is configured.
+2. **First filter-fail emission** (`render.cpp:506–513`): allocated at
+   `W × H × 3` floats, matching the main buffer size.
+3. **Reset()**: if allocated, zeroed via `memset` but **not deallocated**.
+   This preserves the allocation across `ResetWith` cycles. If
+   `anchor_internal_xyz_` is null, it stays null — the no-filter zero-cost
+   path is preserved.
+4. **Destruction**: freed with the `RenderConsumer` (unique_ptr).
+
+---
+
+## §7 Consumer ↔ Filter Interaction
+
+Design A (`doc/filter-architecture.md §2`): the filter gate runs on the
+simulator side. Consumers receive pre-filtered data — `SimData::outgoing_d_` /
+`outgoing_w_` contain only filter-pass rays. Consumers do not hold or consult
+`FilterSpec`.
+
+### §7.1 Filter Change Response Chain
+
+When a filter spec changes:
+
+1. `CommitConfig` is called with new config.
+2. `Stop()` drains all threads.
+3. `NeedsRebuild` returns `false` (filter is not in `RenderConfig`).
+4. `ResetWith` resets accumulators (zeros `internal_xyz_`, anchor buffers).
+5. `Start()` resumes simulation with new scene config (new filter).
+6. New simulation rounds fill `anchor_d_` / `anchor_w_` according to the new
+   filter (ON mode: empty anchor, OFF mode: filter-fail rays populate anchor).
+
+### §7.2 Anchor Lane Design
+
+The anchor lane accumulates filter-fail emission to provide a
+filter-independent EV reference. Key properties:
+
+- **ON mode** (filter active): `anchor_d_`/`anchor_w_` from simulator carry
+  filter-fail rays → accumulated into `anchor_internal_xyz_`.
+- **OFF mode** (no filter): simulator produces no filter-fail rays →
+  `anchor_d_` stays empty → anchor buffers remain null (zero cost).
+- **At snapshot time**: combined emission = filter-pass (`snapshot_xyz_`) +
+  filter-fail (`anchor_snapshot_xyz_`), yielding filter-independent total
+  intensity and P99.5 Y for stable EV anchoring across filter toggles.
+
+See `doc/ev-pipeline-architecture.md §2` for the full EV data flow.
+
+---
+
+## §8 ServerPoller (GUI Consumption Side)
+
+`ServerPoller` (`server_poller.hpp:43`) runs a persistent background thread that
+polls the server via the C API and stages results for the main (GUI) thread.
+
+### §8.1 Polling Contract
+
+1. **Background thread** calls `LUMICE_GetRawXyzResults()` (which internally
+   calls `ServerImpl::GetRawXyzResults()` — the two-phase snapshot protocol).
+2. **Generation tracking**: `last_generation_` detects genuinely new snapshots.
+   If `snapshot_generation` hasn't changed, the poll is a no-op for texture data.
+3. **Quality gate**: skips texture overwrite when `sim_ray_num < min_rays`
+   (calibrated threshold or floor), preventing visible flicker from sparse
+   snapshots. Timeout fallback forces upload after `kQualityGateTimeoutMs`.
+4. **Main thread** calls `TrySyncData()` (try-lock, never blocks) to swap
+   staged data.
+
+### §8.2 Lifecycle
+
+```
+Constructor → worker thread spawned (starts in kPaused)
+
+Start(server):
+  Stop() → clear valid flag → reset generation/quality gate → kRunning → notify
+
+Stop():
+  kPaused → wait for worker to confirm paused (active_ == false)
+
+EnsureRunning(server):
+  if kRunning: no-op
+  if kPaused: resume polling (reset generation/quality gate → kRunning)
+
+~ServerPoller():
+  kTerminating → join worker thread
+```
+
+### §8.3 Data Flow: Poller → Main Thread
+
+```
+  Poller thread                              Main thread
+  ────────────                               ───────────
+  PollOnce():
+    LUMICE_GetRawXyzResults() ──────┐
+    LUMICE_GetCachedStats()         │
+    quality gate check              │
+    lock(data_mutex_)               │
+    staged_ = new data              │
+    unlock                          │
+                                    │     SyncFromPoller():
+                                    │       TrySyncData(out)  ← try_lock(data_mutex_)
+                                    │       swap(out, staged_)
+                                    └─────► upload xyz_data to GPU texture
+```
+
+The `try_lock` in `TrySyncData` ensures the main thread never blocks on the
+poller — if the poller is mid-write, the main thread simply skips this frame.

--- a/doc/capi-lifecycle-architecture.md
+++ b/doc/capi-lifecycle-architecture.md
@@ -1,0 +1,462 @@
+# C API Lifecycle & Design Constraints
+
+This document describes the internal invariants and design constraints of
+Lumice's C API layer — the boundary between GUI / CLI / external consumers and
+the core simulation engine.
+
+**Target audience**: contributors who modify server lifecycle management,
+result retrieval paths, sentinel handling, or the `CommitConfig` dual-path
+logic.
+
+**Scope**: internal contracts, state machine, thread safety model, and
+sentinel-overflow protection. This document does **not** cover:
+
+- How to *use* the API (function signatures, parameters, examples)
+  — see [`doc/c_api.md`](c_api.md).
+- Accumulator/consumer internals (snapshot protocol, `NeedsRebuild` / `ResetWith`)
+  — see [`doc/accumulator-consumer-architecture.md`](accumulator-consumer-architecture.md).
+- EV pipeline or filter architecture
+  — see [`doc/ev-pipeline-architecture.md`](ev-pipeline-architecture.md) and
+  [`doc/filter-architecture.md`](filter-architecture.md).
+
+---
+
+## §1 Overview
+
+The C API (`src/include/lumice.h`, implemented in `src/server/c_api.cpp`)
+wraps the internal C++ `Server` class and exposes an opaque-handle interface
+suitable for FFI consumption. It enforces:
+
+1. A **lifecycle state machine** governing legal calling sequences.
+2. **Per-function contracts** (preconditions, postconditions, error returns).
+3. A **thread safety model** (per-function annotations).
+4. A **sentinel pattern** with overflow protection for result arrays.
+5. **Dual configuration paths** (`CommitConfig` JSON vs. `CommitConfigStruct`).
+6. **SimData side-effect rules** triggered by `CommitConfig`.
+
+Key source files:
+
+| File | Role |
+|------|------|
+| `src/include/lumice.h` | Public C API header — the stable ABI surface |
+| `src/server/c_api.cpp` | C API implementation; wraps `Server` methods |
+| `src/server/server.hpp` / `server.cpp` | `ServerImpl` — state machine, threading, consumer management |
+| `src/server/consumer.hpp` | `IConsume` interface |
+| `src/server/render.hpp` / `render.cpp` | `RenderConsumer` — accumulation, snapshot, XYZ→RGB |
+| `src/server/stats.hpp` / `stats.cpp` | `StatsConsumer` — ray/crystal counters |
+
+---
+
+## §2 API Calling State Machine
+
+### §2.1 State Transitions
+
+The server's externally observable state is a projection of the internal
+`ServerState` enum (`server.cpp`): `kStopped` / `kRunning` / `kTerminating`.
+
+```
+LUMICE_CreateServer / LUMICE_CreateServerEx
+    |
+    v
+[Idle — kStopped, no config committed, threads in cv.wait]
+    |
+    |  LUMICE_CommitConfig* ──> internally: Stop() → rebuild consumers → Start()
+    v
+[Running — kRunning, simulation active]
+    |                                              ^
+    |  simulation completes (finite rays)          |
+    |  or LUMICE_StopServer                        |
+    v                                              |
+[Idle — kStopped, has_ever_consumed_=false]        |
+    |                                              |
+    +---- LUMICE_CommitConfig* (re-launch) --------+
+    |
+    |  LUMICE_DestroyServer ──> Terminate()
+    v
+[Destroyed — impl_ reset, handle invalid]
+```
+
+Key observations:
+
+- There is no explicit `Run()` API. The server transitions to Running
+  *inside* `CommitConfig`, which calls `Stop() → rebuild → Start()`.
+- `LUMICE_SERVER_NOT_READY` is defined in the `LUMICE_ServerState` enum but
+  is never returned by `LUMICE_QueryServerState`. The implementation maps
+  to either `LUMICE_SERVER_IDLE` or `LUMICE_SERVER_RUNNING`. This enum
+  value is dead code retained for potential future use.
+- `LUMICE_DestroyServer(NULL)` is safe (early return on null check).
+
+### §2.2 State Table
+
+| Current State | API Call | Next State | Notes |
+|---------------|----------|------------|-------|
+| Idle | `CommitConfig*` | Running | Stop (no-op if already stopped) → rebuild → Start |
+| Idle | `StopServer` | Idle | No-op (already stopped) |
+| Idle | `DestroyServer` | Destroyed | `Terminate()` → `~ServerImpl` joins all threads |
+| Running | `CommitConfig*` | Running | Stop (drains workers) → rebuild → Start |
+| Running | `StopServer` | Idle | Drains queues, waits for `active_workers_==0` |
+| Running | `DestroyServer` | Destroyed | `Terminate()` calls Stop first |
+| Running | `Get*Results` | Running | Triggers snapshot if `snapshot_dirty_` |
+| Running | `QueryServerState` | Running | Read-only status check |
+| Destroyed | Any | UB | Handle is invalid after `DestroyServer` |
+
+---
+
+## §3 Per-Function Contracts
+
+### §3.1 Server Lifecycle APIs
+
+#### `LUMICE_CreateServer()` / `LUMICE_CreateServerEx(config)`
+
+- **Precondition**: none (but see thread safety — §4).
+- **Postcondition**: returns a valid `LUMICE_Server*` with all persistent
+  threads spawned and waiting in `cv.wait` (state = `kStopped`).
+- **Error**: returns `NULL` only on allocation failure.
+- **Side effects**: registers the global logger sink (`spdlog`). The
+  `LUMICE_ServerConfig` struct allows setting `num_workers` and `sim_seed`;
+  `NULL` config or zero fields use defaults.
+  (`c_api.cpp:62–75`)
+
+#### `LUMICE_DestroyServer(server)`
+
+- **Precondition**: `server` is a valid handle or `NULL`.
+- **Postcondition**: all threads joined; handle memory freed. Passing
+  `NULL` is a no-op.
+- **Side effects**: calls `Terminate()` which calls `Stop()` then destroys
+  `ServerImpl`.
+  (`c_api.cpp:78–84`)
+
+### §3.2 Configuration APIs
+
+#### `LUMICE_CommitConfig(server, config_str)` / `LUMICE_CommitConfigFromFile(server, filename)`
+
+- **Precondition**: `server != NULL`, input non-null.
+- **Postcondition**: on success, server is Running with new config active.
+  On failure, server may be in `kError` status (parse failures leave the
+  running server untouched; only the status is set to `kError`).
+- **Error returns**: `LUMICE_ERR_NULL_ARG`, `LUMICE_ERR_INVALID_JSON`,
+  `LUMICE_ERR_INVALID_CONFIG`, `LUMICE_ERR_MISSING_FIELD`,
+  `LUMICE_ERR_INVALID_VALUE`.
+- **Internal sequence**: parse JSON → `Stop()` → consumer rebuild/reuse →
+  update `active_scene_` → `Start()`.
+  (`c_api.cpp:125–156`, `server.cpp:226–335`)
+
+#### `LUMICE_CommitConfigStruct(server, config, out_reused)`
+
+- **Precondition**: `server != NULL`, `config != NULL`. Array counts must
+  not exceed `LUMICE_MAX_CONFIG_*` limits.
+- **Postcondition**: same as `CommitConfig` (JSON path). If `out_reused`
+  is non-null, set to `1` when consumers were reused, `0` when rebuilt.
+- **Internal path**: `ConfigToJson(*config)` → `Server::CommitConfig(json, &reused)`.
+  The struct path always produces `dual_fisheye_equal_area` lens at 180° FOV
+  (see §6.2).
+  (`c_api.cpp:313–336`)
+
+#### `LUMICE_ParseConfigString(json_str, out)` / `LUMICE_ParseConfigFile(filename, out)`
+
+- **Precondition**: pointers non-null.
+- **Postcondition**: `out` populated with parsed config. The `spectrum`
+  field points to static storage — the caller must not free it.
+- **Side effects**: none (pure parsing, no server state change).
+- **Supported subset**: only `type="raypath"` filters; only string-form
+  spectrum (`"D65"`, `"D50"`, `"A"`, `"E"`); renderer lens/view/visible/
+  background fields are ignored.
+  (`c_api.cpp:670–704`)
+
+### §3.3 Result Retrieval APIs
+
+All result APIs follow the sentinel pattern (see §5).
+
+#### `LUMICE_GetRenderResults(server, out, max_count)`
+
+- **Precondition**: `server != NULL`, `out != NULL`.
+- **Postcondition**: `out[0..count-1]` filled with sRGB uint8 results.
+  Sentinel at `out[count]` if `count < max_count`.
+- **Internal**: calls `DoSnapshot()` which acquires `consumer_mutex_` →
+  `PrepareSnapshot()` → `snapshot_mutex_` → `PostSnapshot()` → cache.
+  (`c_api.cpp:708–732`)
+
+#### `LUMICE_GetRawXyzResults(server, out, max_count)`
+
+- **Precondition**: same as above.
+- **Postcondition**: `out[0..count-1]` filled with raw XYZ float data
+  plus metadata (`snapshot_intensity`, `intensity_factor`, `has_valid_data`,
+  `snapshot_generation`, `effective_pixels`, anchor fields).
+- **Internal**: independent snapshot path — `PrepareSnapshot()` under
+  `consumer_mutex_`, `CountEffectivePixels()` outside lock, results under
+  `snapshot_mutex_`. Increments `snapshot_generation_` on actual snapshot.
+  (`c_api.cpp:735–766`)
+
+#### `LUMICE_GetStatsResults(server, out, max_count)`
+
+- **Precondition**: same as above.
+- **Postcondition**: `out[0]` filled if stats available. Sentinel at
+  `out[count]` if `count < max_count`.
+- **Internal**: triggers `DoSnapshot()` — includes `PostSnapshot()`
+  XYZ→RGB conversion (unlike `GetCachedStats`).
+  (`c_api.cpp:769–791`)
+
+#### `LUMICE_GetCachedStats(server, out)`
+
+- **Precondition**: `server != NULL`, `out != NULL`.
+- **Postcondition**: `out` filled with most recent cached stats. Returns
+  all-zero struct if no snapshot has been taken.
+- **Internal**: only acquires `snapshot_mutex_` — does **not** trigger
+  `DoSnapshot()`. Stats come from the last `GetRawXyzResults` or
+  `GetStatsResults` call.
+  (`c_api.cpp:794–809`)
+
+### §3.4 State & Control APIs
+
+#### `LUMICE_QueryServerState(server, out)`
+
+- **Precondition**: `server != NULL`, `out != NULL`.
+- **Postcondition**: `*out` set to `LUMICE_SERVER_IDLE` or
+  `LUMICE_SERVER_RUNNING`.
+- **Internal**: reads `status_` under `status_mutex_`; if Running, also
+  polls simulator idle state and `scene_gen_active_` flag.
+  (`c_api.cpp:813–825`, `server.cpp:541–574`)
+
+#### `LUMICE_StopServer(server)`
+
+- **Precondition**: `server` is valid or `NULL` (null is safe).
+- **Postcondition**: server is Idle. Worker threads are drained (not
+  terminated — they return to `cv.wait`).
+  (`c_api.cpp:828–834`, `server.cpp:486–539`)
+
+### §3.5 Stateless Utility APIs
+
+These functions have no shared state and are always thread-safe:
+
+| Function | Precondition | Notes |
+|----------|-------------|-------|
+| `LUMICE_GetCrystalMesh(server, json, out)` | `json != NULL`, `out != NULL` | `server` is unused (reserved) |
+| `LUMICE_ValidateRaypathText(text, kind, out_state, out_msg, size)` | all pointers non-null | Pure validation |
+| `LUMICE_IsLegalFace(kind, face)` | none | Pure function |
+| `LUMICE_MaxFov(type)` | none | Pure function |
+| `LUMICE_XyzToSrgbUint8(xyz_in, out, count, scale)` | `xyz_in != NULL`, `out != NULL` | Batch conversion |
+
+---
+
+## §4 Thread Safety Model
+
+| Function | Thread-safe | Protection | Notes |
+|----------|-------------|------------|-------|
+| `LUMICE_CreateServer*` | No | — | Global logger sink registration is not atomic |
+| `LUMICE_DestroyServer` | No | — | Destructor joins threads; concurrent calls UB |
+| `LUMICE_CommitConfig*` | No | — | Modifies `config_manager_`, calls Stop/Start |
+| `LUMICE_StopServer` | No | — | Direct state/queue mutation |
+| `LUMICE_SetLogCallback` | No | static bool (non-atomic) | First-call sink registration has a race window |
+| `LUMICE_SetLogLevel` | Conditional | spdlog internal lock | Thread-safe for concurrent calls; ordering not guaranteed |
+| `LUMICE_QueryServerState` | Yes | `status_mutex_` | Read-only poll; safe from any thread |
+| `LUMICE_GetRenderResults` | Yes | `consumer_mutex_` (TicketMutex) + `snapshot_mutex_` | Two-phase snapshot protocol |
+| `LUMICE_GetRawXyzResults` | Yes | same as above | GUI polling thread uses this path |
+| `LUMICE_GetStatsResults` | Yes | same as above | Triggers DoSnapshot |
+| `LUMICE_GetCachedStats` | Yes | `snapshot_mutex_` | Read-only cache; no DoSnapshot |
+| `LUMICE_GetCrystalMesh` | Yes | — | No shared state (`server` param unused) |
+| `LUMICE_ValidateRaypathText` | Yes | — | Pure function |
+| `LUMICE_IsLegalFace` | Yes | — | Pure function |
+| `LUMICE_MaxFov` | Yes | — | Pure function |
+| `LUMICE_XyzToSrgbUint8` | Yes | — | Pure function |
+| `LUMICE_ParseConfigString` | Yes | — | Pure function |
+| `LUMICE_ParseConfigFile` | Yes | — | Pure function |
+
+**Mutex types**:
+
+- **`TicketMutex`** (`server.cpp:37–53`): FIFO spinlock using
+  `atomic<uint32_t>` ticket/serving counters. Prevents starvation that
+  occurs with Windows SRWLOCK under high-frequency locking
+  (see [`doc/accumulator-consumer-architecture.md` §4.1](accumulator-consumer-architecture.md)).
+- **`std::mutex`**: used for `snapshot_mutex_`, `status_mutex_`,
+  `start_mutex_`, `prod_mutex_`, `scene_mutex_`.
+
+**Practical rule**: a single "owner thread" should perform all non-thread-safe
+operations (`Create`, `CommitConfig`, `Stop`, `Destroy`). Polling threads
+may safely call `QueryServerState` and `Get*Results` concurrently.
+
+---
+
+## §5 Sentinel Pattern & Overflow Protection
+
+### §5.1 Convention
+
+Result retrieval APIs use a sentinel-terminated array pattern. The sentinel
+is a zero-initialized struct written at `out[count]` **only** when
+`count < max_count` (i.e., there is a spare slot).
+
+| Function | Sentinel field | Sentinel value |
+|----------|---------------|----------------|
+| `LUMICE_GetRenderResults` | `img_buffer` | `NULL` |
+| `LUMICE_GetRawXyzResults` | `xyz_buffer` | `NULL` |
+| `LUMICE_GetStatsResults` | `sim_ray_num` | `0` |
+
+When the array is full (`count == max_count`), **no sentinel is written**.
+This is the key safety property — writing a sentinel when the array is full
+would be an out-of-bounds write.
+
+### §5.2 Bug History & Fix (5287efe)
+
+**Bug**: prior to commit `5287efe`, the sentinel guard used `<=` instead
+of `<`:
+
+```cpp
+// BEFORE (buggy)
+if (count <= max_count) {          // wrote sentinel even when count == max_count
+    memset(&out[count], 0, ...);   // out[max_count] is OOB when count == max_count
+}
+```
+
+When `max_count=1` and `results.size()=1`, `count=1 == max_count`, and
+the write to `out[1]` was out-of-bounds.
+
+**Fix** (applied at `c_api.cpp:727`, `c_api.cpp:761`, `c_api.cpp:786`):
+
+```cpp
+// AFTER (fixed)
+if (count < max_count) {
+    std::memset(&out[count], 0, sizeof(...));
+}
+```
+
+**Regression test**: `test/e2e/test_capi_sentinel_overflow.py` exercises
+3 configs × 12 rounds = 36 server lifecycles using `max_count=1` to guard
+against reintroduction.
+
+### §5.3 Caller Contract
+
+There are two valid calling conventions:
+
+**Sentinel iteration** (requires N+1 array):
+
+```c
+LUMICE_RawXyzResult arr[N + 1]{};   // value-initialize to all zeros
+LUMICE_GetRawXyzResults(server, arr, N);
+for (int i = 0; arr[i].xyz_buffer != NULL; i++) {
+    // use arr[i]
+}
+```
+
+The caller must value-initialize the array (`{}` or `memset`) so that
+natural zero values act as sentinels even when the API fills all N slots
+(in which case no API-written sentinel exists at `arr[N]`).
+
+**Direct index access** (exact-size array):
+
+```c
+LUMICE_RawXyzResult arr[N];
+LUMICE_GetRawXyzResults(server, arr, N);
+for (int i = 0; i < N; i++) {
+    // use arr[i] directly — check individual fields for validity
+}
+```
+
+No sentinel is needed when the caller uses direct indexing.
+
+---
+
+## §6 CommitConfig Dual Paths
+
+Both paths ultimately call the same internal `Server::CommitConfig(json, out_reused)`.
+
+### §6.1 JSON String Path
+
+`LUMICE_CommitConfig(server, config_str)`:
+1. Null-checks arguments.
+2. Calls `Server::CommitConfig(string)` which parses JSON then delegates
+   to `ServerImpl::CommitConfig(json)`.
+
+This path accepts the **full** configuration format: all filter types
+(distribution, raypath, etc.), array-form spectrum, any lens type, any
+view parameters.
+
+(`c_api.cpp:125–139`)
+
+### §6.2 C Struct Path
+
+`LUMICE_CommitConfigStruct(server, config, out_reused)`:
+1. Null-checks and bounds-checks array counts.
+2. Calls `ConfigToJson(*config)` to convert the C struct to a JSON object.
+3. Calls `Server::CommitConfig(json, &reused)`.
+
+Constraints imposed by the C struct representation:
+
+| Dimension | Struct path limitation |
+|-----------|----------------------|
+| Filter types | `type="raypath"` only |
+| Spectrum | String enumerations only (`"D65"`, `"D50"`, `"A"`, `"E"`) |
+| Lens type | Always `dual_fisheye_equal_area`, FOV 180° |
+| View parameters | Fixed at elevation=0, azimuth=0, roll=0 |
+| Background | Fixed at black (0,0,0) |
+| Visible | Fixed at `"full"` |
+| `out_reused` | Exposes consumer reuse decision (JSON path does not) |
+
+(`c_api.cpp:188–336`)
+
+### §6.3 Semantic Equivalence
+
+For the subset of configurations expressible by `LUMICE_Config`, both paths
+produce **identical** `CommitConfig(json)` calls. The struct path exists to
+eliminate JSON string serialization overhead in the GUI's 50ms commit cycle
+(see task-52.2). The reuse flag (`out_reused`) lets the GUI detect whether
+buffer pointers remain valid.
+
+---
+
+## §7 SimData Side Effects of CommitConfig
+
+### §7.1 Internal Reset Sequence
+
+When `CommitConfig` succeeds, the following sequence occurs
+(`server.cpp:226–335`):
+
+1. **Parse**: temporary `ConfigManager` parses JSON. On failure, the running
+   server is untouched (only `status_` set to `kError`).
+2. **`Stop()`** (`server.cpp:486–539`):
+   - Sets `state_` to `kStopped`.
+   - Shuts down `scene_queue_` and `data_queue_` (unblocks workers).
+   - Calls `Simulator::Stop()` on each worker.
+   - Waits for `active_workers_ == 0`.
+   - Under `consumer_mutex_`: `snapshot_dirty_ = false`,
+     `has_ever_consumed_ = false`.
+   - Under `status_mutex_`: `status_ = kIdle`.
+3. **Consumer decision** (under `consumer_mutex_`):
+   - **Reuse path** (renderer key set unchanged, `NeedsRebuild`=false):
+     calls `rc->ResetWith(new_config)` — resets accumulators, preserves
+     buffer allocations.
+   - **Rebuild path**: `consumers_.clear()` → construct new
+     `RenderConsumer` + `StatsConsumer`.
+4. **Update scene**: `active_scene_ = new SceneConfig`,
+   `scene_generation_++`.
+5. **`Start()`**: queues started, `state_` set to `kRunning`, threads
+   woken via `start_cv_`.
+
+### §7.2 Buffer Lifetime Rules
+
+| Field | State after CommitConfig |
+|-------|------------------------|
+| `has_ever_consumed_` | `false` — new simulation data required |
+| `snapshot_dirty_` | `false` |
+| `snapshot_generation_` | **Unchanged** — only `PrepareSnapshot` increments it; poller tracks its own `last_generation_` |
+| `img_buffer` / `xyz_buffer` pointers | **Invalid on rebuild**; valid on reuse (same allocation). Callers should re-query after `CommitConfig` |
+| `has_valid_data` (C API field) | `0` — maps from `has_ever_consumed_=false` |
+| Cached `StatsResult` | Stale from previous run; `GetCachedStats` returns it until overwritten by next snapshot |
+
+**Rule**: after any `CommitConfig` call, callers must not use previously
+obtained `img_buffer` / `xyz_buffer` pointers. The GUI re-fetches via
+`GetRawXyzResults` on the next poll cycle.
+
+---
+
+## §8 Cross-Reference Index
+
+| Source location | Document section |
+|----------------|-----------------|
+| `src/include/lumice.h:264–269` (result API block comment) | §5 Sentinel Pattern |
+| `src/server/c_api.cpp:726–729` (`GetRenderResults` sentinel) | §5.2 Overflow fix |
+| `src/server/c_api.cpp:760–763` (`GetRawXyzResults` sentinel) | §5.2 Overflow fix |
+| `src/server/c_api.cpp:785–787` (`GetStatsResults` sentinel) | §5.2 Overflow fix |
+| `src/server/c_api.cpp:313` (`CommitConfigStruct` entry) | §6.2 C Struct path |
+| `src/server/server.cpp:226` (`CommitConfig` entry) | §7 SimData side effects |
+| `src/server/server.cpp:526–527` (`has_ever_consumed_ = false`) | §7.1 Reset sequence |
+| `src/server/server.cpp:37–53` (`TicketMutex`) | §4 Thread safety (FIFO mutex) |
+| `test/e2e/test_capi_sentinel_overflow.py` | §5.2 Regression test |

--- a/doc/ev-pipeline-architecture.md
+++ b/doc/ev-pipeline-architecture.md
@@ -92,10 +92,15 @@ per_pixel_intensity = snapshot_intensity_ / (kNormScale × total_pixels)
 anchor_per_pixel    = anchor_snapshot_intensity_ / (kNormScale × total_pixels)
 ```
 
-The `kNormScale` factor (0.08) cancels out in the GUI's `intensity_scale` computation
-(it appears in both the numerator via `snapshot_intensity` and the denominator via the
-same formula), so it does not affect the final displayed brightness. Its purpose is to
-produce per-pixel intensity values in a human-readable range for the C API consumers.
+The `kNormScale` factor (0.08) sets the display brightness baseline: at EV = 0, the
+average illuminated pixel is ~5% brightness. In the GUI's `intensity_scale` computation,
+`kNormScale` algebraically cancels because `ComputeEvAuto()` receives
+`anchor_snapshot_intensity` (which already incorporates `kNormScale`) as an input — the
+resulting `ev_auto` absorbs the scale so that `2^ev_auto / norm_intensity` is independent
+of the specific `kNormScale` value. **C API consumers** receive `per_pixel_intensity`
+values whose absolute magnitude is determined by `kNormScale`; this constant is not an
+arbitrary scale factor and must not be changed without re-calibrating the brightness
+baseline.
 
 ### §2.4 C API Surface
 
@@ -184,9 +189,12 @@ Two events trigger anchor data reset:
 2. **Consumer destruction** (`consumers_.clear()` in the full rebuild path): the
    `RenderConsumer` destructor releases all buffers via `unique_ptr` RAII.
 
-`Reset()` is called by:
-- `ResetWith()` (`render.cpp:712`) — the consumer-reuse path in `CommitConfig()`.
-- `Stop()` → `CommitConfig()` → rebuild path implicitly destroys and recreates.
+`Reset()` is called by `ResetWith()` (`render.cpp:712`) — the consumer-reuse path
+triggered when `CommitConfig()` calls `Stop()` → `ResetWith()` → `Reset()`.
+
+**Rebuild path** (`CommitConfig()` → `Stop()` → `consumers_.clear()` → `~RenderConsumer()`):
+anchor buffers are released via `unique_ptr` RAII. `Reset()` is **not** called; there is
+no zero-and-retain step, only deallocation.
 
 ---
 

--- a/doc/ev-pipeline-architecture.md
+++ b/doc/ev-pipeline-architecture.md
@@ -1,0 +1,373 @@
+# EV Pipeline Architecture
+
+This document describes the internal invariants of Lumice's EV (Exposure Value)
+pipeline — the data flow from raw XYZ accumulation through to the final
+`intensity_scale` that controls pixel brightness in every consumption path.
+
+**Target audience**: contributors who modify the rendering pipeline, the C API
+surface, or the GUI EV controls.
+
+**Scope**: internal invariants and data-flow contracts. This document does **not**
+cover:
+
+- User-visible Adaptive Brightness behavior, the P99.5 algorithm, or additivity
+  — see [`doc/adaptive-brightness.md`](adaptive-brightness.md).
+- The F1 anchor-lane design rationale, `LUMICE_RawXyzResult` field semantics, or
+  filter branch-table routing — see
+  [`doc/filter-architecture.md §7`](filter-architecture.md).
+
+---
+
+## §1 Terminology
+
+| Term | Definition |
+|------|------------|
+| **internal buffer** | Per-`Consume()` accumulation target (`internal_xyz_`, `anchor_internal_xyz_`). Written under the consumer mutex; never read by the GUI. |
+| **snapshot buffer** | Point-in-time copy of the internal buffer (`snapshot_xyz_`, `anchor_snapshot_xyz_`). Produced by `PrepareSnapshot()`; read by `GetRawXyzResult()` and `PostSnapshot()`. |
+| **anchor lane** | The filter-independent accumulation path. Collects filter-fail emission in `anchor_internal_xyz_` and combines it with filter-pass emission in `PrepareSnapshot()` to produce filter-independent statistics. |
+| **`kNormScale`** | Display brightness baseline constant (0.08). Maps per-pixel radiance to a [0, 1] range at EV = 0 so that the average illuminated pixel is ~5% brightness and bright halo features (~20× average) approach full white. Independent of resolution and FOV. Defined in `render.cpp:30`. |
+
+---
+
+## §2 Data Flow
+
+### §2.1 Per-Consume Accumulation
+
+`RenderConsumer::Consume()` (`render.cpp:341`) processes one batch of simulator
+output. Two parallel accumulations happen in every call:
+
+1. **Filtered lane** (always active):
+   - Projects `data.outgoing_d_` / `data.outgoing_w_` (already filter-gated by
+     the simulator — Design A, see `filter-architecture.md §2`) through the lens
+     projection.
+   - Compacts valid in-viewport pixels and accumulates via
+     `SpectrumToXyz()` → `internal_xyz_`.
+   - `total_intensity_ += landed_weight` (sum of all landed ray weights).
+
+2. **Anchor lane** (active only when `data.anchor_d_` is non-empty):
+   - Projects `data.anchor_d_` / `data.anchor_w_` (filter-fail emission) through
+     the same lens projection.
+   - Accumulates via `SpectrumToXyz()` → `anchor_internal_xyz_`.
+   - `anchor_total_intensity_ += anchor_landed`.
+
+**Linearity invariant**: both accumulations are linear in XYZ space — each ray's
+contribution is `CMF(wavelength) × weight`, summed per pixel. This ensures exact
+additivity for complementary filter partitions (see `adaptive-brightness.md §4`).
+
+**Overlap dual-write**: for dual fisheye lens types, pass 2 re-projects overlap-zone
+rays to the opposite hemisphere. This pass does **not** update `total_intensity_`
+(preserves normalization). The anchor lane intentionally skips overlap dual-write:
+the overlap ring is a small geometric artifact that contributes negligibly to the
+P99.5 percentile (`render.cpp:498-501`).
+
+### §2.2 PrepareSnapshot
+
+`PrepareSnapshot()` (`render.cpp:560`) creates a point-in-time snapshot of all
+accumulation state. Called by `DoSnapshot()` under the consumer mutex.
+
+1. `snapshot_xyz_` ← memcpy of `internal_xyz_`.
+2. `snapshot_intensity_` ← `total_intensity_`.
+3. **Anchor P99.5 computation** (when `anchor_internal_xyz_` is non-null):
+   - `anchor_snapshot_xyz_` ← memcpy of `anchor_internal_xyz_`.
+   - `anchor_snapshot_intensity_` = `snapshot_intensity_` + `anchor_total_intensity_`
+     (filter-pass + filter-fail combined landed intensity).
+   - Computes `anchor_p995_y_`: the P99.5 value of the Y channel across all pixels
+     where `snapshot_xyz_[i*3+1] + anchor_snapshot_xyz_[i*3+1] > 0`. Uses
+     `std::nth_element` at index `⌊count × 0.995⌋`, clamped to `count - 1`.
+
+**Caching invariant**: `anchor_p995_y_` is computed once per snapshot and cached until
+the next `PrepareSnapshot()` call. It is never incrementally updated between snapshots.
+
+**Zero-skip semantics**: pixels with zero combined Y are excluded from the P99.5
+population. This matches the GUI-side `ComputeP995Y()` in `gui_ev_auto.hpp:12` and
+ensures the percentile reflects only illuminated pixels.
+
+### §2.3 kNormScale and Per-Pixel Intensity
+
+`GetRawXyzResult()` (`render.cpp:673`) converts the raw accumulated
+`snapshot_intensity_` to a per-pixel intensity:
+
+```
+per_pixel_intensity = snapshot_intensity_ / (kNormScale × total_pixels)
+anchor_per_pixel    = anchor_snapshot_intensity_ / (kNormScale × total_pixels)
+```
+
+The `kNormScale` factor (0.08) cancels out in the GUI's `intensity_scale` computation
+(it appears in both the numerator via `snapshot_intensity` and the denominator via the
+same formula), so it does not affect the final displayed brightness. Its purpose is to
+produce per-pixel intensity values in a human-readable range for the C API consumers.
+
+### §2.4 C API Surface
+
+`LUMICE_RawXyzResult` (`lumice.h:66-89`) exposes the following EV-relevant fields:
+
+| Field | Source |
+|-------|--------|
+| `xyz_buffer` | `snapshot_xyz_` (filtered XYZ data) |
+| `snapshot_intensity` | Per-pixel filtered intensity |
+| `intensity_factor` | CLI/config EV factor `2^EV` |
+| `effective_pixels` | Non-zero pixel count |
+| `anchor_p995_y` | Server-side F1 anchor P99.5 of combined Y |
+| `anchor_snapshot_intensity` | Per-pixel combined (filter-pass + filter-fail) intensity |
+
+**Lifetime**: the `xyz_buffer` pointer is valid until the next
+`LUMICE_GetRawXyzResults()` or `LUMICE_CommitConfig()` call. The sentinel value is
+`xyz_buffer == NULL`.
+
+### §2.5 GUI SyncFromPoller
+
+`SyncFromPoller()` (`app.cpp:756`) transfers data from the poller thread to GUI state.
+The EV-relevant logic (`app.cpp:805-811`):
+
+```
+filter present:   p995_raw_y ← anchor_p995_y
+                  ev_auto    ← ComputeEvAuto(anchor_p995_y, anchor_snapshot_intensity, target_white)
+
+no filter:        p995_raw_y ← p995_y          (from filtered snapshot; ≡ total emission)
+                  ev_auto    ← ComputeEvAuto(p995_y, snapshot_intensity, target_white)
+```
+
+**Source-coherence invariant**: the EV numerator (`p995_raw_y`) and the normalization
+denominator (`norm_intensity`) must always come from the same data source — either
+both from the anchor lane, or both from the filtered snapshot. This is enforced by
+the dual condition `anchor_p995_y > 0 && anchor_snapshot_intensity > 0`.
+
+---
+
+## §3 Anchor Lane Lifecycle
+
+### §3.1 Lazy Allocation
+
+Anchor buffers (`anchor_internal_xyz_`, `anchor_snapshot_xyz_`) are **not** allocated
+in the `RenderConsumer` constructor (`render.cpp:321-338`). They are lazily allocated
+on the first `Consume()` call where `data.anchor_d_` is non-empty
+(`render.cpp:506-513`).
+
+**Zero-cost invariant**: when no filter is configured, the simulator never produces
+filter-fail rays (`SimData::anchor_d_` stays empty), so anchor buffers are never
+allocated and the anchor lane has zero memory and zero CPU cost.
+
+### §3.2 Per-Consume Accumulation
+
+When `data.anchor_d_` is non-empty:
+
+1. Lazy-allocate `anchor_internal_xyz_` and `anchor_snapshot_xyz_` (if first time).
+2. Project `anchor_d_` through the same lens projection as the filtered lane.
+3. Compact valid in-viewport pixels.
+4. `SpectrumToXyz()` → `anchor_internal_xyz_`.
+5. `anchor_total_intensity_ += anchor_landed`.
+
+The anchor lane accumulates only filter-fail emission. Filter-pass emission is already
+in `internal_xyz_`. The combined buffer is reconstructed pixel-by-pixel in
+`PrepareSnapshot()` (§2.2).
+
+### §3.3 PrepareSnapshot Cached State
+
+`PrepareSnapshot()` computes three cached values from the anchor lane:
+
+| Cached field | Formula | Reset condition |
+|---|---|---|
+| `anchor_snapshot_xyz_[i]` | memcpy of `anchor_internal_xyz_[i]` | `Reset()` zeros `anchor_internal_xyz_` |
+| `anchor_snapshot_intensity_` | `snapshot_intensity_ + anchor_total_intensity_` | `Reset()` zeros both components |
+| `anchor_p995_y_` | P99.5 of `(snapshot_xyz_[i*3+1] + anchor_snapshot_xyz_[i*3+1])` over positive pixels | `Reset()` sets to 0 |
+
+These values are read-only between snapshots. No incremental update path exists.
+
+### §3.4 Reset Conditions
+
+Two events trigger anchor data reset:
+
+1. **`Reset()`** (`render.cpp:691`): zeros `anchor_internal_xyz_` (if allocated),
+   `anchor_total_intensity_`, `anchor_snapshot_intensity_`, and `anchor_p995_y_`.
+   Does **not** deallocate the buffer (preserves allocation for reuse).
+
+2. **Consumer destruction** (`consumers_.clear()` in the full rebuild path): the
+   `RenderConsumer` destructor releases all buffers via `unique_ptr` RAII.
+
+`Reset()` is called by:
+- `ResetWith()` (`render.cpp:712`) — the consumer-reuse path in `CommitConfig()`.
+- `Stop()` → `CommitConfig()` → rebuild path implicitly destroys and recreates.
+
+---
+
+## §4 Three Consumption Paths
+
+Three code paths consume the EV pipeline output and compute `intensity_scale`. All
+three use the same formula:
+
+```
+ev_total        = exposure_offset + ev_auto
+intensity_factor = 2^ev_total
+norm_intensity   = anchor_snapshot_intensity  (when anchor lane active)
+                 | snapshot_intensity          (degenerate / no-filter path)
+intensity_scale  = intensity_factor / norm_intensity   (0 if norm_intensity ≤ 0)
+```
+
+### §4.1 Display Path
+
+`app_panels.cpp:816-824` — sets the GPU shader uniform each frame:
+
+```cpp
+float ev_total = rc.exposure_offset + g_state.ev_auto;
+pp.exposure.intensity_factor = std::pow(2.0f, ev_total);
+float norm_intensity = (g_state.anchor_snapshot_intensity > 0.0f && g_state.p995_raw_y > 0.0f)
+                           ? g_state.anchor_snapshot_intensity
+                           : g_state.snapshot_intensity;
+pp.exposure.intensity_scale = norm_intensity > 0 ? pp.exposure.intensity_factor / norm_intensity : 0.0f;
+```
+
+### §4.2 Export Path
+
+`BuildExportParams()` (`app.cpp:297-306`) — constructs `PreviewParams` for PNG export.
+Explicitly mirrors the display path formula. The inline comment documents the
+intentional byte-identity with the shader uniform.
+
+### §4.3 Screenshot / .lmc Thumbnail
+
+`RefreshCpuTextureForSave()` (`app.cpp:241-256`) — CPU-side XYZ→sRGB for `.lmc`
+thumbnail. Uses cached `g_state.anchor_snapshot_intensity` rather than a fresh
+`LUMICE_GetRawXyzResults()` call. This introduces a potential ≤1-frame drift from the
+display path, which is acceptable for thumbnails (not user-visible in real time).
+
+### §4.4 Consistency Invariant
+
+All three paths share the same formula by construction. The dual condition
+(`anchor_snapshot_intensity > 0 && p995_raw_y > 0`) ensures the EV numerator
+(`ev_auto`, derived from `p995_raw_y`) and the normalization denominator
+(`norm_intensity`) always come from the same data source.
+
+**Drift scope**: the screenshot path reads cached `g_state` values that may lag the
+most recent `SyncFromPoller()` by at most one frame. Since `.lmc` thumbnail is saved
+on user action (not streamed), this drift is imperceptible.
+
+---
+
+## §5 `unfiltered_intensity` Semantics
+
+### §5.1 Filter Present
+
+When a filter spec is configured:
+
+- The simulator produces both `outgoing_d_/w_` (filter-pass) and `anchor_d_/w_`
+  (filter-fail) in each `SimData` batch.
+- The anchor lane accumulates filter-fail emission in `anchor_internal_xyz_`.
+- `PrepareSnapshot()` combines filter-pass (`snapshot_xyz_`) and filter-fail
+  (`anchor_snapshot_xyz_`) pixel-by-pixel to compute `anchor_p995_y_`.
+- `anchor_snapshot_intensity_` = filter-pass intensity + filter-fail intensity,
+  representing the total landed intensity across all rays regardless of filter.
+
+### §5.2 No-Filter Degenerate
+
+When no filter is configured:
+
+- The simulator produces no filter-fail rays (`anchor_d_` stays empty).
+- `anchor_internal_xyz_` is never allocated (§3.1 lazy allocation guard).
+- `PrepareSnapshot()` skips the anchor computation (`anchor_internal_xyz_` is null).
+- `anchor_p995_y_` and `anchor_snapshot_intensity_` remain at their `Reset()` values
+  (both 0).
+
+### §5.3 Equivalence Invariant
+
+In the no-filter scenario, the GUI detects `anchor_p995_y == 0` and falls back to the
+filtered snapshot path (`SyncFromPoller`, `app.cpp:808-810`). This is numerically
+equivalent to the anchor path because:
+
+- Without a filter, every ray passes the (vacuous) filter. There are zero filter-fail
+  rays.
+- Therefore `filtered_emission ≡ total_emission`.
+- `p995_y(filtered) ≡ p995_y(total)` and
+  `snapshot_intensity ≡ anchor_snapshot_intensity` (if anchor were active).
+
+The fallback is a missing-data guard, not a semantic mode switch.
+
+---
+
+## §6 CommitConfig Impact on Anchor Data
+
+`CommitConfig()` (`server.cpp:263-308`) always calls `Stop()` before modifying
+consumers. `Stop()` transitions the server to `kStopped` and sets
+`has_ever_consumed_ = false` (`server.cpp:524`).
+
+### §6.1 Reuse Path
+
+When `NeedsRebuild()` returns false (layout fields unchanged):
+
+```
+CommitConfig → Stop() → ResetWith(new_config) → Reset()
+```
+
+`Reset()` zeros all anchor accumulators but **does not deallocate** anchor buffers.
+The `unique_ptr`s retain their allocations for reuse by subsequent `Consume()` calls.
+
+### §6.2 Rebuild Path
+
+When `NeedsRebuild()` returns true (layout fields changed):
+
+```
+CommitConfig → Stop() → consumers_.clear() → new RenderConsumer(...)
+```
+
+`consumers_.clear()` triggers `~RenderConsumer()`, which releases all buffers
+(including anchor buffers) via `unique_ptr` RAII. New consumers start with null
+anchor buffers (lazy allocation resumes on first filter-fail data).
+
+### §6.3 Filter Switch Semantics
+
+Filter configuration is **not** in the `NeedsRebuild()` field set — the filter is
+applied simulator-side (Design A), not in the consumer. However, filter switches in
+the GUI trigger `CommitConfig()`, which always calls `Stop()` → `Reset()` (or
+rebuild). Therefore:
+
+**Invariant**: anchor data is always zeroed on filter switch. The anchor lane
+re-accumulates from scratch after each filter change. For the same scene geometry,
+the anchor P99.5 converges to the same value regardless of which filter is active,
+because the anchor combines filter-pass and filter-fail emission (total emission is
+filter-independent).
+
+This is by design: "anchor doesn't reset" refers to the semantic property that the
+anchor value is filter-independent, not that the buffer persists across filter
+switches.
+
+### §6.4 NeedsRebuild Trigger Fields
+
+`NeedsRebuild()` (`render_config.cpp:164`) compares layout-affecting fields only:
+
+| Field | Triggers rebuild |
+|-------|:---:|
+| `resolution_` | ✓ |
+| `lens_` | ✓ |
+| `lens_shift_` | ✓ |
+| `view_` | ✓ |
+| `visible_` | ✓ |
+| `overlap_` | ✓ |
+| `background_`, `ray_color_`, `opacity_`, `intensity_factor_`, `norm_mode_`, grids | ✗ (appearance only) |
+
+A `static_assert(sizeof(RenderConfig) == 144)` guards against silent field additions
+(`render_config.cpp:166`).
+
+---
+
+## §7 Source Reference Table
+
+| Invariant / Concept | Source Location |
+|---|---|
+| `kNormScale` definition (0.08) | `render.cpp:30` |
+| `Consume()` — filtered + anchor parallel accumulation | `render.cpp:341-547` |
+| Anchor lazy allocation guard | `render.cpp:506-513` |
+| Anchor overlap skip rationale | `render.cpp:498-501` |
+| `PrepareSnapshot()` — anchor P99.5 computation | `render.cpp:560-593` |
+| P99.5 nth_element index formula | `render.cpp:585-591` |
+| `GetRawXyzResult()` — per-pixel intensity formula | `render.cpp:673-688` |
+| `Reset()` — anchor zeroing semantics | `render.cpp:691-710` |
+| `ResetWith()` — config update + reset | `render.cpp:712-717` |
+| Constructor — lazy allocation comment | `render.cpp:334-337` |
+| `CommitConfig()` — Stop→Reset/Rebuild→Start | `server.cpp:263-308` |
+| `has_ever_consumed_` reset in Stop | `server.cpp:524` |
+| `NeedsRebuild()` — layout field comparison | `render_config.cpp:164-173` |
+| `sizeof(RenderConfig)` static_assert | `render_config.cpp:166` |
+| `ComputeP995Y()` / `ComputeEvAuto()` | `gui_ev_auto.hpp:12-46` |
+| `SyncFromPoller()` — anchor source selection + ev_auto | `app.cpp:756-813` |
+| `BuildExportParams()` — export EV consistency | `app.cpp:297-306` |
+| `RefreshCpuTextureForSave()` — .lmc thumbnail EV | `app.cpp:241-256` |
+| Display path `ev_total` / `intensity_scale` | `app_panels.cpp:816-824` |
+| `LUMICE_RawXyzResult` anchor fields | `lumice.h:66-89` |

--- a/doc/raypath-rayseg-architecture.md
+++ b/doc/raypath-rayseg-architecture.md
@@ -1,0 +1,285 @@
+# RaySeg Architecture: Field Invariants, Chain Rules, and State Machine
+
+This document specifies the run-time constraints of the `RaySeg` struct — field semantics,
+initialization rules, state-machine transitions, and filter interface contracts. It
+complements `doc/raypath-symmetry.md` (PBD symbolic semantics) and
+`doc/filter-architecture.md` (filter routing design); see §5 for exact boundary.
+
+**Target audience**: contributors working on the simulator core, filter subsystem,
+multi-scatter propagation, or consumer pipeline.
+
+---
+
+## §1 RaySeg Field Semantics & Invariants
+
+`RaySeg` is defined in `src/core/raypath.hpp:50-140`. Each field is listed below with its
+semantic role, valid range, and sentinel values.
+
+### Geometric Fields
+
+| Field | Type | Semantics | Coordinate Space | Source |
+|-------|------|-----------|-----------------|--------|
+| `d_[3]` | `float[3]` | Ray direction (unit vector). | Crystal-local when `IsNormal()`; world-space after `CollectData` rotation for outgoing/TIR. | `src/core/raypath.hpp:53` |
+| `p_[3]` | `float[3]` | Ray **end** point (not start point). | Same coordinate-space rule as `d_`. | `src/core/raypath.hpp:54` |
+| `w_` | `float` | Ray weight (intensity fraction). Non-negative for live rays; `-1.0f` is the TIR sentinel. | — | `src/core/raypath.hpp:55` |
+| `from_face_` | `IdType` | Polygon-face index the segment originated from (parent's `to_face_`). `kInvalidId` for the first segment of a chain. | — | `src/core/raypath.hpp:57-61` |
+| `to_face_` | `IdType` | Polygon-face index this segment hit. `kInvalidId` means "no hit" — either outgoing candidate or TIR-stopped. | — | `src/core/raypath.hpp:62-66` |
+
+### Chain & Identity Fields
+
+| Field | Type | Semantics | Source |
+|-------|------|-----------|--------|
+| `prev_ray_idx_` | `size_t` | Index of parent segment in `all_data`. `kInfSize` for root rays (first MS layer). | `src/core/raypath.hpp:68` |
+| `root_ray_idx_` | `size_t` | Index of the chain root in `all_data`. All segments in one ray tree share this value. | `src/core/raypath.hpp:69` |
+| `crystal_idx_` | `IdType` | Index into `SimData::crystals_[]`. Range: `[0, kMaxCrystalNum)` or `kInvalidId` (init sentinel). | `src/core/raypath.hpp:71` |
+| `crystal_config_id_` | `IdType` | `Crystal::config_id_` — ties the segment to its configuration-level crystal identity. | `src/core/raypath.hpp:72` |
+| `crystal_rot_` | `Rotation` | Crystal-to-world rotation matrix. Sampled per root ray; propagated to all children. | `src/core/raypath.hpp:73` |
+| `rp_` | `RaypathRecorder` | Raypath in the **current** crystal, as a face-number sequence. | `src/core/raypath.hpp:91` |
+
+### State Flags
+
+| Field | Type | Semantics | Source |
+|-------|------|-----------|--------|
+| `is_continue_` | `bool` | Set when this outgoing candidate continues to the next MS layer. Only meaningful when `to_face_ == kInvalidId && w_ >= 0`. Default `false`. | `src/core/raypath.hpp:78` |
+| `is_filter_dropped_` | `bool` | Set when the outgoing candidate fails the per-crystal filter check. Mutually exclusive with `is_continue_`. | `src/core/raypath.hpp:84` |
+| `is_prior_filter_failed_` | `bool` | Cross-layer persistent flag: set when any upstream MS layer's filter rejects this ray. Propagated via `TraceRayBasicInfo`. Reset only in `InitRayFirstMs`. | `src/core/raypath.hpp:90` |
+
+### N4 Construction-Time Invariants
+
+Checked by `RaySeg::IsValidComplete()` at `RayBuffer::EmplaceBack(RaySeg)` entry
+(debug-only via `assert`). Source: `src/core/raypath.hpp:106-139`.
+
+| ID | Invariant | Predicate |
+|----|-----------|-----------|
+| N4-1 | `to_face_` in valid polygon range | Omitted — requires external crystal context. |
+| N4-2 | `w_` is non-negative or the TIR sentinel `-1.0f` | `IsValidW(w)` |
+| N4-3 | `is_continue_` implies `to_face_ == kInvalidId` | `IsValidContinueFace(is_continue_, to_face_)` |
+| N4-4 | `crystal_idx_` in `[0, kMaxCrystalNum)` or `kInvalidId` | `IsValidCrystalIdx(crystal_idx_)` |
+| N4-5 | `d_` and `p_` components are finite (no NaN/Inf) | `IsValidVec3Finite(d_)`, `IsValidVec3Finite(p_)` |
+
+---
+
+## §2 Ray Chain Construction & Traversal
+
+### all_data Layout
+
+`all_data` (`RayBuffer`) is the flat append-only store for all segments across all crystals
+and MS layers within one `SimulateOneWavelength` call. Segments are appended in
+initialization order (source: `src/core/simulator.cpp:182,215,699`):
+
+```
+all_data = [ init_segs_crystal_0 | init_segs_crystal_1 | ... |
+             hit1_children_c0    | hit1_children_c1    | ... |
+             hit2_children_c0    | ...                        ]
+```
+
+### prev_ray_idx_ / root_ray_idx_ Semantics
+
+- **Root rays** (first MS layer): `prev_ray_idx_ = kInfSize`. `root_ray_idx_` is the
+  segment's own index in `all_data` (source: `src/core/simulator.cpp:151`).
+- **Continuation rays** (subsequent MS layers): `prev_ray_idx_` inherits from the
+  `is_continue_` parent in the prior layer (the value is NOT reset in `InitRayOtherMs`
+  because it was already valid from the prior layer's `CollectData`).
+  `root_ray_idx_` is reassigned to the new `all_data` offset
+  (source: `src/core/simulator.cpp:207`).
+- **Hit-loop children**: `TraceRayBasicInfo` copies `root_ray_idx_` from parent to both
+  child segments (reflect + refract). `prev_ray_idx_` is NOT set by `TraceRayBasicInfo` —
+  it remains whatever value the buffer slot held. In practice, the reflect/refract children
+  are new slots written by `Propagate`/`HitSurface` and then field-copied in the manual
+  loop (source: `src/core/simulator.cpp:380-396`).
+
+### crystal_idx_ Chain-Aware Propagation
+
+`crystal_idx_` is set once per crystal in `InitRay_other_info`
+(source: `src/core/simulator.cpp:149`) and propagated to both child segments in
+`TraceRayBasicInfo` (source: `src/core/simulator.cpp:388-389`). It identifies which
+`Crystal` instance (in `SimData::crystals_[]`) the segment belongs to.
+
+### from_face_ / to_face_ Split
+
+The `from_face_` / `to_face_` pair implements a linked-list of polygon faces along the ray:
+
+1. **Entry segment** (`InitRay_p_fid`): `from_face_ = kInvalidId`, `to_face_` = sampled
+   polygon face (source: `src/core/simulator.cpp:76-77`).
+2. **Hit-loop children** (`TraceRayBasicInfo`): each child's `from_face_` = parent's
+   `to_face_` (the face just hit); `to_face_` = result of `Propagate` (next face hit, or
+   `kInvalidId` for outgoing/TIR) (source: `src/core/simulator.cpp:371-377,383-385`).
+
+The source-face guard passed to `Propagate` uses the parent's `to_face_` via
+`BufferWrapper` with `step=2` (shared by reflect+refract pair), NOT `from_face_`
+directly.
+
+### Raypath Recorder (rp_)
+
+- Initialized in `InitRay_other_info`: cleared, then first face-number appended via
+  `crystal.GetFn(to_face_)` (source: `src/core/simulator.cpp:152-153`).
+- Extended in `FillRayOtherInfo`: each child with `to_face_ != kInvalidId` gets the
+  face-number appended (source: `src/core/simulator.cpp:403-410`).
+- Copied from parent to both children in `TraceRayBasicInfo`
+  (source: `src/core/simulator.cpp:381-382`).
+- Maximum length: `kMaxHits` (64). Overflow silently drops
+  (source: `src/core/raypath.cpp:6-8`).
+
+---
+
+## §3 Segment State Machine
+
+### State Derivation
+
+Segment kind is derived from two primary fields (`to_face_`, `w_`) and two 1-bit flags
+(`is_continue_`, `is_filter_dropped_`). The five states are **mutually exclusive and
+exhaustive** (source: `src/core/raypath.hpp:93-104`):
+
+```
+                        ┌─────────────────────────────────────┐
+                        │          w_ < 0?                    │
+                        │   YES ──► TIR (total reflection)    │
+                        │   NO  ──┐                           │
+                        │         │                           │
+                        │    to_face_ != kInvalidId?          │
+                        │   YES ──► NORMAL (in-crystal)       │
+                        │   NO  ──┐                           │
+                        │         │  (outgoing candidate)     │
+                        │    is_continue_?                    │
+                        │   YES ──► CONTINUE (next MS)        │
+                        │   NO  ──┐                           │
+                        │    is_filter_dropped_?              │
+                        │   YES ──► FILTER-DROPPED (anchor)   │
+                        │   NO  ──► OUTGOING (emit)           │
+                        └─────────────────────────────────────┘
+```
+
+| State | Predicate | Meaning |
+|-------|-----------|---------|
+| TIR | `w_ < 0` | Total internal reflection; ray is absorbed. |
+| Normal | `to_face_ != kInvalidId && w_ >= 0` | Ray hit another face; continues tracing inside the crystal. |
+| Outgoing | `to_face_ == kInvalidId && w_ >= 0 && !is_continue_ && !is_filter_dropped_` | Ray exits crystal, passes filter (or no filter), does not continue to next MS. Emitted to output. |
+| Continue | `is_continue_` (implies `to_face_ == kInvalidId && w_ >= 0`) | Ray exits crystal and continues to next MS layer. |
+| Filter-Dropped | `is_filter_dropped_` (implies `to_face_ == kInvalidId && w_ >= 0`) | Ray exits crystal but fails filter; routed to anchor lane. |
+
+### Transition Rules in CollectData
+
+`CollectData` (source: `src/core/simulator.cpp:413-474`) is the sole state-assignment
+function. It processes `buffer_data[1]` (the output of `TraceRayBasicInfo` + `FillRayOtherInfo`)
+and writes the state flags.
+
+**Pre-loop reset** (pool-reuse guard): both `is_continue_` and `is_filter_dropped_` are
+explicitly reset to `false` for every segment at the top of the loop
+(source: `src/core/simulator.cpp:434-435`).
+
+**Branch table** for outgoing candidates (`to_face_ == kInvalidId && w_ >= 0`):
+
+| Filter | Prior Failed | Prob | is_continue_ | is_filter_dropped_ | is_prior_filter_failed_ | Destination |
+|--------|-------------|------|--------------|-------------------|------------------------|-------------|
+| pass | no | pass | true | false | unchanged | next MS |
+| pass | no | fail | false | false | unchanged | outgoing buffer |
+| pass | yes | pass | true | false | unchanged | next MS (anchor bypass) |
+| pass | yes | fail | false | true | unchanged | anchor lane |
+| fail | — | pass | true | false | **set true** | next MS |
+| fail | — | fail | false | true | **set true** | anchor lane |
+
+Source: `src/core/simulator.cpp:430-458`. See also `doc/filter-architecture.md §7` for the
+anchor-lane design rationale.
+
+**Coordinate rotation**: outgoing candidates have `d_` and `p_` rotated from crystal-local
+to world-space (`crystal_rot_.Apply`) **before** the filter check
+(source: `src/core/simulator.cpp:442-443`). TIR segments are rotated **after** the state
+branch (source: `src/core/simulator.cpp:463-466`). Normal segments remain in crystal-local
+coordinates.
+
+**Routing after state assignment**:
+- `IsNormal()` → re-enters `buffer_data[0]` for the next hit iteration
+  (source: `src/core/simulator.cpp:468-469`).
+- `IsContinue()` → appended to `init_data[1]` for the next MS layer
+  (source: `src/core/simulator.cpp:471-472`).
+- `IsOutgoing()` / `IsFilterDropped()` → collected in the main loop into `outgoing_*` /
+  `anchor_*` vectors respectively (source: `src/core/simulator.cpp:700-714`).
+
+### Reset Points Summary
+
+| Field | Reset Location | Trigger | Source |
+|-------|---------------|---------|--------|
+| `is_continue_` | `CollectData` loop top | Every segment, every hit iteration | `src/core/simulator.cpp:434` |
+| `is_continue_` | `InitRayOtherMs` step 1.4 | Pool-reuse guard for MS layer entry | `src/core/simulator.cpp:211` |
+| `is_filter_dropped_` | `CollectData` loop top | Every segment, every hit iteration | `src/core/simulator.cpp:435` |
+| `is_prior_filter_failed_` | `InitRayFirstMs` step 1.4 | Once per root ray (first MS only) | `src/core/simulator.cpp:179` |
+| `rp_` | `InitRay_other_info` | Each crystal initialization | `src/core/simulator.cpp:152` |
+
+**Key invariant**: `is_prior_filter_failed_` is the **only** cross-MS-layer persistent bool.
+It is set in `CollectData` when a filter fails (source: `src/core/simulator.cpp:447`) and
+propagated to child segments in `TraceRayBasicInfo` (source: `src/core/simulator.cpp:386-387`).
+It is reset only in `InitRayFirstMs` (source: `src/core/simulator.cpp:179`), never in
+`InitRayOtherMs` — this is by design, so that a filter failure in layer N causes all
+downstream layers to route the ray to the anchor lane.
+
+---
+
+## §4 Filter Interface Contract
+
+### FilterSpec::Check Preconditions
+
+`FilterSpec::Check(const RaySeg& ray)` is called inside `CollectData` on outgoing
+candidates only (source: `src/core/simulator.cpp:445`). At the point of call:
+
+1. **Coordinate space**: `d_` and `p_` have already been rotated to world-space via
+   `crystal_rot_.Apply()` (source: `src/core/simulator.cpp:442-443`).
+2. **Raypath**: `rp_` is fully populated for the current crystal (all face-numbers appended
+   by `FillRayOtherInfo`).
+3. **Segment kind**: `to_face_ == kInvalidId && w_ >= 0` (outgoing candidate).
+
+### Fields Consumed by Filter Implementations
+
+| FilterSpec subclass | RaySeg fields consumed | Source |
+|--------------------|----------------------|--------|
+| `NoneSpec` | None (always returns true) | `src/core/filter_spec.cpp:144` |
+| `RaypathSpec` | `rp_` (via `RaypathOrbit::Contains`) | `src/core/filter_spec.cpp:152` |
+| `EntryExitSpec` | `rp_[0]` and `rp_[size_-1]` (entry/exit face numbers) | `src/core/filter_spec.cpp:163-169` |
+| `DirectionSpec` | `d_[3]` (world-space direction, dot product against target) | `src/core/filter_spec.cpp:185` |
+| `CrystalSpec` | `crystal_config_id_` | `src/core/filter_spec.cpp:195` |
+| `ComplexSpec` | Delegates to sub-filters (OR-of-AND composition) | `src/core/filter_spec.cpp:206-219` |
+
+### FilterSpec::Create
+
+`FilterSpec::Create(config, crystal, axis_dist)` builds the spec from the filter
+configuration bound to a crystal (source: `src/core/filter_spec.cpp:277-284`). It
+pre-computes:
+- `d_applicable`: whether D symmetry applies (azimuth uniform + roll mean at 30° multiple).
+- `sigma_a`: the mirror parameter for D symmetry reduction.
+- `action_`: filter-in or filter-out (set after construction).
+
+These are **construction-time** computations. The `Match()` call on the hot path is
+stateless — no per-ray mutation.
+
+---
+
+## §5 Boundary with raypath-symmetry.md
+
+| Concern | This document | `doc/raypath-symmetry.md` |
+|---------|--------------|--------------------------|
+| RaySeg struct fields & invariants | §1 — full field table, sentinel values, N4 checks | Not covered |
+| Ray chain construction (prev/root indices) | §2 — all_data layout, index propagation | Not covered |
+| Segment state machine (TIR/Normal/Outgoing/Continue/FilterDropped) | §3 — derivation rules, CollectData branch table, reset points | Not covered |
+| Filter interface contract | §4 — preconditions, consumed fields per FilterSpec | Not covered |
+| P, B, D symmetry toggles | Not covered (see cross-ref below) | §3 — full toggle semantics, enabling conditions |
+| Face-number encoding (fn) | §2 (briefly, as raypath recorder input) | §2a — face numbering convention table |
+| Canonical form / orbit reduction | Not covered | §3-§4 — P/B/D reduction formulas |
+| GUI filter behavior | Not covered | §6 — D checkbox, informational indicator |
+
+### Cross-References
+
+- Raypath face-number encoding and PBD symmetry: `doc/raypath-symmetry.md`
+- Filter routing design (Design A), anchor-lane semantics: `doc/filter-architecture.md §2/§7`
+- Filter JSON configuration schema: `doc/configuration.md`
+- Crystal orientation sampling: `doc/crystal-orientation-sampling.md`
+
+---
+
+## Appendix: Key Constants
+
+| Constant | Value | Defined in | Usage |
+|----------|-------|-----------|-------|
+| `kInvalidId` | `0xffff` | `src/core/def.hpp:11` | "No face" / "no crystal" sentinel for `IdType` fields |
+| `kInfSize` | `SIZE_MAX` | `src/core/def.hpp:12` | "No parent" sentinel for `prev_ray_idx_` |
+| `kMaxHits` | `64` | `src/core/def.hpp:24` | Maximum face hits per crystal; caps `RaypathRecorder` |
+| `kMaxCrystalNum` | `16` | `src/core/def.hpp:26` | Upper bound for `crystal_idx_` (N4-4) |
+| `kSmallBatchRayNum` | `32` | `src/core/simulator.hpp:64` | Inner-loop batch size for ray tracing |

--- a/src/config/render_config.cpp
+++ b/src/config/render_config.cpp
@@ -161,6 +161,8 @@ void to_json(nlohmann::json& j, const RenderConfig& r) {
 }
 
 
+// See doc/accumulator-consumer-architecture.md §5.1 (layout vs. appearance classification),
+// §5.2 (sizeof sentinel).
 bool NeedsRebuild(const RenderConfig& a, const RenderConfig& b) {
   // Bump this when adding fields to RenderConfig — then classify as layout or appearance.
   static_assert(sizeof(RenderConfig) == 144, "Update NeedsRebuild when RenderConfig fields change");

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -47,6 +47,7 @@ struct RaypathHash {
 };
 
 
+// See doc/raypath-rayseg-architecture.md §1 for field invariants and state-machine semantics.
 struct RaySeg {
   // NOTE: if IsNormal(), d and p are in crystal-local coordinates; otherwise
   // d and p are in world coordinates.

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -175,6 +175,7 @@ void InitRayFirstMs(RandomNumberGenerator& rng, const SunParam& light_param, con
   InitRay_other_info(curr_crystal, curr_crystal_id, all_data.size_, buffer_data);
 
   // 1.4 reset cross-layer state (pool-reuse guard: Reset() may not zero memory)
+  // See doc/raypath-rayseg-architecture.md §3 "Reset Points Summary".
   for (auto& r : buffer_data[0]) {
     r.is_prior_filter_failed_ = false;
   }
@@ -208,6 +209,7 @@ void InitRayOtherMs(RandomNumberGenerator& rng, const RayBuffer init_data[2], si
 
   // 1.4 reset is_continue_ (pool-reuse guard: init_data carries is_continue_=true
   // from CollectData; must reset before entering the new MS layer's hit loop)
+  // See doc/raypath-rayseg-architecture.md §3 "Reset Points Summary".
   for (auto& r : buffer_data[0]) {
     r.is_continue_ = false;
   }
@@ -410,6 +412,7 @@ void FillRayOtherInfo(const Crystal& curr_crystal, RayBuffer buffer_data[2]) {
 }
 
 
+// See doc/raypath-rayseg-architecture.md §3 for the segment state-machine transition rules.
 void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const FilterSpec* spec,  // input
                  RayBuffer* buffer_data, RayBuffer* init_data) {                             // output
   // F1 anchor-lane semantics (see doc/filter-architecture.md §7): the filter is NOT a

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -558,7 +558,9 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Re-runs simulation; accumulated rays reset");
     }
+    ImGui::BeginGroup();
     SliderWithInput("EV##display", &r.exposure_offset, -6.0f, 6.0f, "%.1f");
+    ImGui::EndGroup();
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Exposure value offset for display brightness");
     }

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -499,6 +499,9 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
       ImGui::BeginDisabled(is_globe);
     }
     ImGui::Checkbox("Front##visible", &r.front);
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+      ImGui::SetTooltip("Show front hemisphere only\n(combine with Upper/Full/Lower)");
+    }
     if (!full_sky) {
       ImGui::EndDisabled();
     }
@@ -556,6 +559,9 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
       ImGui::SetTooltip("Re-runs simulation; accumulated rays reset");
     }
     SliderWithInput("EV##display", &r.exposure_offset, -6.0f, 6.0f, "%.1f");
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Exposure value offset for display brightness");
+    }
 
     ImGui::SeparatorText("Aspect Ratio");
     int preset_idx = static_cast<int>(g_state.aspect_preset);

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -767,9 +767,15 @@ static void RenderSharedFilterControls(bool d_applicable) {
   if (ImGui::RadioButton("Filter In##filter_action", g_filter_top.action == 0)) {
     g_filter_top.action = 0;
   }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Show only rays matching the filter");
+  }
   ImGui::SameLine();
   if (ImGui::RadioButton("Filter Out##filter_action", g_filter_top.action == 1)) {
     g_filter_top.action = 1;
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Hide rays matching the filter");
   }
 
   // P/B/D Checkbox — H4 修正 (issue per-type-direction / 178.5): only raypath
@@ -782,8 +788,14 @@ static void RenderSharedFilterControls(bool d_applicable) {
       (g_filter_active_type == FilterEditType::kRaypath || g_filter_active_type == FilterEditType::kEntryExit);
   if (sym_active) {
     ImGui::Checkbox("P##filter_modal", &g_filter_top.sym_p);
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Prism-face reflection symmetry");
+    }
     ImGui::SameLine();
     ImGui::Checkbox("B##filter_modal", &g_filter_top.sym_b);
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Basal-face reflection symmetry");
+    }
     ImGui::SameLine();
     ImGui::Checkbox("D##filter_modal", &g_filter_top.sym_d);
     if (!d_applicable) {
@@ -1711,6 +1723,9 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       // Invariant: do NOT touch g_active_modal here (must stay kOpen for the
       // reopen gate to fire in Frame N+2).
     }
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Apply parameter changes to simulation in real-time");
   }
 
   if (dispatched_immediate) {

--- a/src/gui/gui_ev_auto.hpp
+++ b/src/gui/gui_ev_auto.hpp
@@ -7,7 +7,7 @@
 
 namespace lumice::gui {
 
-// See doc/ev-pipeline-architecture.md §2.5
+// See doc/ev-pipeline-architecture.md §2.2 (zero-skip semantics), §2.5 (GUI usage)
 // Extract non-zero Y-channel values from a packed XYZ float array and return
 // their P99.5 value.  Returns 0 if the array has no positive Y entries.
 inline float ComputeP995Y(const std::vector<float>& xyz_data) {

--- a/src/gui/gui_ev_auto.hpp
+++ b/src/gui/gui_ev_auto.hpp
@@ -7,6 +7,7 @@
 
 namespace lumice::gui {
 
+// See doc/ev-pipeline-architecture.md §2.5
 // Extract non-zero Y-channel values from a packed XYZ float array and return
 // their P99.5 value.  Returns 0 if the array has no positive Y entries.
 inline float ComputeP995Y(const std::vector<float>& xyz_data) {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -865,11 +865,15 @@ void RenderScatteringSection(GuiState& state) {
 
 void RenderSceneControls(GuiState& state) {
   ImGui::SeparatorText("Sun");
+  ImGui::BeginGroup();
   DIRTY_IF(SliderWithInput("Altitude", &state.sun.altitude, -90.0f, 90.0f));
+  ImGui::EndGroup();
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Sun elevation angle above the horizon");
   }
+  ImGui::BeginGroup();
   DIRTY_IF(SliderWithInput("Diameter", &state.sun.diameter, 0.1f, 5.0f));
+  ImGui::EndGroup();
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Angular diameter of the sun disk");
   }
@@ -887,6 +891,7 @@ void RenderSceneControls(GuiState& state) {
     ImGui::SetTooltip("Run simulation continuously until manually stopped");
   }
   ImGui::PopItemWidth();
+  ImGui::BeginGroup();
   if (!state.sim.infinite) {
     DIRTY_IF(SliderWithInput("Rays(M)", &state.sim.ray_num_millions, 0.1f, 100.0f));
   } else {
@@ -894,10 +899,13 @@ void RenderSceneControls(GuiState& state) {
     SliderWithInput("Rays(M)", &state.sim.ray_num_millions, 0.1f, 100.0f);
     ImGui::EndDisabled();
   }
+  ImGui::EndGroup();
   if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
     ImGui::SetTooltip("Number of rays to trace, in millions");
   }
+  ImGui::BeginGroup();
   DIRTY_IF(SliderIntWithInput("Max hits", &state.sim.max_hits, 1, 64));
+  ImGui::EndGroup();
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Maximum number of crystal face hits per ray path");
   }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -866,14 +866,26 @@ void RenderScatteringSection(GuiState& state) {
 void RenderSceneControls(GuiState& state) {
   ImGui::SeparatorText("Sun");
   DIRTY_IF(SliderWithInput("Altitude", &state.sun.altitude, -90.0f, 90.0f));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Sun elevation angle above the horizon");
+  }
   DIRTY_IF(SliderWithInput("Diameter", &state.sun.diameter, 0.1f, 5.0f));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Angular diameter of the sun disk");
+  }
   ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
   DIRTY_IF(ImGui::Combo("Spectrum", &state.sun.spectrum_index, kSpectrumNames, kSpectrumCount));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Light source spectrum for wavelength-dependent refraction");
+  }
   ImGui::PopItemWidth();
 
   ImGui::SeparatorText("Simulation");
   ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
   DIRTY_IF(ImGui::Checkbox("Infinite rays", &state.sim.infinite));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Run simulation continuously until manually stopped");
+  }
   ImGui::PopItemWidth();
   if (!state.sim.infinite) {
     DIRTY_IF(SliderWithInput("Rays(M)", &state.sim.ray_num_millions, 0.1f, 100.0f));
@@ -882,7 +894,13 @@ void RenderSceneControls(GuiState& state) {
     SliderWithInput("Rays(M)", &state.sim.ray_num_millions, 0.1f, 100.0f);
     ImGui::EndDisabled();
   }
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip("Number of rays to trace, in millions");
+  }
   DIRTY_IF(SliderIntWithInput("Max hits", &state.sim.max_hits, 1, 64));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Maximum number of crystal face hits per ray path");
+  }
 }
 
 #undef DIRTY_IF

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -146,6 +146,7 @@ void ServerPoller::WorkerLoop() {
   }
 }
 
+// See doc/accumulator-consumer-architecture.md §8.1 (polling contract), §8.3 (data flow).
 void ServerPoller::PollOnce() {
   auto* server = server_;
   if (!server) {

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -261,6 +261,7 @@ LUMICE_ErrorCode LUMICE_ParseConfigString(const char* json_str, LUMICE_Config* o
 LUMICE_ErrorCode LUMICE_ParseConfigFile(const char* filename, LUMICE_Config* out);
 
 // =============== Results ===============
+// See doc/capi-lifecycle-architecture.md §5 for sentinel contract.
 // Unified pattern: (server, out, max_count) -> LUMICE_ErrorCode, sentinel-terminated.
 // Sentinel is written at out[count] only when count < max_count.
 // When the array is full (count == max_count), no sentinel slot is written;

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -310,6 +310,7 @@ static nlohmann::json ConfigToJson(const LUMICE_Config& c) {
   return root;
 }
 
+// Struct->JSON path: see doc/capi-lifecycle-architecture.md §6.2.
 LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_Config* config, int* out_reused) {
   if (!server || !config) {
     return LUMICE_ERR_NULL_ARG;
@@ -723,7 +724,7 @@ LUMICE_ErrorCode LUMICE_GetRenderResults(LUMICE_Server* server, LUMICE_RenderRes
     out[i].img_buffer = render_results[i].img_buffer_;
   }
 
-  // Sentinel — only when caller provided an extra slot (count < max_count)
+  // Sentinel: see doc/capi-lifecycle-architecture.md §5.2 (fix: 5287efe).
   if (count < max_count) {
     std::memset(&out[count], 0, sizeof(LUMICE_RenderResult));
   }
@@ -757,7 +758,7 @@ LUMICE_ErrorCode LUMICE_GetRawXyzResults(LUMICE_Server* server, LUMICE_RawXyzRes
     out[i].anchor_snapshot_intensity = results[i].anchor_snapshot_intensity_;
   }
 
-  // Sentinel — only when caller provided an extra slot (count < max_count)
+  // Sentinel: see doc/capi-lifecycle-architecture.md §5.2 (fix: 5287efe).
   if (count < max_count) {
     std::memset(&out[count], 0, sizeof(LUMICE_RawXyzResult));
   }
@@ -782,7 +783,7 @@ LUMICE_ErrorCode LUMICE_GetStatsResults(LUMICE_Server* server, LUMICE_StatsResul
     }
   }
 
-  // Sentinel — only when caller provided an extra slot (count < max_count)
+  // Sentinel: see doc/capi-lifecycle-architecture.md §5.2 (fix: 5287efe).
   if (count < max_count) {
     std::memset(&out[count], 0, sizeof(LUMICE_StatsResult));
   }

--- a/src/server/consumer.hpp
+++ b/src/server/consumer.hpp
@@ -9,6 +9,7 @@
 namespace lumice {
 
 // =============== Interface ===============
+// See doc/accumulator-consumer-architecture.md §2 for the consumer contract and method semantics.
 /**
  * @brief Consumer interface for processing simulation data
  * @details This interface defines the contract for consumers that process simulation data.

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -557,6 +557,7 @@ void RenderConsumer::LogConsumeProfile() const {
             consume_count_, avg_total, avg_proj, avg_proj / avg_total * 100, avg_accum, avg_accum / avg_total * 100);
 }
 
+// See doc/ev-pipeline-architecture.md §3.3
 void RenderConsumer::PrepareSnapshot() {
   int total_pix = config_.resolution_[0] * config_.resolution_[1];
   std::memcpy(snapshot_xyz_.get(), internal_xyz_.get(), total_pix * 3 * sizeof(float));
@@ -670,6 +671,7 @@ Result RenderConsumer::GetResult() const {
   return RenderResult{ config_.id_, config_.resolution_[0], config_.resolution_[1], snapshot_image_buffer_.get() };
 }
 
+// See doc/ev-pipeline-architecture.md §2.3
 RawXyzResult RenderConsumer::GetRawXyzResult() const {
   int total_pix = config_.resolution_[0] * config_.resolution_[1];
   float per_pixel_intensity = total_pix > 0 ? snapshot_intensity_ / (kNormScale * total_pix) : 0.0f;
@@ -688,6 +690,7 @@ RawXyzResult RenderConsumer::GetRawXyzResult() const {
            anchor_per_pixel };
 }
 
+// See doc/ev-pipeline-architecture.md §3.4
 void RenderConsumer::Reset() {
   total_intensity_ = 0;
   snapshot_intensity_ = 0;

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -558,6 +558,7 @@ void RenderConsumer::LogConsumeProfile() const {
 }
 
 // See doc/ev-pipeline-architecture.md §3.3
+// See doc/accumulator-consumer-architecture.md §4.2 (two-phase snapshot protocol, Phase 1).
 void RenderConsumer::PrepareSnapshot() {
   int total_pix = config_.resolution_[0] * config_.resolution_[1];
   std::memcpy(snapshot_xyz_.get(), internal_xyz_.get(), total_pix * 3 * sizeof(float));
@@ -593,6 +594,7 @@ void RenderConsumer::PrepareSnapshot() {
   }
 }
 
+// See doc/accumulator-consumer-architecture.md §4.2 (Phase 1.5 — runs outside consumer_mutex_).
 void RenderConsumer::CountEffectivePixels() {
   int total_pix = config_.resolution_[0] * config_.resolution_[1];
   int count = 0;
@@ -691,6 +693,7 @@ RawXyzResult RenderConsumer::GetRawXyzResult() const {
 }
 
 // See doc/ev-pipeline-architecture.md §3.4
+// See doc/accumulator-consumer-architecture.md §3.1 (reset path), §6.1 (anchor buffer lifecycle).
 void RenderConsumer::Reset() {
   total_intensity_ = 0;
   snapshot_intensity_ = 0;
@@ -712,6 +715,7 @@ void RenderConsumer::Reset() {
   anchor_p995_y_ = 0;
 }
 
+// See doc/accumulator-consumer-architecture.md §5.3 (ResetWith path — layout fields guaranteed identical).
 void RenderConsumer::ResetWith(const RenderConfig& new_config) {
   // NeedsRebuild guarantees layout fields (resolution, lens, view, visible, filter) are identical,
   // so assigning the full config is safe — layout-derived state (rot_, buffers) stays valid.

--- a/src/server/render.hpp
+++ b/src/server/render.hpp
@@ -12,6 +12,7 @@ namespace lumice {
 constexpr int kMinWavelength = 360;
 constexpr int kMaxWavelength = 830;
 
+// See doc/accumulator-consumer-architecture.md §3 (state machine), §4 (thread safety), §6 (invariants).
 class RenderConsumer : public IConsume {
  public:
   explicit RenderConsumer(RenderConfig config);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -33,6 +33,7 @@ namespace lumice {
 // which doesn't guarantee fairness — a high-frequency locker (ConsumeData) can starve
 // a low-frequency waiter (Poller) indefinitely. TicketMutex guarantees FIFO ordering:
 // each waiter gets a ticket and is served in order.
+// See doc/accumulator-consumer-architecture.md §4.1.
 class TicketMutex {
  public:
   void lock() {  // NOLINT(readability-identifier-naming) — C++ Lockable requires lowercase
@@ -267,6 +268,7 @@ Error ServerImpl::CommitConfig(const nlohmann::json& config_json, bool* out_reus
   auto stop_ms = std::chrono::duration<double, std::milli>(stop_end - stop_start).count();
 
   // Check if consumers can be reused (same renderer key set, no layout changes).
+  // See doc/accumulator-consumer-architecture.md §5.4 (reuse eligibility).
   auto old_renderers = config_manager_.renderers_;
   config_manager_ = std::move(new_config);
 
@@ -333,6 +335,7 @@ Error ServerImpl::CommitConfig(const nlohmann::json& config_json, bool* out_reus
 }
 
 
+// See doc/accumulator-consumer-architecture.md §4.2 (two-phase snapshot protocol).
 void ServerImpl::DoSnapshot() {
   // Phase 1: memcpy under consumer_mutex_ (short hold).
   // Copy shared_ptrs so consumers stay alive even if Stop() clears consumers_.

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -222,6 +222,7 @@ ServerImpl::~ServerImpl() {
 }
 
 
+// Lifecycle reset sequence: see doc/capi-lifecycle-architecture.md §7.
 // NOLINTNEXTLINE(readability-function-size)
 Error ServerImpl::CommitConfig(const nlohmann::json& config_json, bool* out_reused) {
   auto commit_start = std::chrono::steady_clock::now();
@@ -524,7 +525,8 @@ void ServerImpl::Stop() {
     // Don't clear consumers_ here — CommitConfig decides whether to rebuild or reuse.
     // Consumers are destroyed either by CommitConfig (rebuild path) or ~ServerImpl().
     snapshot_dirty_ = false;
-    has_ever_consumed_ = false;  // New consumers have no data yet
+    // Resets data-valid flag: see doc/capi-lifecycle-architecture.md §7.1.
+    has_ever_consumed_ = false;
   }
   {
     std::lock_guard<std::mutex> lock(status_mutex_);


### PR DESCRIPTION
## Summary

- **Architecture docs**: Added four new docs covering the EV pipeline, RayPath/RaySeg, accumulator/consumer, and C API lifecycle — capturing data-flow, invariants, and key design decisions that are hard to derive from code alone.
- **Cross-reference comments**: Added brief `// See doc/…` pointers in source files so future readers can locate the relevant architecture doc from the code.
- **GUI tooltips**: Added hover tooltips to non-obvious controls (crystal population params, ray-path filter checkboxes, wavelength selector) for UX consistency.
- **Tooltip hover fix**: Wrapped `SliderWithInput` calls in `ImGui::BeginGroup`/`EndGroup` so the tooltip hover area covers the full composite widget, not just the last sub-widget.

## Test plan

- [x] Existing unit tests and GUI tests pass (`./scripts/build.sh -gtj release`)
- [x] E2E tests pass (`pytest test/e2e/ -v`)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)