### PR TITLE
chore: batch-clean 5 deferred misc backlog items (#292)

### DIFF
--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -278,7 +278,6 @@ Two scenarios:
 | `--log-panel` | off | Show the log panel during test |
 | `--dorun-delay <ms>` | 0 | Add artificial delay to `DoRun` (simulate slow environment) |
 | `--skip-calibration` | off | Skip startup quality threshold calibration |
-| `--perf-bench` | off | Run `--perf-bench` mode: standalone throughput measurement |
 
 ### macOS
 
@@ -340,20 +339,6 @@ Reflects real user experience. Requires a display environment with a visible win
 5. Enable file logging (GUI Log panel → Enable File Log)
 6. Analyze the log file with the analysis script
 
-### Automated --perf-bench Mode
-
-The `--perf-bench` flag provides a standalone throughput measurement that runs for a
-fixed duration and reports average rays/sec. Useful for apples-to-apples comparisons
-between builds or platforms without GUI interaction.
-
-```bash
-# macOS
-./build/cmake_install/LumiceGUI --perf-bench
-
-# Windows (via remote watcher, see doc/windows-remote-testing.md)
-./scripts/win_remote_test.sh ./LumiceGUI.exe --perf-bench
-```
-
 ### Remote Windows Testing
 
 For Windows testing without physical access, use the watcher-based remote workflow.
@@ -367,14 +352,14 @@ See [Windows Remote Testing Guide](windows-remote-testing.md) for setup instruct
 
 ### Comparison
 
-| Condition | GUI Perf Test | Manual Test | --perf-bench |
-|-----------|--------------|-------------|--------------|
-| Window | hidden (default) / visible (`--visible`) | visible | visible |
-| VSync | off (default) / on (`--vsync`) | on (system default) | on (system default) |
-| Frame limit | on (default) / off (`--no-frame-limit`) | on | on |
-| Input | automated (ImGui Test Engine) | manual (slider drag) | none (steady-state only) |
-| Reproducibility | high | low (human variance) | high |
-| Reflects real UX | partially (with `--visible --vsync`) | yes | partially |
+| Condition | GUI Perf Test | Manual Test |
+|-----------|--------------|-------------|
+| Window | hidden (default) / visible (`--visible`) | visible |
+| VSync | off (default) / on (`--vsync`) | on (system default) |
+| Frame limit | on (default) / off (`--no-frame-limit`) | on |
+| Input | automated (ImGui Test Engine) | manual (slider drag) |
+| Reproducibility | high | low (human variance) |
+| Reflects real UX | partially (with `--visible --vsync`) | yes |
 
 ## 4. Log Analysis Script
 

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -181,7 +181,6 @@ push 到 `main` 的 benchmark 结果会通过
 | `--log-panel` | 关 | 测试期间显示日志面板 |
 | `--dorun-delay <ms>` | 0 | 为 `DoRun` 添加人为延迟（模拟慢环境） |
 | `--skip-calibration` | 关 | 跳过启动时质量阈值校准 |
-| `--perf-bench` | 关 | 运行 `--perf-bench` 模式：独立吞吐量测量 |
 
 ### macOS
 
@@ -243,19 +242,6 @@ Get-Content perf_stderr.txt
 5. 启用文件日志（GUI Log 面板 → Enable File Log）
 6. 使用分析脚本分析日志文件
 
-### 自动化 --perf-bench 模式
-
-`--perf-bench` 标志提供独立吞吐量测量，运行固定时长后报告平均 rays/sec。
-适用于不同构建或平台之间的 apple-to-apple 比较，无需 GUI 交互。
-
-```bash
-# macOS
-./build/cmake_install/LumiceGUI --perf-bench
-
-# Windows（通过远程 watcher，参见 doc/windows-remote-testing_zh.md）
-./scripts/win_remote_test.sh ./LumiceGUI.exe --perf-bench
-```
-
 ### Windows 远程测试
 
 无需物理接触即可测试 Windows，使用 watcher 远程工作流。
@@ -269,14 +255,14 @@ Get-Content perf_stderr.txt
 
 ### 对比
 
-| 条件 | GUI 性能测试 | 手动测试 | --perf-bench |
-|------|-------------|---------|--------------|
-| 窗口 | 隐藏（默认）/ 可见（`--visible`） | 可见 | 可见 |
-| VSync | 关（默认）/ 开（`--vsync`） | 开（系统默认） | 开（系统默认） |
-| 帧率限制 | 开（默认）/ 关（`--no-frame-limit`） | 开 | 开 |
-| 输入 | 自动化（ImGui Test Engine） | 手动（滑动条拖拽） | 无（仅稳态） |
-| 可重复性 | 高 | 低（人为差异） | 高 |
-| 反映真实体验 | 部分（配合 `--visible --vsync`） | 是 | 部分 |
+| 条件 | GUI 性能测试 | 手动测试 |
+|------|-------------|---------|
+| 窗口 | 隐藏（默认）/ 可见（`--visible`） | 可见 |
+| VSync | 关（默认）/ 开（`--vsync`） | 开（系统默认） |
+| 帧率限制 | 开（默认）/ 关（`--no-frame-limit`） | 开 |
+| 输入 | 自动化（ImGui Test Engine） | 手动（滑动条拖拽） |
+| 可重复性 | 高 | 低（人为差异） |
+| 反映真实体验 | 部分（配合 `--visible --vsync`） | 是 |
 
 ## 4. 日志分析脚本
 

--- a/doc/windows-remote-testing.md
+++ b/doc/windows-remote-testing.md
@@ -52,9 +52,6 @@ gh run download <RUN_ID> --name gui-test-windows-msvc --dir /tmp/ci-win
 # Run perf test with VSync (real display)
 ./scripts/win_remote_test.sh /tmp/ci-win/bin/gui_test.exe \
   --filter perf_test --vsync --log-level verbose
-
-# Run --perf-bench for throughput measurement
-./scripts/win_remote_test.sh /tmp/ci-win/bin/LumiceGUI.exe --perf-bench
 ```
 
 ### 3. Collect Results

--- a/doc/windows-remote-testing_zh.md
+++ b/doc/windows-remote-testing_zh.md
@@ -48,9 +48,6 @@ gh run download <RUN_ID> --name gui-test-windows-msvc --dir /tmp/ci-win
 # 运行 VSync 下的性能测试（真实显示器）
 ./scripts/win_remote_test.sh /tmp/ci-win/bin/gui_test.exe \
   --filter perf_test --vsync --log-level verbose
-
-# 运行 --perf-bench 吞吐量测量
-./scripts/win_remote_test.sh /tmp/ci-win/bin/LumiceGUI.exe --perf-bench
 ```
 
 ### 3. 收集结果

--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -20,8 +20,10 @@ namespace lumice {
 // seam is the canonical out path), shrinking back to 192. scrum-258.2 adds
 // exit_records_ (vector<ExitRayRecord>, 24B) for rich exit metadata,
 // bumping 192 → 216. scrum-268.8 (DR-3) adds outgoing_wl_ (vector<float>, 24B)
-// for per-ray wavelength CMF, bumping 216 → 240.
-static_assert(sizeof(SimData) == 240, "SimData size changed — update copy/move ctors and operators");
+// for per-ray wavelength CMF, bumping 216 → 240. chore-292 (A2) removes the
+// vestigial outgoing_indices_ (vector<size_t>, 24B) — its content was never
+// read; the consumer's outgoing-ray count is outgoing_w_.size() — shrinking 240 → 216.
+static_assert(sizeof(SimData) == 216, "SimData size changed — update copy/move ctors and operators");
 
 namespace {
 
@@ -307,16 +309,15 @@ SimData::SimData(size_t capacity) : curr_wl_(0.0f), rays_(capacity) {}
 
 SimData::SimData(const SimData& other)
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(other.rays_), crystals_(other.crystals_),
-      crystal_axis_dists_(other.crystal_axis_dists_), outgoing_indices_(other.outgoing_indices_),
-      outgoing_d_(other.outgoing_d_), outgoing_w_(other.outgoing_w_), outgoing_wl_(other.outgoing_wl_),
-      exit_records_(other.exit_records_), root_ray_count_(other.root_ray_count_) {}
+      crystal_axis_dists_(other.crystal_axis_dists_), outgoing_d_(other.outgoing_d_), outgoing_w_(other.outgoing_w_),
+      outgoing_wl_(other.outgoing_wl_), exit_records_(other.exit_records_), root_ray_count_(other.root_ray_count_) {}
 
 SimData::SimData(SimData&& other) noexcept
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(std::move(other.rays_)),
       crystals_(std::move(other.crystals_)), crystal_axis_dists_(std::move(other.crystal_axis_dists_)),
-      outgoing_indices_(std::move(other.outgoing_indices_)), outgoing_d_(std::move(other.outgoing_d_)),
-      outgoing_w_(std::move(other.outgoing_w_)), outgoing_wl_(std::move(other.outgoing_wl_)),
-      exit_records_(std::move(other.exit_records_)), root_ray_count_(other.root_ray_count_) {}
+      outgoing_d_(std::move(other.outgoing_d_)), outgoing_w_(std::move(other.outgoing_w_)),
+      outgoing_wl_(std::move(other.outgoing_wl_)), exit_records_(std::move(other.exit_records_)),
+      root_ray_count_(other.root_ray_count_) {}
 
 SimData& SimData::operator=(const SimData& other) {
   if (&other == this) {
@@ -328,7 +329,6 @@ SimData& SimData::operator=(const SimData& other) {
   rays_ = other.rays_;
   crystals_ = other.crystals_;
   crystal_axis_dists_ = other.crystal_axis_dists_;
-  outgoing_indices_ = other.outgoing_indices_;
   outgoing_d_ = other.outgoing_d_;
   outgoing_w_ = other.outgoing_w_;
   outgoing_wl_ = other.outgoing_wl_;
@@ -347,7 +347,6 @@ SimData& SimData::operator=(SimData&& other) noexcept {
   rays_ = std::move(other.rays_);
   crystals_ = std::move(other.crystals_);
   crystal_axis_dists_ = std::move(other.crystal_axis_dists_);
-  outgoing_indices_ = std::move(other.outgoing_indices_);
   outgoing_d_ = std::move(other.outgoing_d_);
   outgoing_w_ = std::move(other.outgoing_w_);
   outgoing_wl_ = std::move(other.outgoing_wl_);  // scrum-268.8 (DR-3): was missing

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -136,11 +136,11 @@ struct SimData {
   RayBuffer rays_;
   std::vector<Crystal> crystals_;
   std::vector<AxisDistribution> crystal_axis_dists_;  // parallel to crystals_
-  std::vector<size_t> outgoing_indices_;              // Indices of kOutgoing rays in rays_ (filled by Simulator)
 
   // Pre-packed outgoing ray data for cache-friendly access in Consume().
   // Tightly packed by outgoing order: outgoing_d_[k*3..k*3+2] and outgoing_w_[k]
-  // correspond to outgoing_indices_[k]. Filled by Simulator alongside outgoing_indices_.
+  // are parallel — one entry per outgoing ray. Filled by Simulator. The outgoing
+  // ray count is outgoing_w_.size() (the consumer's single source of truth).
   std::vector<float> outgoing_d_;  // direction (3 floats per outgoing ray)
   std::vector<float> outgoing_w_;  // weight (1 float per outgoing ray)
   // scrum-268.8 (DR-3): per-outgoing-ray wavelength (nm). When non-empty the

--- a/src/core/cpu_trace_backend.cpp
+++ b/src/core/cpu_trace_backend.cpp
@@ -284,9 +284,15 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
   // Exit seam (scrum-258.2): append this layer's rich outgoing records to
   // the session-level accumulator BEFORE projection. ReadbackExitRays
   // returns these for the simulator to drive the legacy consumer projection
-  // (which still consumes dir/weight extracted from each record). The
-  // ScatterOutgoingToXyz call below stays for now so ReadbackImage keeps
-  // returning a populated image (parity-harness/oracle path).
+  // (which still consumes dir/weight extracted from each record).
+  //
+  // [PARITY-ORACLE] The ScatterOutgoingToXyz accumulation below is
+  // DELIBERATELY RETAINED (not exit-seam leftover): it keeps xyz_buf_
+  // populated so ReadbackImage() can serve as the CPU-vs-Metal parity
+  // reference image. Production GUI/CLI never reads this image — they use
+  // ReadbackExitRays + legacy projection — only the parity harness does
+  // (see the [TEST-ONLY] note on ReadbackImage in cpu_trace_backend.hpp).
+  // Do NOT remove without retiring the Metal/Cpu parity battery.
   size_t exit_n = outgoing_records.size();
   std::vector<float> outgoing_d(exit_n * 3);
   std::vector<float> outgoing_w(exit_n);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -770,7 +770,6 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
   size_t original_ray_num = ray_num;  // ray_num is overwritten in the ms loop; keep original for normalization.
 
   RayBuffer all_data = AllocateAllData(config, ray_num);
-  std::vector<size_t> outgoing_indices;
   std::vector<float> outgoing_d;
   std::vector<float> outgoing_w;
   auto& init_data = workspace.init_data;
@@ -886,13 +885,11 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
           CollectData(rng_, m, spec.get(),      // input
                       buffer_data, init_data);  // output
 
-          // 2.4 Copy to all_data + collect outgoing indices.
-          size_t base_index = all_data.size_;
+          // 2.4 Copy to all_data + collect outgoing rays (d/w pre-pack).
           all_data.EmplaceBack(buffer_data[1]);
           for (size_t j = 0; j < buffer_data[1].size_; j++) {
             const auto& r = buffer_data[1][j];
             if (r.IsOutgoing()) {
-              outgoing_indices.push_back(base_index + j);
               outgoing_d.push_back(r.d_[0]);
               outgoing_d.push_back(r.d_[1]);
               outgoing_d.push_back(r.d_[2]);
@@ -926,7 +923,6 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
   sim_data.crystals_ = std::move(all_crystals);
   sim_data.crystal_axis_dists_ = std::move(all_axis_dists);
   sim_data.rays_ = std::move(all_data);
-  sim_data.outgoing_indices_ = std::move(outgoing_indices);
   sim_data.outgoing_d_ = std::move(outgoing_d);
   sim_data.outgoing_w_ = std::move(outgoing_w);
   sim_data.root_ray_count_ = original_ray_num;
@@ -946,8 +942,8 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
 //   - No ReadbackImage / no Y-channel reverse-compute. The backend's
 //     per-batch O(W*H) image readback is replaced by an O(exit rays)
 //     buffer copy (see TraceBackend::ReadbackExitRays).
-//   - SimData carries outgoing_d_/w_ + a dummy outgoing_indices_
-//     (consumer reads .size() only — confirmed by render.cpp:75 / 148 grep).
+//   - SimData carries outgoing_d_/w_ as the single payload form; the consumer
+//     derives the outgoing-ray count from outgoing_w_.size().
 //   - root_ray_count_ = ray_num distinguishes a valid backend batch from
 //     the queue shutdown sentinel (default-constructed SimData has
 //     root_ray_count_ == 0); the sentinel discriminator lives in
@@ -1043,9 +1039,8 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   // the legacy consumer via outgoing_d_/w_. The rich metadata
   // (path / crystal_id / ms_layer_idx) is forwarded into
   // sim_data.exit_records_ for 258.3 filter + symmetry fold to consume —
-  // 258.2 only produces it. The consumer reads `outgoing_indices_.size()`
-  // (and a non-empty assertion in render.cpp:148), never its values —
-  // fill a dummy zero index per ray.
+  // 258.2 only produces it. The consumer derives the outgoing-ray count from
+  // outgoing_w_.size() (and a non-empty assertion in render.cpp).
   size_t exit_count = exit_records.size();
   // 0-exit batch: still Emplace a SimData so server.cpp::ConsumeData decrements
   // sim_scene_cnt_. root_ray_count_=ray_num>0 distinguishes from the shutdown
@@ -1085,9 +1080,6 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);
   sim_data.exit_records_ = std::move(exit_records);
-  // dummy: consumer reads .size() only (render.cpp:75); real per-ray indices
-  // arrive when 258.3 unifies outgoing_d_/w_ with exit_records_.
-  sim_data.outgoing_indices_.assign(exit_count, 0);
   data_queue_->Emplace(std::move(sim_data));
 }
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     bool keep_console = false;
     for (int i = 1; i < argc; ++i) {
       std::string_view arg(argv[i]);
-      if (arg == "--perf-bench" || arg == "-v" || arg == "-d" || arg == "--log-level" || arg == "--core-log-level") {
+      if (arg == "-v" || arg == "-d" || arg == "--log-level" || arg == "--core-log-level") {
         keep_console = true;
         break;
       }
@@ -57,15 +57,11 @@ int main(int argc, char** argv) {
   timeBeginPeriod(1);
 #endif
 
-  // Parse perf-bench flag early — needed before glfwSwapInterval.
-  bool perf_bench = false;
+  // Parse --skip-calibration flag early.
   bool skip_calibration = false;
   for (int i = 1; i < argc; ++i) {
     std::string_view arg(argv[i]);
-    if (arg == "--perf-bench") {
-      perf_bench = true;
-      skip_calibration = true;
-    } else if (arg == "--skip-calibration") {
+    if (arg == "--skip-calibration") {
       skip_calibration = true;
     }
   }
@@ -113,7 +109,7 @@ int main(int argc, char** argv) {
 
   glfwSetWindowSizeLimits(window, gui::kMinWindowWidth, gui::kMinWindowHeight, GLFW_DONT_CARE, GLFW_DONT_CARE);
   glfwMakeContextCurrent(window);
-  glfwSwapInterval(perf_bench ? 0 : 1);  // VSync off for perf-bench to match test binary
+  glfwSwapInterval(1);  // VSync on
 
   if (!gui::InitGLLoader()) {
     glfwDestroyWindow(window);
@@ -140,7 +136,7 @@ int main(int argc, char** argv) {
 
   gui::g_state = gui::InitDefaultState();
 
-  // perf_bench and skip_calibration already parsed above (before glfwSwapInterval).
+  // skip_calibration already parsed above (before glfwSwapInterval).
 
   // Create Lumice server.
   gui::g_server = LUMICE_CreateServer();
@@ -258,101 +254,6 @@ int main(int argc, char** argv) {
   // Must happen after server creation but before the main loop.
   if (!skip_calibration) {
     gui::CalibrateQualityThreshold();
-  }
-
-  // --perf-bench: use EXACTLY the same startup path as test_gui_main.cpp's StartPerfSimulation,
-  // measure steady-state throughput for 2 seconds, print result, and exit.
-  // This allows apples-to-apples comparison with gui_test --filter perf_test.
-  if (perf_bench) {
-    // Disable runtime viewport creation for perf-bench only. Platform callbacks remain
-    // registered from ImGui_ImplGlfw_Init; this flag gate merely skips per-frame viewport
-    // update/render cost so steady-state measurement is not polluted by window management.
-    io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
-    // Same config as StartPerfSimulation in test_gui_main.cpp
-    gui::g_state.sun.altitude = 20.0f;
-    gui::g_state.sun.diameter = 0.5f;
-    gui::g_state.sun.spectrum_index = 2;
-    gui::g_state.sim.infinite = true;
-    gui::g_state.sim.max_hits = 8;
-    {
-      auto& r = gui::g_state.renderer;
-      r.lens_type = 1;
-      r.fov = 360.0f;
-      r.sim_resolution_index = 0;  // 512
-      r.visible = 2;
-      r.background[0] = r.background[1] = r.background[2] = 0.0f;
-      r.exposure_offset = 0.0f;
-    }
-    gui::DoRun();
-
-    // Wait for first data
-    auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (gui::g_state.stats_sim_ray_num == 0 && std::chrono::steady_clock::now() < timeout) {
-      glfwPollEvents();
-      gui::SyncFromPoller();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-
-    // Measure for 2 seconds
-    auto start_rays = gui::g_state.stats_sim_ray_num;
-    auto start_time = std::chrono::steady_clock::now();
-    auto end_time = start_time + std::chrono::seconds(2);
-    int frames = 0;
-    while (std::chrono::steady_clock::now() < end_time) {
-      glfwPollEvents();
-      gui::SyncFromPoller();
-
-      ImGui_ImplOpenGL3_NewFrame();
-      ImGui_ImplGlfw_NewFrame();
-      ImGui::NewFrame();
-
-      int win_w = 0, win_h = 0;
-      glfwGetWindowSize(window, &win_w, &win_h);
-      auto lw = static_cast<float>(win_w);
-      auto lh = static_cast<float>(win_h);
-      gui::RenderTopBar(lw);
-      gui::RenderLeftPanel(lh);
-      gui::RenderRightPanel(window, lw, lh);
-      gui::RenderPreviewPanel(window, lw, lh);
-      gui::RenderStatusBar(lw, lh);
-      gui::RenderEditModals(gui::g_state, window);
-
-      ImGui::Render();
-      int dw = 0, dh = 0;
-      glfwGetFramebufferSize(window, &dw, &dh);
-      glViewport(0, 0, dw, dh);
-      glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-      glClear(GL_COLOR_BUFFER_BIT);
-      if (gui::g_preview_vp.active) {
-        gui::g_preview.Render(gui::g_preview_vp.vp_x, gui::g_preview_vp.vp_y, gui::g_preview_vp.vp_w,
-                              gui::g_preview_vp.vp_h, gui::g_preview_vp.params);
-      }
-      ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-      glfwSwapBuffers(window);
-      frames++;
-    }
-
-    auto end_rays = gui::g_state.stats_sim_ray_num;
-    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - start_time).count();
-    double rps = elapsed > 0 ? static_cast<double>(end_rays - start_rays) / elapsed : 0;
-    fprintf(stderr, "[PERF-BENCH] steady_state: %.1f rays/sec (%lu rays in %.1fs, %d frames, %.1f FPS)\n", rps,
-            end_rays - start_rays, elapsed, frames, frames / elapsed);
-
-    // Cleanup and exit
-    gui::g_server_poller.Stop();
-    gui::g_thumbnail_cache.Destroy();
-    gui::g_crystal_renderer.Destroy();
-    gui::g_preview.Destroy();
-    LUMICE_DestroyServer(gui::g_server);
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
-    glfwDestroyWindow(window);
-    glfwTerminate();
-#ifdef _WIN32
-    timeEndPeriod(1);
-#endif
-    return 0;
   }
 
   // Window size callback: detect user manual resize vs programmatic resize

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -45,14 +45,14 @@ RenderConsumer::RenderConsumer(RenderConfig config)
 
 
 void RenderConsumer::Consume(const SimData& data) {
-  // scrum-258.1: SimData carries a single payload form — outgoing_d_/w_ +
-  // outgoing_indices_(.size() only) — regardless of whether the simulator
-  // ran via the legacy CPU path or a TraceBackend (exit seam). Both
-  // converge here and run through the projection pipeline below.
+  // scrum-258.1: SimData carries a single payload form — outgoing_d_/w_ —
+  // regardless of whether the simulator ran via the legacy CPU path or a
+  // TraceBackend (exit seam). Both converge here and run through the
+  // projection pipeline below.
   auto t0 = std::chrono::steady_clock::now();
   // Resize pre-allocated buffers if needed (grow-only).
   // Use outgoing count for capacity — it's the upper bound for filtered rays.
-  size_t outgoing_count = data.outgoing_indices_.size();
+  size_t outgoing_count = data.outgoing_w_.size();
   size_t needed = std::max(data.rays_.size_, outgoing_count);
   if (needed > buf_capacity_) {
     buf_capacity_ = needed;
@@ -128,7 +128,7 @@ void RenderConsumer::Consume(const SimData& data) {
 
   // Copy pre-filtered outgoing rays into contiguous buffers (Design A:
   // simulator-side filter has already dropped non-matching rays).
-  assert(!data.outgoing_indices_.empty() || data.rays_.Empty());
+  assert(!data.outgoing_w_.empty() || data.rays_.Empty());
   size_t filtered_ray_num = outgoing_count;
   if (!data.outgoing_d_.empty()) {
     std::memcpy(d_buf_.get(), data.outgoing_d_.data(), filtered_ray_num * 3 * sizeof(float));

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -45,7 +45,8 @@ RenderConsumer::RenderConsumer(RenderConfig config)
 
 
 void RenderConsumer::Consume(const SimData& data) {
-  // scrum-258.1: SimData carries a single payload form — outgoing_d_/w_ —
+  // scrum-258.1: SimData carries a single payload form — outgoing_d_/w_
+  // (plus the optional per-ray outgoing_wl_ added in scrum-268.8 (DR-3)) —
   // regardless of whether the simulator ran via the legacy CPU path or a
   // TraceBackend (exit seam). Both converge here and run through the
   // projection pipeline below.

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -766,6 +766,9 @@ void ServerImpl::ConsumeData() {
                 chunk.outgoing_d_.assign(
                     sim_data.outgoing_d_.begin() + static_cast<std::ptrdiff_t>(emitted) * 3,
                     sim_data.outgoing_d_.begin() + static_cast<std::ptrdiff_t>(emitted + chunk_count) * 3);
+                // Invariant: outgoing_w_ is sliced to exactly chunk_count, so
+                // chunk.outgoing_w_.size() == chunk_count is the consumer's
+                // per-chunk outgoing-ray count (it reads .size(), see render.cpp).
                 chunk.outgoing_w_.assign(
                     sim_data.outgoing_w_.begin() + static_cast<std::ptrdiff_t>(emitted),
                     sim_data.outgoing_w_.begin() + static_cast<std::ptrdiff_t>(emitted + chunk_count));

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -785,7 +785,6 @@ void ServerImpl::ConsumeData() {
                       sim_data.exit_records_.begin() + static_cast<std::ptrdiff_t>(emitted),
                       sim_data.exit_records_.begin() + static_cast<std::ptrdiff_t>(emitted + chunk_count));
                 }
-                chunk.outgoing_indices_.assign(chunk_count, 0);
               }
               for (auto& c : consumers_) {
                 c->Consume(chunk);
@@ -799,7 +798,7 @@ void ServerImpl::ConsumeData() {
           auto lock_us = std::chrono::duration<double, std::micro>(t_lock1 - t_lock0).count();
           auto consume_us = std::chrono::duration<double, std::micro>(t_consume - t_lock1).count();
           ILOG_DEBUG(logger_, "ConsumeData: batch rays={} outgoing={} lock={:.0f}us consume={:.0f}us",
-                     sim_data.rays_.size_, sim_data.outgoing_indices_.size(), lock_us, consume_us);
+                     sim_data.rays_.size_, sim_data.outgoing_w_.size(), lock_us, consume_us);
           if (!first_consume_logged) {
             ILOG_INFO(logger_, "ConsumeData: first batch consumed ({} ray segments)", sim_data.rays_.size_);
             first_consume_logged = true;

--- a/test/e2e/configs/parity_single_ms_filter.json
+++ b/test/e2e/configs/parity_single_ms_filter.json
@@ -28,7 +28,7 @@
     "max_hits": 7,
     "scattering": [
       {
-        "prob": 1.0,
+        "prob": 0.0,
         "entries": [
           { "crystal": 1, "proportion": 10, "filter": 1 }
         ]

--- a/test/parity-cross-backend/backend/test_metal_exit_seam_parity.py
+++ b/test/parity-cross-backend/backend/test_metal_exit_seam_parity.py
@@ -232,9 +232,15 @@ _RAW_THRESHOLDS = {
     # measurement 0.9986 ≈ noise floor 0.9988; threshold = 0.97.
     "ms_multi_crystal_filtered":    (0.97, 0.97),
     "parity_ms_prob05_filter":      (0.97, 0.97),
-    # parity_single_ms_filter dropped: legacy returns all-zero buffer after
-    # the prob=0.0→1.0 fix (commit 0d03388); metal/cpu_backend raise PY
-    # exceptions on it. Test is `@pytest.mark.skip`-marked — no threshold.
+    # parity_single_ms_filter repaired (chore-292 A4): the 258.6 review change
+    # prob=0.0→1.0 (commit 0d03388) zero-signalled this SINGLE-layer scene —
+    # prob=1.0 makes every ray continue to a nonexistent next layer (0 exits),
+    # while prob=0.0 = pure single-scatter (all rays exit). Reverted to 0.0,
+    # which is the semantically-correct "single MS" value and distinct from
+    # parity_ms_prob05_filter (prob=0.5). Calibrated 2026-06-24:
+    # metal ds=0.9984 psnr=28.84dB / cpu_backend ds=0.9986 psnr=29.34dB
+    # → threshold = floor(0.9984 × 100) / 100 − 0.02 = 0.97 for both.
+    "parity_single_ms_filter":      (0.97, 0.97),
     #
     # 267.4 matrix extension: complex filter coverage (Step 5 calibrated
     # 2026-06-14):
@@ -379,14 +385,6 @@ def test_parity_single_ms_no_filter():
 # --- Single MS + filter ---------------------------------------------------- #
 
 @pytest.mark.slow
-@pytest.mark.skip(
-    reason="parity_single_ms_filter became zero-signal after the 258.6 "
-           "code-review prob=0.0→1.0 fix (commit 0d03388): single-MS + "
-           "raypath filter [3,5] survival rate collapsed to near-zero rays "
-           "(eff_px=1, snap=0.0 in legacy). Metal/cpu_backend raise "
-           "PY_EXCEPTION (exit_code=2). Config-level issue, out of scope "
-           "for 258.6.2. Skip until the scene is repaired or replaced.",
-)
 def test_parity_single_ms_filter():
     cm, pm, cc, pc = _parity_axes("parity_single_ms_filter")
     print(f"[parity] parity_single_ms_filter: metal ds={cm:.4f} psnr={pm:.2f}dB | cpu_backend ds={cc:.4f} psnr={pc:.2f}dB")

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -944,6 +944,7 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   const uint64_t kSnapGen = self.generation_;
   const size_t kSnapRaysSize = self.rays_.size_;
   RaySeg* snap_rays_ptr = self.rays_.rays_.get();
+  const size_t kSnapOutgoingWSize = self.outgoing_w_.size();
   const size_t kSnapCrystalsSize = self.crystals_.size();
 
   // Use an alias reference to bypass -Wself-move warning.
@@ -954,5 +955,6 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_EQ(self.generation_, kSnapGen);
   EXPECT_EQ(self.rays_.size_, kSnapRaysSize);
   EXPECT_EQ(self.rays_.rays_.get(), snap_rays_ptr);
+  EXPECT_EQ(self.outgoing_w_.size(), kSnapOutgoingWSize);
   EXPECT_EQ(self.crystals_.size(), kSnapCrystalsSize);
 }

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -44,7 +44,9 @@ static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 // shrinking back to 192. scrum-258.2 adds exit_records_
 // (vector<ExitRayRecord>, 24B), bumping 192 → 216. scrum-268.8 (DR-3) adds
 // outgoing_wl_ (vector<float>, 24B) for per-ray wavelength, bumping 216 → 240.
-static_assert(sizeof(SimData) == 240,
+// chore-292 (A2) removes the vestigial outgoing_indices_ (vector<size_t>, 24B)
+// — content never read; count = outgoing_w_.size() — shrinking 240 → 216.
+static_assert(sizeof(SimData) == 216,
               "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
               "and sim_data.cpp's static_assert.");
 #endif
@@ -72,7 +74,6 @@ SimData MakePopulatedSimData() {
   for (int i = 0; i < 5; i++) {
     s.rays_.EmplaceBack(MakeRay(i), RaypathRecorder{});
   }
-  s.outgoing_indices_ = { 0, 2, 4 };
   s.outgoing_d_ = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
   s.outgoing_w_ = { 0.5f, 0.7f };
   // scrum-268.8 (DR-3): outgoing_wl_ deep-copy / move coverage.
@@ -791,7 +792,6 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   }
 
   // Vector field equality.
-  EXPECT_EQ(copy.outgoing_indices_, original.outgoing_indices_);
   EXPECT_EQ(copy.outgoing_d_, original.outgoing_d_);
   EXPECT_EQ(copy.outgoing_w_, original.outgoing_w_);
   EXPECT_EQ(copy.outgoing_wl_, original.outgoing_wl_);  // scrum-268.8 (DR-3)
@@ -805,9 +805,6 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   // Deep copy independence — each pointer/container field independently.
   copy.rays_[0].w_ = 999.0f;
   EXPECT_FLOAT_EQ(original.rays_[0].w_, 0.0f) << "rays_ not deep-copied";
-
-  copy.outgoing_indices_.push_back(99);
-  EXPECT_EQ(original.outgoing_indices_.size(), 3u) << "outgoing_indices_ not deep-copied";
 
   copy.outgoing_d_.clear();
   EXPECT_EQ(original.outgoing_d_.size(), 6u) << "outgoing_d_ not deep-copied";
@@ -840,7 +837,6 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   for (int i = 0; i < 5; i++) {
     EXPECT_FLOAT_EQ(target.rays_[i].w_, original.rays_[i].w_);
   }
-  EXPECT_EQ(target.outgoing_indices_, original.outgoing_indices_);
   EXPECT_EQ(target.outgoing_d_, original.outgoing_d_);
   EXPECT_EQ(target.outgoing_w_, original.outgoing_w_);
   EXPECT_EQ(target.outgoing_wl_, original.outgoing_wl_);  // scrum-268.8 (DR-3)
@@ -851,8 +847,6 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   // Deep copy independence.
   target.rays_[0].w_ = 999.0f;
   EXPECT_FLOAT_EQ(original.rays_[0].w_, 0.0f) << "rays_ not deep-assigned";
-  target.outgoing_indices_.push_back(99);
-  EXPECT_EQ(original.outgoing_indices_.size(), 3u) << "outgoing_indices_ not deep-assigned";
   target.exit_records_.clear();
   EXPECT_EQ(original.exit_records_.size(), 2u) << "exit_records_ not deep-assigned";
   target.crystals_.clear();
@@ -868,7 +862,6 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   const size_t kSnapRaysSize = orig.rays_.size_;
   const size_t kSnapRaysCap = orig.rays_.capacity_;
   const float kSnapRay0W = orig.rays_[0].w_;
-  const auto kSnapOutgoingIdx = orig.outgoing_indices_;
   const size_t kSnapCrystalsSize = orig.crystals_.size();
 
   SimData& self_alias = orig;
@@ -880,7 +873,6 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   EXPECT_EQ(orig.rays_.size_, kSnapRaysSize);
   EXPECT_EQ(orig.rays_.capacity_, kSnapRaysCap);
   EXPECT_FLOAT_EQ(orig.rays_[0].w_, kSnapRay0W);
-  EXPECT_EQ(orig.outgoing_indices_, kSnapOutgoingIdx);
   EXPECT_EQ(orig.crystals_.size(), kSnapCrystalsSize);
 }
 
@@ -898,7 +890,6 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   EXPECT_FLOAT_EQ(moved.curr_wl_, 550.0f);
   EXPECT_EQ(moved.generation_, 42u);
   EXPECT_EQ(moved.root_ray_count_, 7u);
-  EXPECT_EQ(moved.outgoing_indices_.size(), 3u);
   EXPECT_EQ(moved.outgoing_d_.size(), 6u);
   EXPECT_EQ(moved.outgoing_w_.size(), 2u);
   EXPECT_EQ(moved.exit_records_.size(), 2u);
@@ -915,7 +906,6 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   // This assertion locks the current observed behavior; if migrating to MSVC
   // STL or a future libc++ change, this may need to be relaxed.
   EXPECT_TRUE(original.crystals_.empty());
-  EXPECT_TRUE(original.outgoing_indices_.empty());
   EXPECT_TRUE(original.outgoing_d_.empty());
   EXPECT_TRUE(original.outgoing_w_.empty());
   EXPECT_TRUE(original.exit_records_.empty());
@@ -939,7 +929,6 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_EQ(dst.rays_.capacity_, 8u);
   EXPECT_FLOAT_EQ(dst.curr_wl_, 550.0f);
   EXPECT_EQ(dst.generation_, 42u);
-  EXPECT_EQ(dst.outgoing_indices_.size(), 3u);
   EXPECT_EQ(dst.crystals_.size(), 1u);
 
   // Source moved-from state.
@@ -947,7 +936,6 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_EQ(src.rays_.size_, 0u);
   EXPECT_EQ(src.rays_.capacity_, 0u);
   EXPECT_TRUE(src.crystals_.empty());
-  EXPECT_TRUE(src.outgoing_indices_.empty());
 
   // Self-move-assignment must preserve all fields (source code has
   // &other == this guard). Snapshot → self-move → assert preservation.
@@ -956,7 +944,6 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   const uint64_t kSnapGen = self.generation_;
   const size_t kSnapRaysSize = self.rays_.size_;
   RaySeg* snap_rays_ptr = self.rays_.rays_.get();
-  const size_t kSnapOutgoingIdxSize = self.outgoing_indices_.size();
   const size_t kSnapCrystalsSize = self.crystals_.size();
 
   // Use an alias reference to bypass -Wself-move warning.
@@ -967,6 +954,5 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_EQ(self.generation_, kSnapGen);
   EXPECT_EQ(self.rays_.size_, kSnapRaysSize);
   EXPECT_EQ(self.rays_.rays_.get(), snap_rays_ptr);
-  EXPECT_EQ(self.outgoing_indices_.size(), kSnapOutgoingIdxSize);
   EXPECT_EQ(self.crystals_.size(), kSnapCrystalsSize);
 }


### PR DESCRIPTION
批量收尾 5 条 backlog 中 deferred 的低优先杂项（chore-292，同模式于 #290）。`Lumice --benchmark`（G1 门依赖）不动。

## 动作清单

- **A1** — retire 孤儿 `LumiceGUI --perf-bench`：删 `src/gui/main.cpp` perf_bench 分支 + 4 个 doc 引用（被 `gui_test --filter perf_test` 完全覆盖）。`--skip-calibration` 独立 flag 保留。
- **A2** — 移除 vestigial `SimData::outgoing_indices_`：白盒证实其**内容全树从不被读**（仅 `.size()`，且 `server.cpp` 早已用 `outgoing_w_.size()` 作权威计数），整体移除 member（decl + copy/move + legacy fill + 2 dummy producer）。SimData 240→216 B，行为保持。
- **A3** — exit-seam image-seam"死代码"**前提证伪**：`ReadbackImage`/`ScatterOutgoingToXyz` 是跨后端 parity oracle 基础设施（4 测试文件 + 生产调用），非死代码。改为纯注释正名 `[PARITY-ORACLE]`，**不删**。
- **A4** — 修 `parity_single_ms_filter` 零信号 + 解 skip：258.6 把单层场景 `prob 0.0→1.0` 逻辑反转（prob=1.0 → 全续传到不存在层 → 0 出射）。改回 `prob=0.0`（语义正确的"single MS"），校准 threshold `(0.97, 0.97)`。test 由 SKIP → PASSED（metal ds=0.9984 / cpu ds=0.9986）。
- **A5** — 评估 Metal/Cpu parity smoke 进 CI：**前提证伪** — `ci.yml` 的 `e2e-slow` job 已在 macos-15 真 Metal 上 per-PR + main 跑全套 `test_metal_exit_seam_parity.py`。无需新增；A4 修复的场景已自动进该 CI 门。

## 验证

- `-tj release` ctest **3/3** GREEN
- fast e2e `pytest -m "not slow"` **30 passed**（A2 行为保持）
- full parity `pytest -m "slow and not heavy"`（CI 同口径）**8 passed / 3 deselected**
- code-review **APPROVE**（independent，Critical=0/Major=0/Minor=2/Suggestion=1，均已清）

🤖 Generated with [Claude Code](https://claude.com/claude-code)