### PR TITLE
feat: enable Metal backend on GUI live-preview (dual-fisheye-EA + C API toggle)

### DIFF
--- a/doc/trace_layer.metal
+++ b/doc/trace_layer.metal
@@ -47,6 +47,12 @@ struct KernelParams {
   float cie_z;
   uint  ms_mode;
   uint  out_cap;
+  // Projection routing:
+  //   proj_type == 0: rectangular (legacy az0 path, uses az0)
+  //   proj_type == 1: dual_fisheye_equal_area (uses r_scale / max_abs_dz)
+  uint  proj_type;
+  float r_scale;
+  float max_abs_dz;
 };
 
 inline float GetReflectRatio(float delta, float rr) {
@@ -219,21 +225,69 @@ kernel void trace_layer_kernel(
           float sx = -wx;
           float sy = -wy;
           float sz = -wz;
-          float lon = atan2(sy, sx) - prm.az0;
-          // Wrap lon to [-pi, pi]: equivalent to the while-loops in
-          // RectangularProject. At exact lon == +pi the formula yields -pi;
-          // after the (raw_x mod W) wrap this collapses to the same pixel.
-          lon = lon - 2.0f * M_PI_F * floor((lon + M_PI_F) / (2.0f * M_PI_F));
-          float lat = asin(clamp(sz, -1.0f, 1.0f));
+          if (prm.proj_type == 0u) {
+            float lon = atan2(sy, sx) - prm.az0;
+            // Wrap lon to [-pi, pi]: equivalent to the while-loops in
+            // RectangularProject. At exact lon == +pi the formula yields -pi;
+            // after the (raw_x mod W) wrap this collapses to the same pixel.
+            lon = lon - 2.0f * M_PI_F * floor((lon + M_PI_F) / (2.0f * M_PI_F));
+            float lat = asin(clamp(sz, -1.0f, 1.0f));
 
-          int raw_x = int(floor(lon * proj_scl + img_w_f * 0.5f + 0.5f));
-          int ix = ((raw_x % iw_i) + iw_i) % iw_i;
-          int iy = int(floor(-lat * proj_scl + img_h_f * 0.5f + 0.5f));
-          if (iy >= 0 && iy < ih_i) {
-            uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
-            atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
-            atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
-            atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            int raw_x = int(floor(lon * proj_scl + img_w_f * 0.5f + 0.5f));
+            int ix = ((raw_x % iw_i) + iw_i) % iw_i;
+            int iy = int(floor(-lat * proj_scl + img_h_f * 0.5f + 0.5f));
+            if (iy >= 0 && iy < ih_i) {
+              uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
+              atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            }
+          } else {
+            // proj_type == 1: dual_fisheye_equal_area + opposite-hemisphere overlap.
+            // DRIFT(gpu-metal-shared-kernel): intentional copy of CPU render.cpp:192-214 +
+            //   projection::{FisheyeEqualAreaForward, DualFisheyeToPixel}. Re-home into a
+            //   single-source shared kernel at the CUDA step (backlog: 核心模拟 GPU 迁移路线).
+            int   dual_short = min(int(prm.img_w) / 2, int(prm.img_h));
+            float r          = float(dual_short) * 0.5f;
+            float cy_pix     = img_h_f * 0.5f;
+            float cx_left    = img_w_f * 0.5f - r;
+            float cx_right   = img_w_f * 0.5f + r;
+            bool  is_upper   = (sz >= 0.0f);
+            float z_hemi     = is_upper ? sz : -sz;
+            float k = prm.r_scale / sqrt(1.0f + clamp(z_hemi, -1.0f + 1e-6f, 1.0f));
+            float xn = k * sx;
+            float yn = k * sy;
+            float cx_primary = is_upper ? cx_left : cx_right;
+            float sx_primary = is_upper ? -1.0f : 1.0f;
+            float fx = sx_primary * yn * r + cx_primary;
+            float fy = xn * r + cy_pix;
+            int ix = int(floor(fx + 0.5f));
+            int iy = int(floor(fy + 0.5f));
+            if (ix >= 0 && ix < iw_i && iy >= 0 && iy < ih_i) {
+              uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
+              atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            }
+            if (prm.max_abs_dz > 0.0f && z_hemi < prm.max_abs_dz) {
+              float z_opp = -z_hemi;
+              float k2    = prm.r_scale / sqrt(1.0f + clamp(z_opp, -1.0f + 1e-6f, 1.0f));
+              float xn2   = k2 * sx;
+              float yn2   = k2 * sy;
+              bool  is_upper_opp = !is_upper;
+              float cx_opp       = is_upper_opp ? cx_left : cx_right;
+              float sx_opp       = is_upper_opp ? -1.0f : 1.0f;
+              float fx2 = sx_opp * yn2 * r + cx_opp;
+              float fy2 = xn2 * r + cy_pix;
+              int   ix2 = int(floor(fx2 + 0.5f));
+              int   iy2 = int(floor(fy2 + 0.5f));
+              if (ix2 >= 0 && ix2 < iw_i && iy2 >= 0 && iy2 < ih_i) {
+                uint pix2 = (uint(iy2) * prm.img_w + uint(ix2)) * 3u;
+                atomic_fetch_add_explicit(&image[pix2 + 0u], prm.cie_x * cw, memory_order_relaxed);
+                atomic_fetch_add_explicit(&image[pix2 + 1u], prm.cie_y * cw, memory_order_relaxed);
+                atomic_fetch_add_explicit(&image[pix2 + 2u], prm.cie_z * cw, memory_order_relaxed);
+              }
+            }
           }
         }
       }

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -24,6 +24,7 @@
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
 #include "core/metal_trace_backend.hpp"
+#include "core/projection.hpp"
 #include "core/scatter_accum.hpp"
 #include "core/simulator.hpp"  // PartitionCrystalRayNum
 #include "core/trace_ops.hpp"
@@ -55,6 +56,12 @@ struct KernelParams {
   float cie_z;
   uint  ms_mode;
   uint  out_cap;
+  // Projection routing (host fills per BeginSession lens type):
+  //   proj_type == 0: rectangular (legacy az0-projection, uses az0)
+  //   proj_type == 1: dual_fisheye_equal_area (uses r_scale / max_abs_dz)
+  uint  proj_type;
+  float r_scale;     // equal-area r_scale = 1/sqrt(1+overlap); 1.0 if no overlap
+  float max_abs_dz;  // overlap zone |sky_z| threshold; 0 = no overlap
 };
 
 inline float GetReflectRatio(float delta, float rr) {
@@ -220,18 +227,69 @@ kernel void trace_layer_kernel(
           float sx = -wx;
           float sy = -wy;
           float sz = -wz;
-          float lon = atan2(sy, sx) - prm.az0;
-          lon = lon - 2.0f * M_PI_F * floor((lon + M_PI_F) / (2.0f * M_PI_F));
-          float lat = asin(clamp(sz, -1.0f, 1.0f));
+          if (prm.proj_type == 0u) {
+            float lon = atan2(sy, sx) - prm.az0;
+            lon = lon - 2.0f * M_PI_F * floor((lon + M_PI_F) / (2.0f * M_PI_F));
+            float lat = asin(clamp(sz, -1.0f, 1.0f));
 
-          int raw_x = int(floor(lon * proj_scl + img_w_f * 0.5f + 0.5f));
-          int ix = ((raw_x % iw_i) + iw_i) % iw_i;
-          int iy = int(floor(-lat * proj_scl + img_h_f * 0.5f + 0.5f));
-          if (iy >= 0 && iy < ih_i) {
-            uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
-            atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
-            atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
-            atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            int raw_x = int(floor(lon * proj_scl + img_w_f * 0.5f + 0.5f));
+            int ix = ((raw_x % iw_i) + iw_i) % iw_i;
+            int iy = int(floor(-lat * proj_scl + img_h_f * 0.5f + 0.5f));
+            if (iy >= 0 && iy < ih_i) {
+              uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
+              atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            }
+          } else {
+            // proj_type == 1: dual fisheye equal-area, primary + opposite-hemisphere overlap.
+            // DRIFT(gpu-metal-shared-kernel): intentional duplicate of CPU render.cpp:192-214 +
+            //   projection::{FisheyeEqualAreaForward, DualFisheyeToPixel} (re-home into a single-
+            //   source shared kernel at CUDA step; backlog: 核心模拟 GPU 迁移路线).
+            int   dual_short = min(int(prm.img_w) / 2, int(prm.img_h));
+            float r          = float(dual_short) * 0.5f;
+            float cy_pix     = img_h_f * 0.5f;
+            float cx_left    = img_w_f * 0.5f - r;
+            float cx_right   = img_w_f * 0.5f + r;
+
+            bool  is_upper = (sz >= 0.0f);
+            float z_hemi   = is_upper ? sz : -sz;  // own hemisphere: +|sz|
+            float k = prm.r_scale / sqrt(1.0f + clamp(z_hemi, -1.0f + 1e-6f, 1.0f));
+            float xn = k * sx;
+            float yn = k * sy;
+            float cx_primary = is_upper ? cx_left : cx_right;
+            float sx_primary = is_upper ? -1.0f : 1.0f;
+            float fx = sx_primary * yn * r + cx_primary;
+            float fy = xn * r + cy_pix;
+            int ix = int(floor(fx + 0.5f));
+            int iy = int(floor(fy + 0.5f));
+            if (ix >= 0 && ix < iw_i && iy >= 0 && iy < ih_i) {
+              uint pix = (uint(iy) * prm.img_w + uint(ix)) * 3u;
+              atomic_fetch_add_explicit(&image[pix + 0u], prm.cie_x * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 1u], prm.cie_y * cw, memory_order_relaxed);
+              atomic_fetch_add_explicit(&image[pix + 2u], prm.cie_z * cw, memory_order_relaxed);
+            }
+            // Overlap dual-write: mirror CPU render.cpp:192-214 (opposite hemisphere, dz<0).
+            // Does NOT increment exit_wsum — preserves normalization parity with CPU.
+            if (prm.max_abs_dz > 0.0f && z_hemi < prm.max_abs_dz) {
+              float z_opp = -z_hemi;  // = -|sz| < 0 (matches z_hemi_opp)
+              float k2    = prm.r_scale / sqrt(1.0f + clamp(z_opp, -1.0f + 1e-6f, 1.0f));
+              float xn2   = k2 * sx;
+              float yn2   = k2 * sy;
+              bool  is_upper_opp = !is_upper;
+              float cx_opp       = is_upper_opp ? cx_left : cx_right;
+              float sx_opp       = is_upper_opp ? -1.0f : 1.0f;
+              float fx2 = sx_opp * yn2 * r + cx_opp;
+              float fy2 = xn2 * r + cy_pix;
+              int   ix2 = int(floor(fx2 + 0.5f));
+              int   iy2 = int(floor(fy2 + 0.5f));
+              if (ix2 >= 0 && ix2 < iw_i && iy2 >= 0 && iy2 < ih_i) {
+                uint pix2 = (uint(iy2) * prm.img_w + uint(ix2)) * 3u;
+                atomic_fetch_add_explicit(&image[pix2 + 0u], prm.cie_x * cw, memory_order_relaxed);
+                atomic_fetch_add_explicit(&image[pix2 + 1u], prm.cie_y * cw, memory_order_relaxed);
+                atomic_fetch_add_explicit(&image[pix2 + 2u], prm.cie_z * cw, memory_order_relaxed);
+              }
+            }
           }
           atomic_fetch_add_explicit(exit_cnt, 1u, memory_order_relaxed);
           atomic_fetch_add_explicit(exit_wsum, cw, memory_order_relaxed);
@@ -259,6 +317,9 @@ kernel void trace_layer_kernel(
 
 // Mirror of the Metal-side KernelParams (host layout MUST match the .metal
 // struct field-for-field — all 4-byte scalars, natural alignment).
+// NOTE: field order MUST match MSL KernelParams in kKernelSrc — static_assert
+// guards size only; reviewer-facing field-by-field check is the maintainer's
+// responsibility when adding/reordering members.
 struct KernelParams {
   float    n_idx;
   uint32_t max_hits;
@@ -272,8 +333,11 @@ struct KernelParams {
   float    cie_z;
   uint32_t ms_mode;
   uint32_t out_cap;
+  uint32_t proj_type;
+  float    r_scale;
+  float    max_abs_dz;
 };
-static_assert(sizeof(KernelParams) == 48u,
+static_assert(sizeof(KernelParams) == 60u,
               "KernelParams size mismatch — update host struct to match Metal-side layout");
 
 float ComputeAz0(const Rotation& rot) {
@@ -316,6 +380,11 @@ struct MetalTraceBackend::Impl {
   int    height = 0;
   float  az0 = 0.0f;
   float  cie_x = 0.0f, cie_y = 0.0f, cie_z = 0.0f;
+  // Projection routing — populated by BeginSession per render.lens_.type_.
+  // Mirrors KernelParams fields with the same name; DispatchLayer copies them.
+  uint32_t proj_type = 0u;
+  float    r_scale = 1.0f;
+  float    max_abs_dz = 0.0f;
 
   RandomNumberGenerator rng{ 0 };
 
@@ -671,6 +740,9 @@ void MetalTraceBackend::Impl::DispatchLayer(size_t num_rays,
   params.cie_z    = cie_z;
   params.ms_mode  = ms_mode;
   params.out_cap  = static_cast<uint32_t>(out_cap);
+  params.proj_type  = proj_type;
+  params.r_scale    = r_scale;
+  params.max_abs_dz = max_abs_dz;
 
   EnsureRecSink(num_rays);
   EnsureContBuffer(out_slot);
@@ -769,6 +841,9 @@ void MetalTraceBackend::Impl::Reset() {
   height = 0;
   az0 = 0.0f;
   cie_x = cie_y = cie_z = 0.0f;
+  proj_type = 0u;
+  r_scale = 1.0f;
+  max_abs_dz = 0.0f;
   have_crystal = false;
   current_n_idx = 0.0f;
   out_cap = 0;
@@ -789,13 +864,16 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   assert(!impl_->in_session && "BeginSession called on an already-open session");
   assert(spec.scene != nullptr);
   assert(spec.render != nullptr);
-  assert(spec.render->lens_.type_ == LensParam::kRectangular &&
-         "MetalTraceBackend v1 requires kRectangular lens");
+  assert((spec.render->lens_.type_ == LensParam::kRectangular ||
+          spec.render->lens_.type_ == LensParam::kDualFisheyeEqualArea) &&
+         "MetalTraceBackend supports kRectangular or kDualFisheyeEqualArea lens");
   // az0-projection is only equivalent to RectangularProject at zenith view
-  // (el=90°, ro=0°). Enforce here to avoid silent projection errors for
-  // non-zenith cameras.
-  assert(std::abs(spec.render->view_.el_ - 90.0f) < 0.01f &&
-         "MetalTraceBackend v1 requires zenith view (el≈90°)");
+  // (el=90°, ro=0°). Dual-fisheye-EA covers the full globe, view fields are
+  // unused, so we only assert for the rectangular branch.
+  if (spec.render->lens_.type_ == LensParam::kRectangular) {
+    assert(std::abs(spec.render->view_.el_ - 90.0f) < 0.01f &&
+           "MetalTraceBackend kRectangular requires zenith view (el≈90°)");
+  }
 
   impl_->spec = spec;
   impl_->in_session = true;
@@ -807,6 +885,18 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   Rotation camera_rot = MakeCameraRotation(*spec.render);
   impl_->az0 = ComputeAz0(camera_rot);
   ComputeCmf(spec.wl.wl_, impl_->cie_x, impl_->cie_y, impl_->cie_z);
+
+  // Projection routing — kernel reads proj_type/r_scale/max_abs_dz from
+  // KernelParams (filled by DispatchLayer from these Impl fields).
+  if (spec.render->lens_.type_ == LensParam::kDualFisheyeEqualArea) {
+    impl_->proj_type  = 1u;
+    impl_->max_abs_dz = spec.render->overlap_;
+    impl_->r_scale    = projection::ComputeEARScale(spec.render->overlap_);
+  } else {
+    impl_->proj_type  = 0u;
+    impl_->r_scale    = 1.0f;
+    impl_->max_abs_dz = 0.0f;
+  }
 
   if (spec.seed != 0) {
     impl_->rng.SetSeed(spec.seed);
@@ -947,7 +1037,16 @@ void MetalTraceBackend::EndSession() {
 }
 
 bool MetalTraceBackend::IsCompatible(const RenderConfig& render) const {
-  return render.lens_.type_ == LensParam::kRectangular && std::abs(render.view_.el_ - 90.0f) <= 0.01f;
+  if (render.lens_.type_ == LensParam::kRectangular) {
+    return std::abs(render.view_.el_ - 90.0f) <= 0.01f;
+  }
+  if (render.lens_.type_ == LensParam::kDualFisheyeEqualArea) {
+    // kernel implements fov180 full-globe only; reject custom fov to avoid
+    // silent wrong-projection from non-GUI callers (LUMICE_TRACE_BACKEND=metal
+    // + dual-fisheye config). view.el is unused for full-globe — no constraint.
+    return std::abs(render.lens_.fov_ - 180.0f) <= 0.5f;
+  }
+  return false;
 }
 
 }  // namespace lumice

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -477,7 +477,7 @@ Simulator::Simulator(QueuePtrS<SimBatch> config_queue, QueuePtrS<SimData> data_q
 Simulator::Simulator(Simulator&& other) noexcept
     : config_queue_(std::move(other.config_queue_)), data_queue_(std::move(other.data_queue_)),
       stop_(other.stop_.load()), idle_(other.idle_.load()), seed_(other.seed_), rng_(other.rng_),
-      logger_(std::move(other.logger_)) {}
+      logger_(std::move(other.logger_)), preferred_backend_(other.preferred_backend_.load(std::memory_order_acquire)) {}
 
 Simulator& Simulator::operator=(Simulator&& other) noexcept {
   if (this == &other) {
@@ -491,40 +491,56 @@ Simulator& Simulator::operator=(Simulator&& other) noexcept {
   seed_ = other.seed_;
   rng_ = other.rng_;
   logger_ = std::move(other.logger_);
+  preferred_backend_.store(other.preferred_backend_.load(std::memory_order_acquire), std::memory_order_release);
   return *this;
+}
+
+void Simulator::SetPreferredBackend(int backend) {
+  preferred_backend_.store(backend, std::memory_order_release);
 }
 
 namespace {
 
-// Read LUMICE_TRACE_BACKEND once and create the matching TraceBackend instance.
-// Returns nullptr for the legacy CPU (Simulator::SimulateOneWavelength) path:
-//   - unset / empty / "legacy"      -> nullptr (legacy)
-//   - "cpu_backend"                  -> CpuTraceBackend (debug; non-Apple too)
-//   - "metal" on Apple               -> MetalTraceBackend
-//   - "metal" elsewhere or unknown   -> nullptr (logged once at WARN)
-std::unique_ptr<TraceBackend> CreateBackendFromEnv(Logger& logger) {
+// Create a TraceBackend instance for this Run() entry. Precedence:
+//   1) env-var LUMICE_TRACE_BACKEND (debug/CI override; legacy semantics):
+//      - unset / empty / "legacy"   -> falls through to step 2
+//      - "cpu_backend"               -> CpuTraceBackend
+//      - "metal" on Apple            -> MetalTraceBackend
+//      - "metal" elsewhere / unknown -> nullptr (logged WARN)
+//   2) preferred_backend (set by Server::SetPreferredBackend, default kPreferCpu):
+//      - kPreferMetal on Apple       -> MetalTraceBackend
+//      - any value elsewhere         -> nullptr (silent no-op; GUI checkbox
+//                                       on non-Apple builds equates to CPU)
+// Returns nullptr to keep the legacy CPU path (Simulator::SimulateOneWavelength).
+std::unique_ptr<TraceBackend> CreateBackend(int preferred_backend, Logger& logger) {
   const char* raw = std::getenv("LUMICE_TRACE_BACKEND");
-  if (raw == nullptr) {
-    return nullptr;
-  }
-  std::string name(raw);
-  if (name.empty() || name == "legacy") {
-    return nullptr;
-  }
-  if (name == "cpu_backend") {
-    ILOG_INFO(logger, "LUMICE_TRACE_BACKEND=cpu_backend → routing via CpuTraceBackend");
-    return std::make_unique<CpuTraceBackend>();
-  }
-  if (name == "metal") {
+  if (raw != nullptr) {
+    std::string name(raw);
+    if (name.empty() || name == "legacy") {
+      // fall through to preferred_backend
+    } else if (name == "cpu_backend") {
+      ILOG_INFO(logger, "LUMICE_TRACE_BACKEND=cpu_backend → routing via CpuTraceBackend");
+      return std::make_unique<CpuTraceBackend>();
+    } else if (name == "metal") {
 #if defined(__APPLE__)
-    ILOG_INFO(logger, "LUMICE_TRACE_BACKEND=metal → routing via MetalTraceBackend");
+      ILOG_INFO(logger, "LUMICE_TRACE_BACKEND=metal → routing via MetalTraceBackend");
+      return std::make_unique<MetalTraceBackend>();
+#else
+      ILOG_WARN(logger, "LUMICE_TRACE_BACKEND=metal requested on non-Apple platform; falling back to legacy CPU");
+      return nullptr;
+#endif
+    } else {
+      ILOG_WARN(logger, "Unknown LUMICE_TRACE_BACKEND={}; falling back to preferred backend", name);
+    }
+  }
+  if (preferred_backend == Simulator::kPreferMetal) {
+#if defined(__APPLE__)
+    ILOG_INFO(logger, "preferred_backend=metal → routing via MetalTraceBackend");
     return std::make_unique<MetalTraceBackend>();
 #else
-    ILOG_WARN(logger, "LUMICE_TRACE_BACKEND=metal requested on non-Apple platform; falling back to legacy CPU");
-    return nullptr;
+    return nullptr;  // non-Apple: silent no-op (CPU)
 #endif
   }
-  ILOG_WARN(logger, "Unknown LUMICE_TRACE_BACKEND={}; falling back to legacy CPU", name);
   return nullptr;
 }
 
@@ -579,7 +595,7 @@ void Simulator::Run() {
 
   // Pick a TraceBackend once per Run() entry. nullptr keeps the legacy CPU
   // path (zero behavior change when LUMICE_TRACE_BACKEND is unset).
-  auto backend = CreateBackendFromEnv(logger_);
+  auto backend = CreateBackend(preferred_backend_.load(std::memory_order_acquire), logger_);
   bool warned_no_renders = false;
   bool warned_multi_renderer = false;
   bool warned_compat = false;

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -55,10 +55,20 @@ class Simulator {
   Simulator& operator=(const Simulator& other) = delete;
   Simulator& operator=(Simulator&& other) noexcept;
 
+  // Preferred backend identifiers. MUST stay aligned with the public
+  // LUMICE_BACKEND_* constants in src/include/lumice.h — core does NOT
+  // include the public header to keep the core ← server ← c_api layering.
+  static constexpr int kPreferCpu = 0;
+  static constexpr int kPreferMetal = 1;
+
   void Run();
   void Stop();
   bool IsIdle() const;
   void SetLogLevel(LogLevel level);
+  // Set the preferred trace backend for the next Run() entry. Thread-safe:
+  // server thread writes via release, simulator thread reads via acquire at
+  // the top of Run().
+  void SetPreferredBackend(int backend);
 
  private:
   using CrystalCache = std::vector<std::pair<const CrystalParam*, Crystal>>;
@@ -87,6 +97,10 @@ class Simulator {
   uint32_t seed_;
   RandomNumberGenerator rng_;
   Logger logger_{ "Simulator" };
+  // Preferred trace backend (kPreferCpu/kPreferMetal). release-write by
+  // ServerImpl::SetPreferredBackend, acquire-read at Run() entry. env-var
+  // LUMICE_TRACE_BACKEND still wins.
+  std::atomic<int> preferred_backend_{ kPreferCpu };
 };
 
 // Distributes ray_num rays across crystals proportionally using per-crystal carry with

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -659,6 +659,14 @@ void DoRun() {
     g_server_poller.Stop();  // Must pause before consumer destruction
   }
 
+#if defined(__APPLE__)
+  // Push current backend preference into server BEFORE CommitConfig. The
+  // pref lives on persistent Simulators (server.cpp:182), and the
+  // CommitConfig Stop→Start cycle makes Run() re-enter and pick it up via
+  // acquire on the next dispatch.
+  LUMICE_SetPreferredBackend(g_server, g_state.use_metal_backend ? LUMICE_BACKEND_METAL : LUMICE_BACKEND_CPU);
+#endif
+
   int reused = 0;
   LUMICE_ErrorCode err = LUMICE_OK;
   if (use_json_path) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -660,10 +660,10 @@ void DoRun() {
   }
 
 #if defined(__APPLE__)
-  // Push current backend preference into server BEFORE CommitConfig. The
-  // pref lives on persistent Simulators (server.cpp:182), and the
-  // CommitConfig Stop→Start cycle makes Run() re-enter and pick it up via
-  // acquire on the next dispatch.
+  // Push current backend preference into server BEFORE CommitConfig. The pref
+  // lives on the persistent Simulators (created once at server construction and
+  // never rebuilt by CommitConfig), and the CommitConfig Stop→Start cycle makes
+  // Run() re-enter and pick it up via acquire on the next dispatch.
   LUMICE_SetPreferredBackend(g_server, g_state.use_metal_backend ? LUMICE_BACKEND_METAL : LUMICE_BACKEND_CPU);
 #endif
 

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -473,6 +473,13 @@ struct GuiState {
   // readback via pending_screenshot; that mechanism was retired — see SUMMARY.)
   bool screenshot_include_overlay = false;
 
+#if defined(__APPLE__)
+  // Request Metal trace backend on the next DoRun (Apple-only). Falls back to
+  // CPU silently if the active config is not Metal-compatible. Wired through
+  // LUMICE_SetPreferredBackend in DoRun. UI-only, session-only.
+  bool use_metal_backend = false;
+#endif
+
   // Edit modal mode (UI-only, session-only, not in ConfigSnapshot).
   // Staged mode: BeginPopupModal + OK/Cancel + dirty-mark on tabs.
   // Immediate mode (default, gui-polish-v15 round 2): ImGui::Begin + single

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -939,12 +939,12 @@ void RenderSceneControls(GuiState& state) {
   // path — the checkbox is wired through DIRTY_IF so the next Apply/Run picks
   // up the new preference. Falls back to CPU silently if the active config
   // is not Metal-compatible (see MetalTraceBackend::IsCompatible).
-  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+  // ImGui::Checkbox renders its label to the right and ignores the item-width
+  // stack, so no PushItemWidth wrapper is needed here.
   DIRTY_IF(ImGui::Checkbox("Use Metal GPU", &state.use_metal_backend));
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Use Metal GPU for simulation (falls back to CPU if incompatible)");
   }
-  ImGui::PopItemWidth();
 #endif
 }
 

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -933,6 +933,19 @@ void RenderSceneControls(GuiState& state) {
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Maximum number of crystal face hits per ray path");
   }
+
+#if defined(__APPLE__)
+  // Metal toggle (Apple-only). Switching triggers DoRun via the panel return
+  // path — the checkbox is wired through DIRTY_IF so the next Apply/Run picks
+  // up the new preference. Falls back to CPU silently if the active config
+  // is not Metal-compatible (see MetalTraceBackend::IsCompatible).
+  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+  DIRTY_IF(ImGui::Checkbox("Use Metal GPU", &state.use_metal_backend));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Use Metal GPU for simulation (falls back to CPU if incompatible)");
+  }
+  ImGui::PopItemWidth();
+#endif
 }
 
 #undef DIRTY_IF

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -385,6 +385,22 @@ float LUMICE_MaxFov(LUMICE_LensType type);
 // Returns LUMICE_ERR_NULL_ARG if xyz_in or out is NULL; LUMICE_OK otherwise.
 LUMICE_ErrorCode LUMICE_XyzToSrgbUint8(const float* xyz_in, unsigned char* out, int pixel_count, float intensity_scale);
 
+// =============== Preferred Trace Backend ===============
+// Stable backend identifiers. Future backends (e.g. CUDA) append new positive
+// values; 0 stays CPU so default zero-init = legacy behavior.
+#define LUMICE_BACKEND_CPU 0
+#define LUMICE_BACKEND_METAL 1
+
+// Set preferred trace backend for this server.
+//   backend = LUMICE_BACKEND_CPU   (default): legacy CPU path.
+//   backend = LUMICE_BACKEND_METAL          : request Metal; falls back to CPU
+//                                             if incompatible or unavailable
+//                                             on this platform.
+// Takes effect on the next simulation start (after LUMICE_CommitConfig). The
+// env-var LUMICE_TRACE_BACKEND, when set, overrides this preference.
+// On non-Apple platforms LUMICE_BACKEND_METAL is silently treated as CPU.
+void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend);
+
 #if !defined(_MSC_VER)
 #pragma GCC visibility pop
 #endif

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -397,7 +397,12 @@ LUMICE_ErrorCode LUMICE_XyzToSrgbUint8(const float* xyz_in, unsigned char* out, 
 //                                             if incompatible or unavailable
 //                                             on this platform.
 // Takes effect on the next simulation start (after LUMICE_CommitConfig). The
-// env-var LUMICE_TRACE_BACKEND, when set, overrides this preference.
+// env-var LUMICE_TRACE_BACKEND, when set, overrides this preference:
+//   - "cpu_backend"            forces CPU unconditionally (ignores this pref).
+//   - "metal"                  forces Metal (Apple) regardless of this pref.
+//   - unset / "" / "legacy"    defers to this API preference.
+// (i.e. an empty or "legacy" env-var no longer forces CPU once this pref is
+//  set to LUMICE_BACKEND_METAL — use "cpu_backend" to hard-pin CPU in CI.)
 // On non-Apple platforms LUMICE_BACKEND_METAL is silently treated as CPU.
 void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend);
 

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -829,6 +829,14 @@ void LUMICE_StopServer(LUMICE_Server* server) {
 }
 
 
+void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend) {
+  if (!server) {
+    return;
+  }
+  server->server_->SetPreferredBackend(backend);
+}
+
+
 // =============== Crystal Mesh ===============
 
 // Compute per-face polygon topology from triangle data and face_numbers array.

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -69,6 +69,7 @@ class ServerImpl {
   void Start();
   ServerStatus GetStatus() const;
   bool IsIdle();
+  void SetPreferredBackend(int backend);
 
  private:
   static const int kDefaultSimulatorCnt;  // runtime: PhysicalCoreCount() (SMT siblings left for consumer + OS)
@@ -124,6 +125,12 @@ class ServerImpl {
 
   std::atomic_bool work_started_{ false };
   std::atomic_bool scene_gen_active_{ false };  // True while GenerateScene is actively producing batches
+
+  // Preferred trace backend (LUMICE_BACKEND_CPU/METAL). Cached at server
+  // level so the preference survives Stop()/Start() cycles and is the
+  // authoritative source for any future simulator-rebuild path. Mirrored
+  // into every Simulator via SetPreferredBackend(). Default is CPU.
+  std::atomic<int> preferred_backend_{ 0 };
 
   std::atomic_int sim_scene_cnt_;
   std::mutex scene_mutex_;
@@ -702,6 +709,16 @@ void ServerImpl::GenerateScene() {
 }
 
 
+// =============== ServerImpl::SetPreferredBackend ===============
+void ServerImpl::SetPreferredBackend(int backend) {
+  preferred_backend_.store(backend, std::memory_order_release);
+  std::lock_guard<std::mutex> lock(prod_mutex_);
+  for (auto& s : simulators_) {
+    s.SetPreferredBackend(backend);
+  }
+}
+
+
 // =============== ServerImpl::SetLogLevel ===============
 void ServerImpl::SetLogLevel(LogLevel level) {
   logger_.SetLevel(level);
@@ -810,6 +827,12 @@ void Server::Terminate() {
 void Server::SetLogLevel(LogLevel level) {
   if (impl_) {
     impl_->SetLogLevel(level);
+  }
+}
+
+void Server::SetPreferredBackend(int backend) {
+  if (impl_) {
+    impl_->SetPreferredBackend(backend);
   }
 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -710,6 +710,12 @@ void ServerImpl::GenerateScene() {
 
 
 // =============== ServerImpl::SetPreferredBackend ===============
+// preferred_backend_ is currently write-only: it is the authoritative cache for
+// a future simulator-rebuild path (today simulators_ is built once in the ctor
+// and never rebuilt, so the per-Simulator atomics below are the live source of
+// truth). The cache store intentionally precedes prod_mutex_; any future reader
+// outside this lock must treat it as "may lead the simulators_ state" and add
+// its own ordering, or move the store inside the lock.
 void ServerImpl::SetPreferredBackend(int backend) {
   preferred_backend_.store(backend, std::memory_order_release);
   std::lock_guard<std::mutex> lock(prod_mutex_);

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -270,6 +270,17 @@ class Server {
   void SetLogLevel(LogLevel level);
 
   /**
+   * @brief Set preferred trace backend for this server.
+   * @param backend 0 = CPU (default), 1 = Metal (Apple-only; silent CPU
+   *                fallback elsewhere or when the active config is not
+   *                backend-compatible). Mirrors the public C API constants
+   *                LUMICE_BACKEND_CPU / LUMICE_BACKEND_METAL.
+   * @note Takes effect on the next Simulator::Run() entry (after CommitConfig
+   *       restart). env-var LUMICE_TRACE_BACKEND, when set, overrides this.
+   */
+  void SetPreferredBackend(int backend);
+
+  /**
    * @brief Get server status
    * @return Current server status
    */

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -44,6 +44,24 @@ inline RenderConfig MakeRectangularRender() {
   return cfg;
 }
 
+// Dual-fisheye equal-area RenderConfig matching the GUI's mandatory wire
+// format (c_api.cpp:295: fov180 / full-globe / el=0). `overlap` mirrors
+// kDualFisheyeOverlap on the GUI side (set 0 for the no-overlap variant).
+inline RenderConfig MakeDualFisheyeEARender(float overlap = 0.0f) {
+  RenderConfig cfg;
+  cfg.id_ = 0;
+  cfg.lens_.type_ = LensParam::kDualFisheyeEqualArea;
+  cfg.lens_.fov_ = 180.0f;
+  cfg.resolution_[0] = 128;  // wide enough for left+right circle layout
+  cfg.resolution_[1] = 64;
+  cfg.view_.az_ = 0.0f;
+  cfg.view_.el_ = 0.0f;  // GUI sets el=0 for dual-fisheye (full-globe; unused)
+  cfg.view_.ro_ = 0.0f;
+  cfg.visible_ = RenderConfig::kFull;
+  cfg.overlap_ = overlap;
+  return cfg;
+}
+
 inline SceneConfig MakeMetalScene(size_t max_hits, size_t ms_layers) {
   SceneConfig scene;
   scene.ray_num_ = 0;

--- a/test/test_metal_trace_parity.cpp
+++ b/test/test_metal_trace_parity.cpp
@@ -1197,6 +1197,208 @@ TEST(MetalTraceParity, MetalVsCpuMultiLayerSpatialStructure) {
   // device-side shuffle is implemented.
 }
 
+// =============================================================================
+// Dual-fisheye equal-area parity (task-metal-gui-default Step 5)
+//
+// Validates the kernel's new proj_type==1 path against the production CPU
+// projection (projection::FisheyeEqualAreaForward + DualFisheyeToPixel +
+// render.cpp:192-214 overlap dual-write, all reached via the public
+// ScatterOutgoingToXyz helper in core/scatter_accum.hpp). Per scrum-253 review
+// guidance (memory 253.1) the CPU side runs the REAL production code path —
+// no test-local re-implementation of the dual-fisheye math.
+// =============================================================================
+using metal_test::MakeDualFisheyeEARender;
+
+TEST(MetalTraceParity, DualFisheyeEA_Single_NoOverlap) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeDualFisheyeEARender(/*overlap=*/0.0f);
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  constexpr size_t kRayCount = 4096;
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz_metal(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  LayerStats metal_stats;
+  {
+    MetalTraceBackend metal;
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    metal_stats = h->GetLayerStats();
+    XyzImageData img{ xyz_metal.data(), render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+
+  RandomNumberGenerator oracle_rng(0);
+  SeedRngsLikeMetal(oracle_rng, spec.seed);
+  auto roots = BuildFirstLayerRoots(oracle_rng, spec, kRayCount);
+  auto poly = BuildPolyArrays(roots.crystal);
+  auto oracle =
+      OracleTraceLayer(roots.crystal, poly, roots.n_idx, scene.max_hits_, roots.d, roots.p, roots.w, roots.tf);
+
+  // Project oracle exit rays through the REAL CPU projection (production
+  // ScatterOutgoingToXyz reaches FisheyeEqualAreaForward + DualFisheyeToPixel).
+  std::vector<float> xyz_oracle(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  Rotation camera_rot = MakeCameraRotation(render);
+  ScatterOutgoingToXyz(oracle.exit_d.data(), oracle.exit_w.data(), oracle.exit_w.size(), render, camera_rot,
+                       spec.wl.wl_, xyz_oracle.data());
+
+  EXPECT_EQ(metal_stats.exit_count, oracle.exit_count)
+      << "exit_count mismatch — metal=" << metal_stats.exit_count << " oracle=" << oracle.exit_count;
+  EXPECT_LT(RelErr(metal_stats.exit_w_sum, oracle.exit_w_sum), 5e-4)
+      << "exit_w_sum: metal=" << metal_stats.exit_w_sum << " oracle=" << oracle.exit_w_sum;
+
+  for (int c = 0; c < 3; c++) {
+    double sm = ChannelSum(xyz_metal, c);
+    double so = ChannelSum(xyz_oracle, c);
+    EXPECT_LT(RelErr(sm, so), 5e-4) << "channel=" << c << " metal=" << sm << " oracle=" << so;
+  }
+}
+
+TEST(MetalTraceParity, DualFisheyeEA_Single_WithOverlap) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  // overlap = sin(5°) ≈ kDualFisheyeOverlap (gui_state.hpp:135) — matches the
+  // exact value the GUI live-preview path commits via c_api.cpp.
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeDualFisheyeEARender(/*overlap=*/0.0872f);
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  constexpr size_t kRayCount = 4096;
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz_metal(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  LayerStats metal_stats;
+  {
+    MetalTraceBackend metal;
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    metal_stats = h->GetLayerStats();
+    XyzImageData img{ xyz_metal.data(), render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+
+  RandomNumberGenerator oracle_rng(0);
+  SeedRngsLikeMetal(oracle_rng, spec.seed);
+  auto roots = BuildFirstLayerRoots(oracle_rng, spec, kRayCount);
+  auto poly = BuildPolyArrays(roots.crystal);
+  auto oracle =
+      OracleTraceLayer(roots.crystal, poly, roots.n_idx, scene.max_hits_, roots.d, roots.p, roots.w, roots.tf);
+
+  std::vector<float> xyz_oracle(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  Rotation camera_rot = MakeCameraRotation(render);
+  ScatterOutgoingToXyz(oracle.exit_d.data(), oracle.exit_w.data(), oracle.exit_w.size(), render, camera_rot,
+                       spec.wl.wl_, xyz_oracle.data());
+
+  // exit_count and exit_w_sum are accumulated per-exit-event in the kernel
+  // (a single increment) — the overlap dual-write writes only to image, NOT
+  // to exit_wsum (matches CPU render.cpp:217 "Pass 2 does NOT update
+  // total_intensity_"). The strict equality here pins that invariant: if the
+  // kernel ever double-counts overlap rays into exit_wsum, parity breaks.
+  EXPECT_EQ(metal_stats.exit_count, oracle.exit_count)
+      << "exit_count mismatch — metal=" << metal_stats.exit_count << " oracle=" << oracle.exit_count;
+  EXPECT_LT(RelErr(metal_stats.exit_w_sum, oracle.exit_w_sum), 5e-4)
+      << "exit_w_sum: metal=" << metal_stats.exit_w_sum << " oracle=" << oracle.exit_w_sum;
+
+  for (int c = 0; c < 3; c++) {
+    double sm = ChannelSum(xyz_metal, c);
+    double so = ChannelSum(xyz_oracle, c);
+    EXPECT_LT(RelErr(sm, so), 5e-4) << "channel=" << c << " metal=" << sm << " oracle=" << so;
+  }
+}
+
+TEST(MetalTraceParity, DualFisheyeEA_MultiMS_WithOverlap) {
+  // GUI live-preview commonly drives multi-MS scenes; this case validates the
+  // dual-fisheye-EA kernel + inter-layer frame transit (253.2) together,
+  // against the production CpuTraceBackend on the same config.
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  auto scene = MakeMetalScene(/*max_hits=*/6, /*ms_layers=*/2);
+  for (auto& ms : scene.ms_) {
+    auto& axis = ms.setting_[0].crystal_.axis_;
+    axis.azimuth_dist = Distribution{ DistributionType::kUniform, 0.0f, 360.0f };
+    axis.latitude_dist = Distribution{ DistributionType::kUniform, 0.0f, 360.0f };
+    axis.roll_dist = Distribution{ DistributionType::kUniform, 0.0f, 360.0f };
+  }
+  auto render = MakeDualFisheyeEARender(/*overlap=*/0.0872f);
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 7;
+
+  constexpr size_t kRayCount = 262144;
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  int w = render.resolution_[0];
+  int h = render.resolution_[1];
+  auto pix = static_cast<size_t>(w) * static_cast<size_t>(h);
+
+  auto run_two_layer = [&](TraceBackend& be, std::vector<float>& xyz) {
+    be.BeginSession(spec);
+    auto h0 = be.TraceLayer(RootRaySource::FromHost(host));
+    RecombineSpec rspec;
+    rspec.shuffle = false;
+    auto roots1 = be.Recombine(std::move(h0), rspec);
+    auto h1 = be.TraceLayer(roots1);
+    XyzImageData img{ xyz.data(), w, h };
+    be.ReadbackImage(img);
+    be.EndSession();
+    (void)h1;
+  };
+
+  std::vector<float> xyz_metal(pix * 3, 0.0f);
+  std::vector<float> xyz_cpu(pix * 3, 0.0f);
+  {
+    MetalTraceBackend metal;
+    run_two_layer(metal, xyz_metal);
+  }
+  {
+    CpuTraceBackend cpu;
+    run_two_layer(cpu, xyz_cpu);
+  }
+
+  double corr = YChannelCorrelation(xyz_metal, xyz_cpu);
+  std::cout << "[MEASURE] dual-fisheye-EA multi-MS corr(metal vs cpu)=" << corr << std::endl;
+
+  // Held at 0.95 (same threshold as MetalVsCpuMultiLayerSpatialStructure).
+  // Dual-fisheye-EA has no transcendentals (only sqrt) so parity should be
+  // tighter than rectangular, but the bar stays at 0.95 to detect partial
+  // regressions while tolerating sampling noise at 262144 rays.
+  EXPECT_GT(corr, 0.95) << "Metal dual-fisheye-EA multi-MS does not structurally match CpuTraceBackend";
+}
+
 }  // namespace
 }  // namespace lumice
 


### PR DESCRIPTION
## 背景

GUI live-preview 路径无条件写 `dual_fisheye_equal_area` lens（`c_api.cpp:295`），而旧 `IsCompatible` 只认 `kRectangular` → GUI 每帧静默回退 CPU，已验证的 Metal 加速（~250×）在日常 GUI 使用中白费。

本 PR 让 Metal 后端在 GUI 路径上真正生效：无需 `LUMICE_TRACE_BACKEND` 环境变量，通过 C API 开关 + GUI checkbox 显式启用。

## 主要改动

- **Metal kernel**：新增 `dual_fisheye_equal_area` 投影（fov180/天顶/overlap/full-globe 双半球），含 overlap 区双写（对齐 CPU `render.cpp:217`）；`KernelParams` 扩展 48→60 bytes（`static_assert` 守护）
- **C API**：新增 `LUMICE_SetPreferredBackend(server, int backend)` + `LUMICE_BACKEND_CPU/METAL` 常量（末尾追加，向后兼容）
- **Simulator**：`std::atomic<int> preferred_backend_` 字段 + `CreateBackend`（原 `CreateBackendFromEnv`）扩展，env-var 优先级保留
- **GUI**：Apple-only "Use Metal GPU" checkbox（仅经 C API，不破 API 边界）
- **IsCompatible**：接纳 dual-fisheye-EA（`|fov-180|≤0.5°` 门槛），其余配置仍静默回退 CPU
- **测试**：3 个 parity 测试（NoOverlap/WithOverlap/MultiMS），corr=0.9963，rel ≤ 5e-4

## 验证

- `./scripts/build.sh -tj release` → ✅ 单测全绿
- `pytest test/e2e/ -v` → ✅ 26/26 PASSED
- `*DualFisheyeEA*` parity → ✅ corr=0.9963
- CLI Metal smoke + CPU/Metal PNG 对比 → ✅ PSNR=34.24 dB, corr=0.9791
- **owner GUI 人眼可视验证 → ✅ 通过**（2026-06-09，真实 GUI 切 checkbox，多 config 与 CPU 一致）

## 已知限制 / 后续

- kernel 仅支持 fov180/全天顶/固定 overlap 的 GUI 固定参数；非天顶/非 180° 变体 `IsCompatible` 返回 false（静默 CPU 回退）
- DRIFT 标注：dual-fisheye-EA 分支为有意临时复制，待 CUDA 迁移时 re-home 进 single-source 共享核（backlog B-2）
- owner 验证时另发现两问题，已独立立项：task-255（Metal 日志统一 spdlog）、explore-256（Metal GUI live-preview 性能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)