### PR TITLE
fix(stats): widen ray-count types to 64-bit (Windows u32 overflow) — task-297

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -623,7 +623,7 @@ void CalibrateQualityThreshold() {
   // Uses kCalibrationWindowMs (fixed) instead of kCommitIntervalMs so that changing
   // the commit interval doesn't accidentally tighten/loosen the quality gate.
   double rays_per_window = static_cast<double>(stats[0].sim_ray_num) * kCalibrationWindowMs / elapsed_ms;
-  auto threshold = std::max(kMinRaysFloor, static_cast<unsigned long>(rays_per_window * kCalibrationFraction));
+  auto threshold = std::max(kMinRaysFloor, static_cast<unsigned long long>(rays_per_window * kCalibrationFraction));
 
   g_server_poller.SetCalibratedThreshold(threshold);
   GUI_LOG_INFO("[Calibration] done in {:.0f}ms: {} rays, {:.0f} rays/window({}ms), threshold={}", elapsed_ms,

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -973,11 +973,11 @@ void RenderStatusBar(float window_width, float window_height) {
   // Stats
   if (g_state.stats_sim_ray_num > 0) {
     ImGui::SameLine();
-    unsigned long n = g_state.stats_sim_ray_num;
+    LUMICE_RayCount n = g_state.stats_sim_ray_num;
     char buf[64];
-    if (n >= 1'000'000'000UL) {
+    if (n >= 1'000'000'000ULL) {
       snprintf(buf, sizeof(buf), "| Rays: %.1f x10^9", n / 1e9);
-    } else if (n >= 1'000'000UL) {
+    } else if (n >= 1'000'000ULL) {
       snprintf(buf, sizeof(buf), "| Rays: %.1f x10^6", n / 1e6);
     } else {
       snprintf(buf, sizeof(buf), "| Rays: %.1f x10^3", n / 1e3);

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -981,7 +981,7 @@ void FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
 
   // Scene: simulation
   out->infinite = state.sim.infinite ? 1 : 0;
-  out->ray_num = static_cast<unsigned long>(state.sim.ray_num_millions * 1e6f);
+  out->ray_num = static_cast<LUMICE_RayCount>(state.sim.ray_num_millions * 1e6f);
   out->max_hits = state.sim.max_hits;
 }
 

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -50,7 +50,7 @@ constexpr int kQualityGateTimeoutMs = 500;
 // Floor for the adaptive quality gate threshold (min sim_ray_num for texture upload).
 // After calibration, the actual threshold may be higher (adapted to platform throughput).
 // This floor ensures Windows (lower throughput) never drops below a safe minimum.
-constexpr unsigned long kMinRaysFloor = 5000;
+constexpr unsigned long long kMinRaysFloor = 5000;
 
 // SliderWithInput / control alignment layout constants
 constexpr float kLabelColWidth = 70.0f;

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "gui/gui_constants.hpp"
+#include "include/lumice.h"  // LUMICE_RayCount (64-bit ray-count type)
 
 namespace lumice::gui {
 
@@ -532,11 +533,11 @@ struct GuiState {
   SimState sim_state = SimState::kIdle;
 
   // Stats from last poll
-  unsigned long stats_ray_seg_num = 0;
-  unsigned long stats_sim_ray_num = 0;
-  float snapshot_intensity = 0;            // Per-pixel landed intensity for XYZ→RGB normalization
-  int effective_pixels = 0;                // Non-zero pixel count (for stats display)
-  unsigned long texture_upload_count = 0;  // Cumulative texture uploads (diagnostic counter)
+  LUMICE_RayCount stats_ray_seg_num = 0;
+  LUMICE_RayCount stats_sim_ray_num = 0;
+  float snapshot_intensity = 0;                 // Per-pixel landed intensity for XYZ→RGB normalization
+  int effective_pixels = 0;                     // Non-zero pixel count (for stats display)
+  unsigned long long texture_upload_count = 0;  // Cumulative texture uploads (diagnostic counter)
 
   // Auto-EV runtime state (display layer only, not persisted, not in ConfigSnapshot)
   float p99_raw_y = 0.0f;       // Un-normalized P99 Y value; updated each texture upload

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -104,7 +104,7 @@ void ServerPoller::InvalidateStagedTexture() {
   staged_.has_new_texture = false;
 }
 
-void ServerPoller::SetCalibratedThreshold(unsigned long threshold) {
+void ServerPoller::SetCalibratedThreshold(unsigned long long threshold) {
   calibrated_min_rays_ = threshold;
   calibrated_ = true;
   GUI_LOG_INFO("[Poller] calibration set: threshold={}", threshold);
@@ -185,7 +185,7 @@ void ServerPoller::PollOnce() {
 
       // Quality gate: skip texture overwrite for sparse snapshots (too few rays = visible flicker).
       // Cold start (sim_ray_num == 0) is allowed through — no "old good texture" to preserve.
-      unsigned long min_rays = calibrated_ ? calibrated_min_rays_ : gui::kMinRaysFloor;
+      unsigned long long min_rays = calibrated_ ? calibrated_min_rays_ : gui::kMinRaysFloor;
       bool quality_ok = cached_stats.sim_ray_num == 0 || cached_stats.sim_ray_num >= min_rays;
 
       // Timeout fallback: if quality gate has been rejecting for too long (e.g. empty filter),

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -16,8 +16,8 @@ namespace lumice::gui {
 struct PollerData {
   bool valid = false;  // Set to true by worker after first successful poll
   LUMICE_ServerState server_state = LUMICE_SERVER_IDLE;
-  unsigned long stats_ray_seg_num = 0;
-  unsigned long stats_sim_ray_num = 0;
+  LUMICE_RayCount stats_ray_seg_num = 0;
+  LUMICE_RayCount stats_sim_ray_num = 0;
   std::vector<float> xyz_data;  // XYZ float texture data (for GPU conversion)
   int texture_width = 0;
   int texture_height = 0;
@@ -30,7 +30,7 @@ struct PollerData {
   float intensity_factor = 1.0f;
   int effective_pixels = 0;
   bool has_new_texture = false;
-  unsigned long texture_ray_count = 0;  // Ray count at the time texture data was captured (not global stats)
+  LUMICE_RayCount texture_ray_count = 0;  // Ray count at the time texture data was captured (not global stats)
 };
 
 // Polls the LUMICE server on a background thread (every kPollIntervalMs) and stages
@@ -70,7 +70,7 @@ class ServerPoller {
 
   // Set calibrated quality gate threshold (called once at startup after calibration run).
   // Thread-safe: only called from main thread before any Start().
-  void SetCalibratedThreshold(unsigned long threshold);
+  void SetCalibratedThreshold(unsigned long long threshold);
 
  private:
   enum class State { kPaused, kRunning, kTerminating };
@@ -93,7 +93,7 @@ class ServerPoller {
   // Adaptive quality gate: calibrated threshold set once at startup via SetCalibratedThreshold().
   // If not set (calibrated_ == false), falls back to gui::kMinRaysFloor.
   bool calibrated_{ false };
-  unsigned long calibrated_min_rays_{ 0 };
+  unsigned long long calibrated_min_rays_{ 0 };
 
   // Timeout fallback: force upload if quality gate has been rejecting for too long.
   // Reset in Start(), updated in PollOnce() on each quality_ok pass.

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -53,6 +53,18 @@ typedef enum LUMICE_ServerState_ {
   LUMICE_SERVER_NOT_READY,
 } LUMICE_ServerState;
 
+// =============== Ray Count Type ===============
+// 64-bit count type for ray / ray-segment / crystal totals. Must stay >= 64-bit:
+// `unsigned long` is only 32-bit on Windows (LLP64), which silently truncated
+// totals above 2^32 (the status-bar ray-count rollover reported by Windows users).
+// Used for every field that carries an actual ray-count value across the C API.
+typedef unsigned long long LUMICE_RayCount;
+#if defined(__cplusplus)
+static_assert(sizeof(LUMICE_RayCount) >= 8, "LUMICE_RayCount must be 64-bit (Windows unsigned long is 32-bit)");
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(LUMICE_RayCount) >= 8, "LUMICE_RayCount must be 64-bit (Windows unsigned long is 32-bit)");
+#endif
+
 // =============== Result Structs ===============
 typedef struct LUMICE_RenderResult_ {
   int renderer_id;
@@ -78,9 +90,9 @@ typedef struct LUMICE_RawXyzResult_ {
 } LUMICE_RawXyzResult;
 
 typedef struct LUMICE_StatsResult_ {
-  unsigned long ray_seg_num;
-  unsigned long sim_ray_num;
-  unsigned long crystal_num;
+  LUMICE_RayCount ray_seg_num;
+  LUMICE_RayCount sim_ray_num;
+  LUMICE_RayCount crystal_num;
   // Sentinel: all zeros (sim_ray_num == 0)
 } LUMICE_StatsResult;
 
@@ -216,8 +228,8 @@ typedef struct LUMICE_Config_ {
   const char* spectrum;  // e.g. "D65", "D50", "A", "E"
 
   // Scene: simulation
-  int infinite;           // 1=infinite rays, 0=finite
-  unsigned long ray_num;  // only used when infinite==0
+  int infinite;             // 1=infinite rays, 0=finite
+  LUMICE_RayCount ray_num;  // only used when infinite==0
   int max_hits;
 
   // Scene: scattering

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,7 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
   // transparency; existing keys (mode/workers/cores/rays/rays_per_sec) are kept.
   auto t_run_start = std::chrono::steady_clock::now();
   auto t_active_start = t_run_start;
-  unsigned long rays_at_active_start = 0;
+  LUMICE_RayCount rays_at_active_start = 0;
   bool active_started = false;
   while (true) {
     std::this_thread::sleep_for(kBenchmarkPollInterval);
@@ -160,7 +160,7 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
       continue;
     }
     bool have_stats = LUMICE_GetStatsResults(server, stats, LUMICE_MAX_STATS_RESULTS) == LUMICE_OK;
-    unsigned long cur_rays = have_stats ? stats[0].sim_ray_num : 0;
+    LUMICE_RayCount cur_rays = have_stats ? stats[0].sim_ray_num : 0;
     auto now = std::chrono::steady_clock::now();
 
     // Mark end-of-setup the first time tracing has produced rays.
@@ -172,7 +172,7 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
 
     if (state == LUMICE_SERVER_IDLE && cur_rays > 0) {
       auto t_end = now;
-      unsigned long r_end = cur_rays;
+      LUMICE_RayCount r_end = cur_rays;
       double wall_sec = std::chrono::duration<double>(t_end - t_run_start).count();
       double setup_sec = std::chrono::duration<double>(t_active_start - t_run_start).count();
       double active_sec = std::chrono::duration<double>(t_end - t_active_start).count();

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -541,7 +541,7 @@ static LUMICE_ErrorCode JsonToScene(const nlohmann::json& scene, LUMICE_Config* 
       out->ray_num = 0;
     } else if (rn.is_number()) {
       out->infinite = 0;
-      out->ray_num = rn.get<unsigned long>();
+      out->ray_num = rn.get<LUMICE_RayCount>();
     } else {
       return LUMICE_ERR_INVALID_VALUE;
     }

--- a/test/unit-correctness/config/test_config_snapshot.cpp
+++ b/test/unit-correctness/config/test_config_snapshot.cpp
@@ -168,6 +168,26 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   EXPECT_FALSE(target.save_texture);
 }
 
+TEST(ConfigSnapshot, StatsRayCountsNotClearedByApplyTo) {
+  // Regression (task-fix-stats-ray-count-u32-overflow): GUI stats fields are runtime
+  // state, so ApplyTo (which restores config fields) must leave them untouched — here
+  // shown with > 2^32 values that ApplyTo preserves verbatim.
+  // NOTE: the 64-bit *width* guarantee (the actual Windows truncation fix) is enforced
+  // at compile time by the static_asserts in lumice.h and test_c_api.cpp, NOT by this
+  // test — on a 64-bit-`unsigned long` platform (Mac/Linux) this passes even pre-fix.
+  GuiState source = InitDefaultState();
+  auto snap = GuiState::ConfigSnapshot::From(source);
+
+  GuiState target = InitDefaultState();
+  target.stats_ray_seg_num = 9'000'000'000ULL;  // > UINT32_MAX (4'294'967'295)
+  target.stats_sim_ray_num = 5'000'000'000ULL;
+
+  snap.ApplyTo(target);
+
+  EXPECT_EQ(target.stats_ray_seg_num, 9'000'000'000ULL);
+  EXPECT_EQ(target.stats_sim_ray_num, 5'000'000'000ULL);
+}
+
 TEST(ConfigSnapshot, RoundTripFromThenApplyRestoresConfig) {
   GuiState original = MakeModifiedState();
   auto snap = GuiState::ConfigSnapshot::From(original);

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -15,6 +15,16 @@
 #include "core/def.hpp"
 #include "include/lumice.h"
 
+// Regression guard (task-fix-stats-ray-count-u32-overflow): ray-count fields must be
+// 64-bit so totals > 2^32 never truncate on Windows, where `unsigned long` is 32-bit
+// (the status-bar ray-count rollover reported by Windows users). These field-level
+// asserts complement the header-level guard in lumice.h: they verify the struct fields
+// actually use the 64-bit type, not just that the typedef is wide enough.
+static_assert(sizeof(((LUMICE_StatsResult*)nullptr)->sim_ray_num) >= 8, "stats sim_ray_num must be 64-bit");
+static_assert(sizeof(((LUMICE_StatsResult*)nullptr)->ray_seg_num) >= 8, "stats ray_seg_num must be 64-bit");
+static_assert(sizeof(((LUMICE_StatsResult*)nullptr)->crystal_num) >= 8, "stats crystal_num must be 64-bit");
+static_assert(sizeof(((LUMICE_Config*)nullptr)->ray_num) >= 8, "config ray_num must be 64-bit");
+
 TEST(CrystalMeshApi, PrismVerticesAndEdges) {
   LUMICE_CrystalMesh mesh{};
   const char* json = R"({"type": "prism", "shape": {"height": 1.0}})";
@@ -488,6 +498,22 @@ TEST(ParseConfigApi, MinimalPrismConfig) {
   EXPECT_EQ(config.renderers[0].resolution_w, 800);
   EXPECT_EQ(config.renderers[0].resolution_h, 400);
   EXPECT_FLOAT_EQ(config.renderers[0].opacity, 1.0f);
+}
+
+
+TEST(ParseConfigApi, RayNumAbove32BitNotTruncated) {
+  // Regression (task-fix-stats-ray-count-u32-overflow): config ray_num was parsed via
+  // `rn.get<unsigned long>()`, truncating to 32-bit on Windows. A finite ray_num above
+  // 2^32 must round-trip through LUMICE_ParseConfigString intact.
+  auto root = nlohmann::json::parse(MakeMinimalConfigJson());
+  const LUMICE_RayCount kBigRayNum = 5'000'000'000ULL;  // > UINT32_MAX (4'294'967'295)
+  root["scene"]["ray_num"] = kBigRayNum;
+
+  LUMICE_Config config{};
+  EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_OK);
+  EXPECT_EQ(config.infinite, 0);
+  // Pre-fix on Windows this truncated to 705'032'704; post-fix it holds the full value.
+  EXPECT_EQ(config.ray_num, kBigRayNum);
 }
 
 


### PR DESCRIPTION
修复 Windows 内测用户反馈的 GUI 状态栏「光线总数」超约 43 亿（2³²）后回滚归零。根因 = C API 用 `unsigned long`（Windows LLP64 下仅 32-bit）承载核心 `size_t`（64-bit）累计的光线数，赋值时静默截断。

## 改动范围

把整条「`unsigned long`-on-Windows 截断隐患」**整类**修掉（非只修状态栏触发点），共 15 处：

- 新增公开类型 `LUMICE_RayCount`（=`unsigned long long`）+ 头级 `static_assert(sizeof >= 8)`，覆盖所有编译 `lumice.h` 的 TU，Windows 上一旦回归即编译期 fail。
- `LUMICE_StatsResult` 三字段 + config `ray_num` → `LUMICE_RayCount`（ABI 变更；owner 确认无外部消费方，Unix 布局不变）。
- config `ray_num` 解析/写入链、GUI 统计显示链（poller/state 镜像 + 状态栏局部）、CLI bench 计数 → `LUMICE_RayCount`；内部阈值/诊断族 → 裸 `unsigned long long`。
- 回归：4 条字段级 `static_assert` + 2 条 >2³² 往返测试（config 链 `LUMICE_ParseConfigString` + GUI snapshot `ApplyTo`）。

## 验证

- ✅ Mac 本地：编译 156/156（含 GUI）+ ctest 3 套件全绿 + 两条新回归测试 RUN/OK + format/policy 干净。
- ⏳ **Windows 溢出真机验证 = 本 PR 的 `Windows MSVC x86_64` CI job**（Mac 上 `unsigned long`=64bit 无法复现溢出；该 job 是本修复的真正验收门）。

## 非目标

核心层 ray 计数（已全程 `size_t`，源头正确，不动）；`file_io.cpp:984` 的 `1e6f` float 精度（预存问题，转 backlog）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
