### PR TITLE
fix(task-284): max_hits>15 CPU crash (EmplaceBack arena dup) + no-truncation exit-seam

### DIFF
--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -180,6 +180,21 @@ void RayBuffer::EmplaceBack(RaySeg r, const RaypathRecorder& rec) {
   }
 }
 
+void RayBuffer::EmplaceBack(RaySeg r, const RaypathRecorder& rec, const RayBuffer& arena_src) {
+  // N4 invariant gate (Debug only).
+  assert(r.IsValidComplete());
+  // PRECONDITION: when rec.HasOverflow(), rec.overflow_idx_ must index into
+  // arena_src.overflow_arena_. DupOverflowSlot will then clone that slot into
+  // *this*'s arena and re-route the dst recorder's overflow_idx_. For inline
+  // recorders the arena_src parameter is ignored (DupOverflowSlot no-ops).
+  if (size_ + 1 < capacity_) {
+    rays_[size_] = r;
+    recorders_[size_] = rec;
+    DupOverflowSlot(arena_src, size_);
+    size_++;
+  }
+}
+
 void RayBuffer::EmplaceBack(const RayBuffer& buffer, size_t start, size_t len) {
   // Note: batch condition is `size_ < capacity_` (can fill the last slot);
   // single-ray version uses `size_ + 1 < capacity_` (always leaves one empty).

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -76,7 +76,15 @@ struct RayBuffer {
   // to gate the N4 construction-time invariants (Debug only; noop in Release).
   // Buffer-to-buffer overload below is internal data movement and skips this
   // gate — its inputs were already validated when first emplaced.
+  //
+  // The 2-arg overload accepts ONLY inline recorders (asserts !rec.HasOverflow()).
+  // Overflow-capable recorders MUST use the 3-arg overload below, which carries
+  // the arena source so DupOverflowSlot can clone the slot into *this*. The
+  // unguarded 2-arg call on an overflow recorder used to silently copy
+  // overflow_idx_ pointing into the foreign arena, then null-deref on the next
+  // RecorderFanOut/DupOverflowSlot (root cause of the max_hits>15 crash).
   void EmplaceBack(RaySeg r, const RaypathRecorder& rec);
+  void EmplaceBack(RaySeg r, const RaypathRecorder& rec, const RayBuffer& arena_src);
   void EmplaceBack(const RayBuffer& buffer, size_t start = 0, size_t len = kInfSize);
 
   RaySeg* rays() const;

--- a/src/core/cpu_trace_backend.cpp
+++ b/src/core/cpu_trace_backend.cpp
@@ -104,9 +104,9 @@ void TraceCrystalBatch(RandomNumberGenerator& rng, const Crystal& crystal, size_
       // RecorderDataPtr(j) is read BEFORE all_data.EmplaceBack(workspace[1])
       // mutates workspace[1] (EmplaceBack only writes into all_data here, so
       // workspace[1]'s recorders are still valid). The recorder pointer routes
-      // inline vs overflow arena correctly via the buffer-level resolver — we
-      // truncate at ExitFaceSeq::kCap (= RaypathRecorder::kInlineCap = 15) so
-      // any (rare, currently non-occurring) overflow path is silently capped.
+      // inline vs overflow arena correctly via the buffer-level resolver, and
+      // since task-284 ExitFaceSeq::kCap == kMaxHits the min() below is a
+      // tautological clamp (kept for explicitness; full path always copied).
       all_data.EmplaceBack(workspace[1]);
       for (size_t j = 0; j < workspace[1].size_; j++) {
         const auto& r = workspace[1][j];

--- a/src/core/exit_seam.hpp
+++ b/src/core/exit_seam.hpp
@@ -19,11 +19,14 @@ namespace lumice {
 //   offset 16: ExitFaceSeq path       (65B, inline face sequence; task-284 bumped
 //                                          kCap 15→64 so paths up to kMaxHits=64
 //                                          are no longer silently truncated)
-//   offset 81: uint16_t crystal_id    (2B,  session-level crystal index)
-//   offset 83: uint8_t  ms_layer_idx  (1B,  0-based MS layer index)
-//   offset 84: uint8_t  wl_idx        (1B,  per-ray wavelength pool index;
+//   offset 81: <1B implicit alignment padding> (path ends at 80; uint16_t below
+//                                          needs 2B alignment, so offset 81 is padded)
+//   offset 82: uint16_t crystal_id    (2B,  session-level crystal index)
+//   offset 84: uint8_t  ms_layer_idx  (1B,  0-based MS layer index)
+//   offset 85: uint8_t  wl_idx        (1B,  per-ray wavelength pool index;
 //                                          0 on the CPU backend — pool layout
 //                                          is Metal-specific. scrum-268.8.)
+//   offset 86: <2B trailing padding to align struct to 4B → sizeof 88>
 //   sizeof == 88, align == 4. ExitRayRecord has no on-disk serialization (used
 //   in-process between trace backend and consumer), so the sizeof bump from
 //   task-284's kCap extension only adjusts the static_assert.

--- a/src/core/exit_seam.hpp
+++ b/src/core/exit_seam.hpp
@@ -16,14 +16,17 @@ namespace lumice {
 //
 //   offset 0:  float    dir[3]        (12B, world-space exit direction)
 //   offset 12: float    weight        (4B,  ray weight)
-//   offset 16: ExitFaceSeq path       (16B, inline face sequence)
-//   offset 32: uint16_t crystal_id    (2B,  session-level crystal index)
-//   offset 34: uint8_t  ms_layer_idx  (1B,  0-based MS layer index)
-//   offset 35: uint8_t  wl_idx        (1B,  per-ray wavelength pool index;
+//   offset 16: ExitFaceSeq path       (65B, inline face sequence; task-284 bumped
+//                                          kCap 15→64 so paths up to kMaxHits=64
+//                                          are no longer silently truncated)
+//   offset 81: uint16_t crystal_id    (2B,  session-level crystal index)
+//   offset 83: uint8_t  ms_layer_idx  (1B,  0-based MS layer index)
+//   offset 84: uint8_t  wl_idx        (1B,  per-ray wavelength pool index;
 //                                          0 on the CPU backend — pool layout
 //                                          is Metal-specific. scrum-268.8.)
-//   sizeof == 36, align == 4. Layout/size unchanged from the prior pad_
-//   slot — binary compatible with previously serialized records.
+//   sizeof == 88, align == 4. ExitRayRecord has no on-disk serialization (used
+//   in-process between trace backend and consumer), so the sizeof bump from
+//   task-284's kCap extension only adjusts the static_assert.
 struct ExitRayRecord {
   float dir[3];
   float weight;
@@ -32,7 +35,7 @@ struct ExitRayRecord {
   uint8_t ms_layer_idx;
   uint8_t wl_idx = 0;
 };
-static_assert(sizeof(ExitRayRecord) == 36u,
+static_assert(sizeof(ExitRayRecord) == 88u,
               "ExitRayRecord layout changed — re-check exit-seam wire format and bandwidth budget");
 static_assert(std::is_trivially_copyable_v<ExitRayRecord>,
               "ExitRayRecord must stay trivially copyable for memcpy out of device buffers");

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -2084,11 +2084,11 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   impl_->cont_counts[0] = 0;
   impl_->cont_counts[1] = 0;
   impl_->out_cap = 0;
-  // Exit metadata (scrum-258.2): per-slot stride of buffer(23). Real configs
-  // have max_hits ≤ ExitFaceSeq::kCap (7-8 in practice), so the min() clamp
-  // is defensive against a future scene bumping max_hits beyond 15. Set BEFORE
-  // EnsureExitBuffers (called from TraceLayer's first-MS branch) so the device
-  // allocation reflects the actual stride.
+  // Exit metadata (scrum-258.2): per-slot stride of buffer(23). task-284 bumped
+  // ExitFaceSeq::kCap from 15 to kMaxHits=64; the min() clamp now caps at the
+  // configurable kMaxHits ceiling. Set BEFORE EnsureExitBuffers (called from
+  // TraceLayer's first-MS branch) so the device allocation reflects the actual
+  // stride.
   impl_->face_seq_cap_ = std::min<uint32_t>(
       static_cast<uint32_t>(spec.scene->max_hits_), static_cast<uint32_t>(ExitFaceSeq::kCap));
   // scrum-267 task-fused-emit-gate Step 8: initialize the final-layer index
@@ -2525,17 +2525,28 @@ size_t MetalTraceBackend::ReadbackExitRays(std::vector<ExitRayRecord>& out) {
     RaypathRecorder rec{};
     uint8_t seq_len = std::min<uint8_t>(seq_len_ptr[i], ExitFaceSeq::kCap);
     rec.size_ = seq_len;
-    rec.overflow_idx_ = RaypathRecorder::kNoOverflow;
+    // task-284: paths longer than kInlineCap need a local arena so
+    // FilterSpec::Check can read past rec.data_ without overrunning the inline
+    // buffer. Layout matches RecorderAppend's in-arena format (slot[0]
+    // corresponds to path byte 0; see RaypathOrbit::Contains in filter_spec.cpp).
+    uint8_t local_arena[kMaxHits]{};
+    const bool has_overflow = (seq_len > RaypathRecorder::kInlineCap);
+    rec.overflow_idx_ = has_overflow ? 0 : RaypathRecorder::kNoOverflow;
     // GetFn remap: raw kernel path[] carries poly-face indices; legacy
     // FilterSpec::Check expects post-GetFn ids. Mirrors the (now removed)
     // host frame-transit's GetFn application.
     const uint8_t* raw_seq = seq_data_ptr + i * stride;
     for (uint8_t k = 0; k < seq_len; ++k) {
-      rec.data_[k] = static_cast<uint8_t>(src_crystal.GetFn(static_cast<IdType>(raw_seq[k])));
+      const uint8_t v = static_cast<uint8_t>(src_crystal.GetFn(static_cast<IdType>(raw_seq[k])));
+      if (k < RaypathRecorder::kInlineCap) {
+        rec.data_[k] = v;
+      }
+      local_arena[k] = v;
     }
+    const uint8_t* arena_for_check = has_overflow ? local_arena : nullptr;
 
     const FilterSpec* spec = spec_per_ci[crystal_id].get();
-    bool filter_pass = (spec == nullptr) || spec->Check(r, rec, nullptr);
+    bool filter_pass = (spec == nullptr) || spec->Check(r, rec, arena_for_check);
     if (!filter_pass) {
       continue;
     }
@@ -2555,7 +2566,11 @@ size_t MetalTraceBackend::ReadbackExitRays(std::vector<ExitRayRecord>& out) {
     erec.ms_layer_idx = final_ms_layer;
     erec.wl_idx = static_cast<uint8_t>(wl_idx_ptr[i] & 0xFFu);
     erec.path.size_ = seq_len;
-    std::memcpy(erec.path.data_, rec.data_, seq_len);
+    // task-284: route through local_arena when seq_len > kInlineCap; the inline
+    // rec.data_ only covers the first kInlineCap bytes. local_arena holds the
+    // full path (matches the byte layout RaypathOrbit::Contains expects).
+    const uint8_t* path_src = has_overflow ? local_arena : rec.data_;
+    std::memcpy(erec.path.data_, path_src, seq_len);
     out.push_back(erec);
   }
 

--- a/src/core/raypath.hpp
+++ b/src/core/raypath.hpp
@@ -76,20 +76,23 @@ static_assert(sizeof(RaypathRecorder) == 18,
               "RaypathRecorder layout changed — re-check #247.4 SBO invariants and SimData size");
 
 
-// Inline-only face-sequence for the exit seam (scrum-258.2). Mirrors the inline
-// half of RaypathRecorder but drops overflow_idx_: all real configs have
-// max_hits <= kInlineCap (7-8 in practice), so overflow never fires here. The
-// device-side kernel populates this directly into shared-memory buffers (no
-// device-side dynamic allocation), and the host-side {dir, weight, path,
-// crystal_id, ms_layer_idx} record stays trivially copyable + defined-layout.
+// Face-sequence for the exit seam (scrum-258.2). Mirrors RaypathRecorder's
+// hit buffer but drops overflow_idx_: the exit record is the terminal copy of
+// an outgoing ray's path, so the arena indirection is collapsed into an inline
+// kMaxHits-byte array carrying the full path. task-284 bumped kCap from 15 →
+// kMaxHits=64 so paths longer than kInlineCap are no longer silently capped at
+// the exit seam. The device-side kernel populates this directly into
+// shared-memory buffers (no device-side dynamic allocation), and the host-side
+// {dir, weight, path, crystal_id, ms_layer_idx} record stays trivially copyable
+// + defined-layout.
 struct ExitFaceSeq {
-  static constexpr uint8_t kCap = 15;
-  static_assert(kCap == RaypathRecorder::kInlineCap,
-                "ExitFaceSeq::kCap must stay in sync with RaypathRecorder::kInlineCap");
+  static constexpr uint8_t kCap =
+      static_cast<uint8_t>(kMaxHits);  // 64; decoupled from RaypathRecorder::kInlineCap (task-284)
+  static_assert(kMaxHits <= 0xFFu, "ExitFaceSeq::kCap (uint8_t) requires kMaxHits fits in uint8_t");
   uint8_t size_ = 0;
   uint8_t data_[kCap]{};
 };
-static_assert(sizeof(ExitFaceSeq) == 16u, "ExitFaceSeq layout changed — re-check exit-seam wire format");
+static_assert(sizeof(ExitFaceSeq) == 65u, "ExitFaceSeq layout changed — re-check exit-seam wire format");
 static_assert(std::is_trivially_copyable_v<ExitFaceSeq>,
               "ExitFaceSeq must stay trivially copyable for memcpy out of device buffers");
 

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -474,10 +474,14 @@ void CollectData(RandomNumberGenerator& rng, const MsInfo& ms_info, const Filter
     // 2. Normal rays (to_face_ != kInvalidId && w_ >= 0) stay in crystal-local coordinates.
 
     if (r.IsNormal()) {
-      buffer_data[0].EmplaceBack(r, rec);
+      // rec comes from buffer_data[1]; pass it as arena_src so overflow slots
+      // get duped into buffer_data[0]'s own arena (fix for max_hits>kInlineCap
+      // null-deref: the 2-arg overload would copy overflow_idx_ pointing at the
+      // wrong arena and crash the next RecorderFanOut).
+      buffer_data[0].EmplaceBack(r, rec, buffer_data[1]);
     }
     if (r.IsContinue()) {
-      init_data[1].EmplaceBack(r, rec);
+      init_data[1].EmplaceBack(r, rec, buffer_data[1]);
     }
   }
 }

--- a/test/regression-sentinel/test_max_hits_crash.py
+++ b/test/regression-sentinel/test_max_hits_crash.py
@@ -34,16 +34,37 @@ import pytest
 from test.e2e.runner import find_lumice_binary, get_project_root
 
 
-def _build_config(max_hits: int, ray_num: int = 20000) -> dict:
+def _build_config(max_hits: int, ray_num: int = 20000, metal_compatible: bool = False) -> dict:
+    # halo_22's crystal produces rays that bounce >15 times (confirmed: pre-fix
+    # this config SIGSEGVs at max_hits=16/32 on the legacy CPU path), so it
+    # genuinely exercises the overflow-arena path — the detective power this
+    # sentinel needs.
     base = json.loads((get_project_root() / "test" / "e2e" / "configs" / "halo_22.json").read_text())
     base["scene"]["ray_num"] = ray_num
     base["scene"]["max_hits"] = max_hits
+    if metal_compatible:
+        # halo_22 ships a fisheye_equal_area lens, which MetalTraceBackend rejects
+        # (IsCompatible → false) so LUMICE_TRACE_BACKEND=metal silently falls back
+        # to legacy CPU — that would make the "metal" case a disguised CPU re-run
+        # with zero device coverage. Swap to a dual-fisheye fov=180 renderer (the
+        # exact projection the GUI hardcodes) so the native Metal trace + device
+        # exit-seq readback path actually runs. The crystal/scene (long-path
+        # producer) is untouched.
+        base["render"] = [
+            {
+                "id": 1,
+                "lens": {"type": "dual_fisheye_equal_area", "fov": 180},
+                "resolution": [512, 256],
+                "view": {"elevation": 0},
+                "visible": "full",
+            }
+        ]
     return base
 
 
 def _run_with_max_hits(max_hits: int, backend_env: str | None = None) -> subprocess.CompletedProcess:
     binary = find_lumice_binary()
-    cfg = _build_config(max_hits)
+    cfg = _build_config(max_hits, metal_compatible=(backend_env == "metal"))
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
         json.dump(cfg, f)
         cfg_path = f.name
@@ -74,11 +95,21 @@ def test_max_hits_overflow_cpu_no_crash(max_hits: int) -> None:
 
 @pytest.mark.parametrize("max_hits", [16, 24, 32, 64])
 def test_max_hits_overflow_metal_no_crash(max_hits: int) -> None:
-    """Metal path: max_hits > kInlineCap must not crash via the device readback path."""
+    """Native Metal path: max_hits > kInlineCap must run cleanly through the
+    device trace + exit-seq readback (ExitFaceSeq::kCap == kMaxHits, no
+    truncation). Uses a dual-fisheye fov=180 renderer so the backend does NOT
+    fall back to legacy CPU — otherwise this test would silently re-run the CPU
+    path and have zero device coverage."""
     if os.uname().sysname != "Darwin":
         pytest.skip("Metal backend is macOS-only")
     result = _run_with_max_hits(max_hits, backend_env="metal")
     assert result.returncode == 0, (
         f"Lumice (Metal) exited {result.returncode} for max_hits={max_hits}"
         f"\nstderr:\n{result.stderr}"
+    )
+    # Detective-power guard: fail if the run silently fell back to legacy CPU,
+    # which would void the device-path coverage this test is meant to provide.
+    assert "falling back to legacy CPU" not in result.stderr, (
+        f"Metal backend fell back to legacy CPU for max_hits={max_hits}; this "
+        f"test no longer exercises the native Metal path.\nstderr:\n{result.stderr}"
     )

--- a/test/regression-sentinel/test_max_hits_crash.py
+++ b/test/regression-sentinel/test_max_hits_crash.py
@@ -1,0 +1,84 @@
+"""Regression guard: max_hits > kInlineCap must not crash.
+
+Fix commits: task-284 (single-ray EmplaceBack arena dup + ExitFaceSeq::kCap
+extension to kMaxHits=64).
+
+Root cause: CollectData routed continuation rays through the 2-arg
+RayBuffer::EmplaceBack(RaySeg, RaypathRecorder), which copies overflow_idx_ but
+never calls DupOverflowSlot — so the dst buffer's overflow_arena_ stayed null
+while overflow_idx_ pointed into the src arena. The next
+TraceRayBasicInfo → RecorderFanOut → DupOverflowSlot then dereferenced
+src.overflow_arena_(null) + slot*64 (with slot=0 landing at 0x0) → SIGSEGV.
+
+Trigger conditions:
+- max_hits > RaypathRecorder::kInlineCap (= 15)
+- Any config with ray_num large enough to populate the continuation path.
+
+This test runs a small ray budget at max_hits=32 — the exact reproduction used
+to diagnose the bug — and asserts the process exits cleanly (not by signal).
+Repeats on Metal backend when LUMICE_TRACE_BACKEND=metal is exported.
+
+Runs fast (~1s) so it stays in the default `pytest -v` PR gate (no @pytest.mark.slow).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from test.e2e.runner import find_lumice_binary, get_project_root
+
+
+def _build_config(max_hits: int, ray_num: int = 20000) -> dict:
+    base = json.loads((get_project_root() / "test" / "e2e" / "configs" / "halo_22.json").read_text())
+    base["scene"]["ray_num"] = ray_num
+    base["scene"]["max_hits"] = max_hits
+    return base
+
+
+def _run_with_max_hits(max_hits: int, backend_env: str | None = None) -> subprocess.CompletedProcess:
+    binary = find_lumice_binary()
+    cfg = _build_config(max_hits)
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(cfg, f)
+        cfg_path = f.name
+    try:
+        env = os.environ.copy()
+        if backend_env is not None:
+            env["LUMICE_TRACE_BACKEND"] = backend_env
+        return subprocess.run(
+            [str(binary), "-f", cfg_path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+    finally:
+        Path(cfg_path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("max_hits", [16, 24, 32, 64])
+def test_max_hits_overflow_cpu_no_crash(max_hits: int) -> None:
+    """CPU path: max_hits > kInlineCap must not SIGSEGV (exit 139)."""
+    result = _run_with_max_hits(max_hits)
+    assert result.returncode == 0, (
+        f"Lumice exited {result.returncode} (signal death indicates SIGSEGV "
+        f"regression) for max_hits={max_hits}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("max_hits", [16, 24, 32, 64])
+def test_max_hits_overflow_metal_no_crash(max_hits: int) -> None:
+    """Metal path: max_hits > kInlineCap must not crash via the device readback path."""
+    if os.uname().sysname != "Darwin":
+        pytest.skip("Metal backend is macOS-only")
+    result = _run_with_max_hits(max_hits, backend_env="metal")
+    assert result.returncode == 0, (
+        f"Lumice (Metal) exited {result.returncode} for max_hits={max_hits}"
+        f"\nstderr:\n{result.stderr}"
+    )

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -246,6 +246,65 @@ TEST(RayBufferRecorderTest, FanOutDuplicatesOverflowSlotIntoDstArena) {
 }
 
 
+// task-284 regression: single-ray EmplaceBack(r, rec, arena_src) must clone
+// the overflow slot into *this* buffer's arena. Pre-fix CollectData used the
+// 2-arg EmplaceBack on overflow recorders, leaving overflow_idx_ pointing into
+// the source buffer's arena; the next RecorderFanOut/DupOverflowSlot then
+// dereferenced this->overflow_arena_ (null) → SIGSEGV on max_hits>kInlineCap.
+TEST(RayBufferRecorderTest, EmplaceBackSingleRayWithOverflowDupsArena) {
+  RayBuffer src(4);
+  // Populate src[1] with an overflow recorder of 20 bytes.
+  for (uint8_t i = 0; i < 20; i++) {
+    src.RecorderAppend(1, static_cast<lumice::IdType>(i + 1));
+  }
+  ASSERT_TRUE(src.RecorderAt(1).HasOverflow());
+  src.size_ = 2;  // mirror production caller bookkeeping
+
+  RayBuffer dst(8);
+  dst.EmplaceBack(MakeRay(7), src.RecorderAt(1), src);
+
+  EXPECT_EQ(dst.size_, 1u);
+  EXPECT_FLOAT_EQ(dst[0].w_, 7.0f);
+  ASSERT_TRUE(dst.RecorderAt(0).HasOverflow());
+  EXPECT_EQ(dst.RecorderAt(0).size_, static_cast<uint8_t>(20));
+
+  // dst arena must be independent of src arena.
+  ASSERT_NE(dst.OverflowArena(), nullptr) << "dst arena must be lazily allocated by DupOverflowSlot";
+  const uint8_t* dst_slot = dst.RecorderDataPtr(0);
+  const uint8_t* src_slot = src.RecorderDataPtr(1);
+  ASSERT_NE(dst_slot, src_slot);
+  for (uint8_t i = 0; i < 20; i++) {
+    EXPECT_EQ(dst_slot[i], static_cast<uint8_t>(i + 1)) << "dst byte " << static_cast<int>(i);
+  }
+
+  // Mutating src arena must not bleed into dst.
+  uint8_t snapshot_dst[lumice::kMaxHits];
+  std::memcpy(snapshot_dst, dst_slot, lumice::kMaxHits);
+  src.RecorderDataPtr(1)[0] = 0xAA;
+  EXPECT_EQ(std::memcmp(dst_slot, snapshot_dst, lumice::kMaxHits), 0) << "dst arena aliased src arena";
+}
+
+
+// task-284 inline-recorder path must remain a trivial copy via the 3-arg
+// overload (no arena allocation, identical observable behaviour to the 2-arg
+// overload).
+TEST(RayBufferRecorderTest, EmplaceBackSingleRayInlineSkipsArena) {
+  RayBuffer src(4);
+  src.RecorderAppend(1, static_cast<lumice::IdType>(42));
+  ASSERT_FALSE(src.RecorderAt(1).HasOverflow());
+  src.size_ = 2;
+
+  RayBuffer dst(8);
+  dst.EmplaceBack(MakeRay(3), src.RecorderAt(1), src);
+
+  EXPECT_EQ(dst.size_, 1u);
+  EXPECT_FALSE(dst.RecorderAt(0).HasOverflow());
+  EXPECT_EQ(dst.RecorderAt(0).size_, static_cast<uint8_t>(1));
+  EXPECT_EQ(dst.RecorderAt(0).data_[0], static_cast<uint8_t>(42));
+  EXPECT_EQ(dst.OverflowArena(), nullptr) << "inline path must keep dst arena unallocated";
+}
+
+
 TEST(RayBufferRecorderTest, FanOutInlineRecorderTakesTrivialPath) {
   // Inline recorders must not allocate an arena slot during fan-out (this is
   // the hot path under bench(max_hits=8)).

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -13,12 +13,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstring>
 #include <type_traits>
 #include <utility>
 
 #include "config/sim_data.hpp"
 #include "core/def.hpp"
+#include "core/exit_seam.hpp"
 #include "core/raypath.hpp"
 
 namespace {
@@ -282,6 +284,47 @@ TEST(RayBufferRecorderTest, EmplaceBackSingleRayWithOverflowDupsArena) {
   std::memcpy(snapshot_dst, dst_slot, lumice::kMaxHits);
   src.RecorderDataPtr(1)[0] = 0xAA;
   EXPECT_EQ(std::memcmp(dst_slot, snapshot_dst, lumice::kMaxHits), 0) << "dst arena aliased src arena";
+}
+
+
+// task-284 no-truncation contract: the exit-seam record (ExitFaceSeq) must
+// carry the FULL recorded path up to kMaxHits, NOT silently cap it at the old
+// kInlineCap=15. This mirrors the cpu_trace_backend.cpp exit-record build
+// (seq_len = min(recorder.size_, ExitFaceSeq::kCap); memcpy(path.data_, ...))
+// against a >15-hit overflow recorder, asserting bytes past index 15 survive.
+// Owner-added per code-review Suggestion (direct structural assertion is
+// stronger than the PSNR-noise-floor proxy used in AC2).
+TEST(RayBufferRecorderTest, ExitFaceSeqCarriesFullPathNoTruncationPast15) {
+  // ExitFaceSeq must be able to hold the full path; the whole point of the
+  // task-284 fix is decoupling kCap from kInlineCap.
+  static_assert(lumice::ExitFaceSeq::kCap == static_cast<uint8_t>(lumice::kMaxHits),
+                "ExitFaceSeq::kCap must equal kMaxHits so exit paths are never truncated");
+  ASSERT_GT(lumice::ExitFaceSeq::kCap, lumice::RaypathRecorder::kInlineCap);
+
+  RayBuffer buf(4);
+  constexpr uint8_t kPathLen = 20;  // > kInlineCap (15), exercises the arena
+  for (uint8_t i = 0; i < kPathLen; i++) {
+    buf.RecorderAppend(0, static_cast<lumice::IdType>(i + 1));
+  }
+  const RaypathRecorder& rp = buf.RecorderAt(0);
+  ASSERT_TRUE(rp.HasOverflow());
+  ASSERT_EQ(rp.size_, kPathLen);
+
+  // Replicate the exit-record builder's copy (cpu_trace_backend.cpp).
+  lumice::ExitFaceSeq seq{};
+  const uint8_t* src = buf.RecorderDataPtr(0);
+  auto seq_len = static_cast<uint8_t>(std::min<size_t>(rp.size_, lumice::ExitFaceSeq::kCap));
+  seq.size_ = seq_len;
+  std::memcpy(seq.data_, src, seq_len);
+
+  // The 20-byte path must survive intact — no cap at 15.
+  EXPECT_EQ(seq.size_, kPathLen) << "exit-seam path truncated; kCap regression";
+  for (uint8_t i = 0; i < kPathLen; i++) {
+    EXPECT_EQ(seq.data_[i], static_cast<uint8_t>(i + 1)) << "byte " << static_cast<int>(i);
+  }
+  // Specifically assert the bytes that the OLD kCap=15 design would have dropped.
+  EXPECT_EQ(seq.data_[15], static_cast<uint8_t>(16));
+  EXPECT_EQ(seq.data_[19], static_cast<uint8_t>(20));
 }
 
 


### PR DESCRIPTION
## 问题

GUI/CLI 中 `max_hits > kInlineCap=15` 时 CPU 路径稳定 SIGSEGV（exit 139）。

## 根因（白盒实证）

`CollectData` 续传路径用单射线版 `RayBuffer::EmplaceBack(RaySeg, const RaypathRecorder&)` 把 overflow recorder 搬回另一 buffer——该重载只复制 `overflow_idx_` 却不调 `DupOverflowSlot`，目标 buffer 的 `overflow_arena_` 仍为 null。下一跳 `TraceRayBasicInfo → RecorderFanOut → DupOverflowSlot` 解引用 null arena（slot=0 命中 0x0）→ 崩溃。`assert(!rec.HasOverflow())` 契约守卫在 Release/`NDEBUG` 下被编译掉，故静默损坏。源于 #247.4 SBO（inline 15 + overflow arena）优化的续传路径遗漏。

## 修复

1. **CPU 崩溃**：新增 3-arg `EmplaceBack(r, rec, arena_src)` 重载正确 dup overflow arena；`CollectData` 两处调用点（`simulator.cpp:477/480`）更新。legacy `Simulator` 与 `CpuTraceBackend` 共享此路径，一并修复。
2. **正确性（无静默截断）**：`ExitFaceSeq::kCap` 15→64（=`kMaxHits`），exit-seam 记录完整到 64 命中的路径；Metal `ReadbackExitRays` 用 `local_arena[kMaxHits]` 避免向 15B `rec.data_` 越界写。`ExitRayRecord` sizeof 36→88（in-process，无序列化依赖）。
3. **测试**：
   - 单元：`EmplaceBackSingleRayWithOverflowDupsArena`（arena 独立性）+ `ExitFaceSeqCarriesFullPathNoTruncationPast15`（直接断言 >15 字节不被截断）。
   - 回归哨兵：CPU + 真激活 Metal（dual-fisheye fov180）×{16,24,32,64}，含 no-fallback 断言防"假 Metal"哨兵。

## 验收

- **AC1** CPU 139→0、原生 Metal 无回退运行 ✓
- **AC2** 渲染随 max_hits 不变（mh8 vs mh32 PSNR=20.36dB == 同参数噪声地板 20.33dB）✓
- **AC3** CPU/Metal 吞吐随 max_hits 近似 1/max_hits（per-hit 工作量固有，非本 fix 退化）✓
- **AC4** 单元 + 哨兵全绿；全量 fast 套件 53 passed ✓

## 备注

- 原生 Metal CLI 路径新旧代码均不崩（device path[64] 有界 + 旧代码安全截断）；GUI 偶发 GPU 崩溃用户已确认暂缓，归独立跟踪。
- kCap 采用 flat-64 而非 SBO：`RaypathRecorder` 在 fan-out 热路径保持 SBO 18B，`ExitFaceSeq` 只在出射 seam 每出射线建一次、拷贝频率低，flat-64 带宽成本可忽略（实测吞吐几乎不受影响）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)