### PR TITLE
feat: EntryExit filter expressiveness — wildcard, multi-value OR, length bounds

### DIFF
--- a/doc/filter-architecture.md
+++ b/doc/filter-architecture.md
@@ -161,6 +161,58 @@ decision rule.
 
 `RenderConfig` must not hold filter fields.  Filters are a simulation-side concern only.
 
+### EntryExit filter expressiveness (task-ee-filter-uplift, 2026-06-01)
+
+The `entry_exit` filter type accepts two orthogonal axes of constraint:
+
+1. **Structural axis** — entry-face set × exit-face set, each side independently
+   either a single face number, a list of faces (OR), or wildcard (any face).
+2. **Length axis** — minimum and / or maximum path-length bounds on `RaySeg.rp_.size_`.
+
+The core schema reflects this directly:
+
+```cpp
+// src/config/filter_config.hpp
+struct EntryExitFilterParam {
+  std::optional<IdType> entry_;     // nullopt = wildcard
+  std::optional<IdType> exit_;      // nullopt = wildcard
+  size_t min_len_ = 1;              // path-length lower bound (>=1 by geometry)
+  std::optional<size_t> max_len_;   // nullopt = no upper bound
+};
+```
+
+Match semantics (`EntryExitSpec::Match`, `src/core/filter_spec.cpp`):
+
+| Branch                  | Structural check                                                    |
+|-------------------------|---------------------------------------------------------------------|
+| both ends set           | orbit on `[entry, exit]` against `[rp_[0], rp_[size−1]]`            |
+| only `entry_` set       | orbit on `[entry]` against `[rp_[0]]`                               |
+| only `exit_` set        | orbit on `[exit]` against `[rp_[size−1]]`                           |
+| both wildcard           | structural check skipped; length bounds alone decide                |
+
+Length bounds are evaluated before the orbit check; `size == 0` always rejects
+to keep `rp_[0]` access well-defined.
+
+**Multi-value OR routing** lives in the GUI → core translation layer
+(`src/gui/file_io.cpp::SerializeFilterForCore`).  `EntryExitParams.entry_text`
+and `.exit_text` accept comma-separated face numbers; empty text encodes the
+wildcard.  The serializer takes the cartesian product, emits one EE
+`SimpleFilter` per `(entry, exit)` pair (each carrying the same length bounds),
+then wraps them in a single `ComplexFilter` whose composition is
+`[[id0],[id1],…]`.  This mirrors the raypath multi-segment OR path and keeps
+all "composition" semantics inside `ComplexFilter` — `EntryExitFilterParam`
+itself stays a pure per-end constraint.
+
+The GUI input form is correspondingly two text inputs + a four-mode length
+dropdown (no constraint / strict N / at most N / range [N,M]); see
+`src/gui/edit_modals.cpp::RenderEntryExitSubpanel`.
+
+JSON schema is backward compatible: pre-uplift `{"entry": 3, "exit": 5}`
+deserializes to `entry_=3, exit_=5, min_len_=1, max_len_=nullopt` with no
+behavioral change.  Absent or explicit-null `entry`/`exit`/`max_len` map to
+`nullopt`; absent `min_len` defaults to 1.  The to-json side omits each field
+when it carries the default value.
+
 ---
 
 ## §6 Historical Context

--- a/src/config/config_compare.hpp
+++ b/src/config/config_compare.hpp
@@ -46,7 +46,7 @@ inline bool operator==(const RaypathFilterParam& a, const RaypathFilterParam& b)
 }
 
 inline bool operator==(const EntryExitFilterParam& a, const EntryExitFilterParam& b) {
-  return a.entry_ == b.entry_ && a.exit_ == b.exit_;
+  return a.entry_ == b.entry_ && a.exit_ == b.exit_ && a.min_len_ == b.min_len_ && a.max_len_ == b.max_len_;
 }
 
 inline bool operator==(const DirectionFilterParam& a, const DirectionFilterParam& b) {

--- a/src/config/filter_config.cpp
+++ b/src/config/filter_config.cpp
@@ -21,8 +21,18 @@ struct SimpleFilterParamToJson {
 
   void operator()(const EntryExitFilterParam& p) {
     j_["type"] = "entry_exit";
-    j_["entry"] = p.entry_;
-    j_["exit"] = p.exit_;
+    if (p.entry_.has_value()) {
+      j_["entry"] = *p.entry_;
+    }
+    if (p.exit_.has_value()) {
+      j_["exit"] = *p.exit_;
+    }
+    if (p.min_len_ > 1) {
+      j_["min_len"] = p.min_len_;
+    }
+    if (p.max_len_.has_value()) {
+      j_["max_len"] = *p.max_len_;
+    }
   }
 
   void operator()(const DirectionFilterParam& p) {
@@ -86,6 +96,7 @@ void to_json(nlohmann::json& j, const FilterConfig& f) {
   std::visit(FilterParamToJson{ j }, f.param_);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void from_json(const nlohmann::json& j, FilterConfig& f) {
   j.at("id").get_to(f.id_);
 
@@ -98,8 +109,18 @@ void from_json(const nlohmann::json& j, FilterConfig& f) {
     f.param_ = p;
   } else if (type == "entry_exit") {
     EntryExitFilterParam p{};
-    j.at("entry").get_to(p.entry_);
-    j.at("exit").get_to(p.exit_);
+    if (j.contains("entry") && !j.at("entry").is_null()) {
+      p.entry_ = j.at("entry").get<IdType>();
+    }
+    if (j.contains("exit") && !j.at("exit").is_null()) {
+      p.exit_ = j.at("exit").get<IdType>();
+    }
+    if (j.contains("min_len") && !j.at("min_len").is_null()) {
+      p.min_len_ = j.at("min_len").get<size_t>();
+    }
+    if (j.contains("max_len") && !j.at("max_len").is_null()) {
+      p.max_len_ = j.at("max_len").get<size_t>();
+    }
     f.param_ = p;
   } else if (type == "direction") {
     DirectionFilterParam p{};

--- a/src/config/filter_config.cpp
+++ b/src/config/filter_config.cpp
@@ -1,6 +1,8 @@
 #include "config/filter_config.hpp"
 
 #include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -120,6 +122,20 @@ void from_json(const nlohmann::json& j, FilterConfig& f) {
     }
     if (j.contains("max_len") && !j.at("max_len").is_null()) {
       p.max_len_ = j.at("max_len").get<size_t>();
+    }
+    // Validation per plan §8 AC: min_len >= 1; if max_len set, min_len <= max_len <= kMaxHits.
+    if (p.min_len_ < 1) {
+      throw std::runtime_error("entry_exit filter: min_len must be >= 1, got " + std::to_string(p.min_len_));
+    }
+    if (p.max_len_.has_value()) {
+      if (*p.max_len_ < p.min_len_) {
+        throw std::runtime_error("entry_exit filter: max_len (" + std::to_string(*p.max_len_) +
+                                 ") must be >= min_len (" + std::to_string(p.min_len_) + ")");
+      }
+      if (*p.max_len_ > kMaxHits) {
+        throw std::runtime_error("entry_exit filter: max_len (" + std::to_string(*p.max_len_) +
+                                 ") exceeds kMaxHits (" + std::to_string(kMaxHits) + ")");
+      }
     }
     f.param_ = p;
   } else if (type == "direction") {

--- a/src/config/filter_config.cpp
+++ b/src/config/filter_config.cpp
@@ -133,8 +133,8 @@ void from_json(const nlohmann::json& j, FilterConfig& f) {
                                  ") must be >= min_len (" + std::to_string(p.min_len_) + ")");
       }
       if (*p.max_len_ > kMaxHits) {
-        throw std::runtime_error("entry_exit filter: max_len (" + std::to_string(*p.max_len_) +
-                                 ") exceeds kMaxHits (" + std::to_string(kMaxHits) + ")");
+        throw std::runtime_error("entry_exit filter: max_len (" + std::to_string(*p.max_len_) + ") exceeds kMaxHits (" +
+                                 std::to_string(kMaxHits) + ")");
       }
     }
     f.param_ = p;

--- a/src/config/filter_config.hpp
+++ b/src/config/filter_config.hpp
@@ -1,7 +1,9 @@
 #ifndef CONFIG_FILTER_CONFIG_H_
 #define CONFIG_FILTER_CONFIG_H_
 
+#include <cstddef>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -16,8 +18,10 @@ struct RaypathFilterParam {
 };
 
 struct EntryExitFilterParam {
-  IdType entry_;
-  IdType exit_;
+  std::optional<IdType> entry_;    // nullopt = wildcard (any entry face)
+  std::optional<IdType> exit_;     // nullopt = wildcard (any exit face)
+  size_t min_len_ = 1;             // path length lower bound (>=1 by geometry)
+  std::optional<size_t> max_len_;  // nullopt = no upper bound
 };
 
 struct DirectionFilterParam {

--- a/src/config/raypath_validation.cpp
+++ b/src/config/raypath_validation.cpp
@@ -186,6 +186,36 @@ RaypathValidationResult ValidateRaypathText(const std::string& text, CrystalKind
   return RaypathValidationResult{ RaypathValidation::kValid, std::string{} };
 }
 
+RaypathValidationResult ValidateFaceNumberListText(const std::string& text, CrystalKind kind) {
+  // Empty text = wildcard ("any face") — always valid.
+  if (text.empty()) {
+    return RaypathValidationResult{ RaypathValidation::kValid, std::string{} };
+  }
+  // Trailing comma → kIncomplete (still typing); matches raypath separator UX.
+  if (text.back() == ',') {
+    return RaypathValidationResult{ RaypathValidation::kIncomplete, std::string{} };
+  }
+  // Walk comma-separated tokens; first non-valid token wins.
+  size_t pos = 0;
+  while (pos < text.size()) {
+    size_t end = text.find(',', pos);
+    if (end == std::string::npos) {
+      end = text.size();
+    }
+    if (end == pos) {
+      // Empty interior token (e.g. "3,,4") — definite error, not "still typing".
+      return RaypathValidationResult{ RaypathValidation::kInvalid, "Empty face number in list" };
+    }
+    std::string token = text.substr(pos, end - pos);
+    auto r = ValidateFaceNumberText(token, kind);
+    if (r.state != RaypathValidation::kValid) {
+      return r;
+    }
+    pos = end + 1;
+  }
+  return RaypathValidationResult{ RaypathValidation::kValid, std::string{} };
+}
+
 RaypathValidationResult ValidateFaceNumberText(const std::string& text, CrystalKind kind) {
   if (text.empty()) {
     return RaypathValidationResult{ RaypathValidation::kIncomplete, std::string{} };

--- a/src/config/raypath_validation.hpp
+++ b/src/config/raypath_validation.hpp
@@ -73,6 +73,15 @@ RaypathValidationResult ValidateRaypathText(const std::string& text, CrystalKind
 ///   - Otherwise → kValid.
 RaypathValidationResult ValidateFaceNumberText(const std::string& text, CrystalKind kind);
 
+/// Validate a comma-separated face-number list (used by the Entry-Exit filter
+/// sub-panel's multi-value OR input). Empty text is a wildcard ("any face")
+/// and validates as `kValid`. Each non-empty token is delegated to
+/// `ValidateFaceNumberText`; the first non-valid token determines the
+/// returned state and message. A trailing comma yields `kIncomplete` so the
+/// border colour distinguishes "still typing" from "definitely wrong"
+/// (matches the raypath separator handling).
+RaypathValidationResult ValidateFaceNumberListText(const std::string& text, CrystalKind kind);
+
 }  // namespace lumice
 
 #endif  // CONFIG_RAYPATH_VALIDATION_HPP_

--- a/src/core/filter_spec.cpp
+++ b/src/core/filter_spec.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -157,20 +158,63 @@ class RaypathSpec : public FilterSpec {
 
 class EntryExitSpec : public FilterSpec {
  public:
-  EntryExitSpec(const Crystal& crystal, IdType entry, IdType exit, uint8_t symmetry, int sigma_a, bool d_applicable)
-      : orbit_(BuildOrbit(crystal, std::vector<IdType>{ entry, exit }, symmetry, sigma_a, d_applicable)) {}
+  EntryExitSpec(const Crystal& crystal, std::optional<IdType> entry, std::optional<IdType> exit, size_t min_len,
+                std::optional<size_t> max_len, uint8_t symmetry, int sigma_a, bool d_applicable)
+      : min_len_(min_len), max_len_(max_len), has_entry_(entry.has_value()), has_exit_(exit.has_value()),
+        has_orbit_(has_entry_ || has_exit_),
+        orbit_(BuildOrbitFromEnds(crystal, entry, exit, symmetry, sigma_a, d_applicable)) {}
 
   bool Match(const RaySeg& ray) const override {
-    if (ray.rp_.size_ == 0) {
+    size_t size = ray.rp_.size_;
+    if (size == 0) {
       return false;
+    }
+    if (size < min_len_) {
+      return false;
+    }
+    if (max_len_.has_value() && size > *max_len_) {
+      return false;
+    }
+    if (!has_orbit_) {
+      return true;  // both wildcard: length-only match
     }
     RaypathRecorder ee;
     ee.Clear();
-    ee << ray.rp_[0] << ray.rp_[ray.rp_.size_ - 1];
+    if (has_entry_ && has_exit_) {
+      ee << ray.rp_[0] << ray.rp_[size - 1];
+    } else if (has_entry_) {
+      ee << ray.rp_[0];
+    } else {
+      ee << ray.rp_[size - 1];
+    }
     return orbit_.Contains(ee);
   }
 
  private:
+  static RaypathOrbit BuildOrbitFromEnds(const Crystal& crystal, std::optional<IdType> entry,
+                                         std::optional<IdType> exit, uint8_t symmetry, int sigma_a, bool d_applicable) {
+    std::vector<IdType> rp;
+    if (entry.has_value() && exit.has_value()) {
+      rp.push_back(*entry);
+      rp.push_back(*exit);
+    } else if (entry.has_value()) {
+      rp.push_back(*entry);
+    } else if (exit.has_value()) {
+      rp.push_back(*exit);
+    }
+    // For the double-wildcard case we return a default-constructed orbit that
+    // is never consulted (has_orbit_ guards Match).
+    if (rp.empty()) {
+      return RaypathOrbit{};
+    }
+    return BuildOrbit(crystal, rp, symmetry, sigma_a, d_applicable);
+  }
+
+  size_t min_len_;
+  std::optional<size_t> max_len_;
+  bool has_entry_;
+  bool has_exit_;
+  bool has_orbit_;
   RaypathOrbit orbit_;
 };
 
@@ -234,7 +278,8 @@ struct SimpleSpecCreator {
     return std::make_unique<RaypathSpec>(crystal_, p.raypath_, symmetry_, sigma_a_, d_applicable_);
   }
   std::unique_ptr<FilterSpec> operator()(const EntryExitFilterParam& p) const {
-    return std::make_unique<EntryExitSpec>(crystal_, p.entry_, p.exit_, symmetry_, sigma_a_, d_applicable_);
+    return std::make_unique<EntryExitSpec>(crystal_, p.entry_, p.exit_, p.min_len_, p.max_len_, symmetry_, sigma_a_,
+                                           d_applicable_);
   }
   std::unique_ptr<FilterSpec> operator()(const DirectionFilterParam& p) const {
     return std::make_unique<DirectionSpec>(p.lon_, p.lat_, p.radii_);

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -117,9 +117,10 @@ static EntryExitParams g_ee_params_snapshot;
 // Entry-Exit InputText backing buffers. ImGui needs persistent char arrays
 // for InputText; we mirror them with g_ee_params.{entry,exit}_text on
 // snapshot / commit (mirrors the g_raypath_buf ↔ g_raypath_params.raypath_text
-// pattern).
-static char g_ee_entry_buf[32];
-static char g_ee_exit_buf[32];
+// pattern). 64 bytes comfortably holds a 6-value list of 2-digit faces
+// (e.g. "13,14,15,16,17,18" = 17 chars).
+static char g_ee_entry_buf[64];
+static char g_ee_exit_buf[64];
 
 // ImGui InputText backing store for the raypath text input. The raypath
 // sub-buffer's raypath_text is synced FROM this char array (canonical source)
@@ -721,10 +722,11 @@ static void RenderRaypathSubpanel() {
 // char arrays in place across frames.
 static void RenderEntryExitSubpanel() {
   const auto kind = CurrentValidationKind();
-  const auto v_entry = GuiValidateFaceNumberText(g_ee_entry_buf, kind);
-  const auto v_exit = GuiValidateFaceNumberText(g_ee_exit_buf, kind);
+  const auto v_entry = GuiValidateFaceNumberListText(g_ee_entry_buf, kind);
+  const auto v_exit = GuiValidateFaceNumberListText(g_ee_exit_buf, kind);
 
-  // FrameBg tint mirrors RenderRaypathSubpanel (same helper).
+  // FrameBg tint mirrors RenderRaypathSubpanel (same helper). Empty text
+  // is a wildcard, hence kValid — the border stays neutral.
   ImGui::PushStyleColor(ImGuiCol_FrameBg, ValidationFrameBgColor(v_entry.state));
   ImGui::InputText("Entry##filter_ee_entry", g_ee_entry_buf, sizeof(g_ee_entry_buf));
   ImGui::PopStyleColor();
@@ -740,8 +742,60 @@ static void RenderEntryExitSubpanel() {
     ImGui::TextColored(ImVec4(0.86f, 0.24f, 0.24f, 1.0f), "Exit: %s", v_exit.message.c_str());
   }
 
-  // Shared hint — single value syntax, consistent with EE single-value semantic.
-  ImGui::TextDisabled("e.g. 3");
+  // Shared hint — single value, multi-value OR, or wildcard (empty).
+  ImGui::TextDisabled("e.g. 3 or 3,4 (empty = any)");
+
+  // Length-mode dropdown: four discrete modes drive whether min / max
+  // numeric inputs render. Stored on g_ee_params directly because there is
+  // no large char-buffer to mirror like the text fields.
+  const char* kLengthModeLabels[4] = { "No constraint", "Strict N", "At most N", "Range [N,M]" };
+  if (ImGui::BeginCombo("Length##filter_ee_len_mode", kLengthModeLabels[g_ee_params.length_mode])) {
+    for (int i = 0; i < 4; ++i) {
+      const bool selected = (g_ee_params.length_mode == i);
+      if (ImGui::Selectable(kLengthModeLabels[i], selected)) {
+        g_ee_params.length_mode = i;
+        // Strict mode collapses to a single value: keep min/max in lockstep
+        // so the serializer's "strict N" path always sees a coherent pair.
+        if (i == 1) {
+          g_ee_params.max_len = g_ee_params.min_len;
+        }
+      }
+      if (selected) {
+        ImGui::SetItemDefaultFocus();
+      }
+    }
+    ImGui::EndCombo();
+  }
+
+  if (g_ee_params.length_mode == 1) {
+    // Strict — one numeric input drives both bounds.
+    if (ImGui::InputInt("Length N##filter_ee_strict", &g_ee_params.min_len)) {
+      if (g_ee_params.min_len < 1) {
+        g_ee_params.min_len = 1;
+      }
+      g_ee_params.max_len = g_ee_params.min_len;
+    }
+  } else if (g_ee_params.length_mode == 2) {
+    if (ImGui::InputInt("Max length##filter_ee_max", &g_ee_params.max_len)) {
+      if (g_ee_params.max_len < 1) {
+        g_ee_params.max_len = 1;
+      }
+    }
+  } else if (g_ee_params.length_mode == 3) {
+    if (ImGui::InputInt("Min length##filter_ee_min", &g_ee_params.min_len)) {
+      if (g_ee_params.min_len < 1) {
+        g_ee_params.min_len = 1;
+      }
+      if (g_ee_params.max_len < g_ee_params.min_len) {
+        g_ee_params.max_len = g_ee_params.min_len;
+      }
+    }
+    if (ImGui::InputInt("Max length##filter_ee_max_range", &g_ee_params.max_len)) {
+      if (g_ee_params.max_len < g_ee_params.min_len) {
+        g_ee_params.max_len = g_ee_params.min_len;
+      }
+    }
+  }
 }
 
 // Returns true when the current entry's axis config satisfies D-symmetry
@@ -1126,8 +1180,8 @@ ApplyBuffersResult ApplyBuffersToEntry(GuiState& state) {
     } else {
       const bool buf_changed = IsFilterDirty();
       const auto kind = CurrentValidationKind();
-      const auto v_entry = GuiValidateFaceNumberText(g_ee_params.entry_text, kind);
-      const auto v_exit = GuiValidateFaceNumberText(g_ee_params.exit_text, kind);
+      const auto v_entry = GuiValidateFaceNumberListText(g_ee_params.entry_text, kind);
+      const auto v_exit = GuiValidateFaceNumberListText(g_ee_params.exit_text, kind);
       const bool both_valid = v_entry.state == LUMICE_RAYPATH_VALID && v_exit.state == LUMICE_RAYPATH_VALID;
       if ((g_filter_initial_present || buf_changed) && both_valid) {
         FilterConfig out;
@@ -1629,8 +1683,8 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       // enabled when the user has clicked Remove Filter.
       if (!g_ee_remove_intent) {
         const auto kind = CurrentValidationKind();
-        const auto ve = GuiValidateFaceNumberText(g_ee_entry_buf, kind);
-        const auto vx = GuiValidateFaceNumberText(g_ee_exit_buf, kind);
+        const auto ve = GuiValidateFaceNumberListText(g_ee_entry_buf, kind);
+        const auto vx = GuiValidateFaceNumberListText(g_ee_exit_buf, kind);
         const bool incomplete = ve.state == LUMICE_RAYPATH_INCOMPLETE || vx.state == LUMICE_RAYPATH_INCOMPLETE;
         const bool invalid = ve.state == LUMICE_RAYPATH_INVALID || vx.state == LUMICE_RAYPATH_INVALID;
         if (invalid) {
@@ -1638,7 +1692,7 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
           ok_tooltip = "Filter face number invalid — fix it in the Filter tab";
         } else if (incomplete) {
           ok_disabled = true;
-          ok_tooltip = "Enter entry and exit face numbers";
+          ok_tooltip = "Finish typing the face-number list (remove trailing comma)";
         }
       }
     }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -287,6 +287,11 @@ static int ParseFaceNumberOrZero(const std::string& text) {
 // Sentinel returned by ParseFaceNumberList for the wildcard (empty input).
 static constexpr int kEEWildcardSentinel = -1;
 
+// Local mirror of lumice::kMaxHits (src/core/def.hpp). Hardcoded here to keep
+// the AGENTS.md "src/gui must not include core/ headers directly" boundary
+// intact. Keep in sync if core/def.hpp::kMaxHits changes.
+static constexpr int kEELenAbsoluteMax = 64;
+
 // Parse a comma-separated face-number list (EE multi-value OR input). Empty
 // text returns a single-element list with the wildcard sentinel, so callers
 // can uniformly take the cartesian product. Tokens are individually parsed
@@ -321,7 +326,13 @@ static std::vector<int> ParseFaceNumberList(const std::string& text) {
 // Mirrors the EntryExitParams docstring; see plan §3.3.
 struct EELenBounds {
   int min_len;
-  int max_len;  // -1 = nullopt (no upper bound)
+  // -1 here means "no upper bound" (corresponds to std::optional<size_t> nullopt
+  // on the core EntryExitFilterParam::max_len_). Distinct from
+  // kEEWildcardSentinel which is the face-wildcard marker — same magic value,
+  // different namespace: this one is never confused with a face id because
+  // EELenBounds::max_len is only ever fed to WriteEELengthFields / parsed back
+  // from min/max length JSON fields, not into the entry/exit face channels.
+  int max_len;
 };
 static EELenBounds DecodeLengthMode(int mode, int min_len, int max_len) {
   switch (mode) {
@@ -1059,11 +1070,32 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
           p.length_mode = 1;  // strict
         } else if (has_max && !has_min) {
           p.length_mode = 2;  // upper bound only
+        } else if (has_min && !has_max) {
+          // Lower bound only (min_len without max_len) is not a first-class
+          // GUI mode — collapse it to range with the saturated upper bound so
+          // the dropdown shows something meaningful. Self-generated configs
+          // never hit this branch (to_json omits max_len iff nullopt and only
+          // emits min_len when > 1); third-party hand-authored JSON might.
+          GUI_LOG_WARNING(
+              "[FileIO] entry_exit filter with min_len={} but no max_len; mapping to range mode with max={}",
+              min_v, kEELenAbsoluteMax);
+          p.length_mode = 3;  // range
         } else {
           p.length_mode = 3;  // range
         }
         p.min_len = min_v;
-        p.max_len = has_max ? max_v : min_v;
+        // For has_min && !has_max we synthesize max = kMaxHits so the GUI
+        // range slider has a defined upper anchor; the actual core-side
+        // semantic ("no upper bound") is preserved on subsequent
+        // GUI→core serialization only if the user untouched the field —
+        // any user edit will write max explicitly.
+        if (has_max) {
+          p.max_len = max_v;
+        } else if (has_min) {
+          p.max_len = kEELenAbsoluteMax;
+        } else {
+          p.max_len = min_v;
+        }
         f.param = p;
       } else {
         GUI_LOG_WARNING("[FileIO] Unknown filter type '{}' on core JSON import, defaulting to empty raypath", type_str);

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -209,10 +209,16 @@ static json SerializeFilterForGui(const FilterConfig& f, int id) {
           j["raypath_text"] = p.raypath_text;
         } else if constexpr (std::is_same_v<T, EntryExitParams>) {
           // Persist as text so partial / invalid input round-trips without
-          // surprise int parsing; readers parse on the fly.
+          // surprise int parsing; readers parse on the fly. Length mode and
+          // bounds are GUI-side state (the mode dictates which bound is
+          // user-visible); always serialize so Cancel/Reload preserves the
+          // dropdown selection.
           j["type"] = "entry_exit";
           j["entry_text"] = p.entry_text;
           j["exit_text"] = p.exit_text;
+          j["length_mode"] = p.length_mode;
+          j["min_len"] = p.min_len;
+          j["max_len"] = p.max_len;
         }
       },
       f.param);
@@ -278,6 +284,71 @@ static int ParseFaceNumberOrZero(const std::string& text) {
   return value;
 }
 
+// Sentinel returned by ParseFaceNumberList for the wildcard (empty input).
+static constexpr int kEEWildcardSentinel = -1;
+
+// Parse a comma-separated face-number list (EE multi-value OR input). Empty
+// text returns a single-element list with the wildcard sentinel, so callers
+// can uniformly take the cartesian product. Tokens are individually parsed
+// via ParseFaceNumberOrZero; malformed tokens fall through to 0 there (the
+// OK-button gate stops invalid commits before this is reached in normal
+// use). Trailing comma is ignored — kIncomplete inputs should already have
+// been rejected upstream.
+static std::vector<int> ParseFaceNumberList(const std::string& text) {
+  std::vector<int> out;
+  if (text.empty()) {
+    out.push_back(kEEWildcardSentinel);
+    return out;
+  }
+  size_t pos = 0;
+  while (pos < text.size()) {
+    size_t end = text.find(',', pos);
+    if (end == std::string::npos) {
+      end = text.size();
+    }
+    if (end != pos) {
+      out.push_back(ParseFaceNumberOrZero(text.substr(pos, end - pos)));
+    }
+    pos = end + 1;
+  }
+  if (out.empty()) {
+    out.push_back(kEEWildcardSentinel);
+  }
+  return out;
+}
+
+// Decode the GUI length-mode trio into the core (min_len, max_len) pair.
+// Mirrors the EntryExitParams docstring; see plan §3.3.
+struct EELenBounds {
+  int min_len;
+  int max_len;  // -1 = nullopt (no upper bound)
+};
+static EELenBounds DecodeLengthMode(int mode, int min_len, int max_len) {
+  switch (mode) {
+    case 1:  // strict N
+      return { std::max(min_len, 1), std::max(min_len, 1) };
+    case 2:  // at most N
+      return { 1, std::max(max_len, 1) };
+    case 3:  // range [N,M]
+      return { std::max(min_len, 1), std::max(max_len, std::max(min_len, 1)) };
+    case 0:
+    default:
+      return { 1, -1 };
+  }
+}
+
+// Emit min_len / max_len JSON fields on an EE SimpleFilter following the
+// core schema in src/config/filter_config.cpp: omit min_len when default
+// (==1), omit max_len when unbounded.
+static void WriteEELengthFields(nlohmann::json& j, const EELenBounds& b) {
+  if (b.min_len > 1) {
+    j["min_len"] = b.min_len;
+  }
+  if (b.max_len >= 0) {
+    j["max_len"] = b.max_len;
+  }
+}
+
 // Clamp a GUI int to the C API ID range and warn on overflow.
 static int ClampIdValue(int v, const char* field_name) {
   if (v < 0) {
@@ -337,18 +408,52 @@ static FilterCoreResult SerializeFilterForCore(const FilterConfig& f, int next_f
             result.main_id = complex_id;
           }
         } else if constexpr (std::is_same_v<T, EntryExitParams>) {
-          // Parse text → int at the core boundary. Empty / non-numeric text
-          // falls through to ClampIdValue's negative-clamp path which emits
-          // 0 and a GUI_LOG_WARNING; OK-button gating prevents this from
-          // reaching SerializeFilterForCore in normal operation.
-          int id = next_filter_id_base;
-          int entry_int = ParseFaceNumberOrZero(p.entry_text);
-          int exit_int = ParseFaceNumberOrZero(p.exit_text);
-          result.filters.push_back(BuildCoreSimpleFilterJson(f, id, "entry_exit", [&](json& j) {
-            j["entry"] = ClampIdValue(entry_int, "entry");
-            j["exit"] = ClampIdValue(exit_int, "exit");
-          }));
-          result.main_id = id;
+          // Multi-value OR is expanded to N×M EE SimpleFilters + 1 ComplexFilter,
+          // mirroring the raypath multi-segment path above. Wildcard (empty
+          // text) collapses to a single sentinel so the cartesian product
+          // still yields one pair → one filter. Length bounds (decoded from
+          // the GUI mode dropdown) are written onto each EE SimpleFilter.
+          auto entries = ParseFaceNumberList(p.entry_text);
+          auto exits = ParseFaceNumberList(p.exit_text);
+          const auto bounds = DecodeLengthMode(p.length_mode, p.min_len, p.max_len);
+          const size_t pair_count = entries.size() * exits.size();
+
+          auto emit_ee = [&](int id, int entry_int, int exit_int) {
+            result.filters.push_back(BuildCoreSimpleFilterJson(f, id, "entry_exit", [&](json& j) {
+              if (entry_int != kEEWildcardSentinel) {
+                j["entry"] = ClampIdValue(entry_int, "entry");
+              }
+              if (exit_int != kEEWildcardSentinel) {
+                j["exit"] = ClampIdValue(exit_int, "exit");
+              }
+              WriteEELengthFields(j, bounds);
+            }));
+          };
+
+          if (pair_count <= 1) {
+            int id = next_filter_id_base;
+            emit_ee(id, entries[0], exits[0]);
+            result.main_id = id;
+          } else {
+            std::vector<int> child_ids;
+            child_ids.reserve(pair_count);
+            int idx = 0;
+            for (int e : entries) {
+              for (int x : exits) {
+                int id = next_filter_id_base + idx++;
+                child_ids.push_back(id);
+                emit_ee(id, e, x);
+              }
+            }
+            int complex_id = next_filter_id_base + static_cast<int>(pair_count);
+            json composition = json::array();
+            for (int cid : child_ids) {
+              composition.push_back(json::array({ cid }));
+            }
+            result.filters.push_back(BuildCoreSimpleFilterJson(
+                f, complex_id, "complex", [&composition](json& j) { j["composition"] = composition; }));
+            result.main_id = complex_id;
+          }
         }
       },
       f.param);
@@ -573,6 +678,21 @@ static FilterConfig ParseFilterFromGuiJson(const json& jf) {
     } else if (jf.contains("exit")) {
       int v = jf.value("exit", 0);
       p.exit_text = (v == 0) ? std::string{} : std::to_string(v);
+    }
+    // Length-mode trio: missing in pre-uplift .lmc files; defaults keep the
+    // old "no constraint" behaviour. length_mode is clamped to [0,3] so a
+    // corrupt value does not crash the UI Combo.
+    p.length_mode = jf.value("length_mode", 0);
+    if (p.length_mode < 0 || p.length_mode > 3) {
+      p.length_mode = 0;
+    }
+    p.min_len = jf.value("min_len", 1);
+    p.max_len = jf.value("max_len", 1);
+    if (p.min_len < 1) {
+      p.min_len = 1;
+    }
+    if (p.max_len < 1) {
+      p.max_len = 1;
     }
     f.param = p;
   } else {
@@ -916,13 +1036,34 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
         f.param = RaypathParams{ text };
       } else if (type_str == "entry_exit") {
         // core JSON keeps int "entry" / "exit" — translate to GUI's text
-        // representation (0 → empty so the user-visible "untouched" state
-        // is preserved).
+        // representation. Absent or explicit-null fields are the wildcard
+        // form (post-uplift schema) and map to an empty string. min_len /
+        // max_len are decoded into the four GUI length-mode buckets.
         EntryExitParams p;
-        int entry_int = jf.value("entry", 0);
-        int exit_int = jf.value("exit", 0);
-        p.entry_text = (entry_int == 0) ? std::string{} : std::to_string(entry_int);
-        p.exit_text = (exit_int == 0) ? std::string{} : std::to_string(exit_int);
+        auto read_face = [&](const char* key) -> std::string {
+          if (!jf.contains(key) || jf.at(key).is_null()) {
+            return std::string{};  // wildcard
+          }
+          int v = jf.at(key).get<int>();
+          return (v == 0) ? std::string{} : std::to_string(v);
+        };
+        p.entry_text = read_face("entry");
+        p.exit_text = read_face("exit");
+        const bool has_min = jf.contains("min_len") && !jf.at("min_len").is_null();
+        const bool has_max = jf.contains("max_len") && !jf.at("max_len").is_null();
+        const int min_v = has_min ? std::max(jf.at("min_len").get<int>(), 1) : 1;
+        const int max_v = has_max ? std::max(jf.at("max_len").get<int>(), 1) : 1;
+        if (!has_min && !has_max) {
+          p.length_mode = 0;
+        } else if (has_max && (min_v == max_v) && has_min) {
+          p.length_mode = 1;  // strict
+        } else if (has_max && !has_min) {
+          p.length_mode = 2;  // upper bound only
+        } else {
+          p.length_mode = 3;  // range
+        }
+        p.min_len = min_v;
+        p.max_len = has_max ? max_v : min_v;
         f.param = p;
       } else {
         GUI_LOG_WARNING("[FileIO] Unknown filter type '{}' on core JSON import, defaulting to empty raypath", type_str);

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1077,8 +1077,8 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
           // never hit this branch (to_json omits max_len iff nullopt and only
           // emits min_len when > 1); third-party hand-authored JSON might.
           GUI_LOG_WARNING(
-              "[FileIO] entry_exit filter with min_len={} but no max_len; mapping to range mode with max={}",
-              min_v, kEELenAbsoluteMax);
+              "[FileIO] entry_exit filter with min_len={} but no max_len; mapping to range mode with max={}", min_v,
+              kEELenAbsoluteMax);
           p.length_mode = 3;  // range
         } else {
           p.length_mode = 3;  // range

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -230,16 +230,32 @@ struct RaypathParams {
 };
 
 struct EntryExitParams {
-  // GUI text buffers — validated via raypath_validation::ValidateFaceNumberText
-  // and parsed to int at the GUI→core / GUI→.lmc serialization boundary.
+  // GUI text buffers — validated via raypath_validation::ValidateFaceNumberListText
+  // and parsed to int(s) at the GUI→core / GUI→.lmc serialization boundary.
   // Storing as string lets the user type partial input and lets validation
   // surface "Face N not legal on Prism" messages just like the raypath
-  // sub-panel.
+  // sub-panel.  Empty text encodes the wildcard ("any face") branch.
+  // Multi-value OR is encoded as comma-separated face numbers (e.g. "3,4");
+  // the API translation layer expands the cartesian product into N×M
+  // EntryExit SimpleFilters wrapped by a ComplexFilter (mirrors the raypath
+  // multi-segment path).
   std::string entry_text;
   std::string exit_text;
 
+  // Length constraint UI mode and bounds. The four modes are decoded at the
+  // serializer boundary into (min_len, max_len):
+  //   0 = no constraint    → min=1, max=nullopt
+  //   1 = strict N         → min=max=min_len
+  //   2 = at most N        → min=1, max=max_len
+  //   3 = range [N,M]      → min=min_len, max=max_len
+  // Values are stored 1-based to match the core `size_t min_len_` semantics.
+  int length_mode = 0;
+  int min_len = 1;
+  int max_len = 1;
+
   friend bool operator==(const EntryExitParams& a, const EntryExitParams& b) {
-    return a.entry_text == b.entry_text && a.exit_text == b.exit_text;
+    return a.entry_text == b.entry_text && a.exit_text == b.exit_text && a.length_mode == b.length_mode &&
+           a.min_len == b.min_len && a.max_len == b.max_len;
   }
   friend bool operator!=(const EntryExitParams& a, const EntryExitParams& b) { return !(a == b); }
 };

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -189,11 +189,35 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
           }
           return p.raypath_text;
         } else if constexpr (std::is_same_v<T, EntryExitParams>) {
-          // "?" placeholder so a half-typed (kIncomplete) config still
-          // renders something readable in the entry card summary.
-          const char* e = p.entry_text.empty() ? "?" : p.entry_text.c_str();
-          const char* x = p.exit_text.empty() ? "?" : p.exit_text.c_str();
-          return std::string("EE:") + e + "->" + x;
+          // Format each end as "*" (wildcard / empty), the raw text (single
+          // value), or "{a,b,...}" (multi-value list). Length suffix encodes
+          // the four mode choices so the summary roundtrips with the edit
+          // modal's dropdown.
+          auto format_side = [](const std::string& t) -> std::string {
+            if (t.empty()) {
+              return "*";
+            }
+            if (t.find(',') == std::string::npos) {
+              return t;
+            }
+            return std::string("{") + t + "}";
+          };
+          std::string body = std::string("EE:") + format_side(p.entry_text) + "-" + format_side(p.exit_text);
+          switch (p.length_mode) {
+            case 1:
+              body += " L=" + std::to_string(p.min_len);
+              break;
+            case 2:
+              body += " L<=" + std::to_string(p.max_len);
+              break;
+            case 3:
+              body += " L=[" + std::to_string(p.min_len) + "," + std::to_string(p.max_len) + "]";
+              break;
+            case 0:
+            default:
+              break;
+          }
+          return body;
         } else {
           return "*";
         }

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -99,6 +99,11 @@ inline GuiValidationResult GuiValidateFaceNumberText(const std::string& text, LU
 // kIncomplete. Internal empty token (e.g. "3,,4") → kInvalid. Each
 // non-empty token is delegated to GuiValidateFaceNumberText so the
 // kind-specific legality message stays identical to the single-value path.
+//
+// Logic mirrors lumice::ValidateFaceNumberListText in
+// src/config/raypath_validation.cpp; keep in sync. The GUI tier cannot
+// include core headers directly (AGENTS.md §"Public API boundary"), hence
+// the local copy.
 inline GuiValidationResult GuiValidateFaceNumberListText(const std::string& text, LUMICE_CrystalKind kind) {
   GuiValidationResult r;
   if (text.empty()) {

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -94,6 +94,43 @@ inline GuiValidationResult GuiValidateFaceNumberText(const std::string& text, LU
   return r;
 }
 
+// Validate a comma-separated face-number list (Entry-Exit multi-value OR
+// input). Empty text = wildcard ("any face") → kValid. Trailing comma →
+// kIncomplete. Internal empty token (e.g. "3,,4") → kInvalid. Each
+// non-empty token is delegated to GuiValidateFaceNumberText so the
+// kind-specific legality message stays identical to the single-value path.
+inline GuiValidationResult GuiValidateFaceNumberListText(const std::string& text, LUMICE_CrystalKind kind) {
+  GuiValidationResult r;
+  if (text.empty()) {
+    r.state = LUMICE_RAYPATH_VALID;
+    return r;
+  }
+  if (text.back() == ',') {
+    r.state = LUMICE_RAYPATH_INCOMPLETE;
+    return r;
+  }
+  size_t pos = 0;
+  while (pos < text.size()) {
+    size_t end = text.find(',', pos);
+    if (end == std::string::npos) {
+      end = text.size();
+    }
+    if (end == pos) {
+      r.state = LUMICE_RAYPATH_INVALID;
+      r.message = "Empty face number in list";
+      return r;
+    }
+    auto tok = text.substr(pos, end - pos);
+    auto sr = GuiValidateFaceNumberText(tok, kind);
+    if (sr.state != LUMICE_RAYPATH_VALID) {
+      return sr;
+    }
+    pos = end + 1;
+  }
+  r.state = LUMICE_RAYPATH_VALID;
+  return r;
+}
+
 // Validate raypath text supporting the multi-segment ';' syntax.
 //
 // Job split (per plan):

--- a/test/gui/test_gui_interaction.cpp
+++ b/test/gui/test_gui_interaction.cpp
@@ -3680,18 +3680,27 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(ctx->ItemExists("**/Exit##filter_ee_exit"));
       IM_CHECK(!ctx->ItemExists("**/Raypath##filter_modal"));
 
-      // OK is disabled while EE fields are empty (kIncomplete, not kValid).
-      // post-task-filter-modal-polish-v1 contract: empty face number is not
-      // a committable value — user must type a legal face number first.
+      // post-task-ee-filter-uplift contract: empty entry/exit text encodes
+      // the wildcard ("any face") branch and is itself a committable value.
+      // OK stays enabled with both fields empty (double-wildcard).
       auto info_ok = ctx->ItemInfo("**/" ICON_FA_CHECK " OK##edit_modal");
-      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
 
-      // Type valid face numbers → OK enables.
+      // Type valid face numbers → OK still enabled.
       ctx->ItemInputValue("**/Entry##filter_ee_entry", "1");
       ctx->ItemInputValue("**/Exit##filter_ee_exit", "2");
       ctx->Yield(2);
       auto info_typed = ctx->ItemInfo("**/" ICON_FA_CHECK " OK##edit_modal");
       IM_CHECK((info_typed.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      // Trailing comma → kIncomplete → OK disabled (user is mid-typing).
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "3,");
+      ctx->Yield(2);
+      auto info_trailing = ctx->ItemInfo("**/" ICON_FA_CHECK " OK##edit_modal");
+      IM_CHECK((info_trailing.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+      // Restore typed value so the rest of the test sees a valid buffer.
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "1");
+      ctx->Yield(2);
 
       // Switch to Raypath: EE inputs un-render.
       ctx->ItemClick("**/Raypath##filter_type");
@@ -3754,12 +3763,12 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(f.sym_b);
       IM_CHECK(f.sym_d);
 
-      // FilterSummary EE format: "EE:<entry>-><exit> <In|Out>[ <sym>]" —
-      // entry/exit now render the raw text buffer (kept as-is so partial
-      // input stays visible). ASCII "->" is used so the bundled font always
-      // renders it (U+2192 fell back to "?" glyph on user's machine).
+      // FilterSummary EE format (task-ee-filter-uplift): "EE:<entry>-<exit>
+      // [length-suffix] <In|Out>[ <sym>]". Single values render bare; lists
+      // render in {...}; wildcards render as "*". Length suffix omitted when
+      // mode=0 (no constraint), which is the default for this fresh commit.
       IM_CHECK_STR_EQ(gui::FilterSummary(gui::FilterOf(gui::g_state, gui::g_state.layers[0].entries[0])).c_str(),
-                      "EE:2->5 Out PBD");
+                      "EE:2-5 Out PBD");
     };
   }
 
@@ -3844,6 +3853,104 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
 
       // Remove intent takes precedence: filter must be nullopt regardless of re-typed value.
       IM_CHECK(!gui::g_state.layers[0].entries[0].filter_id.has_value());
+    };
+  }
+
+  // T11b — task-ee-filter-uplift: multi-value OR + InputText round-trip
+  // through the modal. Length-mode dropdown interaction is exercised by a
+  // pure-state test below to avoid driving the BeginCombo widget from the
+  // headless harness (Combo button does not register IMGUI_TEST_ENGINE_ITEM_INFO).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_uplift_multivalue_list");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Entry-Exit##filter_type");
+      ctx->Yield(2);
+
+      // Multi-value entry, single-value exit.
+      ctx->ItemInputValue("**/Entry##filter_ee_entry", "3,4");
+      ctx->ItemInputValue("**/Exit##filter_ee_exit", "5");
+      ctx->Yield(2);
+
+      // OK enabled (list valid).
+      auto info_ok = ctx->ItemInfo("**/" ICON_FA_CHECK " OK##edit_modal");
+      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
+      ctx->Yield(2);
+
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter_id.has_value());
+      const auto& f = gui::g_state.filters[*gui::g_state.layers[0].entries[0].filter_id];
+      const auto& ee = std::get<gui::EntryExitParams>(f.param);
+      IM_CHECK_EQ(ee.entry_text, std::string("3,4"));
+      IM_CHECK_EQ(ee.exit_text, std::string("5"));
+      IM_CHECK_EQ(ee.length_mode, 0);  // default
+
+      // FilterSummary: list end uses {}, single end bare, no length suffix.
+      IM_CHECK_STR_EQ(gui::FilterSummary(gui::FilterOf(gui::g_state, gui::g_state.layers[0].entries[0])).c_str(),
+                      "EE:{3,4}-5 In PBD");
+    };
+  }
+
+  // T11b2 — task-ee-filter-uplift: FilterSummary length-mode formatting.
+  // Length-mode dropdown UI interaction is left to manual verification;
+  // this test pins the four format strings the summary should emit.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_uplift_length_summary_formats");
+    t->TestFunc = [](ImGuiTestContext* /*ctx*/) {
+      auto make_summary = [](int mode, int min_v, int max_v) {
+        gui::FilterConfig fc;
+        gui::EntryExitParams ee;
+        ee.entry_text = "3";
+        ee.exit_text = "5";
+        ee.length_mode = mode;
+        ee.min_len = min_v;
+        ee.max_len = max_v;
+        fc.param = ee;
+        return gui::FilterSummary(std::optional<gui::FilterConfig>{ fc });
+      };
+      IM_CHECK_STR_EQ(make_summary(0, 1, 1).c_str(), "EE:3-5 In PBD");
+      IM_CHECK_STR_EQ(make_summary(1, 2, 2).c_str(), "EE:3-5 L=2 In PBD");
+      IM_CHECK_STR_EQ(make_summary(2, 1, 4).c_str(), "EE:3-5 L<=4 In PBD");
+      IM_CHECK_STR_EQ(make_summary(3, 2, 5).c_str(), "EE:3-5 L=[2,5] In PBD");
+    };
+  }
+
+  // T11c — task-ee-filter-uplift: double-wildcard + no length constraint
+  // commits and renders as "EE:*-*".
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "entry_exit_uplift_double_wildcard");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Entry-Exit##filter_type");
+      ctx->Yield(2);
+
+      // Leave entry/exit empty (= wildcard); default length mode = 0.
+      // Need to "dirty" the filter so the commit branch fires — clicking
+      // the type radio above already does that.
+
+      auto info_ok = ctx->ItemInfo("**/" ICON_FA_CHECK " OK##edit_modal");
+      IM_CHECK((info_ok.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
+      ctx->Yield(2);
+
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter_id.has_value());
+      const auto& f = gui::g_state.filters[*gui::g_state.layers[0].entries[0].filter_id];
+      const auto& ee = std::get<gui::EntryExitParams>(f.param);
+      IM_CHECK(ee.entry_text.empty());
+      IM_CHECK(ee.exit_text.empty());
+      IM_CHECK_EQ(ee.length_mode, 0);
+      IM_CHECK_STR_EQ(gui::FilterSummary(gui::FilterOf(gui::g_state, gui::g_state.layers[0].entries[0])).c_str(),
+                      "EE:*-* In PBD");
     };
   }
 

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -922,20 +922,18 @@ TEST(EntryExitJson, MinLenNullTreatedAsDefault) {
 
 // Plan §8 AC: from_json must reject min_len < 1.
 TEST(EntryExitJson, MinLenZeroRejected) {
-  nlohmann::json j = {
-    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
-    { "exit", 5 }, { "min_len", 0 }
-  };
+  nlohmann::json j = { { "id", 1 },        { "type", "entry_exit" }, { "action", "filter_in" },
+                       { "symmetry", "" }, { "entry", 3 },           { "exit", 5 },
+                       { "min_len", 0 } };
   FilterConfig cfg{};
   EXPECT_THROW(from_json(j, cfg), std::runtime_error);
 }
 
 // Plan §8 AC: from_json must reject max_len < min_len.
 TEST(EntryExitJson, MaxLenLessThanMinLenRejected) {
-  nlohmann::json j = {
-    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
-    { "exit", 5 }, { "min_len", 3 },         { "max_len", 1 }
-  };
+  nlohmann::json j = { { "id", 1 },        { "type", "entry_exit" }, { "action", "filter_in" },
+                       { "symmetry", "" }, { "entry", 3 },           { "exit", 5 },
+                       { "min_len", 3 },   { "max_len", 1 } };
   FilterConfig cfg{};
   EXPECT_THROW(from_json(j, cfg), std::runtime_error);
 }
@@ -943,7 +941,7 @@ TEST(EntryExitJson, MaxLenLessThanMinLenRejected) {
 // Plan §8 AC: from_json must reject max_len > kMaxHits.
 TEST(EntryExitJson, MaxLenExceedsKMaxHitsRejected) {
   nlohmann::json j = {
-    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
+    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" },  { "symmetry", "" }, { "entry", 3 },
     { "exit", 5 }, { "min_len", 1 },         { "max_len", kMaxHits + 1 }
   };
   FilterConfig cfg{};

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -863,6 +863,49 @@ TEST(EntryExitJson, RangeWildcardRoundTrip) {
   ExpectEEEqual(GetEE(cfg2), ee);
 }
 
+// ========== ValidateFaceNumberListText tests ==========
+
+TEST(ValidateFaceNumberListTextTest, Empty_IsValidWildcard) {
+  auto r = ValidateFaceNumberListText("", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kValid);
+  EXPECT_TRUE(r.message.empty());
+}
+
+TEST(ValidateFaceNumberListTextTest, SingleValue_IsValid) {
+  auto r = ValidateFaceNumberListText("3", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kValid);
+}
+
+TEST(ValidateFaceNumberListTextTest, MultiValue_IsValid) {
+  auto r = ValidateFaceNumberListText("3,4,5", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kValid);
+}
+
+TEST(ValidateFaceNumberListTextTest, TrailingComma_IsIncomplete) {
+  auto r = ValidateFaceNumberListText("3,", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kIncomplete);
+}
+
+TEST(ValidateFaceNumberListTextTest, InteriorEmpty_IsInvalid) {
+  auto r = ValidateFaceNumberListText("3,,5", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  EXPECT_NE(r.message.find("Empty"), std::string::npos);
+}
+
+TEST(ValidateFaceNumberListTextTest, IllegalFace_PropagatesMessage) {
+  // 13 is illegal on a prism — list validator delegates to the per-face
+  // validator, so the kind-specific message must surface.
+  auto r = ValidateFaceNumberListText("3,13,5", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  EXPECT_NE(r.message.find("Prism"), std::string::npos);
+  EXPECT_NE(r.message.find("13"), std::string::npos);
+}
+
+TEST(ValidateFaceNumberListTextTest, LeadingComma_IsInvalid) {
+  auto r = ValidateFaceNumberListText(",3", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+}
+
 TEST(EntryExitJson, MinLenNullTreatedAsDefault) {
   // Explicit null on min_len/max_len is tolerated (treated same as absent).
   nlohmann::json j = {

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -693,3 +693,185 @@ TEST(ReduceRaypath_OrbitInvariant, D_Only_Pyramid_AllSigmaA) {
     }
   }
 }
+
+
+// ========== EntryExitFilterParam JSON round-trip tests ==========
+//
+// Cover the optional<entry/exit> + min_len/max_len schema introduced by
+// task-ee-filter-uplift. Backward compatibility: legacy single-value
+// {"entry":3,"exit":5} input must continue to deserialize without loss.
+
+namespace {
+
+FilterConfig MakeEEFilterConfig(IdType id, EntryExitFilterParam ee) {
+  FilterConfig cfg{};
+  cfg.id_ = id;
+  cfg.symmetry_ = FilterConfig::kSymNone;
+  cfg.action_ = FilterConfig::kFilterIn;
+  cfg.param_ = SimpleFilterParam{ ee };
+  return cfg;
+}
+
+EntryExitFilterParam GetEE(const FilterConfig& cfg) {
+  const auto& sp = std::get<SimpleFilterParam>(cfg.param_);
+  return std::get<EntryExitFilterParam>(sp);
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void ExpectEEEqual(const EntryExitFilterParam& a, const EntryExitFilterParam& b) {
+  EXPECT_EQ(a.entry_.has_value(), b.entry_.has_value());
+  if (a.entry_.has_value() && b.entry_.has_value()) {
+    EXPECT_EQ(*a.entry_, *b.entry_);
+  }
+  EXPECT_EQ(a.exit_.has_value(), b.exit_.has_value());
+  if (a.exit_.has_value() && b.exit_.has_value()) {
+    EXPECT_EQ(*a.exit_, *b.exit_);
+  }
+  EXPECT_EQ(a.min_len_, b.min_len_);
+  EXPECT_EQ(a.max_len_.has_value(), b.max_len_.has_value());
+  if (a.max_len_.has_value() && b.max_len_.has_value()) {
+    EXPECT_EQ(*a.max_len_, *b.max_len_);
+  }
+}
+
+}  // namespace
+
+TEST(EntryExitJson, LegacySingleValue_BackwardCompatible) {
+  // Old JSON form lacks min_len / max_len — must deserialise unchanged.
+  nlohmann::json j = { { "id", 1 },        { "type", "entry_exit" }, { "action", "filter_in" },
+                       { "symmetry", "" }, { "entry", 3 },           { "exit", 5 } };
+  FilterConfig cfg{};
+  from_json(j, cfg);
+  auto p = GetEE(cfg);
+  ASSERT_TRUE(p.entry_.has_value());
+  ASSERT_TRUE(p.exit_.has_value());
+  EXPECT_EQ(*p.entry_, 3);
+  EXPECT_EQ(*p.exit_, 5);
+  EXPECT_EQ(p.min_len_, 1u);
+  EXPECT_FALSE(p.max_len_.has_value());
+}
+
+TEST(EntryExitJson, RoundTrip_LegacySingleValue) {
+  EntryExitFilterParam ee;
+  ee.entry_ = 3;
+  ee.exit_ = 5;
+  auto cfg = MakeEEFilterConfig(1, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  // Schema: entry/exit present, min_len/max_len absent (defaults).
+  EXPECT_EQ(j.at("entry").get<int>(), 3);
+  EXPECT_EQ(j.at("exit").get<int>(), 5);
+  EXPECT_FALSE(j.contains("min_len"));
+  EXPECT_FALSE(j.contains("max_len"));
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, EntryWildcard_AbsentField) {
+  EntryExitFilterParam ee;
+  ee.entry_ = std::nullopt;
+  ee.exit_ = 5;
+  auto cfg = MakeEEFilterConfig(2, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  EXPECT_FALSE(j.contains("entry"));
+  EXPECT_EQ(j.at("exit").get<int>(), 5);
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, EntryWildcard_ExplicitNull) {
+  // Explicit null is accepted and maps to nullopt (same as absent).
+  nlohmann::json j = { { "id", 1 },        { "type", "entry_exit" }, { "action", "filter_in" },
+                       { "symmetry", "" }, { "entry", nullptr },     { "exit", 5 } };
+  FilterConfig cfg{};
+  from_json(j, cfg);
+  auto p = GetEE(cfg);
+  EXPECT_FALSE(p.entry_.has_value());
+  ASSERT_TRUE(p.exit_.has_value());
+  EXPECT_EQ(*p.exit_, 5);
+}
+
+TEST(EntryExitJson, DoubleWildcard_EmptyEntryExit) {
+  EntryExitFilterParam ee;
+  ee.entry_ = std::nullopt;
+  ee.exit_ = std::nullopt;
+  auto cfg = MakeEEFilterConfig(3, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  EXPECT_FALSE(j.contains("entry"));
+  EXPECT_FALSE(j.contains("exit"));
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, MaxLenRoundTrip) {
+  EntryExitFilterParam ee;
+  ee.entry_ = 3;
+  ee.exit_ = 5;
+  ee.max_len_ = 5;
+  auto cfg = MakeEEFilterConfig(4, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  EXPECT_EQ(j.at("max_len").get<size_t>(), 5u);
+  EXPECT_FALSE(j.contains("min_len"));  // default min_len=1 omitted
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, StrictLengthRoundTrip) {
+  EntryExitFilterParam ee;
+  ee.entry_ = 3;
+  ee.exit_ = 5;
+  ee.min_len_ = 3;
+  ee.max_len_ = 3;
+  auto cfg = MakeEEFilterConfig(5, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  EXPECT_EQ(j.at("min_len").get<size_t>(), 3u);
+  EXPECT_EQ(j.at("max_len").get<size_t>(), 3u);
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, RangeWildcardRoundTrip) {
+  EntryExitFilterParam ee;
+  ee.entry_ = std::nullopt;
+  ee.exit_ = std::nullopt;
+  ee.min_len_ = 2;
+  ee.max_len_ = 4;
+  auto cfg = MakeEEFilterConfig(6, ee);
+  nlohmann::json j;
+  to_json(j, cfg);
+  EXPECT_FALSE(j.contains("entry"));
+  EXPECT_FALSE(j.contains("exit"));
+  EXPECT_EQ(j.at("min_len").get<size_t>(), 2u);
+  EXPECT_EQ(j.at("max_len").get<size_t>(), 4u);
+
+  FilterConfig cfg2{};
+  from_json(j, cfg2);
+  ExpectEEEqual(GetEE(cfg2), ee);
+}
+
+TEST(EntryExitJson, MinLenNullTreatedAsDefault) {
+  // Explicit null on min_len/max_len is tolerated (treated same as absent).
+  nlohmann::json j = {
+    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
+    { "exit", 5 }, { "min_len", nullptr },   { "max_len", nullptr }
+  };
+  FilterConfig cfg{};
+  from_json(j, cfg);
+  auto p = GetEE(cfg);
+  EXPECT_EQ(p.min_len_, 1u);
+  EXPECT_FALSE(p.max_len_.has_value());
+}

--- a/test/test_filter.cpp
+++ b/test/test_filter.cpp
@@ -4,6 +4,7 @@
 
 #include <nlohmann/json.hpp>
 #include <set>
+#include <stdexcept>
 #include <vector>
 
 #include "config/filter_config.hpp"
@@ -917,4 +918,34 @@ TEST(EntryExitJson, MinLenNullTreatedAsDefault) {
   auto p = GetEE(cfg);
   EXPECT_EQ(p.min_len_, 1u);
   EXPECT_FALSE(p.max_len_.has_value());
+}
+
+// Plan §8 AC: from_json must reject min_len < 1.
+TEST(EntryExitJson, MinLenZeroRejected) {
+  nlohmann::json j = {
+    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
+    { "exit", 5 }, { "min_len", 0 }
+  };
+  FilterConfig cfg{};
+  EXPECT_THROW(from_json(j, cfg), std::runtime_error);
+}
+
+// Plan §8 AC: from_json must reject max_len < min_len.
+TEST(EntryExitJson, MaxLenLessThanMinLenRejected) {
+  nlohmann::json j = {
+    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
+    { "exit", 5 }, { "min_len", 3 },         { "max_len", 1 }
+  };
+  FilterConfig cfg{};
+  EXPECT_THROW(from_json(j, cfg), std::runtime_error);
+}
+
+// Plan §8 AC: from_json must reject max_len > kMaxHits.
+TEST(EntryExitJson, MaxLenExceedsKMaxHitsRejected) {
+  nlohmann::json j = {
+    { "id", 1 },   { "type", "entry_exit" }, { "action", "filter_in" }, { "symmetry", "" }, { "entry", 3 },
+    { "exit", 5 }, { "min_len", 1 },         { "max_len", kMaxHits + 1 }
+  };
+  FilterConfig cfg{};
+  EXPECT_THROW(from_json(j, cfg), std::runtime_error);
 }

--- a/test/test_filter_spec.cpp
+++ b/test/test_filter_spec.cpp
@@ -612,5 +612,162 @@ TEST(DirectionSpec, FilterOut) {
   EXPECT_FALSE(spec->Check(r3));
 }
 
+// =============== EntryExitSpec Match matrix ===============
+//
+// Cover the four wildcard combinations (entry/exit ∈ {value, nullopt})
+// crossed with length-mode variations (no bound / strict / upper / range /
+// same-face reflection). Also pin orbit-invariance under PBD when both ends
+// are set (regression guard for the legacy single-value behavior).
+
+std::unique_ptr<FilterSpec> MakeEESpec(const Crystal& crystal, std::optional<IdType> entry, std::optional<IdType> exit,
+                                       size_t min_len = 1, std::optional<size_t> max_len = std::nullopt,
+                                       uint8_t symmetry = FilterConfig::kSymNone,
+                                       float roll_mean_deg = kSigmaARollDeg[0]) {
+  FilterConfig cfg{};
+  cfg.id_ = 1;
+  cfg.symmetry_ = symmetry;
+  cfg.action_ = FilterConfig::kFilterIn;
+  EntryExitFilterParam p{};
+  p.entry_ = entry;
+  p.exit_ = exit;
+  p.min_len_ = min_len;
+  p.max_len_ = max_len;
+  cfg.param_ = SimpleFilterParam{ p };
+  return FilterSpec::Create(cfg, crystal, MakeAxis(roll_mean_deg));
+}
+
+TEST(EntryExitSpec_Match, LegacySingleValue_Match) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 5 });
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 4, 5 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 4, 6 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 4, 5 })));
+}
+
+TEST(EntryExitSpec_Match, WildcardEntry_OnlyExitConstrains) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, std::nullopt, IdType{ 5 });
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 7, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 5 })));      // size=1: ee={5} matches
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 4 })));  // exit != 5
+  EXPECT_FALSE(spec->Match(MakeRay({ 5, 7 })));  // last = 7
+}
+
+TEST(EntryExitSpec_Match, WildcardExit_OnlyEntryConstrains) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, std::nullopt);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 4, 7 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 4, 5 })));  // entry != 3
+}
+
+TEST(EntryExitSpec_Match, DoubleWildcard_AcceptsAnyNonEmpty) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, std::nullopt, std::nullopt);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 1, 2, 4 })));
+  EXPECT_FALSE(spec->Match(MakeRay({})));  // empty path always rejected
+}
+
+TEST(EntryExitSpec_Match, SameFaceReflection_size1_Match) {
+  // Regression guard: entry=exit, single-hit reflection must match.
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 3 });
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5, 3 })));  // also matches longer paths starting+ending on 3
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 5 })));    // entry=3, exit=5
+}
+
+TEST(EntryExitSpec_Match, StrictLength_Match) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 5 }, /*min_len=*/2, /*max_len=*/2);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));      // size=2 strict
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 4, 5 })));  // size=3 rejected
+  EXPECT_FALSE(spec->Match(MakeRay({ 3 })));        // size=1 < min
+}
+
+TEST(EntryExitSpec_Match, UpperBound_Match) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 5 }, /*min_len=*/1, /*max_len=*/3);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 4, 5 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 4, 6, 5 })));  // size=4 > max
+}
+
+TEST(EntryExitSpec_Match, RangeBound_WildcardEnds) {
+  // Double-wildcard + length range [2,4]: accept any path with 2..4 hits.
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, std::nullopt, std::nullopt, /*min_len=*/2, /*max_len=*/4);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_FALSE(spec->Match(MakeRay({ 3 })));  // size=1 < min
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 4, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 4, 6, 5 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 4, 5, 6, 7 })));  // size=5 > max
+}
+
+TEST(EntryExitSpec_Match, NoUpperBoundDefault_AcceptsLongPath) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 5 });  // min_len=1, max_len=nullopt
+  ASSERT_NE(spec, nullptr);
+  std::vector<IdType> long_path{ 3 };
+  for (int i = 0; i < 60; i++) {  // up to ~kMaxHits=64
+    long_path.push_back(static_cast<IdType>(4 + (i % 4)));
+  }
+  long_path.push_back(5);
+  EXPECT_TRUE(spec->Match(MakeRay(long_path)));
+}
+
+TEST(EntryExitSpec_Match, EmptyRay_RejectedRegardlessOfWildcards) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  for (bool e_wild : { false, true }) {
+    for (bool x_wild : { false, true }) {
+      auto spec = MakeEESpec(prism, e_wild ? std::optional<IdType>{} : std::optional<IdType>{ 3 },
+                             x_wild ? std::optional<IdType>{} : std::optional<IdType>{ 5 });
+      ASSERT_NE(spec, nullptr);
+      EXPECT_FALSE(spec->Match(MakeRay({}))) << "e_wild=" << e_wild << " x_wild=" << x_wild;
+    }
+  }
+}
+
+TEST(EntryExitSpec_Match, MinLenAboveSize_Rejects) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  auto spec = MakeEESpec(prism, std::nullopt, std::nullopt, /*min_len=*/3, /*max_len=*/std::nullopt);
+  ASSERT_NE(spec, nullptr);
+  EXPECT_FALSE(spec->Match(MakeRay({ 3 })));
+  EXPECT_FALSE(spec->Match(MakeRay({ 3, 5 })));
+  EXPECT_TRUE(spec->Match(MakeRay({ 3, 5, 7 })));
+}
+
+// PBD symmetry: every orbit member of (entry=3, exit=5) under PBD must
+// trigger Match()=true when the spec is configured with the seed pair.
+TEST(EntryExitSpec_Match, PBD_OrbitInvariant) {
+  Crystal prism = Crystal::CreatePrism(1.0f);
+  constexpr uint8_t kSym = FilterConfig::kSymP | FilterConfig::kSymD | FilterConfig::kSymB;
+  for (int sigma_a = 0; sigma_a < 6; sigma_a++) {
+    auto spec = MakeEESpec(prism, IdType{ 3 }, IdType{ 5 }, /*min_len=*/1, /*max_len=*/std::nullopt, kSym,
+                           kSigmaARollDeg[sigma_a]);
+    ASSERT_NE(spec, nullptr);
+    auto orbit = prism.ExpandRaypath({ 3, 5 }, kSym, sigma_a, /*d_applicable=*/true);
+    ASSERT_FALSE(orbit.empty());
+    for (size_t i = 0; i < orbit.size(); i++) {
+      SCOPED_TRACE("sigma_a=" + std::to_string(sigma_a) + " orbit[" + std::to_string(i) +
+                   "]=" + FormatRaypath(orbit[i]));
+      EXPECT_TRUE(spec->Match(MakeRay(orbit[i])));
+    }
+  }
+}
+
 }  // namespace
 }  // namespace lumice


### PR DESCRIPTION
## Summary

- **Wildcard entries/exits** via `std::optional<IdType>` (empty input = "any face") — closes the gap where `entry=0`/`exit=0` previously meant "match face 0" instead of "any".
- **Multi-value OR** for entries and exits (e.g. `entry={3,4}, exit={5,6}` matches 4 combinations), routed through the existing `ComplexFilterParam` translation layer at GUI→core serialization, mirroring the Raypath multi-segment path. Core `EntryExitFilterParam` stays single-value; OR is a composition concern, not an intrinsic property.
- **Path-length bounds** via `min_len_` (default 1; admits the entry=exit single-hit surface reflection) and `std::optional<size_t> max_len_` (`nullopt` = no upper bound). Supports four GUI modes: unbounded / strict-N / at-most-N / range [N,M].
- **Architectural principle**: GUI data structures stay free of `ComplexFilterParam`; core `SimpleFilterParam` variants only carry that filter type's intrinsic properties; the API translation layer handles composition. See `doc/filter-architecture.md` §5 for the rationale.

Backlog entries closed: "Entry-Exit Filter 能力扩展" (2026-05-22) + Branch A of "Complex Filter 完整能力".

## Test plan

- [x] `./scripts/build.sh -tj release` — all unit tests pass, including 31+ new EE tests (Match matrix, JSON round-trip, validation guards, backward-compat)
- [x] `./scripts/build.sh -gtj release` — 263/263 GUI tests pass (5 new EE-focused tests)
- [ ] `pytest test/e2e/ -v` — fast E2E suite (CI)
- [ ] `pytest test/e2e/ -v -m slow` — slow E2E suite (touches C API + simulator core, run locally before merge)
- [ ] Manual smoke: load a config with legacy single-value `entry_exit` filter → confirm equivalent semantics; author a new filter with `entry=3,4 / exit=5,6 / strict length=3` → confirm UI summary and runtime behavior

## Notes

- JSON schema is backward-compatible: existing `{"entry": 3, "exit": 5}` configs continue to parse with default `min_len=1, max_len=nullopt`.
- `from_json` now rejects `min_len<1`, `max_len<min_len`, and `max_len>kMaxHits` (plan §8 AC).
- Deviation from plan: FilterSummary uses ASCII `L<=` instead of Unicode `L≤` for cross-platform font compatibility; recorded in `scratchpad/task-ee-filter-uplift/progress.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)