### PR TITLE
docs: promote GPU seam-design blueprint + route history, add knowledge-base discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,48 @@ since both modes share one `psnr_threshold` field.
 - Reference images under `test/e2e/references/*.jpg` and `test/gui/references/*.jpg` are explicitly unignored and may be tracked normally.
 - CI runs build and unit tests on branch pushes; E2E tests run on PRs and `main`.
 
-## Useful Paths
+## Documentation Index (`doc/`)
 
-- Main docs: `README.md`, `README_zh.md`
-- Configuration docs: `doc/configuration.md`
-- Performance testing: `doc/performance-testing.md`
-- Windows remote testing: `doc/windows-remote-testing.md`
+Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant one
+**before** redesigning a subsystem — many decisions are already reasoned out here.
+(Most have a `_zh` Chinese sibling.)
+
+- **Overview / guides**: `README.md`, `architecture.md`, `developer-guide.md`, `gui-guide.md`, `configuration.md`
+- **Core / rendering architecture**: `accumulator-consumer-architecture.md`, `raypath-rayseg-architecture.md`, `raypath-symmetry.md`, `coordinate-convention.md`, `crystal-orientation-sampling.md`, `ev-pipeline-architecture.md`, `adaptive-brightness.md`, `filter-architecture.md`
+- **C API**: `c_api.md`, `capi-lifecycle-architecture.md`
+- **GPU / Metal route** (read these before touching the GPU path):
+  - `seam-design.md` — **the `TraceBackend` host/device seam redesign blueprint**; §5 = single-engine, three-clock-decoupled GPU simulator (the target architecture); §3.6 "原始之罪" = why GPU must not mirror the CPU pipeline.
+  - `gpu-route-history.md` — systematic retrospective of the GPU migration (#250→265): decision evolution, accumulated data assets, leftover-item ledger.
+  - `trace-backend-frame-lifecycle.md` — Metal frame lifecycle (as-built, multi-MS transit, parity harness methodology).
+- **Perf / testing**: `performance-testing.md`, `windows-remote-testing.md`, `xyz-stats-tool.md`
 - Example config: `examples/config_example.json`
+
+## Knowledge Base & Working Discipline
+
+This project carries a deliberate accumulated memory. Its value depends on it being
+**retrieved**, not just stored (信息价值 = 内在价值 × 被检索到的概率). The recurring
+failure mode is starting each session like a newcomer and re-deriving decisions the
+owner already settled. Avoid it:
+
+- **Retrieve before re-deriving.** Before starting work on a continuing/recurring topic
+  (GPU/Metal perf, GUI perf, parity, batch/throughput, architecture decisions), FIRST:
+  1. `grep` `scratchpad/backlog.md` for the topic — it holds owner concerns, start
+     conditions, and dependencies (e.g. concern #2 commit↔batch decoupling).
+  2. Read the relevant prior `scratchpad/explore-*/{SUMMARY,insights}.md` and
+     `scratchpad/scrum-*/SUMMARY.md` — they hold verified conclusions and rejected
+     directions. Check the `doc/` index above.
+  3. **Explicitly continue prior threads** ("this refines concern #X") rather than
+     starting fresh. If new evidence conflicts with a prior conclusion, connect them.
+- **The scratchpad system is the source of truth for in-flight reasoning.**
+  `scratchpad/tasks.md` (the task ledger), `scratchpad/backlog.md` (deferred work +
+  owner concerns), `scratchpad/explore-*/` & `scratchpad/scrum-*/` (per-effort
+  hypotheses/experiments/insights/SUMMARY), `scratchpad/learnings/` (extracted lessons).
+  These are git-ignored working memory — do not treat their absence from git as absence
+  of knowledge.
+- **Promote durable design docs out of `scratchpad/` into `doc/`.** scratchpad is
+  git-ignored, so design docs left there are undiscoverable and get lost (this is how
+  the `seam-design.md` blueprint sat unbuilt). When an explore/scrum produces a durable
+  design or decision record, copy it to `doc/` and add it to the index above.
+- **Think at the architecture level before decomposing into tasks.** The task/scrum
+  machinery rewards fast decomposition and immediate action; resist acting on the first
+  promising small direction before the architecture-level question is reasoned through.

--- a/doc/gpu-route-history.md
+++ b/doc/gpu-route-history.md
@@ -1,0 +1,105 @@
+# GPU 路线系统回顾（#250 → #265，截至 2026-06-13）
+
+> 目的：把 GPU 迁移一路的决策演进、已积累数据、遗留项盘点清楚，作为重新深想的全局参照系。
+> 触发：owner 反思"行动前想得不够深→地基不稳、结论来回摇摆、积累不成形"。
+
+---
+
+## 一、大方向决策演进（每步的决策 + 它修正了什么）
+
+**Phase 0 — 为什么要 GPU（赌注前提）**
+- beam tracing 复盘（03-29）：方差瓶颈=SO(3) 姿态采样 O(1/√N)，算法层无结构改进空间 → 提质唯一路径=加算力。
+- #246 cpu-soa-refactor：量化内存墙（#248）——RaySeg 膨胀致 -29% 退化，SoA option D 落地（168→96B）。坐实"高并发 CPU 内存受限"。
+
+**Phase 1 — GPU 赌注 de-risk（#250）**
+- #250 spike：**GO**。M2 Max ~250× 全 sim、**计算受限**（28<<400 GB/s）、寄存器驻留绕开内存墙、**divergence 证伪**（无需 stream compaction）、原子累加仅 +7%。
+- **06-04 关键 reframe**：把"backend 选型死结"框架松开——dev49 是 NVIDIA 不是 AMD。真实矩阵：M2(开发)=Metal、**dev49(bench)+Windows(用户)=CUDA**。覆盖三台只需 Metal+CUDA+CPU。**定两步走：Step1 Metal/M2，Step2 CUDA/dev49。**
+
+**Phase 2 — 架构：缝（#251）**
+- 决策：**薄 `TraceBackend` 缝 + N 份原生 kernel**（拒可移植 kernel 语言——会藏住寄存器驻留这个 250× 命根、又省不掉每平台 SDK/CI）。
+- 设计铁律：缝粗到整条融合管线 / host 指针不穿缝（device-resident 不透明 handle，**从第 1 天按离散内存语义**）/ 层间重组=backend-local / C API 不变。
+- de-risk：recorder 寄存器压力 ≤16%（唯一真风险，证伪）。
+
+**Phase 3 — 正确性弯路（#252 取消 → #253）**
+- #252 集成路线取消——根因=缝帧生命周期沉默（Metal 漏出射 `crystal_rot_.Apply` → 环塌成带）。**帧是错的。**
+- #253 frame-correctness：修单/多 MS 帧、重做 parity harness（CpuTraceBackend 独立 oracle，弃 kernel-mirror 共享盲区）、1.35× 亮度裁为伪象、owner 人眼把关。corr 0.99/0.997。**任何 perf 工作前必须先有可信正确性。**
+
+**Phase 4 — Metal 进 GUI（#254-255）**
+- #254 Metal kernel + C API 开关 + GUI 复选框 + parity 0.9963。#255 日志统一。
+
+**Phase 5 — GUI perf 转向：缝重设计（#256-259）**
+- #256 metal-gui-perf：**关键发现**——GUI 慢根因=backend-seam 整幅回读税（每 batch O(W×H)），**非 Metal/GPU**。2048×1024 下 Metal 比 legacy 慢 9-57×；合批反超。当时判"GUI 是 GPU 的错误战场"。
+- #257 seam 重设计：缝切在**出射光线**（buffer-egress 非 image），带宽省 266-1362×。路线图 P1 出口侧 / P2 入口侧 root-gen / P3 bulk device-fused。
+- #258 exit-seam scrum：P1 转正为规范出口替代 image-seam。filter parity 真根因=BeginSession 每 SimBatch 重置 RNG（白盒命中）。
+- #259：吞吐未回退。
+
+**Phase 6 — 入口侧 GPU root-gen（#260-261）**
+- #260 rootgen scrum：device root-gen 转正默认供给，单 worker 1.87×/多 ~2×，parity ≥0.99。
+- #261：bench 确证 **b128 单晶体净亏 / 多晶体净赚**。← 第一个诚实的"非一致赢"信号。
+
+**Phase 7 — Profile & 融合（#263-264）**
+- #263 integrated-profile：摩擦=**GPU 命令缓冲往返延迟**（wait 89%）非计算。融合（跳 gen wait）2.41×。async 不值。多 worker=掩盖延迟非并行（单 GPU）。**gen regime 2D（大 batch device-gen 18.5M=2× 天花板）。concern #2 在此结晶。**
+- #264 fusion：融合默认化。单晶体 b128 **2.40×（分母=融合前 Metal，非 legacy）**。
+
+**Phase 8 — GUI 可行性现实核对（#265，本会话）**
+- 裁决(A)：Metal 能胜 legacy 但**无全局单 batch**——轻场景要大/重场景要小（concern #2 跨 regime 坐实）。默认 b128 饿死 GPU。Metal 对重场景拖动痛点有效（4.5× 帧）。
+
+### 演进的元模式
+1. **战略意图始终是"GPU 求吞吐、两步走"**，但 #256 起逐步滑向"在开发机 Mac GUI 上把 Metal 调好"。
+2. **结论反复自我修正**：scrum-260"device-gen 恒默认"→#261"b128 净亏"→#263"regime 2D"→#264"2.40×(vs Metal)"→#265"Metal 输 GUI→b128 饿死→重场景 concern #2"。每步纠正前一步的过度外推，**基线/regime 不断漂移**。
+
+---
+
+## 二、已积累的数据（硬资产）与已探索方向
+
+### 硬数据资产（可信、可复用）
+| 数据 | 值 | 来源 | caveat |
+|---|---|---|---|
+| GPU trace 算力上限 | ~250× 全 sim，计算受限，register-resident | #250 | M2 统一内存 |
+| divergence | 证伪（固定 max_hits，无变长路径） | #250 | — |
+| 原子累加竞争 | +7%，竞争无关 | #250 | — |
+| recorder 寄存器压力 | ≤16%（唯一真风险，证伪） | #251.1 | — |
+| GPU-RNG gen | 171×，端到端恢复 32× | #251.5 | **统一内存，不可外推 CUDA** |
+| 上传 | 非瓶颈（0.54× trace）；host-gen 才是（40.7×） | #251.5 | **统一内存 caveat** |
+| 帧正确性 | 单/多 MS corr 0.99/0.997 vs CPU；1.35×=伪象 | #253 | — |
+| exit-seam 带宽 | 省 266-1362× | #256-258 | — |
+| device root-gen | 单 1.87×/多 ~2×，parity ≥0.99 | #260 | — |
+| 摩擦真身 | GPU 命令缓冲往返**延迟**（wait 89%），非计算 | #263 | — |
+| 多 worker | 掩盖延迟非并行（单 GPU，W6→8 持平） | #263 | — |
+| gen regime 2D | 大 batch device-gen 18.5M=2× 天花板 | #263 | — |
+| 融合 | 2.41×（vs 融合前 Metal） | #263-264 | 分母非 legacy |
+| GUI 可行性 | 轻场景大 batch 2-5× 胜；重场景 concern #2 咬人 | #265 | — |
+
+### 已探索方向 & 裁决
+- 可移植 kernel 语言 → **拒**（藏寄存器驻留杠杆）。
+- async/双缓冲藏延迟 → **拒**（融合已 captures 大头，async 上界 3.07× 不值）。#263
+- 多 worker 求 GPU 并行 → **证伪**（单 GPU）。#263
+- 自适应 gen 策略 → **推迟**（依赖 commit↔batch 解耦；GUI 走大 batch 则 moot）。#263
+
+---
+
+## 三、遗留项盘点（现在看：仍有价值 / 已过时 / 已被取代）
+
+| backlog 条目 | 现状判断 |
+|---|---|
+| **CUDA Step 2（离散显存重测 + master plan 第二步）** [425/120] | ⭐**最高战略价值，未动**。真实部署目标（Windows 用户 + dev49 bench 都是 NVIDIA）。所有 Metal"便宜"结论带统一内存 caveat，CUDA 才是真正受检处。seam 全部设计就是为它零上层改动。 |
+| **commit↔batch 解耦（concern #2）** [565] | ✅**仍有价值，且已被 #265 跨 regime 证明必要**。启动条件（#264 落地）**已满足**。是 GUI 吞吐+响应的根治解。 |
+| **P3 bulk device-fused** [557] | ✅仍有价值，但**属 CUDA/offline 吞吐**（非 GUI），已标 phase-2 CUDA 开篇。 |
+| **golden 光线 absolute 锚测试** [438] | ✅仍有价值，尤其"CUDA backend 立项时一并做"——第二后端正需 absolute 锚分辨"kernel 错"vs"两后端一致都错"。 |
+| **自适应 gen 策略** [579] | ⚠️**部分过时**。#265 显示重场景要小 batch，可能仍相关；但大半被 decouple 工作吸收，待 decouple 后重估。 |
+| **Metal 收尾：默认 batch 调优** [544] | ⚠️**已被 #265 细化/取代**——不是简单"调高默认"，是 concern #2 / regime-aware 问题。 |
+| Metal 收尾：sim_seed 文档 / rpath / single_ms_filter [544] | ✅小清理仍有效。 |
+| **Metal device-RNG root supply** [410] | ❌**已被 scrum-260 实现/取代**，应关闭。 |
+| roofline 内存天花板 [368] / fuse trace→consume [388] | ◽CPU 侧高端 perf，与 GPU 路线正交；仍有效但低优先（多数用户 8C16T 不撞墙）。 |
+
+---
+
+## 四、供讨论的深层张力（observation，非 prescription）
+
+1. **战略漂移：是否在打磨 GPU 的最差战场？** GPU 结构优势在**大批量离线吞吐**（250× 计算受限、register-resident、b2048 18.5M）。而最近所有挣扎（concern #2、b128 饿死、多 worker 非并行、延迟受限）都是 GPU 在 GUI **交互 regime**里打它的**最差仗**。真正的奖品（CUDA 大批量、服务真实用户）一直没动。
+
+2. **regime 结构早就在框架里。** backlog 120 master plan + #263 regime 2D 早把"大 batch 赢/小 batch 角落"画出来了。最近 b128输→调大赢→重场景又输的来回，本质是同一 regime 结构被反复**局部重新发现**——因为没回到全局参照系。正是 owner 说的"想得不够深"：已有全局框架没被复用。
+
+3. **CUDA 是房间里的大象。** Metal phase-1 越打磨 GUI 细节，离 seam 真正受检点（离散显存、CUDA）越远。所有 unified-memory caveat 的结论都欠一次 CUDA 兑现。
+
+4. **基线漂移=摇摆的机制根源。** 每个"×几"在不同分母下成立（融合前Metal/legacy CPU/CpuTraceBackend/host-gen），跨节点不一致→似是而非。已固化 `feedback_perf_baseline_is_legacy_cpu`，但历史结论需用统一基线重读。

--- a/doc/seam-design.md
+++ b/doc/seam-design.md
@@ -1,0 +1,206 @@
+# TraceBackend host/device seam 重新设计 — 设计讨论
+
+> 本文整理 explore-256 收敛后、owner 与 assistant 的架构讨论，作为 explore-257 各假设的论证底稿。
+> 性质：**设计推理记录**，不是定稿规范。记录"为什么这么想"、考虑过的替代、以及尚未拍板的待定项。
+> 事实基座：`../explore-metal-gui-perf/`（exp#1/#4/#5）。
+
+---
+
+## 1. 缘起
+
+explore-256 定位到：GUI 开 Metal 后比 legacy 慢 9-57×，根因不是 GPU/Metal，而是 **TraceBackend seam 的架构税**——backend 每个 128 光线的小 batch 都做一次 O(W×H) 的整幅图 `ReadbackImage`+Y-sum；legacy 每 batch 只发 O(光线) 原始光线、把投影/累加留给 consumer 增量做。
+
+最初的"修复"建议是合批(把 backend batch 128→8192，exp#5 证明能反超 legacy 1.1-2.6×)。但 owner 指出这是**治标且破坏物理**：batch 大小与晶体几何随机性采样是耦合的——当前每 batch 只采一个晶体几何，合批=许多光线共用一个几何，几何分布被严重欠采样。理想是 batch=1(每光线独立几何)，128 是 CPU 上效率与几何随机性的折中。
+
+于是问题被迫回到根上：**当前 seam 设计本身是否合理？** 拆成两个子问题：
+- **Q1：进入 device 的点到底在哪？**
+- **Q2：出 device 的点到底在哪？**
+
+owner 立场：方向上赞成尽量多链路上 device(fusion kernel)，但当前 seam/kernel 规划不够好，值得重设；且 CPU/GPU 不必 bit-for-bit，**统计等价即可**。
+
+---
+
+## 2. 核心诊断：三个时钟被焊死
+
+当前 Metal seam 把三个**本应独立**的"时钟"全部 = "每 128 光线一次 backend session"：
+
+| 时钟 | 由谁驱动 | 理想粒度 |
+|------|----------|----------|
+| **几何采样** | 物理(每个光子遇到独立晶体) | 趋近 per-ray |
+| **trace 派发** | GPU 占用率/效率 | 大(10⁴-10⁶) |
+| **图像回读** | 显示响应性 | 显示节奏/按需 |
+
+焊在一起 → 任一旋钮和另外两个打架：调大 batch 提效率→几何随机性崩；保几何随机性→batch 小→回读税炸。
+
+**legacy 之所以"还行"**：它碰巧把"几何时钟"(32 光线粒度)和"回读时钟"(consumer 增量成像)解对了，只是"trace 时钟"对 GPU 太小(128)。
+
+**redesign 的本质 = 给三个时钟各自独立的频率。**
+
+事实校准（代码读出）：
+- legacy/CpuBackend `kSmallBatchRayNum=32`：每 32 光线一个随机几何。
+- Metal `ResolveLayerCrystalForCi`→`MakeCrystal` 每 ci 每 TraceLayer 一次：**每 batch 一个几何**。即 Metal 在 batch=128 时几何采样已比 legacy 粗 4×，合批 8192 则粗 256×。
+
+---
+
+## 3. Q1 — 进入 device 的点
+
+### 3.1 理论最优：入口尽量上移到"场景分布参数 + RNG seed"
+
+让几何采样 / 取向 / 根光线生成全部 per-thread 发生在 device。一举三得：
+- 几何时钟与 trace 时钟解耦(每线程=自己的几何=batch-1 物理，无论派发多大)；
+- 消掉 exp#1 的 host-bound root-gen 瓶颈；
+- 对 CUDA 是刚需(否则每光线几何要走 PCIe)。
+
+GPU RNG(前序 task/explore 已认可的方向)是使能器。
+
+### 3.2 几何：三条路线
+
+| 路线 | 机制 | 评价 |
+|------|------|------|
+| (a) 内核内逐线程造几何 | kernel 从分布参数采 height/face_distance + 造多面体面/法线 | 最纯粹，但工程量+正确性风险大；且**违反"几何单源"约束**(GPU 要一套几何构造代码) |
+| **(b) 几何池**(推荐) | host 一次性造 **K 个**几何打包上传，每线程 RNG 随机选索引 | 满足"统计等价"；几何构造**单源留 CPU**(复用 `MakeCrystal`)；GPU 只读不造；CUDA 友好(每 session 一次上传 ~K×1KB) |
+| (c) CPU-RNG-async | 几何留 CPU 采，双缓冲流水线隐藏开销 | 见 §3.3，被 (b) 支配，留作 fallback |
+
+#### 3.3 辨析：池化 ≠ CPU-async（两个正交的轴）
+
+讨论中澄清的关键点——它们长得像但回答不同问题：
+- **池化**动的是**工作量**：几何构造次数 = K，与 N、与 batch 都无关；per-ray 指派是廉价随机下标。**直接拨动"几何时钟"**，同步也成立。
+- **CPU-async**动的是**时序**：host 工作量没少，只是用并发挪出关键路径。**不碰几何时钟**——若配"每 batch 一个几何"，耦合原封不动，只藏了 host-bound 性能症状。
+
+→ 池化修根因，async 修症状。两者 2×2 可叠加。**池化即使不 async 也解耦了物理。**
+
+#### 3.4 标定 K：方差分解
+
+```
+总方差 ≈ 几何采样方差 (~1/K) + 光线/取向/波长方差 (~1/N)
+```
+取 K 使 1/K 项相对 1/N 可忽略即可。N/K 的复用只是"每个形状多打几束光"。池化是 legacy"32 光线共用一形状"的推广，把复用因子从 batch 解放、并用随机指派消掉连续 batch 的相关性。**有原则可标定，不是 hack。**
+
+### 3.5 "线程 = 光线 + 晶体索引"模型 与 divergence 成本
+
+把"晶体"从"光线被批在其下的实体"重构为"光线读取的那段三角形数据"：一次巨型 dispatch，几何 buffer 持多个晶体三角形，per-ray index 选晶体，每线程对自己的晶体三角形 trace。
+
+**per-ray 不同三角形在 GPU 上不是零成本，但很便宜**：
+- 内存 divergence：同 warp 读不同晶体地址 → 失 coalescing。但晶体几何极小(~1KB)，trace 是 compute-bound，几何读占比小。
+- **一次加载多次复用**：一条光线在同一晶体里反复弹射，开头把几何载入寄存器/私有内存一次，之后每弹射是寄存器访问；散读代价被多次弹射摊薄。
+- 控制 divergence：不同晶体类型面数不齐 → warp 等最长；纯 prism 无忧，混合类型用 **wavefront 排序**(按类型分桶)消解，v1 可缓。
+
+这正是生产级 GPU 光追的常态(不同光线打不同三角形)；halo 还更简单(每光线由索引直知晶体，连 BVH 都不用，每弹射 O(面数))。
+
+### 3.6 CPU 与 GPU 流水线不必结构镜像（"原始之罪"）
+
+254/253 花大力气让 GPU **镜像** CPU 流水线(采一晶体→批光线变换到局部系→trace→反变换)，甚至为 parity 对齐逐光线坐标系。**正是这个镜像把 CPU 的"批共用晶体"结构搬上 GPU。**
+
+CPU 批的原因是 cache/setup 摊薄("32 光线/晶体"是 CPU 决策)；GPU 靠成千线程并行摊薄，机制不同，批结构不该迁移。GPU-native 单元 = 线程 = 一条光线 + 它的晶体。两后端只需**物理上统计等价**，不需执行结构对齐——把"统计等价即可"从 RNG 推广到整条流水线。
+
+**推论**：parity 应在累加图像层面测(统计分布)，不再对齐逐光线坐标系(253 的 corr 0.93 真正该锚定的层次)。
+
+### 3.7 几何单源 = 不需要 GPU 几何代码
+
+(b) 池化的副产物：几何构造**完全留在 CPU 单源**(现有 `MakeCrystal`)，GPU 侧没有任何几何构造代码。owner 担心的"CPU/GPU 两套几何"被绕开。分工浮现：**复杂但稀少(几何构造)留 CPU/每 session 一次；简单但海量(采样+trace)上 GPU 逐线程。**
+
+---
+
+## 4. Q2 — 出 device 的点
+
+### 4.1 seam 应切在"出射光线"边界，不是"成品图像"边界
+
+出射光线是**渲染器无关**的物理输出；投影/累加依赖 renderer(镜头/视角/filter)。当前 Metal 把投影焊进 trace → 烤死一个 renderer + 逼每 batch 回读整幅图。legacy 的高效正来自分离(发光线、consumer 投影)。
+
+### 4.2 为什么 image 出口对 GUI 次优（精确版）
+
+- **view 无关 vs view 特定**：出射光线 view 无关；image 烤死一个 view。GUI 价值在廉价迭代(改视角/镜头/filter/曝光，多数不改物理只改投影)。手里有出射光线 → 改视角是 O(光线) 重投影、不重 trace；只留 image → 只能全部重 trace。image 出口关死这扇门，buffer 出口保留 optionality(即使 v1 不实现光线缓存，seam 形态不堵死它)。
+- **多 renderer**：buffer 出口 = trace 一次、consumer 投影 N 次，trace 不需知道 renderer；image 出口 = N 套 device 累加 + N 投影 pass。
+- **filter**：buffer 出口让 filter 跑 consumer(灵活)；image 出口若扔光线，filter 必须上 device，改 filter≈重跑。
+
+### 4.3 诚实的反点：纯吞吐 image 出口反而可能赢
+
+大 batch 下 image 出口回读是固定 O(W×H)、摊到每光线趋近 0、投影在 GPU；buffer 出口导出 O(出射光线)、每光线常数成本不随 batch 摊薄。所以"视角固定熬收敛"的稳态里 image 出口更省。**→ GUI 选 buffer 出口的理由是灵活性/可迭代性，不是速度。**
+
+### 4.4 收口：seam 永在出射光线，投影是可插拔策略
+
+- **seam(出射记录 buffer)= 永久规范边界。**
+- **投影 = 挂在 seam 下游的可配置 stage**：GUI 用 CPU consumer(灵活)；bulk 用 device-fused image(吞吐)。
+- 两个出口安放成"按 workload 选策略"，不是二选一/先后取代。
+- v2 级 hybrid：当前视角 device 累加快速收敛 + 出射光线 ring buffer 让视角切换瞬间重投影预览、后台重 trace 热身。
+
+### 4.5 富出射 metadata —— 富 ≠ 重
+
+owner 定调：**富出射是必须，不是可选**；filter 缺席的原型无法接入 GUI；至少光路 recorder 要带出来；必要时可重设计 metadata 结构。
+
+好消息(代码读出)：想要的紧凑结构**已存在且已压过**——`src/core/raypath.hpp` 的 `RaypathRecorder` 共 18B：
+```
+offset 0:  uint8_t  size_                (1B, ≤ max_hits)
+offset 1:  uint8_t  data_[kInlineCap=15] (15B inline 面序列，面 ID 存 uint8)
+offset 16: uint16_t overflow_idx_        (2B, 超 15 跳指向 arena)
+```
+一条富出射记录 ≈ `{dir(fp16×3=6B) + weight(4B) + crystal_id(2B) + 路径(18B)} ≈ 30B/出射光线`。10⁶ 光线 ≈ 30MB，与一次 2048×1024 整幅图同量级、按大 batch 摊薄 → **GUI 可接受，富出射不必然是带宽瓶颈**。
+
+#### 让富出射在 GPU 上可行的关键一刀
+
+`RaypathRecorder` 的 **overflow arena**(>15 跳动态分配)在 GPU 上是噩梦。但所有真实配置 `max_hits` 7-8 < kInlineCap=15 → **overflow 永不触发**。所以 GPU 导出路径：
+- 断言 **inline-only**，**砍掉 arena**，导出 = 定长 per-ray 记录、零动态分配。
+- 这就是 owner 说的"重设计 metadata"的落点：把 CPU 那套 overflow 复杂度**设计掉**。甚至按配置实际 max_hits 裁剪 inline 面数组(常 ≤8，省一半)——但属"先量后优"，30B 已够用。
+
+#### 对称折叠留 consumer
+
+`RaypathOrbit`/`ReduceRaypath`/`BuildOrbit` 的对称规约依赖晶体配置 → 留 filter 侧。**GPU 只导出原始面序列，对称折叠+匹配在 consumer，kernel 保持笨。**
+
+### 4.6 带宽与 regime 收口
+
+富出射是 O(出射光线)。GUI(中等 batch)不在乎；bulk 巨量 N 时这个 O(N) 导出本身就不想付 → 正是切到 device 侧 filter+投影(image 出口)的触发点。**同一套出射记录结构：GUI 在 host 侧消费，bulk 在 device 侧消费。**
+
+### 4.7 两个诚实的坑
+
+1. **真·新功能**：当前 Metal `rec_sink[tid]=rec_csum` 只是每光线一个 float 校验和(parity 用)，未导出路径。要让 kernel 在 trace 中逐跳 append `to_face_` 到 per-thread 定长数组并写出——中等改动，从零加。
+2. **MS 多层作用域**：路径是 per-(光线, MS层, 晶体)，每层换晶体、recorder 重起、不跨层累加。单 MS 干净；多 MS 下"filter 作用哪层 / 出射记录带几层路径"需在 schema 定死。
+
+---
+
+## 5. 统一后的 seam 形态（待验证草案）
+
+```
+host 一次/session:
+  采 K 个晶体几何 (MakeCrystal, 单源)  ──上传──►  device: 三角形池 buffer
+  场景分布参数 + RNG seed             ──────────►
+
+device 巨型 dispatch (batch = 纯性能旋钮):
+  线程 = 一条光线:
+    RNG 选晶体索引 (池, K 受方差标定)
+    GPU 采样: 取向 / 入射点 / 波长
+    trace (穿 MS 各层, continuation 全程不出 device)
+    逐跳记录 to_face_ → 定长 inline 面序列
+    写出射记录 {dir, weight, crystal_id, 面序列}  ──► device: 出射记录 buffer  ◄── 规范 seam
+                                                                  │
+                          ┌───────────────────────────────────────┴───────────────────┐
+                  GUI 策略 (灵活)                                          bulk 策略 (吞吐)
+            出射记录 ──► host consumer:                          出射记录留 device ──► device:
+              filter(对称折叠) + 投影 + 增量累加                    filter + 投影 + 累加
+              (导出 O(光线), 解 exp#4 痛点)                         只回读图像(显示节奏/一次)
+```
+
+三时钟独立：几何=逐线程(池索引)、trace=dispatch 尺寸纯性能、回读=下游策略各自节奏。
+
+---
+
+## 6. 待定项（收敛前需各下判断）
+
+1. 池化 K 的方差标定；device 侧池 vs host 上传一次。
+2. 出射记录精确 schema：dir 精度、面序列定长宽度、crystal_id 宽度、**MS 多层作用域**。
+3. 混合晶体类型控制 divergence：是否需 wavefront 排序(v1 可缓)。
+4. 寄存器压力：复杂晶体(pyramid)面数多压低 occupancy。
+5. explore-256 插桩去向：回退 vs 转正(`LUMICE_BATCH_RAY_NUM` 可能成正式旋钮)。
+
+## 7. 关键风险点（各需最小原型实测）
+
+- per-ray 不同晶体的 divergence 实测开销(vs 全批共享一晶体)。
+- 富出射记录导出带宽(30B/ray × N vs 整幅图)在 GUI 默认分辨率的实测。
+- buffer 出口 + consumer 投影在 GUI 默认 2048×1024 是否复现 legacy 量级吞吐(正面解 exp#4)。
+
+## 8. 建议分步实现路线（草案，待探索验证后细化）
+
+- **P0 验证(本探索)**：三个风险点各跑最小原型，定 schema 与 K，出数据流定稿。
+- **P1 出口侧先行**：backend 改 buffer 出口(富出射记录)+ consumer 投影/filter。**单独即可解 owner 的 GUI 痛点**(导出 O(光线) 非 O(W×H))，且复用现有 consumer，风险最低。
+- **P2 入口侧上移**：几何池上传 + per-ray 采样/晶体索引上 GPU，解耦几何时钟、消 host-bound。
+- **P3 bulk 路径**：device 侧 filter+投影(image 出口)，服务 CUDA/offline 吞吐。
+- parity 全程改统计级口径(累加图像 corr)。


### PR DESCRIPTION
## 摘要

把两份长期有价值的 GPU 路线设计文档从 git-ignored `scratchpad/` 提升到 tracked `doc/`，并在 AGENTS.md 固化检索纪律——根治"重要设计文档不可发现、每会话从零开始"的积累失效（`seam-design.md` 的 §5 蓝图之所以一直没被实现，部分原因正是它埋在 gitignored scratchpad 里不可发现）。

## 改动

- **`doc/seam-design.md`**（新）：`TraceBackend` host/device 缝重设计；§5 = 单引擎、三时钟解耦的 GPU simulator（目标架构）；§3.6「原始之罪」= GPU 不该镜像 CPU 流水线。
- **`doc/gpu-route-history.md`**（新）：#250→265 GPU 迁移系统回顾（决策演进 / 数据资产 / 遗留盘点）。
- **`AGENTS.md`**：新增 Documentation Index（覆盖 doc/ 架构/C API/GPU 路线）+ Knowledge Base & Working Discipline（检索优先、scratchpad 即累积记忆、提升 doc、架构先于拆解）。

纯文档 + 项目指令，无代码/行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)