### PR TITLE
fix(core/gui): geometry numerical hardening (scrum-280, explore-279 follow-up)

### DIFF
--- a/src/core/geo3d.cpp
+++ b/src/core/geo3d.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "core/math.hpp"
+#include "util/logger.hpp"
 
 namespace lumice {
 
@@ -359,6 +360,23 @@ size_t FillHexCrystalCoef(float upper_alpha, float lower_alpha, float h1, float 
   constexpr float kMaxPyramidAlpha = 89.9f;  // degrees — above this, face degenerates to basal
   bool has_upper = h1 > math::kFloatEps && upper_alpha >= kMinPyramidAlpha && upper_alpha <= kMaxPyramidAlpha;
   bool has_lower = h3 > math::kFloatEps && lower_alpha >= kMinPyramidAlpha && lower_alpha <= kMaxPyramidAlpha;
+
+  // Zero-volume degenerate guard (task-280.6): when both pyramidal caps are dropped
+  // (wedge > kMaxPyramidAlpha or h1/h3 == 0) AND the prism segment h2 ≈ 0, the upper
+  // and lower basal faces coincide → zero-thickness hexagon. Downstream Triangulate
+  // computes Vec3FromTo(body_center, face_center) → (0,0,0), and Normalize3 produces
+  // NaN normals that silently poison the renderer. Emit a warning and short-circuit
+  // to an empty plane set, mirroring the kMaxPyramidAlpha degradation pattern.
+  // (doc/numerical-robustness.md §5: use <eps, not ==0.)
+  // TODO(tech-debt): the basal+prism plane equations above are written into out_coef
+  // before this early return — wasted writes but no UB since callers honor the
+  // returned plane_cnt as the effective length. A future refactor could hoist
+  // has_upper/has_lower computation to the top of the function for true early exit.
+  if (!has_upper && !has_lower && h2 < math::kFloatEps) {
+    LOG_WARNING("FillHexCrystalCoef: zero-volume crystal (prism_h={:.4e}, no valid pyramidal faces); skipping",
+                static_cast<double>(h2));
+    return 0;
+  }
 
   // Upper pyramidal faces (6, if h1 > 0)
   if (has_upper) {

--- a/src/core/geo3d.cpp
+++ b/src/core/geo3d.cpp
@@ -410,23 +410,8 @@ size_t FillHexCrystalCoef(float upper_alpha, float lower_alpha, float h1, float 
     for (size_t i = 0; i < cnt * 4; i++) {
       coef_d[i] = static_cast<double>(out_coef[i]);
     }
-    auto solve_planes_d = [](const double* c1, const double* c2, const double* c3, double* res) -> bool {
-      double det = c1[0] * c2[1] * c3[2] + c1[1] * c2[2] * c3[0] + c1[2] * c2[0] * c3[1] - c1[2] * c2[1] * c3[0] -
-                   c1[0] * c2[2] * c3[1] - c1[1] * c2[0] * c3[2];
-      if (std::fabs(det) < 1e-10) {
-        return false;
-      }
-      double x = c1[3] * c2[2] * c3[1] + c1[1] * c2[3] * c3[2] + c1[2] * c2[1] * c3[3] -  //
-                 c1[1] * c2[2] * c3[3] - c1[2] * c2[3] * c3[1] - c1[3] * c2[1] * c3[2];
-      double y = c1[0] * c2[2] * c3[3] + c1[2] * c2[3] * c3[0] + c1[3] * c2[0] * c3[2] -  //
-                 c1[3] * c2[2] * c3[0] - c1[0] * c2[3] * c3[2] - c1[2] * c2[0] * c3[3];
-      double z = c1[3] * c2[1] * c3[0] + c1[0] * c2[3] * c3[1] + c1[1] * c2[0] * c3[3] -  //
-                 c1[0] * c2[1] * c3[3] - c1[1] * c2[3] * c3[0] - c1[3] * c2[0] * c3[1];
-      res[0] = x / det;
-      res[1] = y / det;
-      res[2] = z / det;
-      return true;
-    };
+    // Plane-triple intersection delegates to the single-source SolvePlanesD
+    // (math.hpp) — scale-invariant singularity check on the normalized det.
     auto is_in_polyhedron_d = [](int n, const double* coef, const double xyz[3]) -> bool {
       for (int j = 0; j < n; j++) {
         if (coef[j * 4 + 0] * xyz[0] + coef[j * 4 + 1] * xyz[1] + coef[j * 4 + 2] * xyz[2] + coef[j * 4 + 3] > 1e-10) {
@@ -442,7 +427,7 @@ size_t FillHexCrystalCoef(float upper_alpha, float lower_alpha, float h1, float 
     for (size_t i = 2; i < cnt; i++) {
       for (size_t j = i + 1; j < cnt; j++) {
         for (size_t k = j + 1; k < cnt; k++) {
-          if (!solve_planes_d(coef_d.data() + i * 4, coef_d.data() + j * 4, coef_d.data() + k * 4, xyz)) {
+          if (!SolvePlanesD(coef_d.data() + i * 4, coef_d.data() + j * 4, coef_d.data() + k * 4, xyz)) {
             continue;
           }
           if (is_in_polyhedron_d(static_cast<int>(cnt - 2), coef_d.data() + 8, xyz)) {

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -629,15 +629,39 @@ void from_json(const nlohmann::json& obj, AxisDistribution& axis) {
 }
 
 
+// Singularity threshold for Cramer's-rule det computed on UNIT-NORMALIZED line /
+// plane normals. After in-function normalization, det = sin(angle-between-normals)
+// (2D) or det = scalar triple product of three unit normals = sin(trihedral angle)
+// (3D), both bounded in [-1, 1]. The threshold therefore measures angular
+// degeneracy and is scale-invariant w.r.t. the caller's normal magnitudes (see
+// doc/numerical-robustness.md §2; task-solveplanes-det-normalization).
+// Calibrated against the double-precision sweep: legitimate triples in wedge
+// 60-89.9° geometry have min|det_norm| ≈ 2.6e-6, spurious near-degenerate
+// triples tail off below 1.6e-7 — 1e-6 sits inside that gap with margin to
+// both sides. Float follows the same calibration (tail is wider in float but
+// the legitimate floor is the same, since the geometry is the same).
+constexpr float kSingularDetNormF = 1e-6f;
+
 bool SolveLines(const float* coef1, const float* coef2, float* res) {
-  float det = coef1[0] * coef2[1] - coef2[0] * coef1[1];
-  if (FloatEqualZero(det)) {
+  // Normalize each line normal (a, b) so the det becomes scale-invariant.
+  float mag1 = std::sqrt(coef1[0] * coef1[0] + coef1[1] * coef1[1]);
+  float mag2 = std::sqrt(coef2[0] * coef2[0] + coef2[1] * coef2[1]);
+  if (mag1 < math::kFloatEps || mag2 < math::kFloatEps) {
     res[0] = std::numeric_limits<float>::quiet_NaN();
     res[1] = std::numeric_limits<float>::quiet_NaN();
     return false;
   }
-  float x = (coef1[1] * coef2[2] - coef2[1] * coef1[2]) / det;
-  float y = (coef1[2] * coef2[0] - coef2[2] * coef1[0]) / det;
+  float c1[3]{ coef1[0] / mag1, coef1[1] / mag1, coef1[2] / mag1 };
+  float c2[3]{ coef2[0] / mag2, coef2[1] / mag2, coef2[2] / mag2 };
+
+  float det = c1[0] * c2[1] - c2[0] * c1[1];
+  if (FloatEqualZero(det, kSingularDetNormF)) {
+    res[0] = std::numeric_limits<float>::quiet_NaN();
+    res[1] = std::numeric_limits<float>::quiet_NaN();
+    return false;
+  }
+  float x = (c1[1] * c2[2] - c2[1] * c1[2]) / det;
+  float y = (c1[2] * c2[0] - c2[2] * c1[0]) / det;
   res[0] = x;
   res[1] = y;
   return true;
@@ -645,20 +669,38 @@ bool SolveLines(const float* coef1, const float* coef2, float* res) {
 
 
 bool SolvePlanes(const float* coef1, const float* coef2, const float* coef3, float* res) {
-  float det = coef1[0] * coef2[1] * coef3[2] + coef1[1] * coef2[2] * coef3[0] + coef1[2] * coef2[0] * coef3[1] -
-              coef1[2] * coef2[1] * coef3[0] - coef1[0] * coef2[2] * coef3[1] - coef1[1] * coef2[0] * coef3[2];
-  if (FloatEqualZero(det)) {
+  // Normalize each plane normal so the det becomes scale-invariant — bounded in
+  // [-1, 1] and equal to sin(trihedral angle). Avoids the historical issue where
+  // an absolute threshold on the raw det (which scales with |n1||n2||n3|) could
+  // either over-reject legitimate triples whose normals happen to have small
+  // magnitude, or under-reject near-degenerate triples whose normals are large.
+  float mag1 = Norm3(coef1);
+  float mag2 = Norm3(coef2);
+  float mag3 = Norm3(coef3);
+  if (mag1 < math::kFloatEps || mag2 < math::kFloatEps || mag3 < math::kFloatEps) {
     res[0] = std::numeric_limits<float>::quiet_NaN();
     res[1] = std::numeric_limits<float>::quiet_NaN();
     res[2] = std::numeric_limits<float>::quiet_NaN();
     return false;
   }
-  float x = coef1[3] * coef2[2] * coef3[1] + coef1[1] * coef2[3] * coef3[2] + coef1[2] * coef2[1] * coef3[3] -
-            coef1[1] * coef2[2] * coef3[3] - coef1[2] * coef2[3] * coef3[1] - coef1[3] * coef2[1] * coef3[2];
-  float y = coef1[0] * coef2[2] * coef3[3] + coef1[2] * coef2[3] * coef3[0] + coef1[3] * coef2[0] * coef3[2] -
-            coef1[3] * coef2[2] * coef3[0] - coef1[0] * coef2[3] * coef3[2] - coef1[2] * coef2[0] * coef3[3];
-  float z = coef1[3] * coef2[1] * coef3[0] + coef1[0] * coef2[3] * coef3[1] + coef1[1] * coef2[0] * coef3[3] -
-            coef1[0] * coef2[1] * coef3[3] - coef1[1] * coef2[3] * coef3[0] - coef1[3] * coef2[0] * coef3[1];
+  float c1[4]{ coef1[0] / mag1, coef1[1] / mag1, coef1[2] / mag1, coef1[3] / mag1 };
+  float c2[4]{ coef2[0] / mag2, coef2[1] / mag2, coef2[2] / mag2, coef2[3] / mag2 };
+  float c3[4]{ coef3[0] / mag3, coef3[1] / mag3, coef3[2] / mag3, coef3[3] / mag3 };
+
+  float det = c1[0] * c2[1] * c3[2] + c1[1] * c2[2] * c3[0] + c1[2] * c2[0] * c3[1] - c1[2] * c2[1] * c3[0] -
+              c1[0] * c2[2] * c3[1] - c1[1] * c2[0] * c3[2];
+  if (FloatEqualZero(det, kSingularDetNormF)) {
+    res[0] = std::numeric_limits<float>::quiet_NaN();
+    res[1] = std::numeric_limits<float>::quiet_NaN();
+    res[2] = std::numeric_limits<float>::quiet_NaN();
+    return false;
+  }
+  float x = c1[3] * c2[2] * c3[1] + c1[1] * c2[3] * c3[2] + c1[2] * c2[1] * c3[3] - c1[1] * c2[2] * c3[3] -
+            c1[2] * c2[3] * c3[1] - c1[3] * c2[1] * c3[2];
+  float y = c1[0] * c2[2] * c3[3] + c1[2] * c2[3] * c3[0] + c1[3] * c2[0] * c3[2] - c1[3] * c2[2] * c3[0] -
+            c1[0] * c2[3] * c3[2] - c1[2] * c2[0] * c3[3];
+  float z = c1[3] * c2[1] * c3[0] + c1[0] * c2[3] * c3[1] + c1[1] * c2[0] * c3[3] - c1[0] * c2[1] * c3[3] -
+            c1[1] * c2[3] * c3[0] - c1[3] * c2[0] * c3[1];
   res[0] = x / det;
   res[1] = y / det;
   res[2] = z / det;
@@ -707,10 +749,6 @@ namespace {
 // residual; using kDoubleEps = 1e-10 would false-reject valid incidences on
 // every prism/pyramid plane and collapse the mesh to its pyramid-only subset.
 constexpr double kIncidenceEpsD = static_cast<double>(math::kFloatEps);
-// Singularity threshold for double Cramer's rule: det of float-derived planes
-// scales with float input squared, so kDoubleEps is the right floor — only
-// truly degenerate (numerically zero) triples should be rejected.
-constexpr double kSingularDetD = 1e-10;
 
 bool FloatEqualZeroD(double a, double threshold = kIncidenceEpsD) {
   return std::fabs(a) < threshold;
@@ -725,27 +763,6 @@ double DiffNorm3D(const double* a, const double* b) {
   double dy = a[1] - b[1];
   double dz = a[2] - b[2];
   return std::sqrt(dx * dx + dy * dy + dz * dz);
-}
-
-bool SolvePlanesD(const double* c1, const double* c2, const double* c3, double* res) {
-  double det = c1[0] * c2[1] * c3[2] + c1[1] * c2[2] * c3[0] + c1[2] * c2[0] * c3[1] - c1[2] * c2[1] * c3[0] -
-               c1[0] * c2[2] * c3[1] - c1[1] * c2[0] * c3[2];
-  if (FloatEqualZeroD(det, kSingularDetD)) {
-    res[0] = std::numeric_limits<double>::quiet_NaN();
-    res[1] = std::numeric_limits<double>::quiet_NaN();
-    res[2] = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
-  double x = c1[3] * c2[2] * c3[1] + c1[1] * c2[3] * c3[2] + c1[2] * c2[1] * c3[3] -  //
-             c1[1] * c2[2] * c3[3] - c1[2] * c2[3] * c3[1] - c1[3] * c2[1] * c3[2];
-  double y = c1[0] * c2[2] * c3[3] + c1[2] * c2[3] * c3[0] + c1[3] * c2[0] * c3[2] -  //
-             c1[3] * c2[2] * c3[0] - c1[0] * c2[3] * c3[2] - c1[2] * c2[0] * c3[3];
-  double z = c1[3] * c2[1] * c3[0] + c1[0] * c2[3] * c3[1] + c1[1] * c2[0] * c3[3] -  //
-             c1[0] * c2[1] * c3[3] - c1[1] * c2[3] * c3[0] - c1[3] * c2[0] * c3[1];
-  res[0] = x / det;
-  res[1] = y / det;
-  res[2] = z / det;
-  return true;
 }
 
 bool IsInPolyhedron3D(int n, const double* coef, const double xyz[3], bool boundary = true) {
@@ -766,6 +783,57 @@ void WidenCoefToDouble(int plane_cnt, const float* coef_f, std::vector<double>& 
 }
 
 }  // namespace
+
+
+// Singularity threshold for the double-precision Cramer's rule, evaluated on
+// UNIT-NORMALIZED plane normals. After in-function normalization, det equals
+// sin(trihedral angle) and is bounded in [-1, 1], so the threshold measures
+// angular degeneracy independent of the caller's normal magnitudes (see
+// doc/numerical-robustness.md §2; task-solveplanes-det-normalization).
+// Calibrated against the wedge sweep in V3TestCrystal (60-89.9°):
+//   - spurious near-degenerate triples tail off below |det_norm| ≈ 1.6e-7
+//   - legitimate extreme-wedge triples have min|det_norm| ≈ 2.6e-6
+// 1e-6 sits inside that gap with ~6× margin to spurious, ~3× to legitimate.
+// Well above double rounding noise (~1e-16).
+constexpr double kSingularDetNormD = 1e-6;
+
+bool SolvePlanesD(const double* coef1, const double* coef2, const double* coef3, double* res) {
+  // Normalize each plane normal so the det is scale-invariant. The geometry
+  // generation pipeline (geo3d.cpp) feeds raw plane coefficients whose normal
+  // magnitudes can drift far from unity at extreme wedges, so a raw det
+  // threshold is ill-defined; after normalization det ∈ [-1, 1] regardless.
+  double mag1 = std::sqrt(coef1[0] * coef1[0] + coef1[1] * coef1[1] + coef1[2] * coef1[2]);
+  double mag2 = std::sqrt(coef2[0] * coef2[0] + coef2[1] * coef2[1] + coef2[2] * coef2[2]);
+  double mag3 = std::sqrt(coef3[0] * coef3[0] + coef3[1] * coef3[1] + coef3[2] * coef3[2]);
+  if (mag1 < kIncidenceEpsD || mag2 < kIncidenceEpsD || mag3 < kIncidenceEpsD) {
+    res[0] = std::numeric_limits<double>::quiet_NaN();
+    res[1] = std::numeric_limits<double>::quiet_NaN();
+    res[2] = std::numeric_limits<double>::quiet_NaN();
+    return false;
+  }
+  double c1[4]{ coef1[0] / mag1, coef1[1] / mag1, coef1[2] / mag1, coef1[3] / mag1 };
+  double c2[4]{ coef2[0] / mag2, coef2[1] / mag2, coef2[2] / mag2, coef2[3] / mag2 };
+  double c3[4]{ coef3[0] / mag3, coef3[1] / mag3, coef3[2] / mag3, coef3[3] / mag3 };
+
+  double det = c1[0] * c2[1] * c3[2] + c1[1] * c2[2] * c3[0] + c1[2] * c2[0] * c3[1] -  //
+               c1[2] * c2[1] * c3[0] - c1[0] * c2[2] * c3[1] - c1[1] * c2[0] * c3[2];
+  if (std::fabs(det) < kSingularDetNormD) {
+    res[0] = std::numeric_limits<double>::quiet_NaN();
+    res[1] = std::numeric_limits<double>::quiet_NaN();
+    res[2] = std::numeric_limits<double>::quiet_NaN();
+    return false;
+  }
+  double x = c1[3] * c2[2] * c3[1] + c1[1] * c2[3] * c3[2] + c1[2] * c2[1] * c3[3] -  //
+             c1[1] * c2[2] * c3[3] - c1[2] * c2[3] * c3[1] - c1[3] * c2[1] * c3[2];
+  double y = c1[0] * c2[2] * c3[3] + c1[2] * c2[3] * c3[0] + c1[3] * c2[0] * c3[2] -  //
+             c1[3] * c2[2] * c3[0] - c1[0] * c2[3] * c3[2] - c1[2] * c2[0] * c3[3];
+  double z = c1[3] * c2[1] * c3[0] + c1[0] * c2[3] * c3[1] + c1[1] * c2[0] * c3[3] -  //
+             c1[0] * c2[1] * c3[3] - c1[1] * c2[3] * c3[0] - c1[3] * c2[0] * c3[1];
+  res[0] = x / det;
+  res[1] = y / det;
+  res[2] = z / det;
+  return true;
+}
 
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -246,6 +246,26 @@ bool SolveLines(const float* coef1, const float* coef2, float* res);
 bool SolvePlanes(const float* coef1, const float* coef2, const float* coef3, float* res);
 
 /**
+ * @brief Double-precision variant of @ref SolvePlanes. Same semantics as the
+ *        float version (normalize plane normals internally → scale-invariant
+ *        singularity check on `sin(trihedral angle)`), with all arithmetic in
+ *        double. Used by the geometry-generation pipeline (`geo3d.cpp`
+ *        `FillHexCrystalCoef` apex/anti-apex solve) and by the double mesh
+ *        builder (`SolveConvexPolyhedronVtxD` / `CollectSurfaceVtxD`).
+ *        Single source of truth — no manual copy of this routine should live
+ *        in callers (see doc/numerical-robustness.md §4).
+ *
+ * @param coef1 Coefficients for 1st plane. [a, b, c, d]
+ * @param coef2 Coefficients for 2nd plane. [a, b, c, d]
+ * @param coef3 Coefficients for 3rd plane. [a, b, c, d]
+ * @param res Intersection point. [x, y, z]
+ * @return true Find the intersection.
+ * @return false No intersection (parallel or near-singular triple, or a
+ *         degenerate plane with zero-magnitude normal).
+ */
+bool SolvePlanesD(const double* coef1, const double* coef2, const double* coef3, double* res);
+
+/**
  * @brief Check if a 2D point locates **IN** a polygon. The polygon is defined by intersection of
  *        multiple half planes: a*x + b*y + c <= 0
  *

--- a/src/gui/crystal_renderer.cpp
+++ b/src/gui/crystal_renderer.cpp
@@ -126,7 +126,12 @@ static const char* const kFaceFS = R"glsl(
 in vec3 v_eye_pos;
 out vec4 frag_color;
 void main() {
-  vec3 n = normalize(cross(dFdx(v_eye_pos), dFdy(v_eye_pos)));
+  // Screen-space derivative normal degenerates on slivers/grazing views where
+  // dFdx,dFdy become near-parallel; clamp the cross magnitude so normalize
+  // doesn't propagate NaN into the lighting calc.
+  vec3 raw_n = cross(dFdx(v_eye_pos), dFdy(v_eye_pos));
+  float raw_len = length(raw_n);
+  vec3 n = (raw_len > 1e-6) ? raw_n / raw_len : vec3(0.0, 0.0, 1.0);
   // Ensure normal faces viewer (eye-space camera looks along -Z)
   if (n.z < 0.0) n = -n;
   // Light from upper-left-front in eye space

--- a/src/gui/face_number_overlay.cpp
+++ b/src/gui/face_number_overlay.cpp
@@ -85,23 +85,15 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
     float cy = (p0[1] + p1[1] + p2[1]) / 3.0f;
     float cz = (p0[2] + p1[2] + p2[2]) / 3.0f;
 
-    // Triangle normal = normalize(cross(p1 - p0, p2 - p0)).
-    // Note: we recompute from vertices rather than reusing
-    // LUMICE_CrystalMesh.edge_face_normals because the latter indexes by edge,
-    // not by triangle; there is no direct triangle-to-edge mapping exposed.
-    // Cost is negligible (<=128 triangles).
+    // Triangle normal contribution = cross(p1 - p0, p2 - p0). Modulus is 2×area
+    // so accumulating the un-normalized vector is implicit area weighting; one
+    // final normalization per label replaces the previous absolute-1e-12 per-
+    // triangle threshold and the bias toward the first triangle's plane.
     float e1[3] = { p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2] };
     float e2[3] = { p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2] };
     float nx = e1[1] * e2[2] - e1[2] * e2[1];
     float ny = e1[2] * e2[0] - e1[0] * e2[2];
     float nz = e1[0] * e2[1] - e1[1] * e2[0];
-    float len = nx * nx + ny * ny + nz * nz;
-    if (len > 1e-12f) {
-      float inv = 1.0f / std::sqrt(len);
-      nx *= inv;
-      ny *= inv;
-      nz *= inv;
-    }
 
     // Find existing label bucket.
     int slot = -1;
@@ -124,9 +116,9 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
       out_labels[slot].display_center[0] = 0.0f;
       out_labels[slot].display_center[1] = 0.0f;
       out_labels[slot].display_center[2] = 0.0f;
-      out_labels[slot].display_normal[0] = nx;
-      out_labels[slot].display_normal[1] = ny;
-      out_labels[slot].display_normal[2] = nz;
+      out_labels[slot].display_normal[0] = 0.0f;
+      out_labels[slot].display_normal[1] = 0.0f;
+      out_labels[slot].display_normal[2] = 0.0f;
       out_labels[slot].display_polygon_vertex_count = 0;
       tri_count[slot] = 0;
     }
@@ -134,6 +126,9 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
     out_labels[slot].display_center[0] += cx;
     out_labels[slot].display_center[1] += cy;
     out_labels[slot].display_center[2] += cz;
+    out_labels[slot].display_normal[0] += nx;
+    out_labels[slot].display_normal[1] += ny;
+    out_labels[slot].display_normal[2] += nz;
 
     // Dedup-append each triangle vertex into the per-face polygon bucket.
     AppendPolygonVertex(out_labels[slot], p0);
@@ -143,7 +138,7 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
     tri_count[slot]++;
   }
 
-  // Finalize means.
+  // Finalize means and normalize accumulated area-weighted normals.
   for (int k = 0; k < label_count; ++k) {
     int n = tri_count[k];
     if (n > 1) {
@@ -152,6 +147,17 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
       out_labels[k].display_center[1] *= inv;
       out_labels[k].display_center[2] *= inv;
     }
+    float* nrm = out_labels[k].display_normal;
+    float nlen = std::sqrt(nrm[0] * nrm[0] + nrm[1] * nrm[1] + nrm[2] * nrm[2]);
+    if (nlen > 1e-6f) {
+      nrm[0] /= nlen;
+      nrm[1] /= nlen;
+      nrm[2] /= nlen;
+    } else {
+      nrm[0] = 0.0f;
+      nrm[1] = 0.0f;
+      nrm[2] = 0.0f;
+    }
   }
 
   return label_count;
@@ -159,8 +165,8 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
 
 int AggregateFaceLabelsFromTopology(const float* vertices, int vertex_count, int face_count,
                                     const int* face_numbers_by_face, const int* face_vtx_offsets,
-                                    const int* face_vtx_counts, const int* face_vtx_pool, FaceLabel* out_labels,
-                                    int max_labels) {
+                                    const int* face_vtx_counts, const int* face_vtx_pool, const float* face_normals,
+                                    FaceLabel* out_labels, int max_labels) {
   int label_count = 0;
   for (int fi = 0; fi < face_count && label_count < max_labels; ++fi) {
     int fn = face_numbers_by_face[fi];
@@ -203,30 +209,13 @@ int AggregateFaceLabelsFromTopology(const float* vertices, int vertex_count, int
       label.display_center[2] *= inv;
     }
 
-    // Face normal from first 3 vertices (CCW-ordered by FillPerFaceTopology)
-    if (label.display_polygon_vertex_count >= 3) {
-      const float* p0 = label.display_polygon_verts;
-      const float* p1 = label.display_polygon_verts + 3;
-      const float* p2 = label.display_polygon_verts + 6;
-      float e1[3] = { p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2] };
-      float e2[3] = { p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2] };
-      float nx = e1[1] * e2[2] - e1[2] * e2[1];
-      float ny = e1[2] * e2[0] - e1[0] * e2[2];
-      float nz = e1[0] * e2[1] - e1[1] * e2[0];
-      float len = std::sqrt(nx * nx + ny * ny + nz * nz);
-      if (len > 1e-12f) {
-        nx /= len;
-        ny /= len;
-        nz /= len;
-      }
-      label.display_normal[0] = nx;
-      label.display_normal[1] = ny;
-      label.display_normal[2] = nz;
-    } else {
-      label.display_normal[0] = 0.0f;
-      label.display_normal[1] = 0.0f;
-      label.display_normal[2] = 0.0f;
-    }
+    // Face normal: read the pre-computed area-weighted unit normal at slot fi
+    // (lockstep with face_numbers_by_face[fi] / face_vtx_offsets[fi]). Replaces
+    // the previous GUI-side first-3-vertices cross product (absolute 1e-12
+    // threshold + biased multi-triangle faces toward the first triangle plane).
+    label.display_normal[0] = face_normals[fi * 3 + 0];
+    label.display_normal[1] = face_normals[fi * 3 + 1];
+    label.display_normal[2] = face_normals[fi * 3 + 2];
 
     ++label_count;
   }
@@ -389,7 +378,10 @@ bool ProjectLabelToScreen(const FaceLabel* label, const float rotation[16], cons
   float cx = mvp[0] * p[0] + mvp[4] * p[1] + mvp[8] * p[2] + mvp[12];
   float cy = mvp[1] * p[0] + mvp[5] * p[1] + mvp[9] * p[2] + mvp[13];
   float cw = mvp[3] * p[0] + mvp[7] * p[1] + mvp[11] * p[2] + mvp[15];
-  if (cw == 0.0f) {
+  // Near-singular guard: exact equality misses the cases that actually cause
+  // overflow/NaN downstream (cw within float epsilon of zero). 1e-6f matches
+  // the shader cross-magnitude clamp in crystal_renderer.cpp.
+  if (std::abs(cw) < 1e-6f) {
     return false;
   }
 
@@ -434,7 +426,7 @@ void DrawFaceNumberOverlay(const LUMICE_CrystalMesh* mesh, const float rotation[
   if (mesh->face_count > 0) {
     n = AggregateFaceLabelsFromTopology(mesh->vertices, mesh->vertex_count, mesh->face_count,
                                         mesh->face_numbers_by_face, mesh->face_vtx_offsets, mesh->face_vtx_counts,
-                                        mesh->face_vtx_pool, labels, kMaxFaceLabels);
+                                        mesh->face_vtx_pool, mesh->face_normals, labels, kMaxFaceLabels);
   } else {
     n = AggregateFaceLabels(mesh->vertices, mesh->vertex_count, mesh->triangles, mesh->triangle_count,
                             mesh->face_numbers, labels, kMaxFaceLabels);

--- a/src/gui/face_number_overlay.hpp
+++ b/src/gui/face_number_overlay.hpp
@@ -39,11 +39,14 @@ int AggregateFaceLabels(const float* vertices, int vertex_count, const int* tria
 
 // Aggregate per-face topology (from LUMICE_GetCrystalMesh new fields) into FaceLabel array.
 // Vertices are already CCW-ordered in face_vtx_pool; skips faces with face_numbers_by_face <= 0.
+// `face_normals` is the area-weighted unit normal array
+// (LUMICE_CrystalMesh::face_normals), lockstep with face_numbers_by_face/face_vtx_offsets;
+// non-nullable.
 // Returns the number of labels written.
 int AggregateFaceLabelsFromTopology(const float* vertices, int vertex_count, int face_count,
                                     const int* face_numbers_by_face, const int* face_vtx_offsets,
-                                    const int* face_vtx_counts, const int* face_vtx_pool, FaceLabel* out_labels,
-                                    int max_labels);
+                                    const int* face_vtx_counts, const int* face_vtx_pool, const float* face_normals,
+                                    FaceLabel* out_labels, int max_labels);
 
 // Per-CrystalStyle face-number rendering policy.
 // `visible_*` colors apply to front-facing labels; `hidden_*` apply to back-

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -320,6 +320,10 @@ typedef struct LUMICE_CrystalMesh_ {
   int face_vtx_offsets[LUMICE_MAX_CRYSTAL_FACES];
   int face_vtx_counts[LUMICE_MAX_CRYSTAL_FACES];
   int face_vtx_pool[LUMICE_MAX_CRYSTAL_FACE_VTXPOOL];
+  // Area-weighted unit-length face normals, lockstep with face_numbers_by_face /
+  // face_vtx_offsets / face_vtx_counts: slot [i*3..i*3+2] is the unit normal of
+  // face i for i in [0, face_count). Slots beyond face_count are unspecified.
+  float face_normals[LUMICE_MAX_CRYSTAL_FACES * 3];
 } LUMICE_CrystalMesh;
 
 LUMICE_ErrorCode LUMICE_GetCrystalMesh(LUMICE_Server* server, const char* crystal_json, LUMICE_CrystalMesh* out);

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -981,6 +981,38 @@ static void FillPerFaceTopology(const int* tri, int tri_cnt, const float* vtx, c
       out->face_vtx_pool[pool_offset + k] = unique_verts[k];
     }
     pool_offset += count;
+
+    // Phase B: area-weighted unit-length normal at position `fi`, lockstep with
+    // face_numbers_by_face[fi] / face_vtx_offsets[fi] / face_vtx_counts[fi].
+    // Accumulating un-normalized cross products gives an implicit 2*area weight
+    // per triangle; normalize once at the end. Avoids the GUI's previous
+    // first-triangle-only normal (biased on multi-triangle faces) and the
+    // absolute 1e-12 cross-magnitude threshold.
+    float acc_n[3] = { 0.0f, 0.0f, 0.0f };
+    for (int t = 0; t < tri_cnt; ++t) {
+      if (face_numbers_per_tri[t] != fn) {
+        continue;
+      }
+      const float* a = vtx + tri[t * 3 + 0] * 3;
+      const float* b = vtx + tri[t * 3 + 1] * 3;
+      const float* c = vtx + tri[t * 3 + 2] * 3;
+      float ea[3] = { b[0] - a[0], b[1] - a[1], b[2] - a[2] };
+      float eb[3] = { c[0] - a[0], c[1] - a[1], c[2] - a[2] };
+      acc_n[0] += ea[1] * eb[2] - ea[2] * eb[1];
+      acc_n[1] += ea[2] * eb[0] - ea[0] * eb[2];
+      acc_n[2] += ea[0] * eb[1] - ea[1] * eb[0];
+    }
+    float acc_len = std::sqrt(acc_n[0] * acc_n[0] + acc_n[1] * acc_n[1] + acc_n[2] * acc_n[2]);
+    if (acc_len > 1e-6f) {
+      out->face_normals[fi * 3 + 0] = acc_n[0] / acc_len;
+      out->face_normals[fi * 3 + 1] = acc_n[1] / acc_len;
+      out->face_normals[fi * 3 + 2] = acc_n[2] / acc_len;
+    } else {
+      out->face_normals[fi * 3 + 0] = 0.0f;
+      out->face_normals[fi * 3 + 1] = 0.0f;
+      out->face_normals[fi * 3 + 2] = 0.0f;
+    }
+
     ++fi;
   }
 

--- a/test/gui/functional/test_gui_face_number_overlay.cpp
+++ b/test/gui/functional/test_gui_face_number_overlay.cpp
@@ -725,7 +725,7 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
                                       mesh.face_numbers, labels_old, lumice::gui::kMaxFaceLabels);
       int n_new = lumice::gui::AggregateFaceLabelsFromTopology(
           mesh.vertices, mesh.vertex_count, mesh.face_count, mesh.face_numbers_by_face, mesh.face_vtx_offsets,
-          mesh.face_vtx_counts, mesh.face_vtx_pool, labels_new, lumice::gui::kMaxFaceLabels);
+          mesh.face_vtx_counts, mesh.face_vtx_pool, mesh.face_normals, labels_new, lumice::gui::kMaxFaceLabels);
 
       IM_CHECK_EQ(n_old, n_new);
       IM_CHECK_EQ(n_old, mesh.face_count);

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <fstream>
 #include <limits>
+#include <set>
 #include <utility>
 
 #include "config/config_manager.hpp"
@@ -27,6 +28,21 @@ class V3TestCrystal : public ::testing::Test {
 
   nlohmann::json config_json_;
 };
+
+const std::set<int> kExpectedUpper = { 13, 14, 15, 16, 17, 18 };
+const std::set<int> kExpectedLower = { 23, 24, 25, 26, 27, 28 };
+
+// Returns the set of fn values in [lo..hi] across all polygon faces of c.
+std::set<int> CollectFnSet(const Crystal& c, int lo, int hi) {
+  std::set<int> fns;
+  for (size_t p = 0; p < c.PolygonFaceCount(); p++) {
+    int fn = static_cast<int>(c.GetFn(static_cast<IdType>(p)));
+    if (fn >= lo && fn <= hi) {
+      fns.insert(fn);
+    }
+  }
+  return fns;
+}
 
 TEST_F(V3TestCrystal, CrystalCacheData) {
   auto crystal = Crystal::CreatePrism(1.3);
@@ -598,5 +614,73 @@ TEST_F(V3TestCrystal, PrismHZeroNoLeftoverPrismOrBasal) {
 // flips at wedge = 87.44 deg) is now permanently guarded by
 // `PyramidWedgeSweepNoFalseBasal` above. The raw sweep data lives in
 // scratchpad/task-geometry-gen-numerical-robustness/progress.md (2026-06-19 entry).
+
+// task-280.2 fillhexfnmap-extreme-sentinel — Sentinel A:
+// At extreme wedge (89.0/89.5 deg) full pyramid (h1=0.3, h2=1.0, h3=0.3), the
+// 20 polygon faces must yield Fn sets exactly {13..18} (upper) and {23..28}
+// (lower). Detection power: with first-match instead of argmax in
+// FillHexFnMap's pri loop, a face whose normal aligns with ref_j=4 (60 deg)
+// would still satisfy Dot3(n, ref_3) = cos(89 deg) * cos(60 deg) ~ 0.0087 >
+// kFloatEps and be claimed by j=3, collapsing fn=14 into fn=13 -- the set
+// equality below would fail. The explicit size()==6 assertion makes the
+// 6-fold completeness intent obvious in failure output.
+TEST_F(V3TestCrystal, FillHexFnMapExtremeWedgeFullPyramidSixFold) {
+  for (float wedge : { 89.0f, 89.5f }) {
+    auto c = Crystal::CreatePyramid(wedge, wedge, 0.3f, 1.0f, 0.3f);
+    ASSERT_EQ(c.PolygonFaceCount(), 20u) << "wedge=" << wedge;
+    auto upper = CollectFnSet(c, 13, 18);
+    auto lower = CollectFnSet(c, 23, 28);
+    EXPECT_EQ(upper.size(), 6u) << "upper fn count wedge=" << wedge;
+    EXPECT_EQ(lower.size(), 6u) << "lower fn count wedge=" << wedge;
+    EXPECT_EQ(upper, kExpectedUpper) << "upper fn set wedge=" << wedge;
+    EXPECT_EQ(lower, kExpectedLower) << "lower fn set wedge=" << wedge;
+  }
+}
+
+// task-280.2 Sentinel B: extreme wedge bipyramid (prism_h=0) at 89.0/89.5 deg
+// fills the 1-deg gap left by PrismHZeroNoLeftoverPrismOrBasal (sweeps 60..88
+// deg) and PyramidWedgeSweepNoFalseBasal (sweeps to 89.9 deg but only checks
+// fn != 1/2). This asserts full 6-fold completeness of the Fn allocation.
+TEST_F(V3TestCrystal, FillHexFnMapExtremeWedgeBipyramidSixFold) {
+  const float dist[6]{ 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+  for (float wedge : { 89.0f, 89.5f }) {
+    auto c = Crystal::CreatePyramid(wedge, wedge, 1.0f, 0.0f, 1.0f, dist);
+    ASSERT_EQ(c.PolygonFaceCount(), 12u) << "wedge=" << wedge;
+    auto upper = CollectFnSet(c, 13, 18);
+    auto lower = CollectFnSet(c, 23, 28);
+    EXPECT_EQ(upper.size(), 6u) << "upper fn count bipyramid wedge=" << wedge;
+    EXPECT_EQ(lower.size(), 6u) << "lower fn count bipyramid wedge=" << wedge;
+    EXPECT_EQ(upper, kExpectedUpper) << "upper fn set bipyramid wedge=" << wedge;
+    EXPECT_EQ(lower, kExpectedLower) << "lower fn set bipyramid wedge=" << wedge;
+  }
+}
+
+// task-280.2 Sentinel C: multi-Miller-axis pyramid coverage. Fn allocation
+// must not depend on the specific alpha implied by Miller (i1, i4). Covers
+// four axes at temperate wedge angles where geometry generation is robust.
+TEST_F(V3TestCrystal, FillHexFnMapMillerAxisPyramidSixFold) {
+  const float dist[6]{ 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+  struct MillerCase {
+    int i1;
+    int i4;
+    const char* label;
+  };
+  const MillerCase cases[] = {
+    { 1, 1, "(1,1)" },
+    { 1, 2, "(1,2)" },
+    { 2, 1, "(2,1)" },
+    { 3, 2, "(3,2)" },
+  };
+  for (const auto& mc : cases) {
+    auto c = Crystal::CreatePyramid(mc.i1, mc.i4, mc.i1, mc.i4, 0.3f, 1.0f, 0.3f, dist);
+    ASSERT_EQ(c.PolygonFaceCount(), 20u) << "miller=" << mc.label;
+    auto upper = CollectFnSet(c, 13, 18);
+    auto lower = CollectFnSet(c, 23, 28);
+    EXPECT_EQ(upper.size(), 6u) << "upper fn count miller=" << mc.label;
+    EXPECT_EQ(lower.size(), 6u) << "lower fn count miller=" << mc.label;
+    EXPECT_EQ(upper, kExpectedUpper) << "upper fn set miller=" << mc.label;
+    EXPECT_EQ(lower, kExpectedLower) << "lower fn set miller=" << mc.label;
+  }
+}
 
 }  // namespace

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -683,4 +683,41 @@ TEST_F(V3TestCrystal, FillHexFnMapMillerAxisPyramidSixFold) {
   }
 }
 
+// task-280.6 zero-volume degenerate-crystal guard: when prism_h=0 collides with
+// wedge > kMaxPyramidAlpha (89.9 deg), both pyramidal caps are dropped, leaving
+// upper/lower basal faces at z=0 — a zero-thickness hexagon. Without the guard
+// in FillHexCrystalCoef, Triangulate's Vec3FromTo(body_center, face_center)
+// collapses to (0,0,0) and Normalize3 returns NaN (explore-280.3 reproduce).
+// Detection power: removing the guard makes c.TotalTriangles() > 0 while
+// face normals contain NaN — both branches of the EXPECT below would flip.
+TEST_F(V3TestCrystal, FillHexCrystalCoefZeroVolumeGuardNoNan) {
+  const float dist[6]{ 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+
+  // Issue scenario: wedge=89.95° (> 89.9° kMaxPyramidAlpha) + prism_h=0 → guard
+  // trips → empty crystal (TotalTriangles=0), no NaN normals.
+  auto c = Crystal::CreatePyramid(89.95f, 89.95f, 1.0f, 0.0f, 1.0f, dist);
+  EXPECT_EQ(c.TotalTriangles(), 0u) << "zero-volume guard should yield empty crystal, not NaN-poisoned mesh";
+
+  // Regression: normal pyramid (prism_h>0, wedge=60°) must be unaffected.
+  auto c_normal = Crystal::CreatePyramid(60.0f, 60.0f, 1.0f, 1.0f, 1.0f, dist);
+  ASSERT_GT(c_normal.TotalTriangles(), 0u);
+  const float* face_n = c_normal.GetTriangleNormal();
+  for (size_t i = 0; i < c_normal.TotalTriangles() * 3; i++) {
+    EXPECT_FALSE(std::isnan(face_n[i])) << "normal pyramid triangle " << (i / 3) << " has NaN normal";
+  }
+
+  // Edge case: wedge=89.9° (exactly at kMaxPyramidAlpha, pyramidal caps NOT
+  // dropped per "alpha <= 89.9" condition) with prism_h=0. Per explore-280.3
+  // wedge ≤ 89.9° is safe at any prism_h, so geometry should still build.
+  // Accept either outcome (guard fires or not), but if any triangles exist,
+  // their normals must be finite — that is the real invariant we care about.
+  auto c_boundary = Crystal::CreatePyramid(89.9f, 89.9f, 1.0f, 0.0f, 1.0f, dist);
+  if (c_boundary.TotalTriangles() > 0u) {
+    const float* bn = c_boundary.GetTriangleNormal();
+    for (size_t i = 0; i < c_boundary.TotalTriangles() * 3; i++) {
+      EXPECT_FALSE(std::isnan(bn[i])) << "boundary wedge=89.9° triangle " << (i / 3) << " has NaN normal";
+    }
+  }
+}
+
 }  // namespace

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -246,6 +246,74 @@ TEST(CrystalMeshApi, PerFaceVertexOrderCCW) {
   EXPECT_GT(winding_sum, 0.0f) << "basal face vertices not in CCW order";
 }
 
+// =============== Per-face area-weighted normal tests ===============
+
+TEST(CrystalMeshApi, FaceNormalsUnitLengthPrism) {
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "prism", "shape": {"height": 1.0}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+  ASSERT_GT(mesh.face_count, 0);
+
+  for (int fi = 0; fi < mesh.face_count; ++fi) {
+    int fn = mesh.face_numbers_by_face[fi];
+    const float* n = mesh.face_normals + fi * 3;
+    float len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    EXPECT_NEAR(len, 1.0f, 1e-5f) << "face fi=" << fi << " (fn=" << fn << ") normal not unit length (len=" << len
+                                  << ")";
+  }
+}
+
+TEST(CrystalMeshApi, FaceNormalsOutwardPrism) {
+  // Each face normal must point outward from the face centroid: dot(n, centroid - origin) > 0
+  // for centered hex prism geometry.
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "prism", "shape": {"height": 1.0}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+  ASSERT_GT(mesh.face_count, 0);
+
+  for (int fi = 0; fi < mesh.face_count; ++fi) {
+    int fn = mesh.face_numbers_by_face[fi];
+    int offset = mesh.face_vtx_offsets[fi];
+    int count = mesh.face_vtx_counts[fi];
+    ASSERT_GT(count, 0);
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    for (int k = 0; k < count; ++k) {
+      const float* p = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+      cx += p[0];
+      cy += p[1];
+      cz += p[2];
+    }
+    cx /= count;
+    cy /= count;
+    cz /= count;
+
+    const float* n = mesh.face_normals + fi * 3;
+    float dot = n[0] * cx + n[1] * cy + n[2] * cz;
+    EXPECT_GT(dot, 0.0f) << "face fi=" << fi << " (fn=" << fn << ") normal not outward (dot=" << dot << ")";
+  }
+}
+
+TEST(CrystalMeshApi, FaceNormalsUnitLengthExtremePyramid) {
+  // Extreme-wedge pyramid (close to the catalog-G regime that motivated this task).
+  // Covers lower-pyramidal face numbers (23-28), which exceed LUMICE_MAX_CRYSTAL_FACES=24
+  // — exercising the position-based (fi) indexing rather than fn-value indexing.
+  LUMICE_CrystalMesh mesh{};
+  const char* json = R"({"type": "pyramid", "shape": {"prism_h": 0.01, "upper_h": 0.5, "lower_h": 0.5,
+                            "upper_wedge_angle": 87.0, "lower_wedge_angle": 87.0}})";
+  ASSERT_EQ(LUMICE_GetCrystalMesh(nullptr, json, &mesh), LUMICE_OK);
+  ASSERT_GT(mesh.face_count, 0);
+
+  for (int fi = 0; fi < mesh.face_count; ++fi) {
+    int fn = mesh.face_numbers_by_face[fi];
+    const float* n = mesh.face_normals + fi * 3;
+    float len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    EXPECT_NEAR(len, 1.0f, 1e-5f) << "extreme pyramid fi=" << fi << " (fn=" << fn << ") normal len=" << len;
+  }
+}
+
 TEST(CrystalMeshApi, PerFacePoolBoundary) {
   LUMICE_CrystalMesh mesh{};
   const char* json = R"({"type": "pyramid", "shape": {"prism_h": 1.0, "upper_h": 0.5, "lower_h": 0.5}})";


### PR DESCRIPTION
## Summary

Lands the explore-279 numerical-robustness audit hardening backlog (scrum-geometry-numerical-hardening, tasks 280.2/280.4/280.5/280.6). Preventive hardening of the "absolute-epsilon tolerance on scale-variant geometry" failure mode shared by task-275~278. Doc guardrail (280.1) already merged via #136.

## Commits

- `de0779c5` **test(crystal)**: FillHexFnMap extreme-wedge (89°+) & Miller-axis 6-fold sentinels — closes the 88°-only gap from task-278 (zero production change)
- `0e69bc19` **fix(core)**: SolvePlanes det normalization (entry-normalized normals + absolute threshold, scheme b) + lift `SolvePlanesD` as single source of truth + eliminate geo3d inline copy. Threshold 1e-6 (16.7× gap)
- `fddf6fe4` **fix(gui)**: area-weighted face normals (via C API `face_normals[fi*3]`) + shader cross NaN clamp + perspective-divide guard (P2 display)
- `d6fea472` **fix(core)**: zero-volume crystal guard in `FillHexCrystalCoef` — closes a reachable `Normalize3(0,0,0)=NaN` path found by explore-280.3 (prism_h=0 ∧ wedge>89.9°)

## Key finding (explore-280.3)

Pushing the wedge sweep past the existing `kMaxPyramidAlpha=89.9°` guard revealed a **config-reachable** NaN: `prism_h=0 ∧ wedge>89.9°` collapses to a zero-thickness hexagon → `Normalize3(0,0,0)`. Fixed in 280.6 (now returns empty crystal + warning, aligned with the existing degradation paradigm). Also confirmed `Rotation(from,to)` divide-by-theta is dead code (no callers) — left unguarded by design.

## Verification

- unit-correctness 572→575, parity, golden-analytic all green; e2e `pytest` 44 passed / 1 skipped
- Reverse-detection power demonstrated for the new sentinels/guards
- Normal crystals (prism_h>0 / wedge≤89.9°): bit-identical physical output; only extreme-degenerate domain changed

## Deferred

- Extreme-flat GUI label-orientation manual visual check (needs display server; unit tests cover extreme-geometry normal unit-length/outwardness)
- A7 `Rotation(from,to)` dead-code cleanup → backlog
- Absolute-eps lint gate → backlog (value/design not established)

🤖 Generated with [Claude Code](https://claude.com/claude-code)