### PR TITLE
fix(core): PolygonFaceOfTri argmax for extreme-wedge entry-face mapping

### DIFF
--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -2013,9 +2013,12 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
   // Triangle-level geometry (task-260.2). Uploaded so the device root-gen
   // kernel can replicate InitRay_p_fid: area×facing-weighted triangle pick +
   // uniform sample inside the triangle, plus tri→polygon mapping.
-  // tri_to_poly is computed by mirroring simulator.cpp::PolygonFaceOfTri
-  // (which is file-static); same Dot3 > 1-1e-3 criterion against polygon
-  // normals already uploaded above.
+  // tri_to_poly mirrors simulator.cpp::detail::PolygonFaceOfTri: argmax over
+  // polygon-face normals with a sanity floor (kFaceCoplanarFloor=1e-2). A
+  // first-match `dot > 1-1e-3` cannot distinguish adjacent upper-pyramid faces
+  // on extreme-wedge (~≥87.4°) crystals (dot ≈ 0.9994).
+  // NOTE: kFaceCoplanarFloor must match the value in crystal.cpp::BuildPolygonFaceData
+  // and simulator.cpp::detail::PolygonFaceOfTri.
   size_t tri_cnt = crystal.TotalTriangles();
   EnsureTriBuffers(tri_cnt);
   std::memcpy([tri_vtx_buf_ contents], crystal.GetTriangleVtx(),
@@ -2028,18 +2031,22 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
   const float* poly_norms_src = crystal.GetPolygonFaceNormal();
   auto* tri_to_poly_ptr = static_cast<uint16_t*>([tri_to_poly_buf_ contents]);
   constexpr uint16_t kInvalidIdU16 = 0xffffu;
+  constexpr float kFaceCoplanarFloor = 1e-2f;
   for (size_t t = 0; t < tri_cnt; t++) {
     const float* tn = tri_norms_src + t * 3;
-    uint16_t mapped = kInvalidIdU16;
+    int best_p = -1;
+    float best_dot = -1.0f;
     for (size_t p = 0; p < poly_cnt; p++) {
       const float* pn = poly_norms_src + p * 3;
       float dot = tn[0] * pn[0] + tn[1] * pn[1] + tn[2] * pn[2];
-      if (dot > 1.0f - 1e-3f) {
-        mapped = static_cast<uint16_t>(p);
-        break;
+      if (dot > best_dot) {
+        best_dot = dot;
+        best_p = static_cast<int>(p);
       }
     }
-    tri_to_poly_ptr[t] = mapped;
+    tri_to_poly_ptr[t] = (best_p >= 0 && best_dot >= 1.0f - kFaceCoplanarFloor)
+                             ? static_cast<uint16_t>(best_p)
+                             : kInvalidIdU16;
   }
 }
 

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -36,21 +36,37 @@
 
 namespace lumice {
 
-// Maps a triangle id to its polygon-face index by matching unit normals
-// (BuildPolygonFaceData uses the same dot>1-1e-3 criterion). Returns kInvalidId
-// if no polygon face matches. Used only by InitRay_p_fid below — keeping it
-// file-local avoids reintroducing a Crystal-level reverse mapping that is
-// otherwise unneeded after the from_face_/to_face_ split.
-static IdType PolygonFaceOfTri(const Crystal& crystal, int tri_id) {
+namespace detail {
+
+// Maps a triangle id to its polygon-face index via argmax of the dot product
+// against polygon-face normals (kFaceCoplanarFloor=1e-2). Mirrors the
+// BuildPolygonFaceData side (crystal.cpp); a first-match `dot > 1-1e-3` cannot
+// distinguish adjacent upper-pyramid faces on extreme-wedge (~≥87.4°) crystals
+// because their normals' dot ≈ 0.9994. Returns kInvalidId only if the best
+// match is below the sanity floor (~8.1° slack), which should not happen for
+// valid crystals. Exposed in detail:: for unit-test access; not part of the
+// public API.
+// NOTE: kFaceCoplanarFloor must match the value in crystal.cpp::BuildPolygonFaceData.
+IdType PolygonFaceOfTri(const Crystal& crystal, int tri_id) {
   const float* tn = crystal.GetTriangleNormal() + tri_id * 3;
   const float* pn = crystal.GetPolygonFaceNormal();
+  constexpr float kFaceCoplanarFloor = 1e-2f;
+  int best_p = -1;
+  float best_dot = -1.0f;
   for (size_t p = 0; p < crystal.PolygonFaceCount(); p++) {
-    if (Dot3(tn, pn + p * 3) > 1.0f - 1e-3f) {
-      return static_cast<IdType>(p);
+    float dot = Dot3(tn, pn + p * 3);
+    if (dot > best_dot) {
+      best_dot = dot;
+      best_p = static_cast<int>(p);
     }
   }
-  return kInvalidId;
+  if (best_p < 0 || best_dot < 1.0f - kFaceCoplanarFloor) {
+    return kInvalidId;
+  }
+  return static_cast<IdType>(best_p);
 }
+
+}  // namespace detail
 
 /**
  * @brief Sample on crystal & init origin (p, from_face_, to_face_) of rays.
@@ -86,7 +102,7 @@ void InitRay_p_fid(const Crystal& curr_crystal, RayBuffer* ray_buf_ptr) {
     SampleTrianglePoint(face_vtx + tri_id * 9, r.p_);
     // Initial entry segment: no source face, hit face = the sampled one's polygon.
     r.from_face_ = kInvalidId;
-    r.to_face_ = PolygonFaceOfTri(curr_crystal, tri_id);
+    r.to_face_ = detail::PolygonFaceOfTri(curr_crystal, tri_id);
     if (r.to_face_ == kInvalidId) {
       // Triangle has no matching polygon face — should not happen for a valid crystal.
       // Zero weight to suppress downstream contribution; HitSurface also guards

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -143,6 +143,14 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
 // Internal: exposed for unit testing; not part of the public C API.
 Rotation BuildCrystalRotation(float azimuth_rad, float latitude_rad, float roll_rad);
 
+namespace detail {
+// Maps a triangle id to its polygon-face index via argmax of the dot product
+// against polygon-face normals (kFaceCoplanarFloor=1e-2). Used by InitRay_p_fid
+// to label the initial entry segment. Exposed for unit-test access; not part
+// of the public C API.
+IdType PolygonFaceOfTri(const Crystal& crystal, int tri_id);
+}  // namespace detail
+
 }  // namespace lumice
 
 #endif  // CORE_SIMULATOR_H_

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -473,8 +473,9 @@ TEST(DetailIsDApplicable, Conditions) {
 }
 
 // D4 invariant: every triangle's normal must align with at least one polygon-face
-// normal (dot > 1-1e-3), ensuring PolygonFaceOfTri always finds a match on valid
-// crystals and HitSurface's polygon-face normal equals the per-triangle normal.
+// normal (dot > 1-1e-3) on standard crystals. This is the geometric premise that
+// lets PolygonFaceOfTri's argmax (kFaceCoplanarFloor=1e-2 slack) always find a
+// match, and that HitSurface's polygon-face normal equals the per-triangle normal.
 TEST_F(V3TestCrystal, EveryTriangleMapsToCoplanarPolygon) {
   auto prism = Crystal::CreatePrism(1.3);
   auto pyramid = Crystal::CreatePyramid(0.3f, 1.0f, 0.3f);

--- a/test/unit-correctness/core/test_simulator.cpp
+++ b/test/unit-correctness/core/test_simulator.cpp
@@ -4,11 +4,13 @@
 #include <cstddef>
 #include <limits>
 #include <numeric>
+#include <set>
 #include <vector>
 
 #include "config/filter_config.hpp"
 #include "config/proj_config.hpp"
 #include "config/sim_data.hpp"
+#include "core/crystal.hpp"
 #include "core/filter_spec.hpp"
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
@@ -670,6 +672,63 @@ TEST(SimulatorEffectiveSeed, TwoZeroSeedInstancesDistinct) {
   EXPECT_NE(a.GetEffectiveSeed(), b.GetEffectiveSeed());
   EXPECT_NE(a.GetEffectiveSeed(), 0u);
   EXPECT_NE(b.GetEffectiveSeed(), 0u);
+}
+
+// Regression sentinel for the PolygonFaceOfTri argmax fix: PolygonFaceOfTri
+// must map each of the 6 upper-pyramid polygon faces uniquely on
+// extreme-wedge crystals. The buggy
+// first-match (`dot > 1-1e-3`) collapses ≥2 physical faces onto the lowest
+// polygon index because adjacent upper-face normals dot to ~0.9994. argmax
+// + sanity floor distinguishes them.
+//
+// Identification: upper-pyramid faces carry Fn ∈ {13..18} (per
+// crystal.cpp::CreatePyramid Miller-axis numbering); we count distinct polygon
+// indices returned by detail::PolygonFaceOfTri for every triangle whose Fn is
+// in that range.
+constexpr IdType kUpperPyramidFnLo = 13;
+constexpr IdType kUpperPyramidFnHi = 18;
+
+size_t CountDistinctUpperPolyFaces(const Crystal& crystal, bool* any_invalid_out = nullptr) {
+  std::set<IdType> polys;
+  bool any_invalid = false;
+  for (size_t t = 0; t < crystal.TotalTriangles(); t++) {
+    IdType fn = crystal.GetFn(static_cast<int>(t));
+    if (fn < kUpperPyramidFnLo || fn > kUpperPyramidFnHi) {
+      continue;
+    }
+    IdType poly = detail::PolygonFaceOfTri(crystal, static_cast<int>(t));
+    if (poly == kInvalidId) {
+      any_invalid = true;
+      continue;
+    }
+    polys.insert(poly);
+  }
+  if (any_invalid_out) {
+    *any_invalid_out = any_invalid;
+  }
+  return polys.size();
+}
+
+TEST(PolygonFaceOfTriArgmax, ExtremeWedge88SixDistinctUpperFaces) {
+  // Extreme wedge 88° — the buggy first-match collapses upper-pyramid triangles
+  // to ≤4 distinct polygon faces; argmax must recover the full 6.
+  auto crystal = Crystal::CreatePyramid(88.0f, 88.0f, 1.0f, 0.0f, 1.0f);
+  bool any_invalid = false;
+  size_t distinct = CountDistinctUpperPolyFaces(crystal, &any_invalid);
+  EXPECT_EQ(distinct, 6u) << "extreme-wedge 88°: upper-pyramid triangles should map to 6 distinct "
+                             "polygon faces under argmax (buggy first-match collapses to ≤4)";
+  EXPECT_FALSE(any_invalid) << "no upper-pyramid triangle should fall below kFaceCoplanarFloor on a "
+                               "valid crystal";
+}
+
+TEST(PolygonFaceOfTriArgmax, NormalWedge87SixDistinctUpperFaces) {
+  // Sanity baseline at the threshold edge — argmax must match first-match's
+  // behavior here (already 6 distinct under either rule).
+  auto crystal = Crystal::CreatePyramid(87.0f, 87.0f, 1.0f, 0.0f, 1.0f);
+  bool any_invalid = false;
+  size_t distinct = CountDistinctUpperPolyFaces(crystal, &any_invalid);
+  EXPECT_EQ(distinct, 6u);
+  EXPECT_FALSE(any_invalid) << "no upper-pyramid triangle should fall below kFaceCoplanarFloor at wedge 87°";
 }
 
 }  // namespace


### PR DESCRIPTION
## 问题

极扁双锥（pyramid + `prism_h=0` + wedge ≥ ~87.4°）下，用 raypath filter 分离单光路时发现对称性破缺：6 条本应 6 重旋转等价的光路（13-25/14-26/15-27/16-28/17-23/18-24）中，**17-23、18-24 两条凭空消失**；最初观察到的镜像对（14:{28,26} 等）也不对称。

## 根因（白盒定位）

`PolygonFaceOfTri`（`src/core/simulator.cpp`，入射采样将三角形映射到多边形面）使用 **first-match** `dot > 1 - 1e-3`。极扁下相邻上锥面法向近垂直，点乘 `0.9994² + 0.0349²·cos60° = 0.99939 > 0.999`，容差**分不开 ±60° 邻面**；first-match 总返回最低 polygon index：

| 物理面(方位) | first-match → 记录 |
|---|---|
| 13(0°)/14(60°)/18(300°) | **13**（三面塌成一个） |
| 15(120°) | 14 |
| 16(180°) | 15 |
| 17(240°) | 16 |

→ 入射 Fn13 = 3×份额、Fn17/18 = **0** → 光路 17-23/18-24 无布居。白盒 entry-tally 与手算逐位吻合（Fn13=1,001,068；Fn17/18=0）。

这是 **task-276（#133）把 `BuildPolygonFaceData` 改 argmax 修极扁假基面的漏网兄弟**——同款 `dot>1-1e-3` 病症残留在反向 tri→poly 查找。

## 修复

`PolygonFaceOfTri` first-match → **argmax + sanity floor**（`kFaceCoplanarFloor = 1e-2`，与 `BuildPolygonFaceData` 一致）。CPU（`simulator.cpp`）+ Metal（`metal_trace_backend.mm` `tri_to_poly`）双修，保 parity。

## 验证

- **新单元哨兵有真检测力**：`PolygonFaceOfTriArgmax.ExtremeWedge88SixDistinctUpperFaces` 在 buggy first-match 上 FAILED、argmax 上 PASS，wedge-87 对照 PASS。
- **Ground truth**：6 条等价光路全部复活（17-23/18-24 从 0 → 有光弧）；入射 Fn 分布恢复对称（13-18 各 ~333k）；镜像对 @20M 光线 0.975-0.995。
- 全 ctest 绿（unit-correctness / parity 含 Metal / golden-analytic），无回归；GUI raypath filter 人眼复核通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)