### PR TITLE
chore: deferred quality cleanup (scrum-298) — e2e ref regen + geometry predicate single-source + ray_num float precision

### DIFF
--- a/doc/numerical-robustness.md
+++ b/doc/numerical-robustness.md
@@ -65,6 +65,10 @@ drift. Prefer a shared helper; if a backend boundary forces duplication (e.g. th
 `tri_to_poly` kernel mirroring the CPU function), add a `// must match X` comment and a
 parity test, and fix both together.
 
+Convergence log (geometry-gen double-precision predicates):
+- `SolvePlanesD` — converged in task-280.4 (`geo3d.cpp` inline copy removed; single source `math.hpp::SolvePlanesD`).
+- `IsInPolyhedron3D` — converged in task-geometry-predicate-single-source (`geo3d.cpp::is_in_polyhedron_d` lambda removed; single source `math.hpp::IsInPolyhedron3D` with `kIncidenceEpsD = 1e-5`, replacing the lambda's drifted `1e-10`).
+
 ### 5. **Guard normalizations and divisions** by potentially-zero quantities
 `Normalize3`, `cross / |cross|`, `x / det`, `x / extent`, perspective divide — all
 produce NaN/Inf on degenerate inputs (collinear vertices, parallel normals, edge-on

--- a/src/core/geo3d.cpp
+++ b/src/core/geo3d.cpp
@@ -428,17 +428,9 @@ size_t FillHexCrystalCoef(float upper_alpha, float lower_alpha, float h1, float 
     for (size_t i = 0; i < cnt * 4; i++) {
       coef_d[i] = static_cast<double>(out_coef[i]);
     }
-    // Plane-triple intersection delegates to the single-source SolvePlanesD
-    // (math.hpp) — scale-invariant singularity check on the normalized det.
-    auto is_in_polyhedron_d = [](int n, const double* coef, const double xyz[3]) -> bool {
-      for (int j = 0; j < n; j++) {
-        if (coef[j * 4 + 0] * xyz[0] + coef[j * 4 + 1] * xyz[1] + coef[j * 4 + 2] * xyz[2] + coef[j * 4 + 3] > 1e-10) {
-          return false;
-        }
-      }
-      return true;
-    };
-
+    // Plane-triple intersection + containment both delegate to single-source
+    // math.hpp helpers (SolvePlanesD scale-invariant det; IsInPolyhedron3D with
+    // kIncidenceEpsD=1e-5 absorbing float-input precision residuals).
     double z_max = std::numeric_limits<double>::lowest();
     double z_min = std::numeric_limits<double>::max();
     double xyz[3];
@@ -448,7 +440,7 @@ size_t FillHexCrystalCoef(float upper_alpha, float lower_alpha, float h1, float 
           if (!SolvePlanesD(coef_d.data() + i * 4, coef_d.data() + j * 4, coef_d.data() + k * 4, xyz)) {
             continue;
           }
-          if (is_in_polyhedron_d(static_cast<int>(cnt - 2), coef_d.data() + 8, xyz)) {
+          if (IsInPolyhedron3D(static_cast<int>(cnt - 2), coef_d.data() + 8, xyz)) {
             z_max = std::max(z_max, xyz[2]);
             z_min = std::min(z_min, xyz[2]);
           }

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -765,16 +765,6 @@ double DiffNorm3D(const double* a, const double* b) {
   return std::sqrt(dx * dx + dy * dy + dz * dz);
 }
 
-bool IsInPolyhedron3D(int n, const double* coef, const double xyz[3], bool boundary = true) {
-  double th = boundary ? kIncidenceEpsD : -kIncidenceEpsD;
-  for (int j = 0; j < n; j++) {
-    if (Dot3D(coef + j * 4, xyz) + coef[j * 4 + 3] > th) {
-      return false;
-    }
-  }
-  return true;
-}
-
 void WidenCoefToDouble(int plane_cnt, const float* coef_f, std::vector<double>& coef_d) {
   coef_d.resize(plane_cnt * 4);
   for (int i = 0; i < plane_cnt * 4; i++) {
@@ -783,6 +773,17 @@ void WidenCoefToDouble(int plane_cnt, const float* coef_f, std::vector<double>& 
 }
 
 }  // namespace
+
+
+bool IsInPolyhedron3D(int n, const double* coef, const double xyz[3], bool boundary) {
+  double th = boundary ? kIncidenceEpsD : -kIncidenceEpsD;
+  for (int j = 0; j < n; j++) {
+    if (Dot3D(coef + j * 4, xyz) + coef[j * 4 + 3] > th) {
+      return false;
+    }
+  }
+  return true;
+}
 
 
 // Singularity threshold for the double-precision Cramer's rule, evaluated on

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -292,6 +292,19 @@ bool IsInPolygon2(int n, const float* coef, const float xy[2], bool boundary = t
 bool IsInPolyhedron3(int n, const float* coef, const float xyz[3], bool boundary = true);
 
 /**
+ * @brief Double-precision variant of @ref IsInPolyhedron3. Containment threshold is
+ *        `kIncidenceEpsD = 1e-5` (matches the float-input precision floor; see
+ *        doc/numerical-robustness.md §4 "single source of truth").
+ *
+ * @param n Number of half spaces.
+ * @param coef Coefficients of half spaces, [a, b, c, d] × n.
+ * @param xyz Point to be checked.
+ * @param boundary Whether to treat points on the boundary as "inside" (default true).
+ * @return true if the point is inside (or on the boundary when @p boundary is true).
+ */
+bool IsInPolyhedron3D(int n, const double* coef, const double xyz[3], bool boundary = true);
+
+/**
  * @brief Find all vertices of a convex polyhedron, which is defined by intersection of multiple half spaces:
  *        a*x + b*y + c*z + d <= 0
  *

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -738,7 +738,7 @@ std::string SerializeCoreConfig(const GuiState& state) {
   if (state.sim.infinite) {
     scene["ray_num"] = "infinite";
   } else {
-    auto ray_num = static_cast<size_t>(state.sim.ray_num_millions * 1e6f);
+    auto ray_num = static_cast<size_t>(state.sim.ray_num_millions * 1e6);
     scene["ray_num"] = ray_num;
   }
   scene["max_hits"] = state.sim.max_hits;
@@ -981,7 +981,7 @@ void FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
 
   // Scene: simulation
   out->infinite = state.sim.infinite ? 1 : 0;
-  out->ray_num = static_cast<LUMICE_RayCount>(state.sim.ray_num_millions * 1e6f);
+  out->ray_num = static_cast<LUMICE_RayCount>(state.sim.ray_num_millions * 1e6);
   out->max_hits = state.sim.max_hits;
 }
 
@@ -1338,7 +1338,7 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
       if (js["ray_num"].is_string() && js["ray_num"].get<std::string>() == "infinite") {
         state.sim.infinite = true;
       } else if (js["ray_num"].is_number()) {
-        state.sim.ray_num_millions = static_cast<float>(js["ray_num"].get<size_t>()) / 1e6f;
+        state.sim.ray_num_millions = static_cast<float>(js["ray_num"].get<size_t>()) / 1e6;
       }
     }
     state.sim.max_hits = js.value("max_hits", 8);

--- a/test/e2e-correctness/references/color_01.jpg
+++ b/test/e2e-correctness/references/color_01.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:580dc45ad9e5b54d944c6ad02b25d4ba9bd16a42e01a113c8166905f1f246f1c
-size 37827
+oid sha256:472bde1af93be18e8bf4e75c4e96d4cb541a532f76993c164a315825c9594ae1
+size 21098

--- a/test/e2e-correctness/test_smoke.py
+++ b/test/e2e-correctness/test_smoke.py
@@ -19,7 +19,13 @@ REFERENCES_DIR = get_project_root() / "test" / "e2e-correctness" / "references"
 # Calibrated by running each config 3 times and taking min_psnr - 3dB.
 # Set to None to skip PSNR check for that output.
 PSNR_THRESHOLDS = {
-    "color_01": 27.1,
+    # color: 5-wavelength discrete-spectrum (440/510/550/590/640nm). Reference
+    # regenerated post-296.7 fix (sim_scene_cnt_ 1-vs-N, commit 5513906d) which
+    # restored full 50M-ray sampling. Run-to-run PSNR (3 runs, 2026-06-26):
+    # 39.08/39.63/39.70 dB. Threshold = min - 3dB = 36.0 dB (was 27.1 dB;
+    # +8.9dB tightening confirms owner hypothesis that prior threshold was
+    # artificially low due to discrete-spectrum undersampling bug).
+    "color_01": 36.0,
     "cza_01": 41.5,
     "filters_01": 26.7,
     "halo_22_01": 26.7,


### PR DESCRIPTION
GPU 无关的「遗留质量清理」（scrum-298），收掉 scrum-296 / task-297 / task-276(PR#133) 留下的明显但非阻塞质量问题。延续 #290 / #293 的 deferred-cleanup 模式。3 个独立子任务，每项独立 commit、独立复核。

## 子任务

| commit | 子任务 | 内容 |
|---|---|---|
| `f8adf9c2` | discrete-spectrum e2e 参考图重生成 | 296.7 的 `sim_scene_cnt_` 1-vs-N 计数失衡（backend-agnostic，已合 main）修复前，discrete-spectrum 配置欠采样 ~N×、参考图偏噪。用 post-296.7 干净 build 重生成 `color_01.jpg`（50M 满采样，旧 ~10M），阈值 27.1→36.0 dB（+8.9 收紧）。**实查 config 后确认只有 color 真受影响**（5 波长 N≥2）；multi_lens/parhelion/render_opts 是单波长、multi_scatter 是 D75 illuminant，均计数平衡不受影响。 |
| `deacfd5a` | geometry 谓词单源化 | `geo3d.cpp` 的 `is_in_polyhedron_d` 本地 lambda（漂移的绝对阈值 1e-10）去重为复用 `math.cpp` `IsInPolyhedron3D`（`kIncidenceEpsD=1e-5`，吸收 float 系数精度残差 ~1e-7）。消除谓词重复 + 统一 epsilon（task-276/PR#133 code-review Minor #1+#2）。语义逐行等价、仅 epsilon 窗口收敛；现有几何不触发该窗口，行为零变化。 |
| `bab0d6cc` | GUI ray_num float 精度 | `file_io.cpp` 三站点 `ray_num_millions * 1e6f` / `/ 1e6f` → double `1e6`，与 task-297 把 `ray_num` 放宽到 64-bit 的高精度意图一致。 |

## 验证

- 298.1：e2e smoke `2 passed`（含新 color 参考图 + 新阈值）。
- 298.2：`build.sh -tj release` ctest 4/4 全绿（含极端 wedge 哨兵）+ plan-review/code-review 双 APPROVE。
- 298.3：`src/gui` 无 `1e6f` 残留 + GUI build 4/4。

## 注意

- 298.1 的 color 阈值 36.0 dB 是 macOS 同平台标定；处于已验证的"干净高 PSNR"档（3dB 余量历史足够吸收跨平台噪声），本 PR 的 Linux E2E CI 是最终裁判。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
