### PR TITLE
docs: align EV/filter architecture docs to single-lane (post anchor-lane removal)

### DIFF
--- a/doc/ev-pipeline-architecture.md
+++ b/doc/ev-pipeline-architecture.md
@@ -10,11 +10,18 @@ surface, or the GUI EV controls.
 **Scope**: internal invariants and data-flow contracts. This document does **not**
 cover:
 
-- User-visible Adaptive Brightness behavior, the P99.5 algorithm, or additivity
-  — see [`doc/adaptive-brightness.md`](adaptive-brightness.md).
-- The F1 anchor-lane design rationale, `LUMICE_RawXyzResult` field semantics, or
-  filter branch-table routing — see
-  [`doc/filter-architecture.md §7`](filter-architecture.md).
+- User-visible Adaptive Brightness behavior, the P99 anchor algorithm, or the
+  brightness-target rationale — see [`doc/adaptive-brightness.md`](adaptive-brightness.md).
+- Simulator-side filter routing (Design A) and the `CollectData` branch table
+  — see [`doc/filter-architecture.md`](filter-architecture.md).
+
+> **Historical note**: earlier revisions of this pipeline carried a second
+> "F1 anchor lane" that accumulated filter-fail emission separately to produce a
+> filter-independent P99.5 statistic. That lane was **removed in PR #115**
+> (`task-remove-anchor-lane`, commit `6375ee0`). The current pipeline is a single
+> lane that anchors EV on the visible (filtered) framebuffer's own P99. If you find
+> stray references to `anchor_d_`, `anchor_internal_xyz_`, `anchor_p995_y`, or a
+> "dual lane", they are stale — the live code has none of these.
 
 ---
 
@@ -22,9 +29,9 @@ cover:
 
 | Term | Definition |
 |------|------------|
-| **internal buffer** | Per-`Consume()` accumulation target (`internal_xyz_`, `anchor_internal_xyz_`). Written under the consumer mutex; never read by the GUI. |
-| **snapshot buffer** | Point-in-time copy of the internal buffer (`snapshot_xyz_`, `anchor_snapshot_xyz_`). Produced by `PrepareSnapshot()`; read by `GetRawXyzResult()` and `PostSnapshot()`. |
-| **anchor lane** | The filter-independent accumulation path. Collects filter-fail emission in `anchor_internal_xyz_` and combines it with filter-pass emission in `PrepareSnapshot()` to produce filter-independent statistics. |
+| **internal buffer** | Per-`Consume()` accumulation target (`internal_xyz_`). Written under the consumer mutex; never read by the GUI. |
+| **snapshot buffer** | Point-in-time copy of the internal buffer (`snapshot_xyz_`). Produced by `PrepareSnapshot()`; read by `GetRawXyzResult()` and the poller. |
+| **EV anchor (P99)** | The P99 of the non-zero Y channel of the snapshot, computed **GUI-side** in the poller thread (`ComputeP99Y`, `gui_ev_auto.hpp`). Drives `ev_auto`. Not a server-side field. |
 | **`kNormScale`** | Display brightness baseline constant (0.08). Maps per-pixel radiance to a [0, 1] range at EV = 0 so that the average illuminated pixel is ~5% brightness and bright halo features (~20× average) approach full white. Independent of resolution and FOV. Defined in `render.cpp:30`. |
 
 ---
@@ -33,316 +40,249 @@ cover:
 
 ### §2.1 Per-Consume Accumulation
 
-`RenderConsumer::Consume()` (`render.cpp:341`) processes one batch of simulator
-output. Two parallel accumulations happen in every call:
+`RenderConsumer::Consume()` (`render.cpp:336`) processes one batch of simulator
+output. There is a **single accumulation lane**:
 
-1. **Filtered lane** (always active):
-   - Projects `data.outgoing_d_` / `data.outgoing_w_` (already filter-gated by
-     the simulator — Design A, see `filter-architecture.md §2`) through the lens
-     projection.
-   - Compacts valid in-viewport pixels and accumulates via
-     `SpectrumToXyz()` → `internal_xyz_`.
-   - `total_intensity_ += landed_weight` (sum of all landed ray weights).
+- Projects `data.outgoing_d_` / `data.outgoing_w_` (already filter-gated by the
+  simulator — Design A, see `filter-architecture.md §2`) through the lens projection.
+- Compacts valid in-viewport pixels and accumulates via
+  `SpectrumToXyz()` → `internal_xyz_`.
+- `total_intensity_ += landed_weight` (sum of all landed ray weights).
 
-2. **Anchor lane** (active only when `data.anchor_d_` is non-empty):
-   - Projects `data.anchor_d_` / `data.anchor_w_` (filter-fail emission) through
-     the same lens projection.
-   - Accumulates via `SpectrumToXyz()` → `anchor_internal_xyz_`.
-   - `anchor_total_intensity_ += anchor_landed`.
+**Design A**: the filter runs simulator-side, so all rays in `data.outgoing_*` have
+already passed the filter. Filter-fail rays are terminated in the simulator (they are
+never emitted to the consumer); there is no second buffer for them. The consumer
+simply projects and accumulates.
 
-**Linearity invariant**: both accumulations are linear in XYZ space — each ray's
-contribution is `CMF(wavelength) × weight`, summed per pixel. This ensures exact
-additivity for complementary filter partitions (see `adaptive-brightness.md §4`).
+**Linearity invariant**: accumulation is linear in XYZ space — each ray's
+contribution is `CMF(wavelength) × weight`, summed per pixel.
 
-**Overlap dual-write**: for dual fisheye lens types, pass 2 re-projects overlap-zone
-rays to the opposite hemisphere. This pass does **not** update `total_intensity_`
-(preserves normalization). The anchor lane intentionally skips overlap dual-write:
-the overlap ring is a small geometric artifact that contributes negligibly to the
-P99.5 percentile (`render.cpp:498-501`).
+**Overlap dual-write** (`render.cpp:452-486`): for dual fisheye lens types, pass 2
+re-projects overlap-zone rays to the opposite hemisphere, filling the ring
+`r ∈ (r_scale, 1]`. This pass does **not** update `total_intensity_` — it preserves
+normalization (the overlap ring is a small geometric artifact).
 
-### §2.2 PrepareSnapshot
+### §2.2 PrepareSnapshot and Effective Pixels
 
-`PrepareSnapshot()` (`render.cpp:560`) creates a point-in-time snapshot of all
-accumulation state. Called by `DoSnapshot()` under the consumer mutex.
+`PrepareSnapshot()` (`render.cpp:508`) creates a point-in-time snapshot under the
+consumer mutex. It is intentionally minimal — no percentile is computed server-side:
 
 1. `snapshot_xyz_` ← memcpy of `internal_xyz_`.
 2. `snapshot_intensity_` ← `total_intensity_`.
-3. **Anchor P99.5 computation** (when `anchor_internal_xyz_` is non-null):
-   - `anchor_snapshot_xyz_` ← memcpy of `anchor_internal_xyz_`.
-   - `anchor_snapshot_intensity_` = `snapshot_intensity_` + `anchor_total_intensity_`
-     (filter-pass + filter-fail combined landed intensity).
-   - Computes `anchor_p995_y_`: the P99.5 value of the Y channel across all pixels
-     where `snapshot_xyz_[i*3+1] + anchor_snapshot_xyz_[i*3+1] > 0`. Uses
-     `std::nth_element` at index `⌊count × 0.995⌋`, clamped to `count - 1`.
 
-**Caching invariant**: `anchor_p995_y_` is computed once per snapshot and cached until
-the next `PrepareSnapshot()` call. It is never incrementally updated between snapshots.
+`CountEffectivePixels()` (`render.cpp:515`, runs outside the mutex) then counts
+non-zero pixels into `effective_pix_` (floored to ≥ 1), used for stats display.
 
-**Zero-skip semantics**: pixels with zero combined Y are excluded from the P99.5
-population. This matches the GUI-side `ComputeP995Y()` in `gui_ev_auto.hpp:12` and
-ensures the percentile reflects only illuminated pixels.
+**Zero-skip semantics**: the EV anchor population excludes pixels with zero Y. This
+exclusion happens GUI-side in `ComputeP99Y()` (`gui_ev_auto.hpp`, §2.5), which only
+pushes `Y > 0` entries (or `> 0` coarse bins under downsampling) into the percentile
+population. The server snapshot itself is not filtered — it carries the full buffer.
 
 ### §2.3 kNormScale and Per-Pixel Intensity
 
-`GetRawXyzResult()` (`render.cpp:673`) converts the raw accumulated
+`GetRawXyzResult()` (`render.cpp:593`) converts the raw accumulated
 `snapshot_intensity_` to a per-pixel intensity:
 
 ```
 per_pixel_intensity = snapshot_intensity_ / (kNormScale × total_pixels)
-anchor_per_pixel    = anchor_snapshot_intensity_ / (kNormScale × total_pixels)
 ```
 
 The `kNormScale` factor (0.08) sets the display brightness baseline: at EV = 0, the
-average illuminated pixel is ~5% brightness. In the GUI's `intensity_scale` computation,
-`kNormScale` algebraically cancels because `ComputeEvAuto()` receives
-`anchor_snapshot_intensity` (which already incorporates `kNormScale`) as an input — the
-resulting `ev_auto` absorbs the scale so that `2^ev_auto / norm_intensity` is independent
-of the specific `kNormScale` value. **C API consumers** receive `per_pixel_intensity`
-values whose absolute magnitude is determined by `kNormScale`; this constant is not an
-arbitrary scale factor and must not be changed without re-calibrating the brightness
-baseline.
+average illuminated pixel is ~5% brightness. In the GUI's `intensity_scale`
+computation, `kNormScale` algebraically cancels because `ComputeEvAuto()` receives
+the per-pixel `snapshot_intensity` (which already incorporates `kNormScale`) as its
+denominator input — the resulting `ev_auto` absorbs the scale so that
+`2^ev_auto / snapshot_intensity` is independent of the specific `kNormScale` value.
+**C API consumers** receive `snapshot_intensity` values whose absolute magnitude is
+determined by `kNormScale`; this constant is not an arbitrary scale factor and must
+not be changed without re-calibrating the brightness baseline.
 
 ### §2.4 C API Surface
 
-`LUMICE_RawXyzResult` (`lumice.h:66-89`) exposes the following EV-relevant fields:
+`LUMICE_RawXyzResult` (`lumice.h:66-78`) exposes the following EV-relevant fields:
 
 | Field | Source |
 |-------|--------|
-| `xyz_buffer` | `snapshot_xyz_` (filtered XYZ data) |
-| `snapshot_intensity` | Per-pixel filtered intensity |
+| `xyz_buffer` | `snapshot_xyz_` (filtered XYZ data; `NULL` sentinel) |
+| `snapshot_intensity` | Per-pixel landed intensity (`snapshot_intensity_ / (kNormScale × total_pixels)`) |
 | `intensity_factor` | CLI/config EV factor `2^EV` |
-| `effective_pixels` | Non-zero pixel count |
-| `anchor_p995_y` | Server-side F1 anchor P99.5 of combined Y |
-| `anchor_snapshot_intensity` | Per-pixel combined (filter-pass + filter-fail) intensity |
+| `has_valid_data` | Non-zero once simulation has produced data (reset on `CommitConfig`/`Stop`) |
+| `snapshot_generation` | Increments per snapshot; compare to detect data changes |
+| `effective_pixels` | Non-zero pixel count (stats display) |
+
+The EV anchor (P99) is **not** a C API field — it is derived GUI-side from
+`xyz_buffer` (§2.5). C API consumers that need an anchor must compute their own.
 
 **Lifetime**: the `xyz_buffer` pointer is valid until the next
-`LUMICE_GetRawXyzResults()` or `LUMICE_CommitConfig()` call. The sentinel value is
-`xyz_buffer == NULL`.
+`LUMICE_GetRawXyzResults()` or `LUMICE_CommitConfig()` call.
 
-### §2.5 GUI SyncFromPoller
+### §2.5 GUI Poller and SyncFromPoller
 
-`SyncFromPoller()` (`app.cpp:756`) transfers data from the poller thread to GUI state.
-The EV-relevant logic (`app.cpp:805-811`):
+The EV anchor is computed on the **poller thread**, not the server. In
+`ServerPoller` (`server_poller.cpp:215`):
 
 ```
-# NOTE: the "filter present" branch describes the F1 anchor lane, REMOVED in
-#       PR #115. Current code has a single self-P99 path (the "no filter" branch).
-#       anchor_p995_y / anchor_snapshot_intensity are dead historical fields kept
-#       under their P99.5-era names; only the live "no filter" path was renamed to P99.
-filter present:   p99_raw_y ← anchor_p995_y   (dead: anchor lane, removed PR #115)
-                  ev_auto    ← ComputeEvAuto(anchor_p995_y, anchor_snapshot_intensity, target_white)
-
-no filter:        p99_raw_y ← p99_y          (from filtered snapshot; ≡ total emission)
-                  ev_auto    ← ComputeEvAuto(p99_y, snapshot_intensity, target_white)
+staged_.p99_y = ComputeP99Y(xyz_data, width, height, kEvAutoDownsampleFactor)
 ```
 
-**Source-coherence invariant**: the EV numerator (`p99_raw_y`) and the normalization
-denominator (`norm_intensity`) must always come from the same data source — either
-both from the anchor lane, or both from the filtered snapshot. This is enforced by
-the dual condition `anchor_p995_y > 0 && anchor_snapshot_intensity > 0`.
+`ComputeP99Y()` (`gui_ev_auto.hpp:76`) with `kEvAutoDownsampleFactor = 8`:
+
+1. Box-sum downsamples the Y channel onto a coarse `(w/8) × (h/8)` grid
+   (`DownsampleBoxSumY`; trailing rows/cols that don't divide evenly are dropped).
+2. Takes the P99 over the **non-zero coarse bins** (`nth_element` at
+   `⌊count × 0.99⌋`, clamped to `count - 1`).
+3. Divides by `f² = 64` to return a **fine-equivalent P99**.
+4. Falls back to the fine per-pixel P99 path if `f ≤ 1` or the coarse grid collapses.
+
+Rationale (`scrum-auto-ev-77halo-followup`): coarse bins have `f²` larger expected
+hit count, so the P99-over-lit anchor stabilises earlier in sparse scenes and previews
+brighten faster, while staying mathematically equivalent to the fine anchor:
+`ev = log2(target_linear × snapshot_fine / (P99_coarse / f²))`.
+
+> Because of the `/f²` rescale, `PollerData.p99_y` is **only** an EV anchor, not a
+> raw per-pixel Y measurement — downstream consumers must not treat it as one.
+
+`SyncFromPoller()` (`app.cpp:741`) then transfers the result to GUI state with a
+**single path** (no filter/no-filter branch):
+
+```
+g_state.snapshot_intensity = data.snapshot_intensity
+g_state.p99_raw_y          = data.p99_y
+g_state.ev_auto            = ComputeEvAuto(p99_raw_y, snapshot_intensity, target_white)
+```
+
+`ComputeEvAuto()` (`gui_ev_auto.hpp:123`) returns
+`log2(target_linear / (p99_raw_y / snapshot_intensity))`, clamped to `[-6, 6]`, or
+`0` if either input is non-positive.
 
 ---
 
-## §3 Anchor Lane Lifecycle
+## §3 Snapshot and Reset Lifecycle
 
-### §3.1 Lazy Allocation
+### §3.1 Buffer Allocation
 
-Anchor buffers (`anchor_internal_xyz_`, `anchor_snapshot_xyz_`) are **not** allocated
-in the `RenderConsumer` constructor (`render.cpp:321-338`). They are lazily allocated
-on the first `Consume()` call where `data.anchor_d_` is non-empty
-(`render.cpp:506-513`).
+`RenderConsumer` allocates its four buffers eagerly in the constructor
+(`render.cpp:321-333`), sized to `resolution[0] × resolution[1] × 3`:
+`internal_xyz_`, `snapshot_xyz_`, `snapshot_work_`, `snapshot_image_buffer_`. There
+is no lazy/conditional allocation — every consumer has exactly one accumulation lane.
 
-**Zero-cost invariant**: when no filter is configured, the simulator never produces
-filter-fail rays (`SimData::anchor_d_` stays empty), so anchor buffers are never
-allocated and the anchor lane has zero memory and zero CPU cost.
+### §3.2 Reset Conditions
 
-### §3.2 Per-Consume Accumulation
+Two events clear accumulation state:
 
-When `data.anchor_d_` is non-empty:
+1. **`Reset()`** (`render.cpp:609`): zeros `total_intensity_`, `snapshot_intensity_`,
+   `effective_pix_`, and `internal_xyz_`. It does **not** zero `snapshot_xyz_`
+   (the next `PrepareSnapshot()` memcpys over it) and does **not** deallocate buffers.
+   `has_ever_consumed_ = false` (set in `Stop()`) ensures `GetRawXyzResults()` reports
+   `has_valid_data = false` until new data arrives, preventing stale snapshot reads.
 
-1. Lazy-allocate `anchor_internal_xyz_` and `anchor_snapshot_xyz_` (if first time).
-2. Project `anchor_d_` through the same lens projection as the filtered lane.
-3. Compact valid in-viewport pixels.
-4. `SpectrumToXyz()` → `anchor_internal_xyz_`.
-5. `anchor_total_intensity_ += anchor_landed`.
+2. **Consumer destruction**: the `RenderConsumer` destructor releases all buffers via
+   `unique_ptr` RAII (the full-rebuild path, §6.2).
 
-The anchor lane accumulates only filter-fail emission. Filter-pass emission is already
-in `internal_xyz_`. The combined buffer is reconstructed pixel-by-pixel in
-`PrepareSnapshot()` (§2.2).
-
-### §3.3 PrepareSnapshot Cached State
-
-`PrepareSnapshot()` computes three cached values from the anchor lane:
-
-| Cached field | Formula | Reset condition |
-|---|---|---|
-| `anchor_snapshot_xyz_[i]` | memcpy of `anchor_internal_xyz_[i]` | `Reset()` zeros `anchor_internal_xyz_` |
-| `anchor_snapshot_intensity_` | `snapshot_intensity_ + anchor_total_intensity_` | `Reset()` zeros both components |
-| `anchor_p995_y_` | P99.5 of `(snapshot_xyz_[i*3+1] + anchor_snapshot_xyz_[i*3+1])` over positive pixels | `Reset()` sets to 0 |
-
-These values are read-only between snapshots. No incremental update path exists.
-
-### §3.4 Reset Conditions
-
-Two events trigger anchor data reset:
-
-1. **`Reset()`** (`render.cpp:691`): zeros `anchor_internal_xyz_` (if allocated),
-   `anchor_total_intensity_`, `anchor_snapshot_intensity_`, and `anchor_p995_y_`.
-   Does **not** deallocate the buffer (preserves allocation for reuse).
-
-2. **Consumer destruction** (`consumers_.clear()` in the full rebuild path): the
-   `RenderConsumer` destructor releases all buffers via `unique_ptr` RAII.
-
-`Reset()` is called by `ResetWith()` (`render.cpp:712`) — the consumer-reuse path
+`Reset()` is called by `ResetWith()` (`render.cpp:621`) — the consumer-reuse path
 triggered when `CommitConfig()` calls `Stop()` → `ResetWith()` → `Reset()`.
-
-**Rebuild path** (`CommitConfig()` → `Stop()` → `consumers_.clear()` → `~RenderConsumer()`):
-anchor buffers are released via `unique_ptr` RAII. `Reset()` is **not** called; there is
-no zero-and-retain step, only deallocation.
 
 ---
 
 ## §4 Three Consumption Paths
 
 Three code paths consume the EV pipeline output and compute `intensity_scale`. All
-three use the same formula:
+three use the same formula with a single normalization denominator:
 
 ```
-ev_total        = exposure_offset + ev_auto
+ev_total         = exposure_offset + ev_auto
 intensity_factor = 2^ev_total
-norm_intensity   = anchor_snapshot_intensity  (when anchor lane active)
-                 | snapshot_intensity          (degenerate / no-filter path)
-intensity_scale  = intensity_factor / norm_intensity   (0 if norm_intensity ≤ 0)
+intensity_scale  = intensity_factor / snapshot_intensity   (0 if snapshot_intensity ≤ 0)
 ```
 
 ### §4.1 Display Path
 
-`app_panels.cpp:816-824` — sets the GPU shader uniform each frame:
+`app_panels.cpp:820-823` — sets the GPU shader uniform each frame:
 
 ```cpp
 float ev_total = rc.exposure_offset + g_state.ev_auto;
 pp.exposure.intensity_factor = std::pow(2.0f, ev_total);
-float norm_intensity = (g_state.anchor_snapshot_intensity > 0.0f && g_state.p995_raw_y > 0.0f)
-                           ? g_state.anchor_snapshot_intensity
-                           : g_state.snapshot_intensity;
+float norm_intensity = g_state.snapshot_intensity;
 pp.exposure.intensity_scale = norm_intensity > 0 ? pp.exposure.intensity_factor / norm_intensity : 0.0f;
 ```
 
 ### §4.2 Export Path
 
-`BuildExportParams()` (`app.cpp:297-306`) — constructs `PreviewParams` for PNG export.
-Explicitly mirrors the display path formula. The inline comment documents the
-intentional byte-identity with the shader uniform.
+`BuildExportParams()` (`app.cpp:284-289`) — constructs `PreviewParams` for PNG export.
+Mirrors the display-path formula exactly (`norm_intensity = g_state.snapshot_intensity`).
 
 ### §4.3 Screenshot / .lmc Thumbnail
 
-`RefreshCpuTextureForSave()` (`app.cpp:241-256`) — CPU-side XYZ→sRGB for `.lmc`
-thumbnail. Uses cached `g_state.anchor_snapshot_intensity` rather than a fresh
-`LUMICE_GetRawXyzResults()` call. This introduces a potential ≤1-frame drift from the
-display path, which is acceptable for thumbnails (not user-visible in real time).
+`RefreshCpuTextureForSave()` (`app.cpp:227-248`) — CPU-side XYZ→sRGB for the `.lmc`
+thumbnail. Recomputes `intensity_scale` from `xyz_results[0].snapshot_intensity` and
+`g_state.ev_auto` via `LUMICE_XyzToSrgbUint8`. This may lag the display path by at most
+one frame, which is acceptable for thumbnails (saved on user action, not streamed).
 
 ### §4.4 Consistency Invariant
 
-All three paths share the same formula by construction. The dual condition
-(`anchor_snapshot_intensity > 0 && p995_raw_y > 0`) ensures the EV numerator
-(`ev_auto`, derived from `p995_raw_y`) and the normalization denominator
-(`norm_intensity`) always come from the same data source.
-
-**Drift scope**: the screenshot path reads cached `g_state` values that may lag the
-most recent `SyncFromPoller()` by at most one frame. Since `.lmc` thumbnail is saved
-on user action (not streamed), this drift is imperceptible.
+All three paths share the same formula by construction, and all three use
+`snapshot_intensity` as the single normalization denominator. Because `ev_auto`'s
+numerator (`p99_raw_y`) and this denominator both derive from the **same snapshot**,
+the EV is source-coherent without any cross-source guard.
 
 ---
 
-## §5 `unfiltered_intensity` Semantics
+## §5 Filter Present vs No Filter (Design A)
 
-### §5.1 Filter Present
+Under Design A there is no separate filter-independent statistic — the EV always
+anchors on the visible (filtered) framebuffer:
 
-When a filter spec is configured:
+- **Filter present**: the simulator drops filter-fail rays before emission, so the
+  consumer only ever sees filter-pass emission in `outgoing_*`. The snapshot, its
+  P99 anchor, and `snapshot_intensity` all describe the filtered image.
+- **No filter**: every ray passes the (vacuous) filter, so the same single lane
+  carries the full emission. No code path differs between the two cases.
 
-- The simulator produces both `outgoing_d_/w_` (filter-pass) and `anchor_d_/w_`
-  (filter-fail) in each `SimData` batch.
-- The anchor lane accumulates filter-fail emission in `anchor_internal_xyz_`.
-- `PrepareSnapshot()` combines filter-pass (`snapshot_xyz_`) and filter-fail
-  (`anchor_snapshot_xyz_`) pixel-by-pixel to compute `anchor_p995_y_`.
-- `anchor_snapshot_intensity_` = filter-pass intensity + filter-fail intensity,
-  representing the total landed intensity across all rays regardless of filter.
-
-### §5.2 No-Filter Degenerate
-
-When no filter is configured:
-
-- The simulator produces no filter-fail rays (`anchor_d_` stays empty).
-- `anchor_internal_xyz_` is never allocated (§3.1 lazy allocation guard).
-- `PrepareSnapshot()` skips the anchor computation (`anchor_internal_xyz_` is null).
-- `anchor_p995_y_` and `anchor_snapshot_intensity_` remain at their `Reset()` values
-  (both 0).
-
-### §5.3 Equivalence Invariant
-
-In the no-filter scenario, the GUI detects `anchor_p995_y == 0` and falls back to the
-filtered snapshot path (`SyncFromPoller`, `app.cpp:808-810`). This is numerically
-equivalent to the anchor path because:
-
-- Without a filter, every ray passes the (vacuous) filter. There are zero filter-fail
-  rays.
-- Therefore `filtered_emission ≡ total_emission`.
-- `p995_y(filtered) ≡ p995_y(total)` and
-  `snapshot_intensity ≡ anchor_snapshot_intensity` (if anchor were active).
-
-The fallback is a missing-data guard, not a semantic mode switch.
+This is the substantive change from the removed anchor-lane design: brightness is now
+normalized to *what is shown*, not to a reconstructed filter-independent total. A
+direct consequence is that switching filters changes the EV anchor (the visible image
+changed); this is intentional.
 
 ---
 
-## §6 CommitConfig Impact on Anchor Data
+## §6 CommitConfig Impact
 
-`CommitConfig()` (`server.cpp:263-308`) always calls `Stop()` before modifying
-consumers. `Stop()` transitions the server to `kStopped` and sets
-`has_ever_consumed_ = false` (`server.cpp:524`).
+`CommitConfig()` (`server.cpp:227`) always calls `Stop()` before modifying consumers.
+`Stop()` (`server.cpp:487`) transitions the server to stopped and sets
+`has_ever_consumed_ = false` (`server.cpp:529`).
 
 ### §6.1 Reuse Path
 
 When `NeedsRebuild()` returns false (layout fields unchanged):
 
 ```
-CommitConfig → Stop() → ResetWith(new_config) → Reset()
+CommitConfig → Stop() → ResetWith(new_config) → Reset()   (server.cpp:296)
 ```
 
-`Reset()` zeros all anchor accumulators but **does not deallocate** anchor buffers.
-The `unique_ptr`s retain their allocations for reuse by subsequent `Consume()` calls.
+`Reset()` zeros the accumulators but retains the buffers for reuse.
 
 ### §6.2 Rebuild Path
 
 When `NeedsRebuild()` returns true (layout fields changed):
 
 ```
-CommitConfig → Stop() → consumers_.clear() → new RenderConsumer(...)
+CommitConfig → Stop() → consumers_.clear() → new RenderConsumer(...)   (server.cpp:304)
 ```
 
-`consumers_.clear()` triggers `~RenderConsumer()`, which releases all buffers
-(including anchor buffers) via `unique_ptr` RAII. New consumers start with null
-anchor buffers (lazy allocation resumes on first filter-fail data).
+`consumers_.clear()` triggers `~RenderConsumer()`, releasing all buffers via
+`unique_ptr` RAII. New consumers start fresh.
 
 ### §6.3 Filter Switch Semantics
 
 Filter configuration is **not** in the `NeedsRebuild()` field set — the filter is
 applied simulator-side (Design A), not in the consumer. However, filter switches in
-the GUI trigger `CommitConfig()`, which always calls `Stop()` → `Reset()` (or
-rebuild). Therefore:
-
-**Invariant**: anchor data is always zeroed on filter switch. The anchor lane
-re-accumulates from scratch after each filter change. For the same scene geometry,
-the anchor P99.5 converges to the same value regardless of which filter is active,
-because the anchor combines filter-pass and filter-fail emission (total emission is
-filter-independent).
-
-This is by design: "anchor doesn't reset" refers to the semantic property that the
-anchor value is filter-independent, not that the buffer persists across filter
-switches.
+the GUI still trigger `CommitConfig()`, which always calls `Stop()` → `Reset()` (or
+rebuild). Therefore accumulation always restarts on a filter switch, and the EV anchor
+re-derives from the new filtered image (§5).
 
 ### §6.4 NeedsRebuild Trigger Fields
 
-`NeedsRebuild()` (`render_config.cpp:164`) compares layout-affecting fields only:
+`NeedsRebuild()` (`render_config.cpp:165`) compares layout-affecting fields only:
 
 | Field | Triggers rebuild |
 |-------|:---:|
@@ -352,10 +292,10 @@ switches.
 | `view_` | ✓ |
 | `visible_` | ✓ |
 | `overlap_` | ✓ |
-| `background_`, `ray_color_`, `opacity_`, `intensity_factor_`, `norm_mode_`, grids | ✗ (appearance only) |
+| `background_`, `ray_color_`, `opacity_`, `intensity_factor_`, grids | ✗ (appearance only) |
 
-A `static_assert(sizeof(RenderConfig) == 144)` guards against silent field additions
-(`render_config.cpp:166`).
+A `static_assert(sizeof(RenderConfig) == 136)` guards against silent field additions
+(`render_config.cpp:167`).
 
 ---
 
@@ -364,22 +304,25 @@ A `static_assert(sizeof(RenderConfig) == 144)` guards against silent field addit
 | Invariant / Concept | Source Location |
 |---|---|
 | `kNormScale` definition (0.08) | `render.cpp:30` |
-| `Consume()` — filtered + anchor parallel accumulation | `render.cpp:341-547` |
-| Anchor lazy allocation guard | `render.cpp:506-513` |
-| Anchor overlap skip rationale | `render.cpp:498-501` |
-| `PrepareSnapshot()` — anchor P99.5 computation | `render.cpp:560-593` |
-| P99 nth_element index formula | `render.cpp:585-591` |
-| `GetRawXyzResult()` — per-pixel intensity formula | `render.cpp:673-688` |
-| `Reset()` — anchor zeroing semantics | `render.cpp:691-710` |
-| `ResetWith()` — config update + reset | `render.cpp:712-717` |
-| Constructor — lazy allocation comment | `render.cpp:334-337` |
-| `CommitConfig()` — Stop→Reset/Rebuild→Start | `server.cpp:263-308` |
-| `has_ever_consumed_` reset in Stop | `server.cpp:524` |
-| `NeedsRebuild()` — layout field comparison | `render_config.cpp:164-173` |
-| `sizeof(RenderConfig)` static_assert | `render_config.cpp:166` |
-| `ComputeP99Y()` / `ComputeEvAuto()` | `gui_ev_auto.hpp:12-46` |
-| `SyncFromPoller()` — anchor source selection + ev_auto | `app.cpp:756-813` |
-| `BuildExportParams()` — export EV consistency | `app.cpp:297-306` |
-| `RefreshCpuTextureForSave()` — .lmc thumbnail EV | `app.cpp:241-256` |
-| Display path `ev_total` / `intensity_scale` | `app_panels.cpp:816-824` |
-| `LUMICE_RawXyzResult` anchor fields | `lumice.h:66-89` |
+| `Consume()` — single-lane accumulation | `render.cpp:336` |
+| Overlap dual-write (pass 2) | `render.cpp:452-486` |
+| `PrepareSnapshot()` — snapshot + intensity | `render.cpp:508` |
+| `CountEffectivePixels()` | `render.cpp:515` |
+| `PostSnapshot()` — CLI/server 8-bit image | `render.cpp:528` |
+| `GetRawXyzResult()` — per-pixel intensity formula | `render.cpp:593` |
+| `Reset()` — zeroing semantics | `render.cpp:609` |
+| `ResetWith()` — config update + reset | `render.cpp:621` |
+| Constructor — eager buffer allocation | `render.cpp:321-333` |
+| `RawXyzResult` (internal struct) | `server.hpp:134` |
+| `LUMICE_RawXyzResult` (C API) | `lumice.h:66-78` |
+| `CommitConfig()` — Stop→Reset/Rebuild | `server.cpp:227` |
+| `Stop()` — `has_ever_consumed_` reset | `server.cpp:487,529` |
+| `NeedsRebuild()` — layout field comparison | `render_config.cpp:165-175` |
+| `sizeof(RenderConfig)` static_assert (136) | `render_config.cpp:167` |
+| `DownsampleBoxSumY()` / `ComputeP99Y()` / `ComputeEvAuto()` | `gui_ev_auto.hpp:27,76,123` |
+| `kEvAutoDownsampleFactor` (8) | `gui_ev_auto.hpp:19` |
+| Poller P99 anchor computation | `server_poller.cpp:215` |
+| `SyncFromPoller()` — ev_auto computation | `app.cpp:741` |
+| `BuildExportParams()` — export EV consistency | `app.cpp:284-289` |
+| `RefreshCpuTextureForSave()` — .lmc thumbnail EV | `app.cpp:227-248` |
+| Display path `ev_total` / `intensity_scale` | `app_panels.cpp:820-823` |

--- a/doc/filter-architecture.md
+++ b/doc/filter-architecture.md
@@ -207,7 +207,7 @@ as the canonical routing model.  Off mode redesign was tracked as a backlog item
 
 ### scrum-221 (adaptive-additivity-redesign, 2026-05-24) — Off mode redesign shipped
 
-Implemented Off mode via F1 anchor lane (see §7).  ABI swap removed `unfiltered_*`
+Implemented Off mode via F1 anchor lane.  ABI swap removed `unfiltered_*`
 fields and introduced `anchor_p99_y` / `anchor_snapshot_intensity` (renamed to
 `anchor_p995_y` in apply-new-defaults).  Additivity testing
 (partition invariant) added to the E2E test suite.
@@ -242,11 +242,13 @@ TIR-like semantics) but never reach the consumer's outgoing accumulator.
 The EV offset is sourced from the current frame's visible framebuffer:
 
 ```
-ev = log2(target_linear / (p995_y / snapshot_intensity))
+ev = log2(target_linear / (p99_y / snapshot_intensity))
 ```
 
-The P99.5 is computed in the poller thread (`server_poller.cpp::PollOnce`) over the
-staged XYZ data. See `doc/adaptive-brightness.md` for full EV semantics.
+The P99 anchor is computed in the poller thread (`ServerPoller::WorkerLoop`,
+`server_poller.cpp:215`) over the staged XYZ data, using an f=8 box-sum downsample
+(`ComputeP99Y`). See `doc/ev-pipeline-architecture.md §2.5` and
+`doc/adaptive-brightness.md` for full EV semantics.
 
 ---
 
@@ -271,7 +273,7 @@ anchor points for future contributors:
 | Filter ↔ crystal per-entry config | `src/config/proj_config.hpp` — `ScatteringSetting` |
 | Simulator-side filter check (Design A gate) | `src/core/simulator.cpp` — `CollectData()` |
 | FilterSpec algorithm interface | `src/core/filter_spec.hpp` |
-| C API anchor fields (F1 anchor lane) | `src/include/lumice.h` — `LUMICE_RawXyzResult.anchor_p995_y` / `anchor_snapshot_intensity` |
+| EV pipeline (single-lane, P99 anchor) | `doc/ev-pipeline-architecture.md` |
 | Filter JSON schema | `doc/configuration.md` |
 | Raypath semantics, P/B/D filter toggles | `doc/raypath-symmetry.md` |
 | Adaptive Brightness Off mode, additivity | `doc/adaptive-brightness.md` |

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -503,7 +503,7 @@ void RenderConsumer::LogConsumeProfile() const {
             consume_count_, avg_total, avg_proj, avg_proj / avg_total * 100, avg_accum, avg_accum / avg_total * 100);
 }
 
-// See doc/ev-pipeline-architecture.md §3.3
+// See doc/ev-pipeline-architecture.md §2.2
 // See doc/accumulator-consumer-architecture.md §4.2 (two-phase snapshot protocol, Phase 1).
 void RenderConsumer::PrepareSnapshot() {
   int total_pix = config_.resolution_[0] * config_.resolution_[1];
@@ -604,7 +604,7 @@ RawXyzResult RenderConsumer::GetRawXyzResult() const {
            effective_pix_ };
 }
 
-// See doc/ev-pipeline-architecture.md §3.4
+// See doc/ev-pipeline-architecture.md §3.2
 // See doc/accumulator-consumer-architecture.md §3.1 (reset path).
 void RenderConsumer::Reset() {
   total_intensity_ = 0;


### PR DESCRIPTION
## 背景

两篇架构文档在 F1 anchor lane 移除（PR #115, `6375ee0`）之后未同步，处于自相矛盾/stale 状态。本 PR 把它们对齐到当前代码现状：**单 accumulation lane + EV 锚点 P99（GUI 端 f=8 box-sum 降采样）**。源自一次 backlog 复核。

## 改动

**`doc/ev-pipeline-architecture.md`（全文重写，chore #243 / `39ef4c8`）**
- 该文档由 `task-audit-ev-pipeline` 在 anchor 移除*之前*创建，§2/§3/§5/§6 仍以现在时描述 anchor lane 并引用已删除字段（`data.anchor_d_`、`anchor_p995_y`），同篇 worked-example 又注明 "REMOVED" —— 自相矛盾
- 按*已读代码核实的*现状重写：单 lane（Design A，filter-fail 光线在模拟器侧终止）；P99 锚点在 poller 线程经 `ComputeP99Y` f=8 降采样计算；C API 无 anchor 字段；三消费路径统一以 `snapshot_intensity` 归一化
- §6.4 修正：删除已移除的 `norm_mode_`，`static_assert` 由 144 → 136
- §7 source-reference 行号全部刷新；新增 Historical note 说明 anchor lane 已于 PR #115 移除
- 同步 2 处源码 cross-ref 注释锚点（`render.cpp` §3.3→§2.2、§3.4→§3.2）

**`doc/filter-architecture.md`（§7 局部修正，chore #244 / `565dfb0`）**
- EV 公式 `p995_y` → `p99_y`
- "P99.5 ... `server_poller.cpp::PollOnce`"（`PollOnce` 已不存在）→ "P99 ... `ServerPoller::WorkerLoop`，f=8 降采样"
- Cross-References 表删除指向已删字段的行
- **保留** dated 变更历史段（scrum-221/237）不动 —— 准确历史记录

## 验证

纯文档 + 注释改动，**无行为变更**。文档一致性已 grep 核验：无以现在时描述 active anchor lane 的内容；所有源码 cross-ref 锚点解析正常；残留 `P99.5/anchor_*` token 仅存在于 dated changelog。

🤖 Generated with [Claude Code](https://claude.com/claude-code)