### PR TITLE
feat(gui): runtime backend-availability gate for Metal checkbox

### DIFF
--- a/src/core/metal_trace_backend.hpp
+++ b/src/core/metal_trace_backend.hpp
@@ -23,10 +23,13 @@ namespace lumice {
 
 class Logger;
 
-// Runtime probe for Metal device availability. Returns true iff
-// MTLCreateSystemDefaultDevice() succeeds. Result is cached after the first
-// call (std::call_once), so subsequent calls are a plain memory read; safe
-// to call from any thread. Has no side effects on the cached result besides
+// Runtime probe for Metal device availability. Returns true iff a Metal device
+// is present: first tries MTLCreateSystemDefaultDevice(), and if that is nil
+// falls back to MTLCopyAllDevices() being non-empty (mirrors EnsureDevice's
+// two-step probe; on some Macs the default-device query can return nil while
+// MTLCopyAllDevices still enumerates a usable device). Result is cached after
+// the first call (std::call_once), so subsequent calls are a plain memory read;
+// safe to call from any thread. Has no side effects on the cached result besides
 // the one-time probe — distinct from MetalTraceBackend::Impl::EnsureDevice,
 // which asserts on failure and retains the device reference.
 bool MetalDeviceAvailable();

--- a/src/core/metal_trace_backend.hpp
+++ b/src/core/metal_trace_backend.hpp
@@ -23,6 +23,14 @@ namespace lumice {
 
 class Logger;
 
+// Runtime probe for Metal device availability. Returns true iff
+// MTLCreateSystemDefaultDevice() succeeds. Result is cached after the first
+// call (std::call_once), so subsequent calls are a plain memory read; safe
+// to call from any thread. Has no side effects on the cached result besides
+// the one-time probe — distinct from MetalTraceBackend::Impl::EnsureDevice,
+// which asserts on failure and retains the device reference.
+bool MetalDeviceAvailable();
+
 // MetalLayerHandle — the only host-visible scalar produced per TraceLayer is
 // the continuation count (populated from a 4-byte device readback, equivalent
 // to a 4-byte cudaMemcpy for CUDA backends). Continuation ray buffers

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 #include <variant>
@@ -1251,6 +1252,30 @@ float ComputeJacobianEnvelopeForDeviceGen(const Distribution& dist) {
 }
 
 }  // namespace
+
+bool MetalDeviceAvailable() {
+  static std::once_flag flag;
+  static bool available = false;
+  std::call_once(flag, []() {
+    @autoreleasepool {
+      // Mirror EnsureDevice's two-step probe: MTLCreateSystemDefaultDevice can
+      // return nil on otherwise Metal-capable Macs in certain environments
+      // (e.g. some headless / login-class contexts on M-series chips), while
+      // MTLCopyAllDevices still enumerates the integrated GPU. Treating only
+      // the system-default probe as authoritative would gate the GUI checkbox
+      // off in those environments even though the Metal backend itself runs
+      // fine via the same fallback in EnsureDevice.
+      id<MTLDevice> probe = MTLCreateSystemDefaultDevice();
+      if (probe == nil) {
+        NSArray<id<MTLDevice>>* all = MTLCopyAllDevices();
+        available = (all.count > 0);
+      } else {
+        available = true;
+      }
+    }
+  });
+  return available;
+}
 
 struct MetalTraceBackend::Impl {
   Impl() {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -941,11 +941,17 @@ void RenderSceneControls(GuiState& state) {
   // topologies, so the server is rebuilt and the accumulated image resets on toggle.
   // Falls back to CPU silently if the active config is not Metal-compatible
   // (see MetalTraceBackend::IsCompatible).
+  // Runtime gate: hide the checkbox entirely on Macs without a Metal device
+  // (very old hardware / certain remote sessions / broken GPU drivers), since
+  // selecting it would otherwise hit a nil device in EnsureDevice. The probe
+  // is cached, so the per-frame cost is a plain memory read.
   // ImGui::Checkbox renders its label to the right and ignores the item-width
   // stack, so no PushItemWidth wrapper is needed here.
-  DIRTY_IF(ImGui::Checkbox("Use Metal GPU", &state.use_metal_backend));
-  if (ImGui::IsItemHovered()) {
-    ImGui::SetTooltip("Use Metal GPU for simulation (falls back to CPU if incompatible)");
+  if (LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL)) {
+    DIRTY_IF(ImGui::Checkbox("Use Metal GPU", &state.use_metal_backend));
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("Use Metal GPU for simulation (falls back to CPU if incompatible)");
+    }
   }
 #endif
 }

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -414,6 +414,18 @@ LUMICE_ErrorCode LUMICE_XyzToSrgbUint8(const float* xyz_in, unsigned char* out, 
 // On non-Apple platforms LUMICE_BACKEND_METAL is silently treated as CPU.
 void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend);
 
+// Query whether a trace backend is available on this machine at runtime.
+//   backend = LUMICE_BACKEND_CPU   : always returns 1.
+//   backend = LUMICE_BACKEND_METAL : returns 1 iff Apple build AND a Metal
+//                                    device is present at runtime; 0 otherwise
+//                                    (non-Apple, or Mac without Metal device).
+//   other values                   : returns 0.
+// Result is cached after the first call; safe to call from any thread and from
+// per-frame GUI code.
+// To add a new backend (e.g. CUDA): append LUMICE_BACKEND_CUDA above and add a
+// matching branch here; CPU / Metal semantics are unchanged.
+int LUMICE_IsBackendAvailable(int backend);
+
 #if !defined(_MSC_VER)
 #pragma GCC visibility pop
 #endif

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -13,6 +13,9 @@
 #include "config/render_config.hpp"
 #include "core/crystal.hpp"
 #include "core/geo3d.hpp"
+#if defined(__APPLE__)
+#include "core/metal_trace_backend.hpp"
+#endif
 #include "include/lumice.h"
 #include "server/server.hpp"
 #include "util/callback_sink.hpp"
@@ -835,6 +838,23 @@ void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend) {
     return;
   }
   server->server_->SetPreferredBackend(backend);
+}
+
+
+int LUMICE_IsBackendAvailable(int backend) {
+  try {
+    if (backend == LUMICE_BACKEND_CPU) {
+      return 1;
+    }
+#if defined(__APPLE__)
+    if (backend == LUMICE_BACKEND_METAL) {
+      return lumice::MetalDeviceAvailable() ? 1 : 0;
+    }
+#endif
+    return 0;
+  } catch (...) {
+    return 0;
+  }
 }
 
 

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1172,3 +1172,30 @@ TEST(MaxFovApi, DefaultIs360) {
   EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_DUAL_FISHEYE_STEREOGRAPHIC), 360.0f, 0.01f);
   EXPECT_NEAR(LUMICE_MaxFov(LUMICE_LENS_RECTANGULAR), 360.0f, 0.01f);
 }
+
+TEST(BackendAvailabilityApi, CpuAlwaysAvailable) {
+  EXPECT_EQ(LUMICE_IsBackendAvailable(LUMICE_BACKEND_CPU), 1);
+}
+
+TEST(BackendAvailabilityApi, UnknownBackendReturnsZero) {
+  EXPECT_EQ(LUMICE_IsBackendAvailable(999), 0);
+  EXPECT_EQ(LUMICE_IsBackendAvailable(-1), 0);
+}
+
+TEST(BackendAvailabilityApi, MetalMatchesPlatform) {
+#if defined(__APPLE__)
+  // CI/dev Macs are expected to support Metal (any M-series or post-2012
+  // Intel Mac). If this assertion ever fires in a future environment without
+  // a Metal device, guard the EXPECT with a runtime probe or mark DISABLED.
+  EXPECT_EQ(LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL), 1);
+#else
+  EXPECT_EQ(LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL), 0);
+#endif
+}
+
+TEST(BackendAvailabilityApi, CachedAcrossCalls) {
+  const int kFirst = LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL);
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL), kFirst);
+  }
+}


### PR DESCRIPTION
## 背景
发版前兼容性收口。GUI 的 "Use Metal GPU" checkbox 此前只有编译期 `#if defined(__APPLE__)` 守卫，没有运行时 Metal 设备可用性检查。在无 Metal 设备的 Mac（极老硬件 / 不支持 Metal 的虚拟机或远程桌面 / GPU 驱动异常）上 checkbox 照常出现，勾选后进入 `MetalTraceBackend::EnsureDevice()`，`MTLCreateSystemDefaultDevice()` 返回 nil → Debug 下 assert 崩溃、Release 下对 nil device 发指令行为未定义。

## 改动
- **C API**：新增 `int LUMICE_IsBackendAvailable(int backend)`，复用现有 `LUMICE_BACKEND_*` 枚举（不引入第二套 `LUMICE_GPU_DEVICE_*` 编号）。`CPU`→恒 1；`METAL`→Apple 构建且运行时存在 Metal 设备才为 1；未知值/非 Apple→0。注释写明未来 CUDA 扩展方式。
- **core**：`MetalDeviceAvailable()`，`std::call_once` 缓存探测，无副作用、不 assert（区别于会崩的 `EnsureDevice`）；含 `MTLCopyAllDevices` 后备分支（本机 M2 Max 实测：某些会话下 `MTLCreateSystemDefaultDevice` 返回 nil 而 `MTLCopyAllDevices` 仍返回有效设备）。
- **GUI**：`panels.cpp` checkbox 改为 `#if defined(__APPLE__)` 且 `LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL)` 为真才渲染，保持 GUI→C API→core 边界纪律。
- **测试**：4 个新单元测试（CPU 恒 1 / 未知值 0 / Metal 平台一致性 / 缓存稳定）。

## 效果
三个场景全部收口：Windows/Linux 无 checkbox、无 Metal 设备的 Mac 无 checkbox、有 Metal 的 Mac 正常显示。原 Release 下未定义行为路径被封堵。

## 验证
- Release 构建通过
- 580 单元测试全绿（含 4 新用例）
- GUI build 3 个 ctest target 全绿
- \`pytest -v\`：44 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)