### PR TITLE
chore: clean up Metal compile-path review minors (task-282/283 衍生, #293)

### DIFF
--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -291,7 +291,12 @@ id<MTLLibrary> LoadMetallibFromEmbeddedBytes(id<MTLDevice> device,
   );
   NSError* err = nil;
   id<MTLLibrary> lib = [device newLibraryWithData:data error:&err];
-  if (out_err) { *out_err = err; }
+  // Only surface err on failure. newLibraryWithData leaves err nil on success,
+  // so writing it unconditionally is benign through the outer LoadMetalLibrary
+  // (which clears *out_err to nil on its own success paths) — but it is a
+  // foot-gun if this helper is ever called standalone: it would clobber a
+  // caller's pre-set *out_err on the success path. Keep err scoped to failure.
+  if (lib == nil && out_err) { *out_err = err; }
   return lib;
 }
 

--- a/src/core/metal_trace_backend.mm
+++ b/src/core/metal_trace_backend.mm
@@ -291,11 +291,13 @@ id<MTLLibrary> LoadMetallibFromEmbeddedBytes(id<MTLDevice> device,
   );
   NSError* err = nil;
   id<MTLLibrary> lib = [device newLibraryWithData:data error:&err];
-  // Only surface err on failure. newLibraryWithData leaves err nil on success,
-  // so writing it unconditionally is benign through the outer LoadMetalLibrary
-  // (which clears *out_err to nil on its own success paths) — but it is a
-  // foot-gun if this helper is ever called standalone: it would clobber a
-  // caller's pre-set *out_err on the success path. Keep err scoped to failure.
+  // Contract: *out_err is written iff the load fails. Scoping the write to
+  // lib == nil makes this hold for ANY caller, independent of caller behavior —
+  // newLibraryWithData leaves err nil on success, so an unconditional write
+  // would clobber a standalone caller's pre-set *out_err on the success path.
+  // (The current sole caller, LoadMetalLibrary, also clears *out_err on its own
+  // success paths, so the old unconditional write was benign in practice — but
+  // the contract must not depend on that.)
   if (lib == nil && out_err) { *out_err = err; }
   return lib;
 }

--- a/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
+++ b/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
@@ -208,6 +208,13 @@ struct MetalHarness {
       // the unused production kernels add ~50KB of MSL compile work per test
       // start which is dwarfed by the test's own work and avoids a duplicate
       // helper-string source-of-truth.
+      //
+      // Coupling caveat: since the prefix carries the production trace_layer
+      // kernel, a syntax error in lumice_trace.metal surfaces *here* as this
+      // filter-match parity test failing to compile — a non-obvious failure
+      // mode (the real breakage is in production MSL, not the test kernel). A
+      // future option is a Python-side structural extraction of a helper-only
+      // header (still single-source) to decouple the test from the full kernel.
       NSString* src = [NSString stringWithFormat:@"%s\n%s",
                                                   kLumiceCombinedKernelSrc,
                                                   kFilterMatchTestKernelSrc];


### PR DESCRIPTION
收尾 #290 没清完的 Metal backend 编译路径 code-review 遗留 minor（源自 task-282/283，均非阻塞、双 reviewer APPROVE）。开 `with_code_review`。

## 动作清单（前置核查 live 代码后）

- **A1 — DRY helper** → ⏭ **已解，跳过**：`MetalPipelineAvailable()` 与 `EnsurePso()` 现都走同一 `LoadMetalLibrary` helper，源串 + `MTLCompileOptions` 只出现一次（注释 `metal_trace_backend.mm:408-413` 明示旧重复"structurally gone"）。metallib-first 重构（task-283）已消除该 DRY 隐患。
- **A2 — stale-err 诊断** → ⏭ **moot，跳过**：#290 已去掉 EnsurePso 的 err；gate 与 EnsurePso 现都用 `functionNames` 作 entry-point-missing 诊断（不对称已消）。`LoadMetalLibrary` 成功清 err 是有意设计，强行保留 err 反而回退。
- **A3 — 内层 err 契约** ✅：`LoadMetallibFromEmbeddedBytes` 无条件 `*out_err = err` → 仅失败写（`lib == nil`）+ 契约注释（以 helper 自身契约为主因，耐 outer 重构）。
- **A4 — parity 前缀耦合注释** ✅：filter-match parity 测试拼接生产 trace kernel 处补 caveat（语法错→非直觉编译失败），未来 Python helper-only 抽取选项已登记 backlog。

> A1/A2 经 live 代码证伪为已解/moot（task-283 重构 + #290 overtaken）——连续第二个 chore 出现"task-282/283 deferred review minor 被后续重构 overtaken"的模式。真改 = A3 + A4。

## 验证
- `-tj release` ctest **3/3 GREEN**（含 Metal parity GTest）
- code-review **APPROVE**（independent，Critical=0/Major=0/Minor=0/Suggestion=2，均已清）
- format / policy CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)