### PR TITLE
feat(metal): device GPU root-gen 默认根供给 + 吞吐确证 (P2/scrum-260+261)

### DIFF
--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -179,7 +179,7 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 
 **GPU device root-gen (scrum-260)**: on the Metal backend, root rays (orientation / direction / entry point) are generated on-device via a counter-based PCG stream keyed by `(gen_seed, gen_ray_base + tid)`, replacing host pre-generation + upload. This is the default path (single- and multi-crystal per-ci); statistical equivalence vs legacy is validated by the slow-e2e parity harness (`ds_corr ≥ 0.99`). Throughput uplift is hardware-dependent — quantify on a frequency-locked bench machine.
 
-**Phase-1 confirmed throughput (task-metal-rootgen-throughput-confirm, Mac M2 Max, 2026-06-11)**: device-gen ON vs OFF measured with `scratchpad/bench/device_gen_throughput_bench.py` (`LUMICE_TRACE_BACKEND=metal`; ON = `LUMICE_DISABLE_DEVICE_GEN` unset, OFF = `=1`). 5 reps per cell, median; CoV reported. Activation that ON==GPU PCG vs OFF==host mt19937 is independently asserted by the slow-e2e test `test_device_gen_activation_proof_fixed_seed` (`dual_fisheye_ref` sim_seed=42, rel_err=4.4e-5 ≫ 1e-5 floor — host-gen fallback would give rel_err=0).
+**Phase-1 confirmed throughput (task-metal-rootgen-throughput-confirm, Mac M2 Max, 2026-06-11)**: device-gen ON vs OFF measured with `scratchpad/bench/device_gen_throughput_bench.py` (`LUMICE_TRACE_BACKEND=metal`; ON = `LUMICE_DISABLE_DEVICE_GEN` unset, OFF = `=1`). 5 reps per cell, median; CoV reported. Activation that ON==GPU PCG vs OFF==host mt19937 is independently asserted by the slow-e2e test `test_device_gen_activation_proof_fixed_seed` (`dual_fisheye_ref` sim_seed=42, rel_err=4.4e-5 ≫ 1e-5 floor — host-gen fallback would give rel_err=0). (Note: the bench script lives under the git-ignored `scratchpad/` tree by design — consistent with `seam_exit_bench.py` — and is not committed; re-running requires the author's local copy. The numbers below are the durable record.)
 
 | Config | Batch | Single rps ON | Single rps OFF | ON/OFF (single) | Multi rps ON | Multi rps OFF | ON/OFF (multi) |
 |--------|-------|---------------|----------------|-----------------|--------------|---------------|----------------|
@@ -190,7 +190,7 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 | `ms_multi_crystal`                        | 512  |   311 k |   242 k | 1.28× |  2.63 M |  1.17 M | 2.24× |
 | `ms_multi_crystal`                        | 2048 |   447 k |   318 k | 1.41× |  4.77 M |  1.61 M | **2.95×** |
 
-All cells `routed_ok=True` (no fallback); CoV ≤ 5% for 21 of 24 measurements, max CoV 15.0% (`single_ms` b2048 multi ON — kernel saturation, not thermal). The 15.0% cell sits exactly at the CoV>15% retry threshold and was not re-run because the threshold is strict-greater.
+All cells `routed_ok=True` (no fallback); CoV ≤ 5% for 21 of 24 measurements, max CoV 15.0% (`single_ms` b2048 multi ON — kernel saturation, not thermal). The 15.0% cell sits exactly at the CoV>15% retry threshold and was not re-run because the threshold is strict-greater (per the pre-specified CoV>15% → N=9 retry rule; ≤15% is in-spec, not a license to skip warranted reruns).
 
 **Verdicts**:
 

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -179,6 +179,27 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 
 **GPU device root-gen (scrum-260)**: on the Metal backend, root rays (orientation / direction / entry point) are generated on-device via a counter-based PCG stream keyed by `(gen_seed, gen_ray_base + tid)`, replacing host pre-generation + upload. This is the default path (single- and multi-crystal per-ci); statistical equivalence vs legacy is validated by the slow-e2e parity harness (`ds_corr ≥ 0.99`). Throughput uplift is hardware-dependent — quantify on a frequency-locked bench machine.
 
+**Phase-1 confirmed throughput (task-metal-rootgen-throughput-confirm, Mac M2 Max, 2026-06-11)**: device-gen ON vs OFF measured with `scratchpad/bench/device_gen_throughput_bench.py` (`LUMICE_TRACE_BACKEND=metal`; ON = `LUMICE_DISABLE_DEVICE_GEN` unset, OFF = `=1`). 5 reps per cell, median; CoV reported. Activation that ON==GPU PCG vs OFF==host mt19937 is independently asserted by the slow-e2e test `test_device_gen_activation_proof_fixed_seed` (`dual_fisheye_ref` sim_seed=42, rel_err=4.4e-5 ≫ 1e-5 floor — host-gen fallback would give rel_err=0).
+
+| Config | Batch | Single rps ON | Single rps OFF | ON/OFF (single) | Multi rps ON | Multi rps OFF | ON/OFF (multi) |
+|--------|-------|---------------|----------------|-----------------|--------------|---------------|----------------|
+| `dual_fisheye_ref` (single-MS, 1 crystal) | 128  |   343 k |   476 k | **0.72×** |  2.45 M |  4.03 M | **0.61×** |
+| `dual_fisheye_ref`                        | 512  | 1.22 M | 1.18 M | 1.04× |  9.19 M |  9.34 M | 0.98× |
+| `dual_fisheye_ref`                        | 2048 | 3.06 M | 1.23 M | 2.47× | 23.37 M | 13.27 M | 1.76× |
+| `ms_multi_crystal` (multi-MS, 2 crystals) | 128  |   107 k |   111 k | 0.97× |   979 k |   793 k | **1.23×** |
+| `ms_multi_crystal`                        | 512  |   311 k |   242 k | 1.28× |  2.63 M |  1.17 M | 2.24× |
+| `ms_multi_crystal`                        | 2048 |   447 k |   318 k | 1.41× |  4.77 M |  1.61 M | **2.95×** |
+
+All cells `routed_ok=True` (no fallback); CoV ≤ 5% for 21 of 24 measurements, max CoV 15.0% (`single_ms` b2048 multi ON — kernel saturation, not thermal). The 15.0% cell sits exactly at the CoV>15% retry threshold and was not re-run because the threshold is strict-greater.
+
+**Verdicts**:
+
+- **`dual_fisheye_ref` (single-MS, 1 crystal) at default batch=128 is a NET LOSS for device-gen** (single 0.72×, multi 0.61×). This **contradicts the scrum-260 probe** which reported ~1.87× at the same config — the probe was a single throwaway invocation and did not reflect steady-state behavior. Net gain only kicks in at `batch ≥ ~512` and reaches 2.47× / 1.76× at `batch=2048`. At default batch GPU device-gen pays per-dispatch overhead that the small per-batch ray count cannot amortize.
+- **`ms_multi_crystal` (multi-MS, 2 crystals) at default batch=128 is roughly neutral for single-worker (0.97×) and a net gain (1.23×) for multi-worker.** This is the opposite of the plan's pre-bench hypothesis (which feared multi-crystal per-ci dispatch overhead would dominate); in fact multi-MS workloads amortize device-gen better than single-MS because the multi-MS layer count multiplies the per-batch work GPU-side. At larger batches the multi-MS multi-worker gain grows to 2.24× (b512) and 2.95× (b2048).
+- **Activation cross-check for multi-crystal**: `ms_multi_crystal` multi-worker ON/OFF goes 1.23× → 2.24× → 2.95× as batch grows. The monotone ON-favored ratio with batch (the b2048 crossover predicted by plan §3 Step 3 Minor 1 for "device-gen active but small-dispatch overhead-dominated") confirms device-gen IS activating on multi-crystal per-ci paths; if it had silently fallen back, ON ≡ OFF and the ratio would sit at 1.0 across all batches. The activation-proof test only covers single-crystal; the batch-scaling pattern here is the indirect activation evidence for multi-crystal.
+
+**Implication for default config**: users running the Metal backend at the default `LUMICE_BATCH_RAY_NUM=128` see device-gen **hurt** single-crystal throughput and **help** multi-crystal multi-worker throughput modestly. The strong wins (>2×) require `LUMICE_BATCH_RAY_NUM=2048`. A future task may revisit (a) raising the default batch when device-gen is active, (b) adaptive per-ci batch coalescing for the small-dispatch regime, or (c) selectively disabling device-gen for single-crystal/single-MS scenes at small batches. Until then the escape hatch `LUMICE_DISABLE_DEVICE_GEN=1` is the workaround for users hitting the small-batch single-crystal loss.
+
 Example: measure throughput at a higher batch size to characterize the Metal dispatch amortization curve:
 
 ```bash

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -174,6 +174,10 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
 | `LUMICE_BATCH_RAY_NUM` | 128 | Per-batch ray count sent to the simulator per `SimBatch`. Higher values amortize Metal kernel dispatch overhead; the empirical crossover where the Metal backend outperforms legacy is around 512. Set to a power of two for alignment (e.g. `LUMICE_BATCH_RAY_NUM=512`). Applies at server startup — changing it mid-run has no effect. |
+| `LUMICE_TRACE_BACKEND` | unset (legacy CPU) | Trace backend selection: unset = legacy CPU; `metal` = Metal GPU backend (exit-seam + device root-gen); `cpu_backend` = SoA CPU backend. |
+| `LUMICE_DISABLE_DEVICE_GEN` | unset (device-gen ON) | Escape hatch to force **host** root-ray generation on the Metal backend. Device root-gen (GPU PCG root-ray supply) is the **default** for the Metal backend on eligible layers (single-crystal-per-ci, `tri_count ≤ 64`); it activates on both the deterministic single-worker path and the default multi-worker random path (each worker gets a non-zero derived `effective_seed_`). Set this to `1` only for strict-identity parity tests that mirror the host `std::mt19937` stream (which cannot align with the device PCG stream). Read once per backend instance at construction. |
+
+**GPU device root-gen (scrum-260)**: on the Metal backend, root rays (orientation / direction / entry point) are generated on-device via a counter-based PCG stream keyed by `(gen_seed, gen_ray_base + tid)`, replacing host pre-generation + upload. This is the default path (single- and multi-crystal per-ci); statistical equivalence vs legacy is validated by the slow-e2e parity harness (`ds_corr ≥ 0.99`). Throughput uplift is hardware-dependent — quantify on a frequency-locked bench machine.
 
 Example: measure throughput at a higher batch size to characterize the Metal dispatch amortization curve:
 

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -700,6 +700,14 @@ kernel void gen_root_kernel(
   if (tid >= gp.num_rays) {
     return;
   }
+  // task-260.5 Step 3: categorical_sample(n=0) underflows uint and returns
+  // 0xffffffff, which then indexes tri_vtx / tri_to_poly OOB. tri_count==0
+  // should be impossible (host EnsureTriBuffers asserts tri_cnt > 0) but
+  // a defensive early-out here makes the contract local and avoids a GPU
+  // hang/crash if the host invariant ever breaks.
+  if (gp.tri_count == 0u) {
+    return;
+  }
   uint global_idx = gp.gen_ray_base + tid;
   PcgStream stream;
   stream.seed = gp.gen_seed;
@@ -863,6 +871,16 @@ Logger& EffectiveLogger(Logger* logger) {
 // helper through math.hpp; keeps math.cpp's parity envelope semantics in one
 // place per file (host math kept private; device path uses its own copy).
 // Inputs in degrees, output is the rejection envelope M used as cos(phi)/M.
+//
+// SYNC ANCHOR (task-260.5 Step 5, code-review-01 Minor): these four branches
+// MUST stay numerically identical to the file-static ComputeJacobianEnvelope
+// in src/core/math.cpp (consumed by RandomSampler::SampleSphericalPointsSph,
+// math.cpp:444+ — see in particular the generic-rejection path at math.cpp:504
+// where cos(phi)/M is the acceptance ratio). If math.cpp changes either the
+// 3σ (kGaussian), 1σ (kZigzag), or 5σ (kLaplacian) cutoff, OR adds a new
+// DistributionType, mirror the change here in the SAME PR — silent divergence
+// shows up only under narrow raypath filters and ds_corr will tank, exactly
+// the 260.5 regression class.
 float ComputeJacobianEnvelopeForDeviceGen(const Distribution& dist) {
   switch (dist.type) {
     case DistributionType::kGaussian:
@@ -880,7 +898,22 @@ float ComputeJacobianEnvelopeForDeviceGen(const Distribution& dist) {
 }  // namespace
 
 struct MetalTraceBackend::Impl {
+  Impl() {
+    // task-260.5 Step 4 (code-review-01 Minor): cache the device-gen escape
+    // hatch once per backend instance. LUMICE_DISABLE_DEVICE_GEN is a
+    // process-level config (single-worker server, no in-process re-config),
+    // so reading it per-dispatch (the prior behavior) was needless overhead
+    // and risked observing different values across BeginSession cycles if a
+    // future test toggled it mid-instance. The ctor capture pairs naturally
+    // with the test helpers ForceHostGenForByteIdentity / EnableDeviceGen…,
+    // which already setenv BEFORE constructing a fresh MetalTraceBackend.
+    const char* env = std::getenv("LUMICE_DISABLE_DEVICE_GEN");
+    disable_device_gen_ = env != nullptr && env[0] != '\0' && env[0] != '0';
+  }
+
   Logger* logger_ = nullptr;
+  // Captured at construction from LUMICE_DISABLE_DEVICE_GEN. See ctor above.
+  bool disable_device_gen_ = false;
 
   id<MTLDevice>               device = nil;
   id<MTLCommandQueue>         queue  = nil;
@@ -895,9 +928,22 @@ struct MetalTraceBackend::Impl {
   SessionSpec spec{};
   bool   in_session = false;
   size_t ms_idx = 0;
-  // First-layer root index running counter. BeginSession resets to 0; each
-  // GenerateFirstLayerRootsForCi dispatch advances by the rays it emitted, so
-  // (gen_seed_, gen_ray_base + tid) is a globally unique stream per session.
+  // First-layer root index running counter — globally monotone PCG index
+  // across all SimBatches of a single Simulator::Run().
+  //   * Reset to 0 ONLY at first seeding (BeginSession + !seeded gate), in
+  //     lock-step with rng.SetSeed; Reset()/EndSession do NOT touch it.
+  //   * Each GenerateFirstLayerRootsForCi device-gen dispatch advances it by
+  //     the rays it emitted, so (gen_seed_, gen_ray_base + tid) is a unique
+  //     PCG stream per ray within one Run(). Host-gen also advances it so a
+  //     later device-gen-eligible call in the same session stays monotone.
+  //   * Architectural pre-condition: backend instances are per-Run() (created
+  //     in simulator.cpp:596 / CreateBackend), so `seeded` starts false on
+  //     each new Run() and the counter restarts at 0. If a future refactor
+  //     pools backend instances across Run()s, this contract still holds for
+  //     PCG-stream determinism within a Run() but NOT across pooled Run()s —
+  //     revisit cross-Run() seeding semantics at that point.
+  // Value-initialized to 0 by Impl's = {} member initializer below; the
+  // explicit `= 0` here also serves as the !seeded-gate's pre-seed contract.
   size_t root_ray_count = 0;
   int    width = 0;
   int    height = 0;
@@ -1177,6 +1223,13 @@ void MetalTraceBackend::Impl::EnsureRootBuffers(size_t n) {
 }
 
 void MetalTraceBackend::Impl::EnsureTriBuffers(size_t tri_cnt) {
+  // task-260.5 Step 3: device-gen requires at least one triangle for the
+  // area×facing categorical sampler. A zero-count crystal would underflow
+  // categorical_sample in gen_root_kernel (n=0 → returns 0xffffffff → OOB
+  // index). Production configs always have tri_cnt > 0; this assert catches
+  // a future scene/config bug at the layer-prep stage rather than as a GPU
+  // hang.
+  assert(tri_cnt > 0u && "EnsureTriBuffers: tri_cnt == 0 (gen_root_kernel cannot sample)");
   if (tri_cnt <= tri_buf_capacity_) {
     return;
   }
@@ -1818,7 +1871,14 @@ void MetalTraceBackend::Impl::Reset() {
   }
   in_session = false;
   ms_idx = 0;
-  root_ray_count = 0;
+  // root_ray_count INTENTIONALLY persists across Reset(): each EndSession()
+  // is followed (in the next BeginSession) by another GenerateFirstLayerRootsForCi
+  // dispatch that must observe a globally monotone gen_ray_base. The counter
+  // is reset only on the first seeding (BeginSession + !seeded gate), in
+  // lock-step with rng.SetSeed. Mirror bug of 258.10: if we reset here, the
+  // GPU PCG stream collapses to the same 128-ray range every SimBatch and
+  // narrow raypath-filter parity (test_parity_multi_ms_prob05_filter) drops
+  // to ds_corr=0.33. See task-260.5 SUMMARY / plan §1.
   // gen_seed_ is re-derived from spec.seed every BeginSession; clear so a
   // session that omits spec.seed cannot inherit a previous activation.
   gen_seed_ = 0u;
@@ -1889,7 +1949,10 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   impl_->spec = spec;
   impl_->in_session = true;
   impl_->ms_idx = 0;
-  impl_->root_ray_count = 0;
+  // root_ray_count is reset ONLY at first seeding below (the !seeded gate, in
+  // lock-step with rng.SetSeed). Resetting here unconditionally would collapse
+  // the GPU PCG stream to a single 128-ray range every SimBatch — the mirror
+  // bug of 258.10 (RNG re-seed per batch). See task-260.5 fix.
   impl_->width  = spec.render->resolution_[0];
   impl_->height = spec.render->resolution_[1];
 
@@ -1919,6 +1982,11 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
     RandomNumberGenerator::GetInstance().SetSeed(spec.seed);
     impl_->seeded_seed = spec.seed;
     impl_->seeded = true;
+    // task-260.5: zero the device-gen counter ONLY here, alongside SetSeed.
+    // Subsequent BeginSession cycles within the same Run() (same instance,
+    // same seed) leave root_ray_count untouched so successive SimBatches
+    // consume disjoint PCG ranges (gen_ray_base monotonically increases).
+    impl_->root_ray_count = 0;
   }
   // Device root-gen activation (task-260.2). spec.seed != 0 implies the
   // single-worker determinism contract (server.cpp:184), which is the case we
@@ -2084,16 +2152,15 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
         // crystal_cnt is local to this layer's ms_info; the device-gen guard
         // intentionally inspects this layer's crystal_cnt so multi-crystal
         // layers fall back to the host path regardless of session state.
-        // Read the escape hatch per dispatch (not cached) so tests can toggle
-        // it around BeginSession without process re-launch.
-        const char* disable_env = std::getenv("LUMICE_DISABLE_DEVICE_GEN");
-        bool disable_device_gen = disable_env != nullptr && disable_env[0] != '\0' && disable_env[0] != '0';
+        // The escape hatch is cached once per backend in Impl's ctor (see
+        // task-260.5 Step 4); tests that need to flip it must setenv BEFORE
+        // constructing a new MetalTraceBackend.
         bool can_use_device_gen = !use_host &&
                                   crystal_cnt == 1 &&
                                   impl_->gen_seed_ != 0u &&
                                   impl_->current_crystal.TotalTriangles() <= 64u &&
                                   impl_->root_ray_count <= static_cast<size_t>(UINT32_MAX) - ci_n &&
-                                  !disable_device_gen;
+                                  !impl_->disable_device_gen_;
         in_count = impl_->GenerateFirstLayerRootsForCi(setting, ci, ci_n, can_use_device_gen);
       } else {
         // Stage this ci's slice of the prior continuation buffer into the

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -501,6 +501,18 @@ struct MetalTraceBackend::Impl {
   id<MTLBuffer> root_rot_buf = nil;
   size_t        root_capacity = 0;
 
+  // Triangle-level geometry for device-resident root-gen (task-260.2). Uploaded
+  // by UploadCrystal alongside polygon-level data; sized lazily by
+  // EnsureTriBuffers. The gen kernel reads these to perform area×facing
+  // weighted triangle sampling + entry-point sampling and to map the chosen
+  // triangle back to its polygon face (mirrors PolygonFaceOfTri in
+  // simulator.cpp). face_seq_cap_-style stride is N/A (these are per-triangle).
+  id<MTLBuffer> tri_vtx_buf_     = nil;  // N_tri × 9 float (3 vtx × 3 coords)
+  id<MTLBuffer> tri_norm_buf_    = nil;  // N_tri × 3 float
+  id<MTLBuffer> tri_area_buf_    = nil;  // N_tri × 1 float
+  id<MTLBuffer> tri_to_poly_buf_ = nil;  // N_tri × 1 uint16 (kInvalidId on miss)
+  size_t        tri_buf_capacity_ = 0;
+
   // Continuation ping-pong (indexed by ms_idx & 1).
   id<MTLBuffer> cont_d[2]  = { nil, nil };
   id<MTLBuffer> cont_p[2]  = { nil, nil };
@@ -578,6 +590,7 @@ struct MetalTraceBackend::Impl {
   void EnsureImage(int w, int h);
   void EnsurePolyBuffers(size_t poly_cnt);
   void EnsureRootBuffers(size_t n);
+  void EnsureTriBuffers(size_t tri_cnt);
   void EnsureContBuffer(int slot);
   void EnsureRecSink(size_t n);
   void EnsureExitBuffers(size_t cap);  // exit seam (scrum-258.1)
@@ -705,6 +718,25 @@ void MetalTraceBackend::Impl::EnsureRootBuffers(size_t n) {
   assert(root_rot_buf != nil);
 }
 
+void MetalTraceBackend::Impl::EnsureTriBuffers(size_t tri_cnt) {
+  if (tri_cnt <= tri_buf_capacity_) {
+    return;
+  }
+  tri_buf_capacity_ = tri_cnt;
+  tri_vtx_buf_ = [device newBufferWithLength:tri_cnt * 9 * sizeof(float)
+                                    options:MTLResourceStorageModeShared];
+  assert(tri_vtx_buf_ != nil);
+  tri_norm_buf_ = [device newBufferWithLength:tri_cnt * 3 * sizeof(float)
+                                     options:MTLResourceStorageModeShared];
+  assert(tri_norm_buf_ != nil);
+  tri_area_buf_ = [device newBufferWithLength:tri_cnt * sizeof(float)
+                                     options:MTLResourceStorageModeShared];
+  assert(tri_area_buf_ != nil);
+  tri_to_poly_buf_ = [device newBufferWithLength:tri_cnt * sizeof(uint16_t)
+                                        options:MTLResourceStorageModeShared];
+  assert(tri_to_poly_buf_ != nil);
+}
+
 void MetalTraceBackend::Impl::EnsureContBuffer(int slot) {
   if (out_cap <= cont_capacity[slot]) {
     return;
@@ -802,6 +834,38 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
     for (int k = 0; k < 3; k++) {
       centroid_ptr[f * 3 + k] = (v[0 * 3 + k] + v[1 * 3 + k] + v[2 * 3 + k]) / 3.0f;
     }
+  }
+
+  // Triangle-level geometry (task-260.2). Uploaded so the device root-gen
+  // kernel can replicate InitRay_p_fid: area×facing-weighted triangle pick +
+  // uniform sample inside the triangle, plus tri→polygon mapping.
+  // tri_to_poly is computed by mirroring simulator.cpp::PolygonFaceOfTri
+  // (which is file-static); same Dot3 > 1-1e-3 criterion against polygon
+  // normals already uploaded above.
+  size_t tri_cnt = crystal.TotalTriangles();
+  EnsureTriBuffers(tri_cnt);
+  std::memcpy([tri_vtx_buf_ contents], crystal.GetTriangleVtx(),
+              tri_cnt * 9 * sizeof(float));
+  std::memcpy([tri_norm_buf_ contents], crystal.GetTriangleNormal(),
+              tri_cnt * 3 * sizeof(float));
+  std::memcpy([tri_area_buf_ contents], crystal.GetTirangleArea(),
+              tri_cnt * sizeof(float));
+  const float* tri_norms_src = crystal.GetTriangleNormal();
+  const float* poly_norms_src = crystal.GetPolygonFaceNormal();
+  auto* tri_to_poly_ptr = static_cast<uint16_t*>([tri_to_poly_buf_ contents]);
+  constexpr uint16_t kInvalidIdU16 = 0xffffu;
+  for (size_t t = 0; t < tri_cnt; t++) {
+    const float* tn = tri_norms_src + t * 3;
+    uint16_t mapped = kInvalidIdU16;
+    for (size_t p = 0; p < poly_cnt; p++) {
+      const float* pn = poly_norms_src + p * 3;
+      float dot = tn[0] * pn[0] + tn[1] * pn[1] + tn[2] * pn[2];
+      if (dot > 1.0f - 1e-3f) {
+        mapped = static_cast<uint16_t>(p);
+        break;
+      }
+    }
+    tri_to_poly_ptr[t] = mapped;
   }
 }
 

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -2138,9 +2138,11 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
 
       size_t in_count = 0;
       if (first_ms) {
-        // task-260.2: device root-gen runs when
-        //   (a) single crystal population (multi-crystal stream-shift is left
-        //       to task-260.3 geom-pool);
+        // task-260.2/260.7: device root-gen runs when
+        //   (a) per-ci device-gen; each ci resolves a single crystal via
+        //       ResolveLayerCrystalForCi before this guard, so crystal_cnt > 1
+        //       is safe — per-ci multi-crystal parity verified at ds=0.9998
+        //       (explore-260.3 exp2);
         //   (b) host-supplied root rays are NOT pinned via roots.host.crystal
         //       (matches the use_host=true convention below);
         //   (c) spec.seed != 0 (single-worker determinism contract); and
@@ -2149,14 +2151,10 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
         //   (f) LUMICE_DISABLE_DEVICE_GEN env var is unset (escape hatch for
         //       strict-identity parity tests that mirror the host mt19937
         //       stream — these cannot align with the device PCG stream).
-        // crystal_cnt is local to this layer's ms_info; the device-gen guard
-        // intentionally inspects this layer's crystal_cnt so multi-crystal
-        // layers fall back to the host path regardless of session state.
         // The escape hatch is cached once per backend in Impl's ctor (see
         // task-260.5 Step 4); tests that need to flip it must setenv BEFORE
         // constructing a new MetalTraceBackend.
         bool can_use_device_gen = !use_host &&
-                                  crystal_cnt == 1 &&
                                   impl_->gen_seed_ != 0u &&
                                   impl_->current_crystal.TotalTriangles() <= 64u &&
                                   impl_->root_ray_count <= static_cast<size_t>(UINT32_MAX) - ci_n &&

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <utility>
@@ -2076,15 +2077,23 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
         //       (matches the use_host=true convention below);
         //   (c) spec.seed != 0 (single-worker determinism contract); and
         //   (d) tri_count ≤ kMaxTriPerKernel (kernel stack-array bound); and
-        //   (e) root_ray_count fits in uint32_t (gen_ray_base width).
+        //   (e) root_ray_count fits in uint32_t (gen_ray_base width); and
+        //   (f) LUMICE_DISABLE_DEVICE_GEN env var is unset (escape hatch for
+        //       strict-identity parity tests that mirror the host mt19937
+        //       stream — these cannot align with the device PCG stream).
         // crystal_cnt is local to this layer's ms_info; the device-gen guard
         // intentionally inspects this layer's crystal_cnt so multi-crystal
         // layers fall back to the host path regardless of session state.
+        // Read the escape hatch per dispatch (not cached) so tests can toggle
+        // it around BeginSession without process re-launch.
+        const char* disable_env = std::getenv("LUMICE_DISABLE_DEVICE_GEN");
+        bool disable_device_gen = disable_env != nullptr && disable_env[0] != '\0' && disable_env[0] != '0';
         bool can_use_device_gen = !use_host &&
                                   crystal_cnt == 1 &&
                                   impl_->gen_seed_ != 0u &&
                                   impl_->current_crystal.TotalTriangles() <= 64u &&
-                                  impl_->root_ray_count <= static_cast<size_t>(UINT32_MAX) - ci_n;
+                                  impl_->root_ray_count <= static_cast<size_t>(UINT32_MAX) - ci_n &&
+                                  !disable_device_gen;
         in_count = impl_->GenerateFirstLayerRootsForCi(setting, ci, ci_n, can_use_device_gen);
       } else {
         // Stage this ci's slice of the prior continuation buffer into the

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -379,6 +379,378 @@ kernel void trace_layer_kernel(
   }
   rec_sink[tid] = rec_csum;
 }
+
+// ===================== Device root-gen (task-260.2) ==========================
+//
+// Counter-based PCG root-ray generator. Replaces host-side InitRayFirstMs +
+// memcpy upload when single-crystal + spec.seed != 0 + root_ray_count fits in
+// uint32_t. Parity strategy = statistical (ds_corr ≥ 0.99) — host mt19937 and
+// device PCG streams are not bitwise alignable.
+//
+// PCG stream contract:
+//   per-thread global root index = gen_ray_base + tid
+//   draw counter = mix(gen_seed, global_idx, slot); slot bumps per draw
+// gen_ray_base is the running root_ray_count BEFORE this dispatch, so two
+// successive batches of the same session never reuse the same (gen_seed,
+// global_idx) tuple. Determinism = single-worker (server.cpp:184 enforces
+// sim_seed != 0 → worker_count = 1).
+
+constant uint kLatPathFullSphere    = 0u;  // axis_dist.IsFullSphereUniform()
+constant uint kLatPathNoRandom      = 1u;
+constant uint kLatPathRayleigh      = 2u;  // kGaussian near-pole optimization
+constant uint kLatPathGaussLegacy   = 3u;  // kGaussianLegacy
+constant uint kLatPathGenericReject = 4u;  // kGaussian/kUniform/kZigzag/kLaplacian
+
+// DistributionType enum values (must match src/core/math.hpp). Crystal-rot
+// parity REQUIRES the GenericReject path know the actual proposal type, so
+// lat_dist_type is carried separately from lat_path.
+constant uint kDistNoRandom      = 0u;
+constant uint kDistUniform       = 1u;
+constant uint kDistGaussian      = 2u;
+constant uint kDistZigzag        = 3u;
+constant uint kDistLaplacian     = 4u;
+constant uint kDistGaussianLegacy = 5u;
+
+constant uint kMaxTriPerKernel = 64u;
+constant int  kMaxRejectionAttempts = 1000;
+
+struct GenRootKernelParams {
+  uint  gen_seed;            // PCG master seed (== spec.seed)
+  uint  gen_ray_base;        // running root_ray_count before this dispatch
+  uint  num_rays;
+  uint  tri_count;
+  float sun_lon;             // (sun.azimuth + 180°) in radians
+  float sun_lat;             // (-sun.altitude) in radians
+  float sun_half_angle;      // (sun.diameter / 2) in radians
+  float ray_weight;          // wl_param.weight_
+  uint  lat_path;            // see kLatPath* above
+  uint  lat_dist_type;       // axis_dist.latitude_dist.type (cast to uint)
+  float lat_mean_rad;        // axis_dist.latitude_dist.mean × deg→rad
+  float lat_std_rad;         // axis_dist.latitude_dist.std × deg→rad
+  float lat_rejection_m;     // ComputeJacobianEnvelope (1.0 for skip paths)
+  uint  az_type;
+  float az_mean_rad;
+  float az_std_rad;
+  float az_pad;
+  uint  roll_type;
+  float roll_mean_rad;
+  float roll_std_rad;
+  float roll_pad;
+};
+
+// Counter-based PCG hash (spike-equivalent). u01 maps to [0,1) using top 24
+// bits, matching the spike implementation (scratchpad/explore-gpu-metal-trace-spike).
+inline uint pcg_hash(uint x) {
+  x = x * 747796405u + 2891336453u;
+  x = ((x >> ((x >> 28u) + 4u)) ^ x) * 277803737u;
+  return (x >> 22u) ^ x;
+}
+inline float u01_from_hash(uint h) {
+  return float(h >> 8) * (1.0f / 16777216.0f);
+}
+
+struct PcgStream {
+  uint seed;
+  uint global_idx;
+  uint slot;
+};
+
+inline float pcg_uniform(thread PcgStream& s) {
+  uint h = pcg_hash(s.seed ^ pcg_hash(s.global_idx * 1000003u + s.slot));
+  s.slot++;
+  return u01_from_hash(h);
+}
+
+// Box-Muller standard normal. u1 floored to avoid log(0).
+inline float pcg_gaussian(thread PcgStream& s) {
+  float u1 = max(pcg_uniform(s), 1e-7f);
+  float u2 = pcg_uniform(s);
+  return sqrt(-2.0f * log(u1)) * cos(2.0f * M_PI_F * u2);
+}
+
+// Mirrors RandomNumberGenerator::Get (math.cpp:365-389). mean / std are passed
+// in the SAME unit the host caller uses for the result; SampleSphericalPointsSph
+// always pre-converts axis_dist.{*}.mean/std to radians here, so the radian
+// envelope semantics hold.
+inline float pcg_get_dist(thread PcgStream& s, uint dtype, float mean, float std_val) {
+  if (dtype == kDistNoRandom) {
+    return mean;
+  }
+  if (dtype == kDistUniform) {
+    return (pcg_uniform(s) - 0.5f) * std_val + mean;
+  }
+  if (dtype == kDistGaussian || dtype == kDistGaussianLegacy) {
+    return pcg_gaussian(s) * std_val + mean;
+  }
+  if (dtype == kDistZigzag) {
+    return fabs(std_val * sin(pcg_uniform(s) * 2.0f * M_PI_F) + mean);
+  }
+  // kLaplacian: inverse CDF.
+  float u = pcg_uniform(s);
+  float sgn = (u < 0.5f) ? -1.0f : 1.0f;
+  float arg = max(1.0f - 2.0f * fabs(u - 0.5f), 1e-30f);
+  return mean - std_val * sgn * log(arg);
+}
+
+// Mirrors detail::NormalizeLatitude (math.cpp:542-553).
+inline void normalize_latitude(float phi, thread float& phi_out, thread bool& flip) {
+  float theta = M_PI_2_F - phi;
+  theta = fmod(theta, 2.0f * M_PI_F);
+  if (theta < 0.0f) {
+    theta += 2.0f * M_PI_F;
+  }
+  flip = theta > M_PI_F;
+  if (flip) {
+    theta = 2.0f * M_PI_F - theta;
+  }
+  phi_out = M_PI_2_F - theta;
+}
+
+// Replicates InitRay_rot + SampleSphericalPointsSph (simulator.cpp:138-150 +
+// math.cpp:404/444). All distribution params are pre-converted to radians on
+// the host so the kernel does no degree↔radian conversions.
+inline void sample_lat_lon_roll(thread PcgStream& s,
+                                constant GenRootKernelParams& gp,
+                                thread float& out_lon,
+                                thread float& out_lat,
+                                thread float& out_roll) {
+  float phi = 0.0f;
+  bool flip = false;
+  float lon = 0.0f;
+  if (gp.lat_path == kLatPathFullSphere) {
+    // SampleSphericalPointsSph(no-arg): lat = asin(2u-1); lambda uniform on [0,2π).
+    float u = pcg_uniform(s) * 2.0f - 1.0f;
+    u = clamp(u, -1.0f, 1.0f);
+    phi = asin(u);
+    lon = pcg_uniform(s) * 2.0f * M_PI_F;
+  } else if (gp.lat_path == kLatPathNoRandom) {
+    phi = gp.lat_mean_rad;
+  } else if (gp.lat_path == kLatPathRayleigh) {
+    float dx = pcg_gaussian(s) * gp.lat_std_rad;
+    float dy = pcg_gaussian(s) * gp.lat_std_rad;
+    float colatitude = sqrt(dx * dx + dy * dy);
+    phi = copysign(M_PI_2_F - colatitude, gp.lat_mean_rad);
+    phi = clamp(phi, -M_PI_2_F, M_PI_2_F);
+    if (gp.lat_mean_rad < 0.0f) {
+      phi = fabs(phi);
+      flip = true;
+    }
+  } else if (gp.lat_path == kLatPathGaussLegacy) {
+    float raw = pcg_get_dist(s, kDistGaussianLegacy, gp.lat_mean_rad, gp.lat_std_rad);
+    normalize_latitude(raw, phi, flip);
+  } else {
+    // kLatPathGenericReject (math.cpp:503-517).
+    int attempts = 0;
+    bool accept = false;
+    do {
+      float raw = pcg_get_dist(s, gp.lat_dist_type, gp.lat_mean_rad, gp.lat_std_rad);
+      normalize_latitude(raw, phi, flip);
+      attempts++;
+      if (attempts >= kMaxRejectionAttempts) {
+        break;
+      }
+      float accept_u = pcg_uniform(s);
+      accept = accept_u < cos(phi) / gp.lat_rejection_m;
+    } while (!accept);
+  }
+  if (gp.lat_path != kLatPathFullSphere) {
+    lon = pcg_get_dist(s, gp.az_type, gp.az_mean_rad, gp.az_std_rad);
+  }
+  float roll = pcg_get_dist(s, gp.roll_type, gp.roll_mean_rad, gp.roll_std_rad);
+  if (flip) {
+    lon += M_PI_F;
+    roll += M_PI_F;
+  }
+  out_lon = lon;
+  out_lat = phi;
+  out_roll = roll;
+}
+
+// Computes R = Rz(lon - π) · Ry(lat - π/2) · Rz(roll) using individual axis
+// rotations chained via Rotation::Chain (geo3d.cpp:32-46), matching
+// BuildCrystalRotation in simulator.cpp:128-135. Stored row-major:
+// mat9[i*3+j] = R_{ij}, identical to Rotation::mat_.
+inline void chain_left_mul_9(thread float* m, thread const float* r) {
+  // m <- r * m
+  float t[9];
+  for (uint i = 0u; i < 3u; i++) {
+    for (uint j = 0u; j < 3u; j++) {
+      t[i * 3 + j] = r[i * 3 + 0] * m[0 * 3 + j]
+                   + r[i * 3 + 1] * m[1 * 3 + j]
+                   + r[i * 3 + 2] * m[2 * 3 + j];
+    }
+  }
+  for (uint k = 0u; k < 9u; k++) {
+    m[k] = t[k];
+  }
+}
+
+inline void axis_angle_rotation_9(thread const float* ax, float theta, thread float* out) {
+  float c = cos(theta);
+  float s = sin(theta);
+  float cc = 1.0f - c;
+  out[0] = ax[0] * ax[0] * cc + c;
+  out[1] = ax[0] * ax[1] * cc - ax[2] * s;
+  out[2] = ax[0] * ax[2] * cc + ax[1] * s;
+  out[3] = ax[0] * ax[1] * cc + ax[2] * s;
+  out[4] = ax[1] * ax[1] * cc + c;
+  out[5] = ax[1] * ax[2] * cc - ax[0] * s;
+  out[6] = ax[0] * ax[2] * cc - ax[1] * s;
+  out[7] = ax[1] * ax[2] * cc + ax[0] * s;
+  out[8] = ax[2] * ax[2] * cc + c;
+}
+
+inline void build_crystal_rotation_9(float lon, float lat, float roll, thread float* mat9) {
+  // Rotation(z, roll), then Chain(y, lat-π/2), then Chain(z, lon-π).
+  // Chain left-multiplies the existing matrix, mirroring Rotation::Chain.
+  float ey[3] = { 0.0f, 1.0f, 0.0f };
+  float ez[3] = { 0.0f, 0.0f, 1.0f };
+  axis_angle_rotation_9(ez, roll, mat9);
+  float middle[9];
+  axis_angle_rotation_9(ey, lat - M_PI_2_F, middle);
+  chain_left_mul_9(mat9, middle);
+  float outer[9];
+  axis_angle_rotation_9(ez, lon - M_PI_F, outer);
+  chain_left_mul_9(mat9, outer);
+}
+
+// d_crystal = R^T · d_world. Mirrors Rotation::ApplyInverse using the row-major
+// mat_ layout (geo3d.cpp:77-87) — read column k of R = row k transposed.
+inline void apply_inverse_mat9(thread const float* mat9,
+                               thread const float* d_world,
+                               thread float* d_crystal) {
+  d_crystal[0] = mat9[0] * d_world[0] + mat9[3] * d_world[1] + mat9[6] * d_world[2];
+  d_crystal[1] = mat9[1] * d_world[0] + mat9[4] * d_world[1] + mat9[7] * d_world[2];
+  d_crystal[2] = mat9[2] * d_world[0] + mat9[5] * d_world[1] + mat9[8] * d_world[2];
+}
+
+// SampleSphCapPoint (geo3d.cpp:171-205). Inputs already in radians.
+inline void sample_sph_cap(thread PcgStream& s,
+                           float lon, float lat, float half_angle,
+                           thread float* out_d) {
+  float c_cap = cos(half_angle);
+  float u = pcg_uniform(s);
+  float x = u + (1.0f - u) * c_cap;
+  float r = sqrt(max(1.0f - x * x, 0.0f));
+  float phi = pcg_uniform(s) * 2.0f * M_PI_F;
+  float y = cos(phi) * r;
+  float z = sin(phi) * r;
+  float c_lon = cos(lon);
+  float s_lon = sin(lon);
+  float c_lat = cos(lat);
+  float s_lat = sin(lat);
+  out_d[0] = c_lon * c_lat * x - s_lon * y - c_lon * s_lat * z;
+  out_d[1] = s_lon * c_lat * x + c_lon * y - s_lon * s_lat * z;
+  out_d[2] = s_lat * x + c_lat * z;
+}
+
+// SampleTrianglePoint (geo3d.cpp:153-168). vtx9 = 3 vertices × 3 coords.
+inline void sample_triangle(thread PcgStream& s,
+                            device const float* vtx9,
+                            thread float* out_p) {
+  float u = pcg_uniform(s);
+  float v = pcg_uniform(s);
+  if (u + v > 1.0f) {
+    u = 1.0f - u;
+    v = 1.0f - v;
+  }
+  for (uint k = 0u; k < 3u; k++) {
+    float a = vtx9[k];
+    float b = vtx9[3 + k];
+    float c = vtx9[6 + k];
+    out_p[k] = u * (b - a) + v * (c - a) + a;
+  }
+}
+
+// RandomSample (geo3d.cpp:112-150) — categorical CDF with negative-weight clip.
+// Mirrors host behavior: non-positive total falls back to bin 0.
+inline uint categorical_sample(thread const float* weights, uint n, float u_in) {
+  float total = 0.0f;
+  for (uint i = 0u; i < n; i++) {
+    total += max(weights[i], 0.0f);
+  }
+  if (total <= 0.0f) {
+    return 0u;
+  }
+  float target = u_in * total;
+  float cumsum = 0.0f;
+  for (uint i = 0u; i < n; i++) {
+    cumsum += max(weights[i], 0.0f);
+    if (cumsum > target) {
+      return i;
+    }
+  }
+  return n - 1u;
+}
+
+kernel void gen_root_kernel(
+    device float*           root_d        [[buffer(0)]],
+    device float*           root_p        [[buffer(1)]],
+    device float*           root_w        [[buffer(2)]],
+    device ushort*          root_tf       [[buffer(3)]],
+    device float*           root_rot      [[buffer(4)]],
+    device const float*     tri_vtx       [[buffer(5)]],
+    device const float*     tri_norm      [[buffer(6)]],
+    device const float*     tri_area      [[buffer(7)]],
+    device const ushort*    tri_to_poly   [[buffer(8)]],
+    constant GenRootKernelParams& gp      [[buffer(9)]],
+    uint tid [[thread_position_in_grid]])
+{
+  if (tid >= gp.num_rays) {
+    return;
+  }
+  uint global_idx = gp.gen_ray_base + tid;
+  PcgStream stream;
+  stream.seed = gp.gen_seed;
+  stream.global_idx = global_idx;
+  stream.slot = 0u;
+
+  // 1. Sample crystal orientation (lon, lat, roll) → 3×3 rotation.
+  float lon, lat, roll;
+  sample_lat_lon_roll(stream, gp, lon, lat, roll);
+  float mat9[9];
+  build_crystal_rotation_9(lon, lat, roll, mat9);
+
+  // 2. Sample incident direction in WORLD space, then rotate into crystal-local.
+  float d_world[3];
+  sample_sph_cap(stream, gp.sun_lon, gp.sun_lat, gp.sun_half_angle, d_world);
+  float d_crystal[3];
+  apply_inverse_mat9(mat9, d_world, d_crystal);
+
+  // 3. Triangle area×facing weighted pick → uniform point on the chosen tri.
+  float proj_prob[kMaxTriPerKernel];
+  uint n_tri = min(gp.tri_count, kMaxTriPerKernel);
+  for (uint t = 0u; t < n_tri; t++) {
+    float dot = d_crystal[0] * tri_norm[t * 3 + 0]
+              + d_crystal[1] * tri_norm[t * 3 + 1]
+              + d_crystal[2] * tri_norm[t * 3 + 2];
+    proj_prob[t] = max(-dot * tri_area[t], 0.0f);
+  }
+  float u_cat = pcg_uniform(stream);
+  uint tri_id = categorical_sample(proj_prob, n_tri, u_cat);
+  float p[3];
+  sample_triangle(stream, tri_vtx + tri_id * 9u, p);
+  ushort to_face = tri_to_poly[tri_id];
+  float weight = gp.ray_weight;
+  if (to_face == kInvalidId) {
+    // Mirrors InitRay_p_fid fallback (simulator.cpp:92-94): zero weight when
+    // a triangle has no polygon backing so downstream HitSurface can drop it.
+    weight = 0.0f;
+  }
+
+  // 4. Emit.
+  root_d[tid * 3 + 0] = d_crystal[0];
+  root_d[tid * 3 + 1] = d_crystal[1];
+  root_d[tid * 3 + 2] = d_crystal[2];
+  root_p[tid * 3 + 0] = p[0];
+  root_p[tid * 3 + 1] = p[1];
+  root_p[tid * 3 + 2] = p[2];
+  root_w[tid] = weight;
+  root_tf[tid] = to_face;
+  for (uint k = 0u; k < 9u; k++) {
+    root_rot[tid * 9u + k] = mat9[k];
+  }
+}
 )METAL";
 
 // Mirror of the Metal-side KernelParams (host layout MUST match the .metal
@@ -415,6 +787,47 @@ struct KernelParams {
 static_assert(sizeof(KernelParams) == 76u,
               "KernelParams size mismatch — update host struct to match Metal-side layout");
 
+// Device root-gen latitude path tags. MUST match constant kLatPath* in
+// kKernelSrc — they index into a Metal-side branch table.
+enum LatPath : uint32_t {
+  kLatPathFullSphereHost    = 0u,
+  kLatPathNoRandomHost      = 1u,
+  kLatPathRayleighHost      = 2u,
+  kLatPathGaussLegacyHost   = 3u,
+  kLatPathGenericRejectHost = 4u,
+};
+
+// Mirror of the Metal-side GenRootKernelParams (host layout MUST match the
+// MSL struct field-for-field — all 4-byte scalars, natural alignment).
+// Field order MUST match the MSL struct in kKernelSrc — static_assert guards
+// size only; reviewer-facing field-by-field check is required when adding
+// or reordering members (same convention as KernelParams above).
+struct GenRootKernelParams {
+  uint32_t gen_seed;
+  uint32_t gen_ray_base;
+  uint32_t num_rays;
+  uint32_t tri_count;
+  float    sun_lon;
+  float    sun_lat;
+  float    sun_half_angle;
+  float    ray_weight;
+  uint32_t lat_path;
+  uint32_t lat_dist_type;   // DistributionType cast to uint
+  float    lat_mean_rad;
+  float    lat_std_rad;
+  float    lat_rejection_m;
+  uint32_t az_type;
+  float    az_mean_rad;
+  float    az_std_rad;
+  float    az_pad;
+  uint32_t roll_type;
+  float    roll_mean_rad;
+  float    roll_std_rad;
+  float    roll_pad;
+};
+static_assert(sizeof(GenRootKernelParams) == 84u,
+              "GenRootKernelParams size mismatch — update host struct to match Metal-side layout");
+
 float ComputeAz0(const Rotation& rot) {
   float ax_z[3]{ 0.0f, 0.0f, 1.0f };
   rot.Apply(ax_z);
@@ -444,6 +857,25 @@ Logger& EffectiveLogger(Logger* logger) {
   return logger ? *logger : GetGlobalLogger();
 }
 
+// File-local mirror of the file-static ComputeJacobianEnvelope in math.cpp.
+// Inlined here so device root-gen (task-260.2) does not require exporting that
+// helper through math.hpp; keeps math.cpp's parity envelope semantics in one
+// place per file (host math kept private; device path uses its own copy).
+// Inputs in degrees, output is the rejection envelope M used as cos(phi)/M.
+float ComputeJacobianEnvelopeForDeviceGen(const Distribution& dist) {
+  switch (dist.type) {
+    case DistributionType::kGaussian:
+      return std::cos(std::max(std::abs(dist.mean) - 3.0f * dist.std, 0.0f) * math::kDegreeToRad);
+    case DistributionType::kZigzag:
+      return std::cos(std::max(std::abs(dist.mean) - dist.std, 0.0f) * math::kDegreeToRad);
+    case DistributionType::kLaplacian:
+      return std::cos(std::max(std::abs(dist.mean) - 5.0f * dist.std, 0.0f) * math::kDegreeToRad);
+    case DistributionType::kUniform:
+    default:
+      return 1.0f;
+  }
+}
+
 }  // namespace
 
 struct MetalTraceBackend::Impl {
@@ -452,10 +884,19 @@ struct MetalTraceBackend::Impl {
   id<MTLDevice>               device = nil;
   id<MTLCommandQueue>         queue  = nil;
   id<MTLComputePipelineState> pso    = nil;
+  // Device root-gen PSO (task-260.2). Compiled by EnsurePso alongside the
+  // trace_layer kernel; nil until first BeginSession.
+  id<MTLComputePipelineState> gen_root_pso_ = nil;
+  // Captured from spec.seed by BeginSession. 0 → device gen disabled (host
+  // fallback path). Non-zero implies single-worker determinism contract.
+  uint32_t gen_seed_ = 0u;
 
   SessionSpec spec{};
   bool   in_session = false;
   size_t ms_idx = 0;
+  // First-layer root index running counter. BeginSession resets to 0; each
+  // GenerateFirstLayerRootsForCi dispatch advances by the rays it emitted, so
+  // (gen_seed_, gen_ray_base + tid) is a globally unique stream per session.
   size_t root_ray_count = 0;
   int    width = 0;
   int    height = 0;
@@ -598,7 +1039,11 @@ struct MetalTraceBackend::Impl {
   void ResolveLayerCrystalForCi(const ScatteringSetting& setting, bool use_host,
                                 const HostRayBatch& host_batch);
   size_t GenerateFirstLayerRootsForCi(const ScatteringSetting& setting,
-                                      size_t ci, size_t crystal_ray_num);
+                                      size_t ci, size_t crystal_ray_num,
+                                      bool can_use_device_gen);
+  GenRootKernelParams BuildGenRootParams(const ScatteringSetting& setting,
+                                          size_t crystal_ray_num) const;
+  void DispatchGenRoot(const GenRootKernelParams& gp);
   size_t CopyContSliceToRootBuf(const ScatteringSetting& setting, size_t ci_start, size_t ci_n, int in_slot);
   void DispatchLayer(size_t num_rays,
                      id<MTLBuffer> r_d, id<MTLBuffer> r_p,
@@ -666,6 +1111,18 @@ void MetalTraceBackend::Impl::EnsurePso() {
                "MetalTraceBackend: pipeline state creation failed: {}",
                err.localizedDescription.UTF8String);
     assert(false && "MetalTraceBackend: pipeline state creation failed");
+  }
+
+  // Device root-gen PSO (task-260.2). Same library as trace_layer; compiled
+  // in lock-step so the kernel cache survives across BeginSession invocations.
+  id<MTLFunction> gen_fn = [lib newFunctionWithName:@"gen_root_kernel"];
+  assert(gen_fn != nil && "MetalTraceBackend: gen_root_kernel entry point missing");
+  gen_root_pso_ = [device newComputePipelineStateWithFunction:gen_fn error:&err];
+  if (gen_root_pso_ == nil) {
+    ILOG_ERROR(EffectiveLogger(logger_),
+               "MetalTraceBackend: gen_root pipeline state creation failed: {}",
+               err.localizedDescription.UTF8String);
+    assert(false && "MetalTraceBackend: gen_root pipeline state creation failed");
   }
 }
 
@@ -884,7 +1341,24 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
 }
 
 size_t MetalTraceBackend::Impl::GenerateFirstLayerRootsForCi(const ScatteringSetting& setting,
-                                                              size_t ci, size_t crystal_ray_num) {
+                                                              size_t ci, size_t crystal_ray_num,
+                                                              bool can_use_device_gen) {
+  if (can_use_device_gen) {
+    // Device root-gen path (task-260.2). Replicates InitRayFirstMs on the GPU
+    // using a counter-based PCG stream keyed by (gen_seed_, gen_ray_base+tid).
+    // root_ray_count accumulates across dispatches to keep the global index
+    // monotone across batches of the same session.
+    GenRootKernelParams gp = BuildGenRootParams(setting, crystal_ray_num);
+    gp.gen_seed     = gen_seed_;
+    assert(root_ray_count <= static_cast<size_t>(UINT32_MAX) &&
+           "root_ray_count overflow: TraceLayer must guard can_use_device_gen with UINT32_MAX bound");
+    gp.gen_ray_base = static_cast<uint32_t>(root_ray_count);
+    gp.num_rays     = static_cast<uint32_t>(crystal_ray_num);
+    DispatchGenRoot(gp);
+    root_ray_count += crystal_ray_num;
+    return crystal_ray_num;
+  }
+
   const AxisDistribution& crystal_axis = setting.crystal_.axis_;
 
   RayBuffer workspace[2]{};
@@ -921,7 +1395,105 @@ size_t MetalTraceBackend::Impl::GenerateFirstLayerRootsForCi(const ScatteringSet
     // re-applies the forward rotation before projection (invariant 6).
     std::memcpy(rot_ptr + i * 9, r.crystal_rot_.GetMat(), 9 * sizeof(float));
   }
+  // Accumulate the host-gen count too so a future device-gen-eligible call
+  // within the same session keeps gen_ray_base globally monotone.
+  root_ray_count += n;
   return n;
+}
+
+// Maps host axis_dist + sun + wavelength into the device GenRootKernelParams.
+// All angular fields are pre-converted to radians on the host so the kernel
+// itself does zero degree↔radian conversions.
+GenRootKernelParams MetalTraceBackend::Impl::BuildGenRootParams(
+    const ScatteringSetting& setting, size_t crystal_ray_num) const {
+  GenRootKernelParams gp{};
+  gp.tri_count = static_cast<uint32_t>(current_crystal.TotalTriangles());
+  assert(gp.tri_count <= 64u &&
+         "BuildGenRootParams: tri_count > kMaxTriPerKernel — caller must fall back to host gen");
+  gp.num_rays = static_cast<uint32_t>(crystal_ray_num);
+  // gen_seed / gen_ray_base are filled by the caller (depend on session state).
+
+  const SunParam& sun = spec.scene->light_source_.param_;
+  gp.sun_lon        = (sun.azimuth_ + 180.0f) * math::kDegreeToRad;
+  gp.sun_lat        = -sun.altitude_ * math::kDegreeToRad;
+  gp.sun_half_angle = (sun.diameter_ * 0.5f) * math::kDegreeToRad;
+  gp.ray_weight     = spec.wl.weight_;
+
+  const AxisDistribution& axis_dist = setting.crystal_.axis_;
+  // Latitude path / proposal type, mirroring math.cpp:444 SampleSphericalPointsSph
+  // setup. Stays in sync with that function's three-path decision: Rayleigh
+  // (near-pole Gaussian only) / kGaussianLegacy / generic Jacobian rejection /
+  // kNoRandom, plus a top-level fast path when the distribution is the full
+  // sphere uniform sampler.
+  auto lat_type = axis_dist.latitude_dist.type;
+  float lat_mean_rad = axis_dist.latitude_dist.mean * math::kDegreeToRad;
+  float lat_std_rad  = axis_dist.latitude_dist.std  * math::kDegreeToRad;
+  float rejection_m  = 1.0f;
+  uint32_t lat_path  = kLatPathGenericRejectHost;
+
+  if (axis_dist.IsFullSphereUniform()) {
+    lat_path = kLatPathFullSphereHost;
+  } else if (lat_type == DistributionType::kNoRandom) {
+    lat_path = kLatPathNoRandomHost;
+  } else if (lat_type == DistributionType::kGaussianLegacy) {
+    lat_path = kLatPathGaussLegacyHost;
+  } else if (lat_type == DistributionType::kGaussian) {
+    // Same Rayleigh threshold as math.cpp:469: colatitude_center + 3σ < 0.5°.
+    constexpr float kPolarThresholdRad = 0.5f * math::kDegreeToRad;
+    float colatitude_center = math::kPi_2 - std::abs(lat_mean_rad);
+    bool use_rayleigh = (colatitude_center + 3.0f * lat_std_rad) < kPolarThresholdRad;
+    if (use_rayleigh) {
+      lat_path = kLatPathRayleighHost;
+    } else {
+      lat_path = kLatPathGenericRejectHost;
+      rejection_m = ComputeJacobianEnvelopeForDeviceGen(axis_dist.latitude_dist);
+    }
+  } else {
+    // kUniform / kZigzag / kLaplacian: generic rejection.
+    rejection_m = ComputeJacobianEnvelopeForDeviceGen(axis_dist.latitude_dist);
+  }
+
+  gp.lat_path        = lat_path;
+  gp.lat_dist_type   = static_cast<uint32_t>(lat_type);
+  gp.lat_mean_rad    = lat_mean_rad;
+  gp.lat_std_rad     = lat_std_rad;
+  gp.lat_rejection_m = rejection_m;
+
+  gp.az_type     = static_cast<uint32_t>(axis_dist.azimuth_dist.type);
+  gp.az_mean_rad = axis_dist.azimuth_dist.mean * math::kDegreeToRad;
+  gp.az_std_rad  = axis_dist.azimuth_dist.std  * math::kDegreeToRad;
+  gp.az_pad      = 0.0f;
+
+  gp.roll_type     = static_cast<uint32_t>(axis_dist.roll_dist.type);
+  gp.roll_mean_rad = axis_dist.roll_dist.mean * math::kDegreeToRad;
+  gp.roll_std_rad  = axis_dist.roll_dist.std  * math::kDegreeToRad;
+  gp.roll_pad      = 0.0f;
+  return gp;
+}
+
+void MetalTraceBackend::Impl::DispatchGenRoot(const GenRootKernelParams& gp) {
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+    [enc setComputePipelineState:gen_root_pso_];
+    [enc setBuffer:root_d_buf     offset:0 atIndex:0];
+    [enc setBuffer:root_p_buf     offset:0 atIndex:1];
+    [enc setBuffer:root_w_buf     offset:0 atIndex:2];
+    [enc setBuffer:root_tf_buf    offset:0 atIndex:3];
+    [enc setBuffer:root_rot_buf   offset:0 atIndex:4];
+    [enc setBuffer:tri_vtx_buf_   offset:0 atIndex:5];
+    [enc setBuffer:tri_norm_buf_  offset:0 atIndex:6];
+    [enc setBuffer:tri_area_buf_  offset:0 atIndex:7];
+    [enc setBuffer:tri_to_poly_buf_ offset:0 atIndex:8];
+    [enc setBytes:&gp length:sizeof(GenRootKernelParams) atIndex:9];
+    NSUInteger threads = 64;
+    NSUInteger groups = (static_cast<NSUInteger>(gp.num_rays) + threads - 1) / threads;
+    [enc dispatchThreadgroups:MTLSizeMake(groups, 1, 1)
+        threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+    [enc endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+  }
 }
 
 size_t MetalTraceBackend::Impl::CopyContSliceToRootBuf(const ScatteringSetting& setting,
@@ -1246,6 +1818,9 @@ void MetalTraceBackend::Impl::Reset() {
   in_session = false;
   ms_idx = 0;
   root_ray_count = 0;
+  // gen_seed_ is re-derived from spec.seed every BeginSession; clear so a
+  // session that omits spec.seed cannot inherit a previous activation.
+  gen_seed_ = 0u;
   width = 0;
   height = 0;
   az0 = 0.0f;
@@ -1344,6 +1919,12 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
     impl_->seeded_seed = spec.seed;
     impl_->seeded = true;
   }
+  // Device root-gen activation (task-260.2). spec.seed != 0 implies the
+  // single-worker determinism contract (server.cpp:184), which is the case we
+  // accelerate. spec.seed == 0 keeps gen_seed_ at 0, which forces the host
+  // path in GenerateFirstLayerRootsForCi via the can_use_device_gen guard in
+  // TraceLayer.
+  impl_->gen_seed_ = static_cast<uint32_t>(spec.seed);
 
   impl_->EnsureDevice();
   impl_->EnsurePso();
@@ -1376,7 +1957,9 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
 
     size_t total_ray_num = first_ms ? roots.host.count : roots.device.count;
     if (first_ms) {
-      impl_->root_ray_count = total_ray_num;
+      // root_ray_count is now maintained inside GenerateFirstLayerRootsForCi
+      // (both host and device paths advance it) so device root-gen sees a
+      // globally monotone gen_ray_base across ci slices and successive batches.
       // Exit seam (scrum-258.1): size the session-level exit buffer at the
       // first MS and reset its atomic slot. Multi-MS path grows exit buffer
       // again on the final layer below — see comment there.
@@ -1486,7 +2069,23 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
 
       size_t in_count = 0;
       if (first_ms) {
-        in_count = impl_->GenerateFirstLayerRootsForCi(setting, ci, ci_n);
+        // task-260.2: device root-gen runs when
+        //   (a) single crystal population (multi-crystal stream-shift is left
+        //       to task-260.3 geom-pool);
+        //   (b) host-supplied root rays are NOT pinned via roots.host.crystal
+        //       (matches the use_host=true convention below);
+        //   (c) spec.seed != 0 (single-worker determinism contract); and
+        //   (d) tri_count ≤ kMaxTriPerKernel (kernel stack-array bound); and
+        //   (e) root_ray_count fits in uint32_t (gen_ray_base width).
+        // crystal_cnt is local to this layer's ms_info; the device-gen guard
+        // intentionally inspects this layer's crystal_cnt so multi-crystal
+        // layers fall back to the host path regardless of session state.
+        bool can_use_device_gen = !use_host &&
+                                  crystal_cnt == 1 &&
+                                  impl_->gen_seed_ != 0u &&
+                                  impl_->current_crystal.TotalTriangles() <= 64u &&
+                                  impl_->root_ray_count <= static_cast<size_t>(UINT32_MAX) - ci_n;
+        in_count = impl_->GenerateFirstLayerRootsForCi(setting, ci, ci_n, can_use_device_gen);
       } else {
         // Stage this ci's slice of the prior continuation buffer into the
         // root buffers so the kernel reads a contiguous, aligned input.

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -490,14 +490,13 @@ Simulator::Simulator(QueuePtrS<SimBatch> config_queue, QueuePtrS<SimData> data_q
     : config_queue_(std::move(config_queue)), data_queue_(std::move(data_queue)), stop_(false), idle_(true),
       seed_(seed), effective_seed_(DeriveEffectiveSeed(seed)),
       rng_(seed != 0 ? seed :
-                                    static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count() ^
-                                                          (std::hash<std::thread::id>{}(std::this_thread::get_id())))) {
-}
+                       static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count() ^
+                                             (std::hash<std::thread::id>{}(std::this_thread::get_id())))) {}
 
 Simulator::Simulator(Simulator&& other) noexcept
     : config_queue_(std::move(other.config_queue_)), data_queue_(std::move(other.data_queue_)),
-      stop_(other.stop_.load()), idle_(other.idle_.load()), seed_(other.seed_),
-      effective_seed_(other.effective_seed_), rng_(other.rng_), logger_(std::move(other.logger_)),
+      stop_(other.stop_.load()), idle_(other.idle_.load()), seed_(other.seed_), effective_seed_(other.effective_seed_),
+      rng_(other.rng_), logger_(std::move(other.logger_)),
       preferred_backend_(other.preferred_backend_.load(std::memory_order_acquire)) {}
 
 Simulator& Simulator::operator=(Simulator&& other) noexcept {

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1,6 +1,7 @@
 #include "core/simulator.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -465,17 +466,39 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
 }
 
 
+namespace {
+// Global atomic counter feeding `Simulator::effective_seed_` when the user-facing
+// `seed_` is 0 (task 260.6). `fetch_add(1) + 1u` maps the sequence 0,1,2,...
+// to 1,2,3,..., guaranteeing the derived seed is non-zero (activates the Metal
+// backend's `gen_seed_ != 0` device-gen gate) and pairwise distinct across
+// Simulator instances regardless of which thread constructs them. After 2^32
+// constructions the counter wraps and the next `+1u` returns 0; in practice
+// that point is unreachable (>4e9 Simulator constructions per process).
+// NOTE: do NOT replace with `| 1u` — combined with an init of 0 it produces
+// pairwise collisions (0→1, 1→1, 2→3, 3→3, ...).
+std::atomic<uint32_t> g_simulator_seed_counter{ 0 };
+
+uint32_t DeriveEffectiveSeed(uint32_t seed) {
+  if (seed != 0) {
+    return seed;
+  }
+  return g_simulator_seed_counter.fetch_add(1, std::memory_order_relaxed) + 1u;
+}
+}  // namespace
+
 Simulator::Simulator(QueuePtrS<SimBatch> config_queue, QueuePtrS<SimData> data_queue, uint32_t seed)
     : config_queue_(std::move(config_queue)), data_queue_(std::move(data_queue)), stop_(false), idle_(true),
-      seed_(seed), rng_(seed != 0 ? seed :
+      seed_(seed), effective_seed_(DeriveEffectiveSeed(seed)),
+      rng_(seed != 0 ? seed :
                                     static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count() ^
                                                           (std::hash<std::thread::id>{}(std::this_thread::get_id())))) {
 }
 
 Simulator::Simulator(Simulator&& other) noexcept
     : config_queue_(std::move(other.config_queue_)), data_queue_(std::move(other.data_queue_)),
-      stop_(other.stop_.load()), idle_(other.idle_.load()), seed_(other.seed_), rng_(other.rng_),
-      logger_(std::move(other.logger_)), preferred_backend_(other.preferred_backend_.load(std::memory_order_acquire)) {}
+      stop_(other.stop_.load()), idle_(other.idle_.load()), seed_(other.seed_),
+      effective_seed_(other.effective_seed_), rng_(other.rng_), logger_(std::move(other.logger_)),
+      preferred_backend_(other.preferred_backend_.load(std::memory_order_acquire)) {}
 
 Simulator& Simulator::operator=(Simulator&& other) noexcept {
   if (this == &other) {
@@ -487,6 +510,7 @@ Simulator& Simulator::operator=(Simulator&& other) noexcept {
   stop_ = other.stop_.load();
   idle_ = other.idle_.load();
   seed_ = other.seed_;
+  effective_seed_ = other.effective_seed_;
   rng_ = other.rng_;
   logger_ = std::move(other.logger_);
   preferred_backend_.store(other.preferred_backend_.load(std::memory_order_acquire), std::memory_order_release);
@@ -871,7 +895,10 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     return;
   }
 
-  SessionSpec spec{ &scene, &render, wl_param, seed_ };
+  // Task 260.6: hand the backend `effective_seed_` (non-zero) so device-gen
+  // activates even when the user-facing `seed_` is 0 (default random mode).
+  // When `seed_ != 0` this equals `seed_` → determinism contract unchanged.
+  SessionSpec spec{ &scene, &render, wl_param, effective_seed_ };
   backend.BeginSession(spec);
   // RAII guard: EndSession() is called on all exit paths, including exceptions
   // thrown by TraceLayer/Recombine (which would otherwise skip EndSession).

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -593,6 +593,13 @@ void Simulator::Run() {
 
   // Pick a TraceBackend once per Run() entry. nullptr keeps the legacy CPU
   // path (zero behavior change when LUMICE_TRACE_BACKEND is unset).
+  //
+  // ARCHITECTURAL INVARIANT (task-260.5, scrum-258.10): backend instances are
+  // created PER Run() and never pooled or reused across Run()s. MetalTraceBackend
+  // relies on this to implement the !seeded gate that resets both the RNG state
+  // and root_ray_count exactly once per Run() — if a future refactor introduces
+  // a backend pool, that gate's semantics must be revisited (cross-Run() PCG
+  // determinism + counter rollover both depend on the per-Run() lifecycle here).
   auto backend = CreateBackend(preferred_backend_.load(std::memory_order_acquire), logger_);
   bool warned_no_renders = false;
   bool warned_multi_renderer = false;

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -70,6 +70,14 @@ class Simulator {
   // the top of Run().
   void SetPreferredBackend(int backend);
 
+  // Returns the seed actually handed to the trace backend (task 260.6).
+  // When `seed_ != 0` this equals `seed_`; when `seed_ == 0` this is a
+  // per-instance non-zero value derived from a global atomic counter so the
+  // backend's device-gen path activates in the default multi-worker / random
+  // mode. Stable across the simulator's lifetime — required for the backend's
+  // `seeded_` idempotency contract. Exposed for unit tests only.
+  uint32_t GetEffectiveSeed() const { return effective_seed_; }
+
  private:
   using CrystalCache = std::vector<std::pair<const CrystalParam*, Crystal>>;
   struct SimWorkspace {
@@ -97,6 +105,10 @@ class Simulator {
   std::atomic_bool idle_;
 
   uint32_t seed_;
+  // Non-zero seed handed to TraceBackend in `SimulateOneWavelengthWithBackend`
+  // so the device-gen path activates even when the user-facing `seed_` is 0
+  // (default multi-worker random mode). See task 260.6.
+  uint32_t effective_seed_;
   RandomNumberGenerator rng_;
   Logger logger_{ "Simulator" };
   // Preferred trace backend (kPreferCpu/kPreferMetal). release-write by

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(unit_test
   "${PROJ_TEST_DIR}/test_cpu_trace_backend.cpp"
   "${PROJ_TEST_DIR}/test_metal_trace_backend.cpp"
   "${PROJ_TEST_DIR}/test_metal_trace_parity.cpp"
+  "${PROJ_TEST_DIR}/test_metal_root_gen.cpp"
   "${PROJ_TEST_DIR}/test_exit_records.cpp"
   "${PROJ_TEST_DIR}/test_main.cpp")
 target_include_directories(unit_test

--- a/test/e2e/test_device_gen_default_path.py
+++ b/test/e2e/test_device_gen_default_path.py
@@ -1,0 +1,114 @@
+"""Default-path device-gen sanity test (task 260.6).
+
+Confirms that the Metal device-gen path activates and produces statistically
+equivalent output in the **default multi-worker random mode** (sim_seed=0),
+which is what GUI/CLI users hit by default.
+
+Before task 260.6 the Metal backend's device-gen path was gated on
+`gen_seed_ != 0`, and `sim_seed=0` made the Simulator hand the backend
+`SessionSpec.seed = 0` → device-gen was silently disabled for every default
+render. Task 260.6 derives a non-zero `effective_seed_` per Simulator instance
+from a global atomic counter so device-gen activates on the default path while
+preserving the deterministic semantics of `sim_seed != 0`.
+
+The test runs the metal backend twice with `sim_seed=0`:
+  - device-gen ON  (LUMICE_DISABLE_DEVICE_GEN unset)
+  - device-gen OFF (LUMICE_DISABLE_DEVICE_GEN=1, forces host root-gen)
+and asserts the block-mean (4×4) Pearson correlation between the two raw XYZ
+buffers stays above a conservative floor — both runs are Monte-Carlo with
+different RNG keys, so the metric measures "no systematic divergence" rather
+than bit equality.
+
+@pytest.mark.slow: requires the shared-lib build (`./scripts/build.sh -sj release`).
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
+
+CONFIGS_DIR = Path(__file__).parent / "configs"
+_TIMEOUT = 180
+
+# Pull the block-mean ds-corr metric from the same scratchpad source the
+# 258.6 parity suite uses — single source of truth.
+_HARNESS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "scratchpad" / "scrum-metal-exit-seam" / "task-parity-harness"
+)
+sys.path.insert(0, str(_HARNESS_DIR))
+from _measure_baseline import (  # noqa: E402  (sys.path mutated above)
+    _raw_corr_ds as _raw_corr_ds_impl,
+    _DS_BH,
+    _DS_BW,
+)
+
+
+def _raw_corr_ds(a: BufferedSimResult, b: BufferedSimResult) -> float:
+    return _raw_corr_ds_impl(a, b, _DS_BH, _DS_BW)
+
+
+def _run_metal(config_name: str, disable_device_gen: bool) -> BufferedSimResult:
+    """Run the metal backend with sim_seed=0 (default multi-worker random mode).
+
+    Toggles `LUMICE_DISABLE_DEVICE_GEN` via os.environ around the call. The
+    runner only manages `LUMICE_TRACE_BACKEND`, so this wrapper owns the
+    device-gen env var lifecycle.
+    """
+    env_was_set = "LUMICE_DISABLE_DEVICE_GEN" in os.environ
+    env_old = os.environ.get("LUMICE_DISABLE_DEVICE_GEN")
+    if disable_device_gen:
+        os.environ["LUMICE_DISABLE_DEVICE_GEN"] = "1"
+    else:
+        os.environ.pop("LUMICE_DISABLE_DEVICE_GEN", None)
+    try:
+        cfg = str(CONFIGS_DIR / f"{config_name}.json")
+        return run_scene_capi_buffered(
+            cfg, sim_seed=0, backend="metal", timeout_sec=_TIMEOUT,
+        )
+    finally:
+        if env_was_set:
+            os.environ["LUMICE_DISABLE_DEVICE_GEN"] = env_old
+        else:
+            os.environ.pop("LUMICE_DISABLE_DEVICE_GEN", None)
+
+
+# Initial threshold: 0.85 (plan §6). sim_seed=0 means each run uses a different
+# RNG key, so the metric measures distributional equivalence, not bit equality.
+# Recalibrate if the first run shows the headroom is much larger than 0.05.
+_DS_CORR_FLOOR = 0.85
+
+
+@pytest.mark.slow
+def test_default_path_device_gen_vs_host_gen_single_ms():
+    """sim_seed=0, single-MS scene: device-gen ON vs OFF must agree statistically.
+
+    Uses dual_fisheye_ref (the 258.6 single-MS no-filter parity baseline) — a
+    single-crystal, ≤64-face scene that matches the device-gen activation
+    envelope (single MS layer, host fallback gated on geometry-pool 260.3 not
+    yet landed).
+    """
+    on = _run_metal("dual_fisheye_ref", disable_device_gen=False)
+    off = _run_metal("dual_fisheye_ref", disable_device_gen=True)
+
+    assert on.routed_backend == "metal" and not on.fell_back, (
+        f"device-gen ON run did not route through metal (routed={on.routed_backend!r}, "
+        f"fell_back={on.fell_back}); tail: {on.log_lines[-5:]}"
+    )
+    assert off.routed_backend == "metal" and not off.fell_back, (
+        f"device-gen OFF run did not route through metal (routed={off.routed_backend!r}, "
+        f"fell_back={off.fell_back}); tail: {off.log_lines[-5:]}"
+    )
+
+    ds = _raw_corr_ds(on, off)
+    print(
+        f"[default-path] dual_fisheye_ref sim_seed=0 metal: "
+        f"device-gen ON vs OFF ds_corr={ds:.4f} (floor={_DS_CORR_FLOOR})"
+    )
+    assert ds >= _DS_CORR_FLOOR, (
+        f"dual_fisheye_ref default path: device-gen ON vs OFF ds_corr={ds:.4f} "
+        f"< {_DS_CORR_FLOOR} — systematic divergence between device-gen and "
+        f"host-gen on the default render path."
+    )

--- a/test/e2e/test_device_gen_default_path.py
+++ b/test/e2e/test_device_gen_default_path.py
@@ -25,6 +25,7 @@ import os
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
@@ -50,12 +51,22 @@ def _raw_corr_ds(a: BufferedSimResult, b: BufferedSimResult) -> float:
     return _raw_corr_ds_impl(a, b, _DS_BH, _DS_BW)
 
 
-def _run_metal(config_name: str, disable_device_gen: bool) -> BufferedSimResult:
-    """Run the metal backend with sim_seed=0 (default multi-worker random mode).
+def _run_metal(
+    config_name: str,
+    disable_device_gen: bool,
+    sim_seed: int = 0,
+) -> BufferedSimResult:
+    """Run the metal backend with the given sim_seed.
 
     Toggles `LUMICE_DISABLE_DEVICE_GEN` via os.environ around the call. The
     runner only manages `LUMICE_TRACE_BACKEND`, so this wrapper owns the
     device-gen env var lifecycle.
+
+    sim_seed=0 (default) preserves the original multi-worker random-mode path.
+    Non-zero sim_seed is passed through to `DeriveEffectiveSeed`
+    (src/core/simulator.cpp:481-486) and returned verbatim, collapsing to
+    single-worker — used by the fixed-seed activation proof test to compare
+    PCG(seed) vs mt19937(seed).
     """
     env_was_set = "LUMICE_DISABLE_DEVICE_GEN" in os.environ
     env_old = os.environ.get("LUMICE_DISABLE_DEVICE_GEN")
@@ -66,7 +77,7 @@ def _run_metal(config_name: str, disable_device_gen: bool) -> BufferedSimResult:
     try:
         cfg = str(CONFIGS_DIR / f"{config_name}.json")
         return run_scene_capi_buffered(
-            cfg, sim_seed=0, backend="metal", timeout_sec=_TIMEOUT,
+            cfg, sim_seed=sim_seed, backend="metal", timeout_sec=_TIMEOUT,
         )
     finally:
         if env_was_set:
@@ -111,4 +122,62 @@ def test_default_path_device_gen_vs_host_gen_single_ms():
         f"dual_fisheye_ref default path: device-gen ON vs OFF ds_corr={ds:.4f} "
         f"< {_DS_CORR_FLOOR} — systematic divergence between device-gen and "
         f"host-gen on the default render path."
+    )
+
+
+# Activation-proof RelErr floor. PCG vs mt19937 with the same effective seed
+# yield distinct sample streams; on dual_fisheye_ref the sum-of-XYZ relative
+# difference is ~1% empirically. 1e-5 is conservatively far above the floor of
+# noise but far below the real-signal regime, so a near-zero RelErr unambiguously
+# means device-gen fell back to host-gen and produced bit-identical output.
+_ACTIVATION_RELERR_FLOOR = 1e-5
+
+
+@pytest.mark.slow
+def test_device_gen_activation_proof_fixed_seed():
+    """device-gen ON (GPU PCG) vs OFF (host mt19937) at fixed seed must diverge.
+
+    Uses sim_seed=42. `DeriveEffectiveSeed` (src/core/simulator.cpp:481-486) is
+    `if (seed != 0) return seed;` — non-zero seeds bypass the global atomic
+    counter and are returned verbatim, so ON and OFF both see
+    `effective_seed_=42` deterministically (unit guard:
+    test/test_simulator.cpp:656 SimulatorEffectiveSeed.FixedSeedPreserved).
+    The Metal device-gen gate (src/core/metal_trace_backend.mm:2157-2161)
+    requires `gen_seed_!=0` ∧ `tri_count≤64`; dual_fisheye_ref is a single
+    prism crystal (~20 triangles ≤ 64) and seed=42 ≠ 0, so the activation
+    envelope is satisfied.
+
+    With the same seed but different RNG algorithms (GPU PCG vs host mt19937)
+    the two runs produce visibly different XYZ buffers — the total-sum
+    relative error is ~1% empirically. If device-gen silently fell back to
+    host-gen (same RNG on both sides), ON ≡ OFF byte-for-byte and RelErr ≈ 0,
+    failing the assertion. This closes the "assert-may-pass" hole that
+    sim_seed=0 leaves open (each side draws different atomic-counter seeds,
+    so ds_corr cannot distinguish active vs fallback).
+    """
+    on = _run_metal("dual_fisheye_ref", disable_device_gen=False, sim_seed=42)
+    off = _run_metal("dual_fisheye_ref", disable_device_gen=True, sim_seed=42)
+
+    assert on.routed_backend == "metal" and not on.fell_back, (
+        f"device-gen ON run did not route through metal (routed={on.routed_backend!r}, "
+        f"fell_back={on.fell_back}); tail: {on.log_lines[-5:]}"
+    )
+    assert off.routed_backend == "metal" and not off.fell_back, (
+        f"device-gen OFF run did not route through metal (routed={off.routed_backend!r}, "
+        f"fell_back={off.fell_back}); tail: {off.log_lines[-5:]}"
+    )
+
+    on_sum = float(np.sum(on.flt_buf))
+    off_sum = float(np.sum(off.flt_buf))
+    rel_err = abs(on_sum - off_sum) / (abs(on_sum) + abs(off_sum) + 1e-30)
+    print(
+        f"[activation-proof] dual_fisheye_ref sim_seed=42 metal: "
+        f"on_sum={on_sum:.6e} off_sum={off_sum:.6e} rel_err={rel_err:.3e} "
+        f"(floor={_ACTIVATION_RELERR_FLOOR:.0e})"
+    )
+    assert rel_err > _ACTIVATION_RELERR_FLOOR, (
+        f"dual_fisheye_ref sim_seed=42: device-gen ON vs OFF rel_err={rel_err:.3e} "
+        f"<= {_ACTIVATION_RELERR_FLOOR:.0e} — GPU PCG and host mt19937 produced "
+        f"near-identical output at the same seed. device-gen likely fell back "
+        f"to host-gen; the default-path coverage in this file is then assert-may-pass."
     )

--- a/test/e2e/test_device_gen_default_path.py
+++ b/test/e2e/test_device_gen_default_path.py
@@ -127,9 +127,14 @@ def test_default_path_device_gen_vs_host_gen_single_ms():
 
 # Activation-proof RelErr floor. PCG vs mt19937 with the same effective seed
 # yield distinct sample streams; on dual_fisheye_ref the sum-of-XYZ relative
-# difference is ~1% empirically. 1e-5 is conservatively far above the floor of
-# noise but far below the real-signal regime, so a near-zero RelErr unambiguously
-# means device-gen fell back to host-gen and produced bit-identical output.
+# difference measures ~4e-5 empirically (single-worker sim_seed=42, 2026-06-11).
+# Per-pixel variance is larger but the global sum has strong MC cancellation —
+# total-sum RelErr is the conservative end of the differentiation envelope.
+# Floor 1e-5 is below the ~4e-5 active-path measurement (~4× headroom) and far
+# above the byte-equal fallback regime (rel_err == 0 if device-gen silently
+# degrades to host-gen), so the test cleanly distinguishes the two cases.
+# Both runs are single-worker deterministic at sim_seed=42, so the gap has no
+# run-to-run variance and the 4× headroom is not flaky.
 _ACTIVATION_RELERR_FLOOR = 1e-5
 
 

--- a/test/e2e/test_device_gen_default_path.py
+++ b/test/e2e/test_device_gen_default_path.py
@@ -22,7 +22,7 @@ than bit equality.
 @pytest.mark.slow: requires the shared-lib build (`./scripts/build.sh -sj release`).
 """
 import os
-import sys
+import platform
 from pathlib import Path
 
 import numpy as np
@@ -30,20 +30,22 @@ import pytest
 
 from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
 
-CONFIGS_DIR = Path(__file__).parent / "configs"
-_TIMEOUT = 180
-
-# Pull the block-mean ds-corr metric from the same scratchpad source the
-# 258.6 parity suite uses — single source of truth.
-_HARNESS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "scratchpad" / "scrum-metal-exit-seam" / "task-parity-harness"
-)
-sys.path.insert(0, str(_HARNESS_DIR))
-from _measure_baseline import (  # noqa: E402  (sys.path mutated above)
+# Block-mean ds-corr metric — single source of truth shared with the 258.6
+# parity suite, hoisted into a tracked module (see _parity_metrics.py header).
+from test.e2e._parity_metrics import (
     _raw_corr_ds as _raw_corr_ds_impl,
     _DS_BH,
     _DS_BW,
+)
+
+CONFIGS_DIR = Path(__file__).parent / "configs"
+_TIMEOUT = 180
+
+# Metal backend is Apple-only. Skip on non-Darwin CI runners (the Ubuntu
+# e2e-slow matrix leg) where forcing the metal backend falls back to legacy and
+# the routed-backend assertions below would fail.
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin", reason="Metal backend is only available on macOS"
 )
 
 

--- a/test/e2e/test_device_gen_default_path.py
+++ b/test/e2e/test_device_gen_default_path.py
@@ -153,8 +153,9 @@ def test_device_gen_activation_proof_fixed_seed():
     envelope is satisfied.
 
     With the same seed but different RNG algorithms (GPU PCG vs host mt19937)
-    the two runs produce visibly different XYZ buffers — the total-sum
-    relative error is ~1% empirically. If device-gen silently fell back to
+    the two runs produce different XYZ buffers — the total-sum relative error
+    is ~4e-5 empirically (actual: rel_err=4.4e-5, single-worker sim_seed=42,
+    2026-06-11), ~4× above the 1e-5 floor. If device-gen silently fell back to
     host-gen (same RNG on both sides), ON ≡ OFF byte-for-byte and RelErr ≈ 0,
     failing the assertion. This closes the "assert-may-pass" hole that
     sim_seed=0 leaves open (each side draws different atomic-counter seeds,
@@ -174,6 +175,8 @@ def test_device_gen_activation_proof_fixed_seed():
 
     on_sum = float(np.sum(on.flt_buf))
     off_sum = float(np.sum(off.flt_buf))
+    # Symmetric denominator: more conservative than the single-sided form in
+    # plan §3 pseudo-code; 4× headroom over the floor confirmed empirically.
     rel_err = abs(on_sum - off_sum) / (abs(on_sum) + abs(off_sum) + 1e-30)
     print(
         f"[activation-proof] dual_fisheye_ref sim_seed=42 metal: "

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -30,6 +30,19 @@ inline bool ShouldSkipMetalTests() {
   return env != nullptr && env[0] != '\0' && env[0] != '0';
 }
 
+// task-260.2: when the test asserts byte-identity against a hand-rolled
+// oracle that mirrors the host mt19937 RNG sequence, the Metal device
+// root-gen path (which uses a counter-based PCG stream) cannot be aligned
+// bit-for-bit. Use these helpers at the top of any test to lock the Metal
+// backend to one path. The env var is read per-dispatch in
+// MetalTraceBackend::TraceLayer so toggling between tests is fine.
+inline void ForceHostGenForByteIdentity() {
+  ::setenv("LUMICE_DISABLE_DEVICE_GEN", "1", /*overwrite=*/1);
+}
+inline void EnableDeviceGenForStatisticalParity() {
+  ::unsetenv("LUMICE_DISABLE_DEVICE_GEN");
+}
+
 inline RenderConfig MakeRectangularRender() {
   RenderConfig cfg;
   cfg.id_ = 0;

--- a/test/test_metal_root_gen.cpp
+++ b/test/test_metal_root_gen.cpp
@@ -1,0 +1,253 @@
+// Device root-gen tests (task-260.2). Exercises the Metal device-resident PCG
+// path activated when spec.seed != 0 and crystal_cnt == 1 (see
+// MetalTraceBackend::TraceLayer can_use_device_gen guard in
+// src/core/metal_trace_backend.mm).
+//
+// These tests verify externally observable properties — kernel-internal
+// buffers are pimpl-hidden, so the assertions are at the public API level:
+//
+//   * device-gen determinism: same seed → identical XYZ across two runs.
+//   * device-gen vs host-gen statistical equivalence: aggregate XYZ stays
+//     close (5% rel-err is the Monte Carlo noise floor at N=8192 rays,
+//     well above the ~0.07% drift previously observed in the parity suite).
+//   * device-gen guards: multi-crystal layers and tri_count overrun fall
+//     back to host-gen without crashing.
+//   * counter monotonicity: a second TraceLayer invocation within the same
+//     session produces stable XYZ totals (no batch-wrap collision).
+//
+// Direct kernel-level unit tests (per plan §6) require buffer access that
+// would need invasive pimpl exposure; the integration-level checks here cover
+// the same properties through the public API. The slow e2e parity harness
+// (test/e2e/test_metal_exit_seam_parity.py, M7 acceptance) provides
+// large-N ds_corr verification.
+
+#include <gtest/gtest.h>
+
+#if defined(__APPLE__)
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "config/render_config.hpp"
+#include "core/metal_trace_backend.hpp"
+#include "core/trace_backend.hpp"
+#include "metal_test_helpers.hpp"
+
+namespace lumice {
+namespace {
+
+using metal_test::ChannelSum;
+using metal_test::EnableDeviceGenForStatisticalParity;
+using metal_test::ForceHostGenForByteIdentity;
+using metal_test::MakeMetalScene;
+using metal_test::MakeMultiCrystalScene;
+using metal_test::MakeRectangularRender;
+using metal_test::RelErr;
+using metal_test::ShouldSkipMetalTests;
+
+constexpr size_t kRayCount = 8192;
+
+// Same-seed determinism: two MetalTraceBackend instances with identical spec
+// must produce identical XYZ images via the device-gen path. Validates
+// (gen_seed, gen_ray_base + tid) → reproducible PCG stream within a session
+// and across instances.
+TEST(MetalRootGen, DeviceGenDeterminism) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+  EnableDeviceGenForStatisticalParity();
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz_a(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  std::vector<float> xyz_b(xyz_a.size(), 0.0f);
+  for (int run = 0; run < 2; run++) {
+    MetalTraceBackend metal;
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    XyzImageData img{ run == 0 ? xyz_a.data() : xyz_b.data(),
+                      render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+
+  // Bitwise equality is the contract for fixed-seed reproducibility. GPU
+  // atomic-add ordering can drift across runs at the ULP level on some
+  // devices, so accept a tight Monte-Carlo-floor tolerance (1e-6) rather
+  // than strict ==.
+  for (int c = 0; c < 3; c++) {
+    double sa = ChannelSum(xyz_a, c);
+    double sb = ChannelSum(xyz_b, c);
+    EXPECT_GT(sa, 0.0);
+    EXPECT_LT(RelErr(sa, sb), 1e-3)
+        << "channel=" << c << " run0=" << sa << " run1=" << sb;
+  }
+}
+
+// Device-gen vs host-gen statistical equivalence on aggregate XYZ. Both runs
+// use the same scene + seed; only LUMICE_DISABLE_DEVICE_GEN differs. PCG ≠
+// mt19937 at the per-ray level, so byte equality is not expected — the test
+// asserts aggregate Monte Carlo means coincide within ~5%.
+TEST(MetalRootGen, DeviceGenVsHostGenStatisticalParity) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz_device(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  std::vector<float> xyz_host(xyz_device.size(), 0.0f);
+
+  EnableDeviceGenForStatisticalParity();
+  {
+    MetalTraceBackend metal;
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    XyzImageData img{ xyz_device.data(), render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+
+  ForceHostGenForByteIdentity();
+  {
+    MetalTraceBackend metal;
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    XyzImageData img{ xyz_host.data(), render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+  EnableDeviceGenForStatisticalParity();  // restore default for downstream tests
+
+  double total_device = 0.0;
+  double total_host = 0.0;
+  for (size_t i = 0; i < xyz_device.size(); i++) {
+    ASSERT_TRUE(std::isfinite(xyz_device[i]));
+    ASSERT_TRUE(std::isfinite(xyz_host[i]));
+    total_device += static_cast<double>(xyz_device[i]);
+    total_host += static_cast<double>(xyz_host[i]);
+  }
+  EXPECT_GT(total_device, 0.0);
+  EXPECT_GT(total_host, 0.0);
+  EXPECT_LT(RelErr(total_device, total_host), 0.05)
+      << "total_device=" << total_device << " total_host=" << total_host;
+
+  for (int c = 0; c < 3; c++) {
+    double sd = ChannelSum(xyz_device, c);
+    double sh = ChannelSum(xyz_host, c);
+    EXPECT_LT(RelErr(sd, sh), 0.05)
+        << "channel=" << c << " device=" << sd << " host=" << sh;
+  }
+}
+
+// Multi-crystal layer must fall back to the host-gen path (device-gen is
+// limited to crystal_cnt == 1 in task-260.2; task-260.3 will address
+// multi-crystal via the geometry pool). Verifies the layer runs without
+// crash and produces a finite, non-zero XYZ.
+TEST(MetalRootGen, MultiCrystalFallsBackToHostGen) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+  EnableDeviceGenForStatisticalParity();
+
+  auto scene = MakeMultiCrystalScene(/*max_hits=*/8, /*ms_layers=*/1, /*crystal_count=*/2);
+  auto render = MakeRectangularRender();
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  MetalTraceBackend metal;
+  metal.BeginSession(spec);
+  auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+  ASSERT_NE(h, nullptr);
+  XyzImageData img{ xyz.data(), render.resolution_[0], render.resolution_[1] };
+  metal.ReadbackImage(img);
+  metal.EndSession();
+
+  double total = 0.0;
+  for (size_t i = 0; i < xyz.size(); i++) {
+    ASSERT_TRUE(std::isfinite(xyz[i]));
+    total += static_cast<double>(xyz[i]);
+  }
+  EXPECT_GT(total, 0.0) << "multi-crystal layer produced empty XYZ";
+}
+
+// seed == 0 must use the host-gen path (gen_seed_ == 0 in the
+// can_use_device_gen guard). Result must be finite and non-zero.
+TEST(MetalRootGen, ZeroSeedUsesHostGen) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+  EnableDeviceGenForStatisticalParity();
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 0;  // disables device-gen branch in TraceLayer
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  std::vector<float> xyz(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+  MetalTraceBackend metal;
+  metal.BeginSession(spec);
+  auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+  ASSERT_NE(h, nullptr);
+  XyzImageData img{ xyz.data(), render.resolution_[0], render.resolution_[1] };
+  metal.ReadbackImage(img);
+  metal.EndSession();
+
+  double total = 0.0;
+  for (size_t i = 0; i < xyz.size(); i++) {
+    ASSERT_TRUE(std::isfinite(xyz[i]));
+    total += static_cast<double>(xyz[i]);
+  }
+  EXPECT_GT(total, 0.0);
+}
+
+}  // namespace
+}  // namespace lumice
+
+#endif  // defined(__APPLE__)

--- a/test/test_metal_root_gen.cpp
+++ b/test/test_metal_root_gen.cpp
@@ -79,22 +79,24 @@ TEST(MetalRootGen, DeviceGenDeterminism) {
     metal.BeginSession(spec);
     auto h = metal.TraceLayer(RootRaySource::FromHost(host));
     ASSERT_NE(h, nullptr);
-    XyzImageData img{ run == 0 ? xyz_a.data() : xyz_b.data(),
-                      render.resolution_[0], render.resolution_[1] };
+    XyzImageData img{ run == 0 ? xyz_a.data() : xyz_b.data(), render.resolution_[0], render.resolution_[1] };
     metal.ReadbackImage(img);
     metal.EndSession();
   }
 
-  // Bitwise equality is the contract for fixed-seed reproducibility. GPU
-  // atomic-add ordering can drift across runs at the ULP level on some
-  // devices, so accept a tight Monte-Carlo-floor tolerance (1e-6) rather
-  // than strict ==.
+  // Float-precision equality is the practical contract for fixed-seed
+  // reproducibility on the Metal backend: same PCG range → same sampled
+  // rays, but GPU atomic-add ordering across SIMD groups is permitted to
+  // drift at the ULP level by Metal's relaxed atomic model. RelErr < 1e-3
+  // is far below the ~1% Monte-Carlo noise floor at N=8192 rays yet still
+  // well above any plausible ULP atomic-reorder drift on observed devices,
+  // so it catches RNG / counter / seed regressions cleanly. (Strict == would
+  // be over-tight; loose 1e-6 would no-op the test.)
   for (int c = 0; c < 3; c++) {
     double sa = ChannelSum(xyz_a, c);
     double sb = ChannelSum(xyz_b, c);
     EXPECT_GT(sa, 0.0);
-    EXPECT_LT(RelErr(sa, sb), 1e-3)
-        << "channel=" << c << " run0=" << sa << " run1=" << sb;
+    EXPECT_LT(RelErr(sa, sb), 1e-3) << "channel=" << c << " run0=" << sa << " run1=" << sb;
   }
 }
 
@@ -156,14 +158,12 @@ TEST(MetalRootGen, DeviceGenVsHostGenStatisticalParity) {
   }
   EXPECT_GT(total_device, 0.0);
   EXPECT_GT(total_host, 0.0);
-  EXPECT_LT(RelErr(total_device, total_host), 0.05)
-      << "total_device=" << total_device << " total_host=" << total_host;
+  EXPECT_LT(RelErr(total_device, total_host), 0.05) << "total_device=" << total_device << " total_host=" << total_host;
 
   for (int c = 0; c < 3; c++) {
     double sd = ChannelSum(xyz_device, c);
     double sh = ChannelSum(xyz_host, c);
-    EXPECT_LT(RelErr(sd, sh), 0.05)
-        << "channel=" << c << " device=" << sd << " host=" << sh;
+    EXPECT_LT(RelErr(sd, sh), 0.05) << "channel=" << c << " device=" << sd << " host=" << sh;
   }
 }
 
@@ -245,6 +245,121 @@ TEST(MetalRootGen, ZeroSeedUsesHostGen) {
     total += static_cast<double>(xyz[i]);
   }
   EXPECT_GT(total, 0.0);
+}
+
+// task-260.5: same-instance multi-session must advance gen_ray_base across
+// BeginSession cycles. Pre-fix bug: BeginSession unconditionally reset
+// root_ray_count=0 every cycle, so every cycle consumed the SAME PCG range
+// (gen_ray_base=0..N) and produced identical XYZ. After fix, root_ray_count
+// is reset only on the first seeding (via the `seeded` gate) and persists
+// across Reset(), so each cycle consumes a distinct PCG range → XYZ differs
+// from prior cycles. This is the mirror-bug of 258.10's RNG-reset regression.
+TEST(MetalRootGen, DeviceGenMultiSessionAdvancesGenRayBase) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+  EnableDeviceGenForStatisticalParity();
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  constexpr int kCycles = 3;
+  MetalTraceBackend metal;  // single instance, multiple sessions
+  std::vector<std::vector<float>> xyz_per_cycle(kCycles);
+  for (int cycle = 0; cycle < kCycles; cycle++) {
+    xyz_per_cycle[cycle].assign(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+    metal.BeginSession(spec);
+    auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h, nullptr);
+    XyzImageData img{ xyz_per_cycle[cycle].data(), render.resolution_[0], render.resolution_[1] };
+    metal.ReadbackImage(img);
+    metal.EndSession();
+  }
+
+  // Adjacent cycles must consume *different* PCG ranges → aggregate channel
+  // sum must differ measurably. Empirically (kRayCount=8192, this scene):
+  //   * same PCG range (pre-260.5-fix bug): RelErr ≈ 1e-7 (ULP-only drift
+  //     from GPU atomic-add reorder).
+  //   * different PCG range (post-fix):     RelErr ≥ 1.2e-4 across channels,
+  //     ~3.5e-4 typical (true Monte-Carlo divergence on aggregate sum).
+  // Threshold 1e-5 sits 100× above the ULP floor and ≥12× below the smallest
+  // post-fix difference observed, so it catches "PCG range did not advance"
+  // without flaking on legitimate sample variance.
+  for (int cycle = 1; cycle < kCycles; cycle++) {
+    for (int c = 0; c < 3; c++) {
+      double s_prev = ChannelSum(xyz_per_cycle[cycle - 1], c);
+      double s_curr = ChannelSum(xyz_per_cycle[cycle], c);
+      EXPECT_GT(s_prev, 0.0);
+      EXPECT_GT(RelErr(s_prev, s_curr), 1e-5)
+          << "cycle=" << cycle << " channel=" << c << " prev=" << s_prev << " curr=" << s_curr
+          << " — cycles produced identical PCG range (gen_ray_base not advancing)";
+    }
+  }
+}
+
+// task-260.5 Step 5 (cross-instance multi-session determinism): two independent
+// backend instances with the same seed, each driven through the same
+// multi-session sequence, must produce byte-identical per-cycle XYZ. Validates
+// the R3 architectural invariant — per-Run() backend instance creation in
+// simulator.cpp:596 means `seeded` starts false on each new instance, so the
+// fix's `!seeded` gate restarts root_ray_count from 0 deterministically per
+// Run(). If a future refactor pools or reuses backend instances across Run()s,
+// this test still passes because both instances start at seeded=false here.
+TEST(MetalRootGen, DeviceGenDeterminismCrossInstanceMultiSession) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+  EnableDeviceGenForStatisticalParity();
+
+  auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 42;
+
+  HostRayBatch host;
+  host.count = kRayCount;
+  host.crystal = nullptr;
+  host.refractive_index = 0.0f;
+
+  constexpr int kCycles = 3;
+  std::vector<std::vector<float>> xyz_a(kCycles);
+  std::vector<std::vector<float>> xyz_b(kCycles);
+  for (int instance = 0; instance < 2; instance++) {
+    MetalTraceBackend metal;  // fresh instance each outer iteration
+    auto& sink = (instance == 0) ? xyz_a : xyz_b;
+    for (int cycle = 0; cycle < kCycles; cycle++) {
+      sink[cycle].assign(render.resolution_[0] * render.resolution_[1] * 3, 0.0f);
+      metal.BeginSession(spec);
+      auto h = metal.TraceLayer(RootRaySource::FromHost(host));
+      ASSERT_NE(h, nullptr);
+      XyzImageData img{ sink[cycle].data(), render.resolution_[0], render.resolution_[1] };
+      metal.ReadbackImage(img);
+      metal.EndSession();
+    }
+  }
+
+  for (int cycle = 0; cycle < kCycles; cycle++) {
+    for (int c = 0; c < 3; c++) {
+      double sa = ChannelSum(xyz_a[cycle], c);
+      double sb = ChannelSum(xyz_b[cycle], c);
+      EXPECT_GT(sa, 0.0);
+      EXPECT_LT(RelErr(sa, sb), 1e-3) << "cycle=" << cycle << " channel=" << c << " inst0=" << sa << " inst1=" << sb
+                                      << " — cross-instance determinism broken at this cycle";
+    }
+  }
 }
 
 }  // namespace

--- a/test/test_metal_root_gen.cpp
+++ b/test/test_metal_root_gen.cpp
@@ -1,7 +1,8 @@
-// Device root-gen tests (task-260.2). Exercises the Metal device-resident PCG
-// path activated when spec.seed != 0 and crystal_cnt == 1 (see
-// MetalTraceBackend::TraceLayer can_use_device_gen guard in
-// src/core/metal_trace_backend.mm).
+// Device root-gen tests (task-260.2/260.7). Exercises the Metal device-resident
+// PCG path activated when spec.seed != 0 (see MetalTraceBackend::TraceLayer
+// can_use_device_gen guard in src/core/metal_trace_backend.mm). task-260.7
+// removed the crystal_cnt == 1 gate; multi-crystal layers now also use
+// per-ci device-gen.
 //
 // These tests verify externally observable properties — kernel-internal
 // buffers are pimpl-hidden, so the assertions are at the public API level:
@@ -10,8 +11,8 @@
 //   * device-gen vs host-gen statistical equivalence: aggregate XYZ stays
 //     close (5% rel-err is the Monte Carlo noise floor at N=8192 rays,
 //     well above the ~0.07% drift previously observed in the parity suite).
-//   * device-gen guards: multi-crystal layers and tri_count overrun fall
-//     back to host-gen without crashing.
+//   * device-gen guards: tri_count overrun falls back to host-gen without
+//     crashing; multi-crystal layers stay on device-gen (per-ci).
 //   * counter monotonicity: a second TraceLayer invocation within the same
 //     session produces stable XYZ totals (no batch-wrap collision).
 //
@@ -167,11 +168,10 @@ TEST(MetalRootGen, DeviceGenVsHostGenStatisticalParity) {
   }
 }
 
-// Multi-crystal layer must fall back to the host-gen path (device-gen is
-// limited to crystal_cnt == 1 in task-260.2; task-260.3 will address
-// multi-crystal via the geometry pool). Verifies the layer runs without
-// crash and produces a finite, non-zero XYZ.
-TEST(MetalRootGen, MultiCrystalFallsBackToHostGen) {
+// Multi-crystal layer now uses per-ci device-gen (task-260.7 removed the
+// crystal_cnt == 1 gate; explore-260.3 exp2 verified ds=0.9998). Verifies
+// the layer runs without crash and produces a finite, non-zero XYZ.
+TEST(MetalRootGen, MultiCrystalUsesPerCiDeviceGen) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }

--- a/test/test_metal_trace_parity.cpp
+++ b/test/test_metal_trace_parity.cpp
@@ -53,6 +53,7 @@ using metal_test::ChannelSum;
 using metal_test::MakeMetalScene;
 using metal_test::MakeMultiCrystalScene;
 using metal_test::MakeRectangularRender;
+using metal_test::ForceHostGenForByteIdentity;
 using metal_test::RelErr;
 using metal_test::ShouldSkipMetalTests;
 
@@ -318,6 +319,8 @@ TEST(MetalTraceParity, SingleLayerExitStatsAndXyz) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
+  // Oracle mirrors host mt19937 stream; device PCG (task-260.2) cannot align.
+  ForceHostGenForByteIdentity();
 
   auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
   auto render = MakeRectangularRender();
@@ -384,6 +387,7 @@ TEST(MetalTraceParity, TwoLayerExitStatsAndXyz) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
+  ForceHostGenForByteIdentity();
 
   auto scene = MakeMetalScene(/*max_hits=*/6, /*ms_layers=*/2);
   auto render = MakeRectangularRender();
@@ -465,6 +469,7 @@ TEST(MetalTraceParity, DeepRecorderSingleLayer) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
+  ForceHostGenForByteIdentity();
 
   auto scene = MakeMetalScene(/*max_hits=*/16, /*ms_layers=*/1);
   auto render = MakeRectangularRender();
@@ -1213,6 +1218,7 @@ TEST(MetalTraceParity, DualFisheyeEA_Single_NoOverlap) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
+  ForceHostGenForByteIdentity();
 
   auto scene = MakeMetalScene(/*max_hits=*/8, /*ms_layers=*/1);
   auto render = MakeDualFisheyeEARender(/*overlap=*/0.0f);
@@ -1272,6 +1278,7 @@ TEST(MetalTraceParity, DualFisheyeEA_Single_WithOverlap) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
+  ForceHostGenForByteIdentity();
 
   // overlap = sin(5°) ≈ kDualFisheyeOverlap (gui_state.hpp:135) — matches the
   // exact value the GUI live-preview path commits via c_api.cpp.

--- a/test/test_metal_trace_parity.cpp
+++ b/test/test_metal_trace_parity.cpp
@@ -50,10 +50,10 @@ namespace lumice {
 namespace {
 
 using metal_test::ChannelSum;
+using metal_test::ForceHostGenForByteIdentity;
 using metal_test::MakeMetalScene;
 using metal_test::MakeMultiCrystalScene;
 using metal_test::MakeRectangularRender;
-using metal_test::ForceHostGenForByteIdentity;
 using metal_test::RelErr;
 using metal_test::ShouldSkipMetalTests;
 

--- a/test/test_simulator.cpp
+++ b/test/test_simulator.cpp
@@ -14,6 +14,7 @@
 #include "core/math.hpp"
 #include "core/raypath.hpp"
 #include "core/simulator.hpp"
+#include "util/queue.hpp"
 
 namespace lumice {
 namespace {
@@ -634,6 +635,41 @@ TEST(RaySegValidate, PositionInf) {
   RaySeg r = MakeValidRaySeg();
   r.p_[1] = std::numeric_limits<float>::infinity();
   EXPECT_FALSE(r.IsValidComplete());
+}
+
+// --- Task 260.6: Simulator::effective_seed_ ----------------------------- //
+// When the user-facing seed is 0 (default multi-worker random mode), the
+// Simulator must hand the backend a non-zero, per-instance, pairwise-distinct
+// seed so the Metal device-gen path activates (gated on `gen_seed_ != 0`).
+
+TEST(SimulatorEffectiveSeed, ZeroSeedYieldsNonZero) {
+  auto config_queue = std::make_shared<Queue<SimBatch>>();
+  auto data_queue = std::make_shared<Queue<SimData>>();
+  Simulator sim(config_queue, data_queue, /*seed=*/0);
+  uint32_t derived = sim.GetEffectiveSeed();
+  EXPECT_NE(derived, 0u);
+  // Stable across repeated reads — required so backend's `seeded_` idempotency
+  // gate stays consistent across BeginSession calls.
+  EXPECT_EQ(derived, sim.GetEffectiveSeed());
+}
+
+TEST(SimulatorEffectiveSeed, FixedSeedPreserved) {
+  auto config_queue = std::make_shared<Queue<SimBatch>>();
+  auto data_queue = std::make_shared<Queue<SimData>>();
+  Simulator sim(config_queue, data_queue, /*seed=*/42);
+  EXPECT_EQ(sim.GetEffectiveSeed(), 42u);
+}
+
+TEST(SimulatorEffectiveSeed, TwoZeroSeedInstancesDistinct) {
+  // Global atomic counter monotonically increments per construction; pairwise
+  // distinctness is deterministic, not probabilistic.
+  auto config_queue = std::make_shared<Queue<SimBatch>>();
+  auto data_queue = std::make_shared<Queue<SimData>>();
+  Simulator a(config_queue, data_queue, /*seed=*/0);
+  Simulator b(config_queue, data_queue, /*seed=*/0);
+  EXPECT_NE(a.GetEffectiveSeed(), b.GetEffectiveSeed());
+  EXPECT_NE(a.GetEffectiveSeed(), 0u);
+  EXPECT_NE(b.GetEffectiveSeed(), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
## P2 入口侧：device-resident GPU root-gen 默认根供给

GPU 迁移路线图（explore-257 `SEAM-DESIGN.md §8`）的 **P2 阶段**，承接 scrum-260 + 本机吞吐确证 task-261。

> ⚠️ **Stacked PR**：base 为 `feat/metal-exit-seam`（PR #123）。请先合 #123；合入后本 PR base 会自动指向 main，diff 收敛为仅本阶段 11 文件。

### 背景
把根光线供给从 host 预生成+上传切换为 **device-resident GPU-RNG**（device PCG root-gen），解 ~13.7 Mray/s 的 host-bound 平台。取向拒绝采样/入射点/波长三段采样下放 device per-thread；晶体几何走三角形上传（单源 `MakeCrystal` 留 CPU）。

### 主要改动
- device PCG root-gen kernel + 三角形几何上传（`EnsureTriBuffers`）
- `effective_seed_` 全局原子计数器派生非零种子 → 默认多 worker 路径（sim_seed=0）激活 device-gen
- 放宽 `crystal_cnt==1` 门 → 多晶体走 per-ci device-gen（无需 geom-pool）
- `root_ray_count` reset-once 修复（parity 杀手：原无条件重置使 2M 光线只消费 128 个 PCG 流）
- 本机吞吐确证 bench + sim_seed=42 激活回归测试（PCG≠mt19937，RelErr 4.4e-5）

### Parity（统计等价）
默认单 MS sanity ds_corr **1.0000**；多晶体 **0.9998**；窄 filter **0.9963**；阈值 0.90→0.99。

### ⚠️ Known-issue（不在本 PR 处理，调优另起 PR）
**默认 batch=128 单晶体 device-gen 净亏 0.72×**（小 dispatch 固定开销 > GPU RNG 收益）；大 batch 才解锁增益（b2048 单晶体 2.47×、多晶体 multi-worker 2.95×）。探针时代 "~2×" 已被订正。
- **影响有限**：GPU 路线是 GUI opt-in checkbox（默认仍 legacy CPU，不碰已有功能）+ 未发布。
- 缓解（提高默认 batch / 自适应合批，验收=大 batch parity ≥0.99）作为独立 Metal 收尾 PR 处理。

### 另有遗留（独立 PR 跟进）
- `ServerImpl::Stop()` flaky 死锁（latent infra，极偶发，咬 ctest）→ 独立 detective task。
- `sim_seed=0` root-ray 语义微漂移、rpath 坑 → Metal 收尾清扫。

### 验证
- unit 624 PASS（直跑 `unit_test` binary 绕 ctest 死锁）、fast e2e 22 passed、slow 激活回归 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
