### PR TITLE
perf(worker-default): default worker count to physical cores

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set(lumice_server_src
 
 set(lumice_util_src
   "${PROJ_SRC_DIR}/util/color_space.cpp"
+  "${PROJ_SRC_DIR}/util/cpu_info.cpp"
   "${PROJ_SRC_DIR}/util/illuminant.cpp"
   "${PROJ_SRC_DIR}/util/threading_pool.cpp")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,12 @@ message(STATUS "[src] CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 # ==================================================================================================
 # Add targets
 
+# cpu_info.cpp is compiled directly into the executable: main.cpp calls the
+# internal lumice::PhysicalCoreCount(), which carries hidden visibility and is
+# therefore not exported from the shared `lumice` library (BUILD_SHARED_LIBS).
 add_executable(Lumice
-    "${PROJ_SRC_DIR}/main.cpp")
+    "${PROJ_SRC_DIR}/main.cpp"
+    "${PROJ_SRC_DIR}/util/cpu_info.cpp")
 target_include_directories(Lumice PRIVATE
     ${stb_SOURCE_DIR})
 target_link_libraries(Lumice PRIVATE

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -86,7 +86,7 @@ typedef struct LUMICE_StatsResult_ {
 
 // =============== Server Configuration ===============
 typedef struct LUMICE_ServerConfig_ {
-  int num_workers;        // Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+  int num_workers;        // Number of simulator worker threads. 0 = default (physical core count)
   unsigned int sim_seed;  // Deterministic seed for worker RNGs. 0 = random (default).
                           // Non-zero collapses to 1 worker for bit-stable results.
 } LUMICE_ServerConfig;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 // clang-format on
 
 #include "lumice.h"
+#include "util/cpu_info.hpp"
 
 #ifdef _WIN32
 #define STBIW_WINDOWS_UTF8
@@ -255,7 +256,7 @@ int main(int argc, char** argv) {
     }
 
     auto cores = static_cast<int>(std::thread::hardware_concurrency());
-    int multi_workers = cores > 0 ? cores : 1;
+    int multi_workers = lumice::PhysicalCoreCount();
 
     // Pass 1: single worker, reduced rays
     auto single_config = config_json;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -23,6 +23,7 @@
 #include "server/render.hpp"
 #include "server/server.hpp"
 #include "server/stats.hpp"
+#include "util/cpu_info.hpp"
 #include "util/logger.hpp"
 #include "util/queue.hpp"
 
@@ -70,7 +71,7 @@ class ServerImpl {
   bool IsIdle();
 
  private:
-  static const int kDefaultSimulatorCnt;  // runtime: max(1, hardware_concurrency - 2)
+  static const int kDefaultSimulatorCnt;  // runtime: PhysicalCoreCount() (SMT siblings left for consumer + OS)
   static constexpr int kMaxSceneCnt = 128;
   static constexpr size_t kDefaultRayNum = 128;
 
@@ -136,7 +137,7 @@ class ServerImpl {
   Logger& GetLogger() { return logger_; }
 };
 
-const int ServerImpl::kDefaultSimulatorCnt = std::max(1, static_cast<int>(std::thread::hardware_concurrency()) - 2);
+const int ServerImpl::kDefaultSimulatorCnt = PhysicalCoreCount();
 
 
 template <typename F>

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -181,7 +181,7 @@ class Server {
 
   /**
    * @brief Construct a new Server with specified worker count
-   * @param num_workers Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+   * @param num_workers Number of simulator worker threads. 0 = default (physical core count)
    * @param sim_seed Deterministic RNG seed. 0 = random. Non-zero collapses to 1 worker.
    * @note The server starts running immediately after construction
    */

--- a/src/util/cpu_info.cpp
+++ b/src/util/cpu_info.cpp
@@ -117,8 +117,7 @@ int PhysicalCoreCountWin() {
   if (len == 0) {
     return 0;
   }
-  std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buf(
-      len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+  std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buf(len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
   if (!GetLogicalProcessorInformation(buf.data(), &len)) {
     return 0;
   }

--- a/src/util/cpu_info.cpp
+++ b/src/util/cpu_info.cpp
@@ -1,0 +1,152 @@
+#include "util/cpu_info.hpp"
+
+#include <algorithm>
+#include <thread>
+
+#if defined(OS_LINUX)
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#elif defined(OS_MAC)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(OS_WIN)
+// clang-format off
+#include <windows.h>
+// clang-format on
+#include <vector>
+#endif
+
+namespace lumice {
+
+namespace {
+
+int Fallback() {
+  return std::max(1, static_cast<int>(std::thread::hardware_concurrency()) / 2);
+}
+
+#if defined(OS_LINUX)
+int PhysicalCoreCountLinux() {
+  std::ifstream f("/proc/cpuinfo");
+  if (!f.is_open()) {
+    return 0;
+  }
+  std::set<std::pair<int, int>> pairs;
+  std::set<int> core_ids_only;
+  int cur_physical_id = -1;
+  int cur_core_id = -1;
+  bool saw_any_physical_id = false;
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line.empty()) {
+      if (cur_core_id >= 0) {
+        if (cur_physical_id >= 0) {
+          pairs.emplace(cur_physical_id, cur_core_id);
+        }
+        core_ids_only.insert(cur_core_id);
+      }
+      cur_physical_id = -1;
+      cur_core_id = -1;
+      continue;
+    }
+    auto colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    auto key = line.substr(0, colon);
+    auto val = line.substr(colon + 1);
+    // Trim trailing whitespace from key.
+    while (!key.empty() && (key.back() == ' ' || key.back() == '\t')) {
+      key.pop_back();
+    }
+    // Trim leading whitespace from val.
+    size_t i = 0;
+    while (i < val.size() && (val[i] == ' ' || val[i] == '\t')) {
+      ++i;
+    }
+    val = val.substr(i);
+    if (key == "physical id") {
+      saw_any_physical_id = true;
+      try {
+        cur_physical_id = std::stoi(val);
+      } catch (...) {
+        cur_physical_id = -1;
+      }
+    } else if (key == "core id") {
+      try {
+        cur_core_id = std::stoi(val);
+      } catch (...) {
+        cur_core_id = -1;
+      }
+    }
+  }
+  // Flush last record if file did not end with a blank line.
+  if (cur_core_id >= 0) {
+    if (cur_physical_id >= 0) {
+      pairs.emplace(cur_physical_id, cur_core_id);
+    }
+    core_ids_only.insert(cur_core_id);
+  }
+  if (saw_any_physical_id && !pairs.empty()) {
+    return static_cast<int>(pairs.size());
+  }
+  if (!core_ids_only.empty()) {
+    return static_cast<int>(core_ids_only.size());
+  }
+  return 0;
+}
+#endif
+
+#if defined(OS_MAC)
+int PhysicalCoreCountMac() {
+  int n = 0;
+  size_t sz = sizeof(n);
+  if (sysctlbyname("hw.physicalcpu", &n, &sz, nullptr, 0) != 0) {
+    return 0;
+  }
+  return n > 0 ? n : 0;
+}
+#endif
+
+#if defined(OS_WIN)
+int PhysicalCoreCountWin() {
+  DWORD len = 0;
+  GetLogicalProcessorInformation(nullptr, &len);
+  if (len == 0) {
+    return 0;
+  }
+  std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buf(
+      len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+  if (!GetLogicalProcessorInformation(buf.data(), &len)) {
+    return 0;
+  }
+  int count = 0;
+  for (const auto& info : buf) {
+    if (info.Relationship == RelationProcessorCore) {
+      ++count;
+    }
+  }
+  return count;
+}
+#endif
+
+}  // namespace
+
+int PhysicalCoreCount() {
+  int n = 0;
+#if defined(OS_LINUX)
+  n = PhysicalCoreCountLinux();
+#elif defined(OS_MAC)
+  n = PhysicalCoreCountMac();
+#elif defined(OS_WIN)
+  n = PhysicalCoreCountWin();
+#endif
+  if (n <= 0) {
+    return Fallback();
+  }
+  return n;
+}
+
+}  // namespace lumice

--- a/src/util/cpu_info.hpp
+++ b/src/util/cpu_info.hpp
@@ -1,0 +1,14 @@
+#ifndef UTIL_CPU_INFO_H_
+#define UTIL_CPU_INFO_H_
+
+namespace lumice {
+
+// Returns the number of physical CPU cores on the host machine.
+// On SMT systems this is typically half of std::thread::hardware_concurrency().
+// On detection failure, falls back to max(1, hardware_concurrency() / 2).
+// Always returns a value >= 1.
+int PhysicalCoreCount();
+
+}  // namespace lumice
+
+#endif  // UTIL_CPU_INFO_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(unit_test
   "${PROJ_TEST_DIR}/test_axis_presets.cpp"
   "${PROJ_TEST_DIR}/test_slider_mapping.cpp"
   "${PROJ_TEST_DIR}/test_ev_auto.cpp"
+  "${PROJ_TEST_DIR}/test_cpu_info.cpp"
   "${PROJ_TEST_DIR}/test_main.cpp")
 target_include_directories(unit_test
   PRIVATE ${PROJ_TEST_DIR})

--- a/test/test_cpu_info.cpp
+++ b/test/test_cpu_info.cpp
@@ -1,0 +1,29 @@
+// Tests for src/util/cpu_info.{hpp,cpp} — PhysicalCoreCount() invariants.
+
+#include <thread>
+
+#include "gtest/gtest.h"
+#include "util/cpu_info.hpp"
+
+namespace {
+
+TEST(CpuInfoTest, PhysicalCoreCountIsAtLeastOne) {
+  EXPECT_GE(lumice::PhysicalCoreCount(), 1);
+}
+
+TEST(CpuInfoTest, PhysicalCoreCountDoesNotExceedHardwareConcurrency) {
+  auto hw = static_cast<int>(std::thread::hardware_concurrency());
+  if (hw > 0) {
+    EXPECT_LE(lumice::PhysicalCoreCount(), hw);
+  } else {
+    GTEST_SKIP() << "hardware_concurrency() returned 0; cannot bound PhysicalCoreCount()";
+  }
+}
+
+TEST(CpuInfoTest, PhysicalCoreCountIsStable) {
+  int a = lumice::PhysicalCoreCount();
+  int b = lumice::PhysicalCoreCount();
+  EXPECT_EQ(a, b);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Changes the default worker count from `hardware_concurrency - 2` to the **physical core count**.

The simulation is a memory-bound workload with a dedicated consumer thread. The old `hardware_concurrency - 2` default pushes workers onto SMT siblings, causing L1/L2 contention and consumer starvation. Exploration #248 measured **~48% throughput loss** on a common 8C16T desktop (6.5M vs 9.68M peak rps).

Switching the default to the physical core count leaves SMT siblings free for the consumer (projection + accumulate) and the OS.

## Changes

- **`src/util/cpu_info.{hpp,cpp}`** (new): `PhysicalCoreCount()`, cross-platform
  - Linux: parse `/proc/cpuinfo`
  - macOS: `sysctl hw.physicalcpu`
  - Windows: `GetLogicalProcessorInformation`
  - Fallback `max(1, hw/2)`, always `>= 1`
- **`server.cpp`**: `kDefaultSimulatorCnt = PhysicalCoreCount()`
- **`main.cpp`**: benchmark multi-pass workers = `PhysicalCoreCount()` (align benchmark caliber with the new default)
- Removed EXPLORE-248 temp probe (`LUMICE_BENCH_WORKERS` env + `<cstdlib>`)
- **`lumice.h` / `server.hpp`**: sync `num_workers == 0` default comments
- **`test_cpu_info.cpp`** (new): 3 invariants (`>= 1`, `<= hw_concurrency`, stable)

## Verification

Build + unit tests (incl. `CpuInfoTest` 3/3) + fast-e2e 25/25 green.

> Note: dev49 performance-governor throughput baseline (M4) is deferred to a manual run on the Linux target — local macOS absolute rps is untrustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)