### PR TITLE
fix: ServerImpl::Stop() condition-variable lost-wakeup deadlock + stress regression

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -169,7 +169,16 @@ void ServerImpl::RunPersistentLoop(F work_fn) {
       active_workers_.fetch_add(1);
     }
     work_fn();
-    if (active_workers_.fetch_sub(1) == 1) {
+    // Mutate the CV predicate var under start_mutex_ — the same lock Stop() holds
+    // while checking active_workers_==0. Closes the lost-wakeup window where Stop()
+    // saw the old value and was atomically releasing the lock to enter wait while
+    // the worker's notify_all() fell into the release→park gap.
+    bool last = false;
+    {
+      std::lock_guard<std::mutex> lk(start_mutex_);
+      last = (active_workers_.fetch_sub(1) == 1);
+    }
+    if (last) {
       // Last active worker — notify Stop() if it's waiting
       start_cv_.notify_all();
     }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -120,6 +120,9 @@ class ServerImpl {
   std::atomic<ServerState> state_{ ServerState::kStopped };
   std::mutex start_mutex_;
   std::condition_variable start_cv_;
+  // std::atomic for the lock-free read in Stop()'s wait predicate lambda; mutations
+  // are ALSO guarded by start_mutex_ (see RunPersistentLoop) to close the CV
+  // lost-wakeup window. Keep both layers — do not simplify to plain int.
   std::atomic<int> active_workers_{ 0 };
   std::atomic<uint64_t> start_generation_{ 0 };  // Incremented by Start(); prevents re-entry after natural completion
 

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
@@ -758,8 +759,8 @@ TEST_F(ServerLifecycleApi, GetCachedStatsConsistency) {
 // per-iteration timeout — a hang surfaces as a FAIL() rather than wedging the whole
 // test process. On timeout the worker is detached and server_ is cleared so TearDown
 // neither re-enters Stop() (would deadlock again) nor destroys the server out from
-// under the detached worker (UAF). Leaks the hung server handle, acceptable since the
-// process is about to exit.
+// under the detached worker (UAF). Leaks the hung server handle, acceptable since this
+// test case has already FAILED and the leak is isolated to this iteration's instance.
 TEST_F(ServerLifecycleApi, StressStartStop) {
   constexpr int kIterations = 200;
   constexpr int kStopTimeoutMs = 3000;
@@ -768,13 +769,16 @@ TEST_F(ServerLifecycleApi, StressStartStop) {
   for (int i = 0; i < kIterations; ++i) {
     ASSERT_EQ(LUMICE_CommitConfig(server_, small_cfg.c_str()), LUMICE_OK) << "CommitConfig failed at iter " << i;
 
-    std::atomic<bool> stop_done{ false };
-    std::thread t([&] {
-      LUMICE_StopServer(server_);
-      stop_done.store(true, std::memory_order_release);
+    // shared_ptr + by-value capture keep the worker self-contained: if it is detached and
+    // later unwinds (shouldn't post-fix), it touches neither the stack flag nor the fixture.
+    auto stop_done = std::make_shared<std::atomic<bool>>(false);
+    LUMICE_Server* srv = server_;
+    std::thread t([stop_done, srv] {
+      LUMICE_StopServer(srv);
+      stop_done->store(true, std::memory_order_release);
     });
     auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kStopTimeoutMs);
-    while (!stop_done.load(std::memory_order_acquire)) {
+    while (!stop_done->load(std::memory_order_acquire)) {
       if (std::chrono::steady_clock::now() >= deadline) {
         t.detach();
         // Clear server_ so TearDown skips StopServer/DestroyServer — avoids re-entering

--- a/test/test_c_api.cpp
+++ b/test/test_c_api.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -749,6 +750,42 @@ TEST_F(ServerLifecycleApi, GetCachedStatsConsistency) {
   ASSERT_EQ(LUMICE_GetCachedStats(server_, &cached_again), LUMICE_OK);
   EXPECT_EQ(cached_again.sim_ray_num, cached.sim_ray_num);
   EXPECT_EQ(cached_again.crystal_num, cached.crystal_num);
+}
+
+
+// Regression for ServerImpl::Stop() lost-wakeup deadlock: drives CommitConfig→Stop in
+// a tight loop to hit the narrow race window. Each Stop runs on a worker thread with a
+// per-iteration timeout — a hang surfaces as a FAIL() rather than wedging the whole
+// test process. On timeout the worker is detached and server_ is cleared so TearDown
+// neither re-enters Stop() (would deadlock again) nor destroys the server out from
+// under the detached worker (UAF). Leaks the hung server handle, acceptable since the
+// process is about to exit.
+TEST_F(ServerLifecycleApi, StressStartStop) {
+  constexpr int kIterations = 200;
+  constexpr int kStopTimeoutMs = 3000;
+
+  auto small_cfg = MakeSmallSimConfigJson();
+  for (int i = 0; i < kIterations; ++i) {
+    ASSERT_EQ(LUMICE_CommitConfig(server_, small_cfg.c_str()), LUMICE_OK) << "CommitConfig failed at iter " << i;
+
+    std::atomic<bool> stop_done{ false };
+    std::thread t([&] {
+      LUMICE_StopServer(server_);
+      stop_done.store(true, std::memory_order_release);
+    });
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kStopTimeoutMs);
+    while (!stop_done.load(std::memory_order_acquire)) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        t.detach();
+        // Clear server_ so TearDown skips StopServer/DestroyServer — avoids re-entering
+        // the same deadlock and the UAF on the still-running detached thread.
+        server_ = nullptr;
+        FAIL() << "LUMICE_StopServer hung > " << kStopTimeoutMs << "ms on iteration " << i;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    t.join();
+  }
 }
 
 


### PR DESCRIPTION
## Fix `ServerImpl::Stop()` flaky condition-variable lost-wakeup deadlock

### Symptom
`unit_test` (notably `ServerLifecycleApi`) intermittently hung forever: the main thread parked in `ServerImpl::Stop()` on `start_cv_.wait(active_workers_ == 0)` while all persistent workers were parked in `RunPersistentLoop`'s wait — `active_workers_` was actually `0`, but `Stop()` was never woken (0% CPU, flaky, narrow window). This bit `ctest` / `build.sh -tj` / CI and once froze a task-drive run for 1h13m.

### Root cause
A textbook CV lost-wakeup from mutating the wait-predicate variable outside the waiter's mutex. In `RunPersistentLoop` the increment was under `start_mutex_` but the **decrement + `notify_all()` were not**:

```cpp
active_workers_.fetch_add(1);          // under start_mutex_
...
if (active_workers_.fetch_sub(1) == 1) // NOT under the lock
  start_cv_.notify_all();              // NOT under the lock
```

Interleave: the last worker decrements to 0 and notifies in the gap after `Stop()` checked the predicate (saw `1`) and was atomically releasing the lock to park → the notify is lost → `Stop()` sleeps forever.

### Fix
Move the predicate-variable mutation under `start_mutex_` (the same lock `Stop()` holds while checking it); `notify_all()` stays outside the lock (standard). ~10 lines in `src/server/server.cpp`. Verified `Start()` and `~ServerImpl()` mutate their predicates (`state_`, `start_generation_`) under the lock already — single root cause.

### Regression test
`ServerLifecycleApi.StressStartStop`: 200 iterations of `CommitConfig`→`Stop`, each `Stop` on a worker thread with a 3s deadline. A hang surfaces as `FAIL()` (not a wedged process); on timeout the worker is detached and `server_` is cleared so `TearDown` neither re-enters `Stop()` (would re-deadlock) nor frees the server under the detached worker (UAF). The done-flag is a `shared_ptr<atomic<bool>>` and the worker captures the server pointer by value, so a detached worker is fully self-contained.

Pre-fix reproduction was attempted (unfixed code, N=50 × 10 runs) but the window is too narrow to trigger at that scale (consistent with the bug taking ~1h to surface once); the white-box timing analysis serves as the substitute evidence.

### Verification
- `ServerLifecycleApi.*` 6/6 PASS (incl. `StressStartStop`, 200 iters, ~1.3s)
- `unit_test` full suite green; `ctest` no longer frozen by `ServerImpl::Stop`
- fast e2e: 34 passed / 1 skipped
- clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
