### PR TITLE
fix: degenerate prism-plane spurious-exit misclassification (B-ring thin bipyramid)

### DIFF
--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -291,17 +291,34 @@ kernel void trace_layer_kernel(
       float cw  = (ch == 0u) ? w_refl : w_refr;
       if (cw < 0.0f) { continue; }
 
+      // Convex-body outward short-circuit (mirrors CPU PropagateSlab):
+      // a child ray leaving the source face outward (d · n_src > 0) cannot
+      // hit any other polygon face. Skip the search so far_face stays -1
+      // and the ray is written as outgoing (kInvalidId). Prevents
+      // degenerate infinite planes (e.g. prism walls at prism_h=0) from
+      // being selected at positive t and mis-classifying first-bounce
+      // external reflections as internal transit.
+      bool outward_ray = false;
+      if (to_face != kInvalidId) {
+        float snx = poly_n[to_face * 3u + 0u];
+        float sny = poly_n[to_face * 3u + 1u];
+        float snz = poly_n[to_face * 3u + 2u];
+        outward_ray = (cdx * snx + cdy * sny + cdz * snz) > 0.0f;
+      }
+
       float t_far = 1e30f;
       int   far_face = -1;
-      for (uint fi = 0u; fi < poly_cnt; fi++) {
-        float fnx = poly_n[fi * 3u + 0u];
-        float fny = poly_n[fi * 3u + 1u];
-        float fnz = poly_n[fi * 3u + 2u];
-        float fd  = poly_d[fi];
-        float denom = cdx * fnx + cdy * fny + cdz * fnz;
-        float t = -(ox * fnx + oy * fny + oz * fnz + fd) / denom;
-        if (denom > kFloatEps && t < t_far) {
-          t_far = t; far_face = int(fi);
+      if (!outward_ray) {
+        for (uint fi = 0u; fi < poly_cnt; fi++) {
+          float fnx = poly_n[fi * 3u + 0u];
+          float fny = poly_n[fi * 3u + 1u];
+          float fnz = poly_n[fi * 3u + 2u];
+          float fd  = poly_d[fi];
+          float denom = cdx * fnx + cdy * fny + cdz * fnz;
+          float t = -(ox * fnx + oy * fny + oz * fnz + fd) / denom;
+          if (denom > kFloatEps && t < t_far) {
+            t_far = t; far_face = int(fi);
+          }
         }
       }
       float eps_thr = (to_face != kInvalidId && far_face != int(to_face)) ? -kFloatEps : kFloatEps;

--- a/src/core/optics.cpp
+++ b/src/core/optics.cpp
@@ -78,6 +78,7 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
   alignas(64) float t_far[kMaxSlabRays];
   int far_face[kMaxSlabRays];
   int src_poly[kMaxSlabRays];
+  bool outward[kMaxSlabRays];
 
   for (size_t i = 0; i < num; i++) {
     const float* d = d_in.Ptr(i);
@@ -92,6 +93,17 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
     far_face[i] = -1;
     IdType src_id = from_face_in[i / step];
     src_poly[i] = (src_id != kInvalidId) ? static_cast<int>(src_id) : -1;
+    // Convex-body outward short-circuit: a ray that departs the source face
+    // pointing outward (d · n_src > 0) cannot hit any other face's polygon.
+    // Without this guard, degenerate infinite planes (e.g. prism_h=0 walls)
+    // can be selected at positive t even though their polygon is empty,
+    // mis-classifying first-bounce external reflections as internal transit.
+    outward[i] = false;
+    if (src_poly[i] >= 0) {
+      const float* sn = pn + src_poly[i] * 3;
+      float d_src = dx[i] * sn[0] + dy[i] * sn[1] + dz[i] * sn[2];
+      outward[i] = (d_src > 0.0f);
+    }
   }
 
   // Face-outer, ray-inner: find minimum t among exit faces (denom > eps)
@@ -102,6 +114,9 @@ static void PropagateSlab(const Crystal& crystal, size_t num, size_t step, const
     float fd = pd[fi];
 
     for (size_t i = 0; i < num; i++) {
+      if (outward[i]) {
+        continue;
+      }
       float denom = dx[i] * nx + dy[i] * ny + dz[i] * nz;
       float t = -(px[i] * nx + py[i] * ny + pz[i] * nz + fd) / denom;
       if (denom > math::kFloatEps && t < t_far[i]) {

--- a/test/e2e/configs/degenerate_prism_b_ring.json
+++ b/test/e2e/configs/degenerate_prism_b_ring.json
@@ -1,0 +1,48 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "pyramid",
+      "shape": {
+        "upper_h": 0.5,
+        "lower_h": 0.5,
+        "prism_h": 0.0,
+        "upper_wedge_angle": 88.0,
+        "lower_wedge_angle": 88.0
+      },
+      "axis": {
+        "azimuth": {"type": "uniform", "mean": 0.0, "std": 360.0},
+        "roll":    {"type": "uniform", "mean": 0.0, "std": 360.0},
+        "zenith":  {"type": "gauss_legacy", "mean": 0.0, "std": 0.2}
+      }
+    }
+  ],
+  "filter": [],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 30.0,
+      "diameter": 0.5,
+      "spectrum": "D65"
+    },
+    "ray_num": 50000,
+    "max_hits": 1,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {"crystal": 1, "proportion": 100.0}
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {"type": "dual_fisheye_equal_area", "fov": 180},
+      "resolution": [512, 256],
+      "view": {"elevation": 5.0},
+      "visible": "full"
+    }
+  ]
+}

--- a/test/parity-cross-backend/backend/test_metal_trace_parity.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_parity.cpp
@@ -189,18 +189,30 @@ OracleLayerResult OracleTraceLayer(const Crystal& crystal, const PolyArrays& pol
           continue;
         }
 
+        // Mirror metal_trace_backend.mm: convex-body outward short-circuit
+        // (skip search when the child ray leaves the source face outward).
+        bool outward_ray = false;
+        if (to_face != kInvalidId) {
+          float snx = poly.n[to_face * 3 + 0];
+          float sny = poly.n[to_face * 3 + 1];
+          float snz = poly.n[to_face * 3 + 2];
+          outward_ray = (cdx * snx + cdy * sny + cdz * snz) > 0.0f;
+        }
+
         float t_far = 1e30f;
         int far_face = -1;
-        for (size_t fi = 0; fi < poly_cnt; fi++) {
-          float fnx = poly.n[fi * 3 + 0];
-          float fny = poly.n[fi * 3 + 1];
-          float fnz = poly.n[fi * 3 + 2];
-          float fd = poly.d[fi];
-          float denom = cdx * fnx + cdy * fny + cdz * fnz;
-          float t = -(ox * fnx + oy * fny + oz * fnz + fd) / denom;
-          if (denom > kFloatEps && t < t_far) {
-            t_far = t;
-            far_face = static_cast<int>(fi);
+        if (!outward_ray) {
+          for (size_t fi = 0; fi < poly_cnt; fi++) {
+            float fnx = poly.n[fi * 3 + 0];
+            float fny = poly.n[fi * 3 + 1];
+            float fnz = poly.n[fi * 3 + 2];
+            float fd = poly.d[fi];
+            float denom = cdx * fnx + cdy * fny + cdz * fnz;
+            float t = -(ox * fnx + oy * fny + oz * fnz + fd) / denom;
+            if (denom > kFloatEps && t < t_far) {
+              t_far = t;
+              far_face = static_cast<int>(fi);
+            }
           }
         }
         float eps_thr = (to_face != kInvalidId && far_face != static_cast<int>(to_face)) ? -kFloatEps : kFloatEps;

--- a/test/regression-sentinel/test_degenerate_prism_b_ring.py
+++ b/test/regression-sentinel/test_degenerate_prism_b_ring.py
@@ -1,0 +1,103 @@
+"""Regression guard: degenerate-prism plane misclassified as internal next-face.
+
+Fix commits:
+- b7317619 fix(core): outward-ray short-circuit in PropagateSlab
+- c3aea20f fix(metal): outward-ray short-circuit in trace kernel + mirror in parity oracle
+
+Root cause (white-box proven, see scratchpad/task-degenerate-prism-plane-exit-misclassify/issue.md):
+``Propagate`` (``src/core/optics.cpp``) and the Metal trace kernel selected
+next-face as "the closest half-space plane the ray is exiting (denom > eps) at
+t > 0", *without* a polygon-membership check. On a convex crystal that is
+correct for rays travelling strictly *inside* the body — but for first-bounce
+external reflections at the surface, the infinite plane of a degenerate
+zero-height prism wall (``prism_h=0``) can still be hit at positive t even
+though its polygon is empty. The ray was then mis-classified as internal
+transit instead of outgoing, producing zero output at ``max_hits=1`` for
+extremely flat double-pyramids around wedge 87.4-88°.
+
+The fix adds a convex-body outward short-circuit: if a child ray leaves the
+source face with ``d · n_src > 0`` it cannot hit any other polygon face, so
+``next_face`` stays ``kInvalidId`` and the ray exits cleanly.
+
+This test pins the canonical B-ring scenario (``pyramid``, ``prism_h=0``,
+``upper/lower_wedge_angle=88°``, ``max_hits=1``, ``dual_fisheye_equal_area``
+lens — Metal-compatible) and asserts that the legacy CPU and Metal backends
+both produce a non-zero, broadly consistent image. Pre-fix legacy snapshot
+intensity was 0 at this wedge and Metal hung; post-fix both should match
+within a loose tolerance.
+
+Requires shared-lib build: ./scripts/build.sh -sj release
+Run: pytest test/regression-sentinel/test_degenerate_prism_b_ring.py -v -m slow
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from test.e2e.capi_runner import run_scene_capi_buffered
+from test.e2e.runner import get_project_root
+
+_CONFIG = get_project_root() / "test" / "e2e" / "configs" / "degenerate_prism_b_ring.json"
+
+_TEST_SEED = 42
+
+# Pre-fix legacy snapshot_intensity at this config is exactly 0 (all first-
+# bounce external reflections are mis-classified as internal and dropped at
+# max_hits=1). Post-fix both legacy and Metal land at ~23 with seed=42; a
+# floor of 5.0 leaves a wide margin while cleanly separating "fix works"
+# (>>0) from "fix regressed" (==0). Tighten only if the post-fix value
+# drifts up.
+_MIN_INTENSITY = 5.0
+
+
+@pytest.mark.slow
+def test_degenerate_prism_legacy_emits_nonzero_at_mh1():
+    """Legacy CPU produces non-zero output at the degenerate B-ring scenario.
+
+    Pre-fix: snapshot_intensity == 0 (issue.md "100% → 0% hard flip" at wedge
+    87.5° max_hits=1). Post-fix: outward-ray short-circuit lets first-bounce
+    external reflections exit, restoring non-zero output.
+    """
+    result = run_scene_capi_buffered(str(_CONFIG), sim_seed=_TEST_SEED, backend="legacy")
+    assert result.snapshot_intensity > _MIN_INTENSITY, (
+        "Legacy CPU produced near-zero output on the degenerate B-ring scenario "
+        f"(snapshot_intensity={result.snapshot_intensity:.3f}). The outward-ray "
+        "short-circuit may have regressed — first-bounce external reflections are "
+        "being mis-classified as internal transit at prism_h=0 + wedge=88°."
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.platform != "darwin", reason="Metal backend is macOS-only")
+def test_degenerate_prism_metal_does_not_hang_and_matches_legacy():
+    """Metal completes within the timeout and broadly matches legacy at this scene.
+
+    Pre-fix Metal hung at ``max_hits=1`` on this geometry (issue.md). Post-fix
+    Metal must (a) return without timing out and (b) produce a non-zero output
+    of the same order of magnitude as legacy.
+    """
+    metal = run_scene_capi_buffered(str(_CONFIG), sim_seed=_TEST_SEED, backend="metal", timeout_sec=60)
+    if metal.routed_backend != "metal" or metal.fell_back:
+        pytest.skip(
+            f"Metal backend not active for this scene (routed={metal.routed_backend!r}, "
+            f"fell_back={metal.fell_back}); skipping cross-backend check."
+        )
+
+    legacy = run_scene_capi_buffered(str(_CONFIG), sim_seed=_TEST_SEED, backend="legacy")
+
+    assert metal.snapshot_intensity > _MIN_INTENSITY, (
+        f"Metal snapshot_intensity={metal.snapshot_intensity:.3f} too low — "
+        "outward-ray short-circuit in the Metal kernel may have regressed."
+    )
+    # Loose order-of-magnitude check: legacy and Metal differ in RNG / face
+    # selection details and we only need to catch a real divergence, not enforce
+    # per-pixel parity.
+    ratio = metal.snapshot_intensity / max(legacy.snapshot_intensity, 1e-6)
+    assert 0.3 <= ratio <= 3.0, (
+        f"Metal vs legacy snapshot_intensity ratio {ratio:.3f} out of [0.3, 3.0] "
+        f"(metal={metal.snapshot_intensity:.3f}, legacy={legacy.snapshot_intensity:.3f}). "
+        "Backends diverging on the degenerate B-ring scene — check whether the "
+        "Metal-side outward short-circuit matches the CPU side."
+    )


### PR DESCRIPTION
## 背景

内测成员报 `B-ring test.json`（六角双锥 pyramid，`prism_h=0`，wedge 88°）在 legacy CPU 与 Metal GPU 两路渲染差异极大，legacy 多出很多光弧。多轮白盒调查（含两次自我纠错）定位到一个**两后端共享的几何处理 bug**。

## 根因

`PropagateSlab`（CPU `src/core/optics.cpp`）与 Metal trace kernel（`src/core/metal_trace_backend.mm`）用"最近的、ray 正穿出（`denom>kFloatEps`）的半空间平面、t 最小"确定 next-face，**无多边形成员检查**。对凸晶体内部射线由凸体定理保证正确；但对**第一跳外反射光线**（在表面、朝外走）不成立。

`prism_h=0` 使 6 个棱面退化为零高度面，但其无限竖直平面仍在。极扁双锥（wedge→90° 锥面近水平）中外反射光线在正 t 处穿过某棱面平面 → 被选为 next-face → `to_face_` 置为棱面索引 → `CollectData` 误判为内部续传而非出射。临界顶楔角 ~87.4°→87.5°。

**白盒铁证**：第一跳 reflect 子线分类，wedge 87.4° `exit=20000 hit=0`（全对）→ 87.5° `exit=0 hit=20000`（全错分），100%→0% 硬翻转，误选 to_face=4/5/7（prism 面）。

一个 bug 解释全部症状：max_hits=1 出射归零、能量不饱和（低阶能量被改道涂抹）、legacy/Metal 窄带 ~3× 发散、Metal 在该几何 max_hits=1 死锁。

## 修复

**Outward short-circuit（凸体不变量）**：射线离开 source face 且朝外（`d·n_src > 0`）时，凸体下不可能再命中其他面多边形 → 直接判 `kInvalidId`（出射），跳过 next-face 搜索。CPU + Metal 两路各约 +10 行，无接口变更、无 eps_thr 改动。

- `src/core/optics.cpp`：`PropagateSlab` 增 `outward[]` 判断 + 内循环 skip
- `src/core/metal_trace_backend.mm`：trace kernel 每条 child ray 同款短路；parity oracle 同步
- `test/regression-sentinel/test_degenerate_prism_b_ring.py` + `test/e2e/configs/degenerate_prism_b_ring.json`：固化该退化场景 + Metal/legacy parity

## 验证（修复后，owner 独立复核）

| wedge, mh1 | 修复前 | 修复后 |
|---|---|---|
| 87.5° | legacy 0 / Metal HANG | legacy 10748 / Metal 9743 ✓ |
| 88.0° | legacy 0 / Metal HANG | legacy 10585 / Metal 9743 ✓ |
| 88° mh8 | legacy 560k / Metal 245k（2.3×）| legacy 248656 / Metal 246453（1.009）✓ |

max_hits=1 出射恢复非零、Metal 不再死锁、legacy/Metal parity 恢复、临界顶楔角阶跃平滑为物理渐变。常规几何（prism、28/45/60° pyramid、prism_h>0）无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)