### PR TITLE
fix(gpu): CUDA full multi-CI correctness + device-side recombine shuffle (Metal+CUDA)

### DIFF
--- a/doc/gpu-single-engine-implementation.md
+++ b/doc/gpu-single-engine-implementation.md
@@ -45,6 +45,23 @@
 - +16% 多 MS filter 能量 bug（根因=host `CopyContSliceToRootBuf` 解耦 filter，随删除自愈）。
 - server 构造函数潜伏 bug（legacy CPU 巨型未切块 consume 假象，268.6 白盒证伪后修）。
 
+### 0.1 ⭐ CUDA backend as-built（全量多 CI + 诚实吞吐基线，2026-06-27，task-cuda-throughput-bench）
+
+> CUDA 是 seam 的第二个真实消费者。scrum-295/296 落地单 CI MVP；本轮把它推到**与 legacy 完全对齐的全量多 CI**，并取到第一份**诚实**吞吐基线。设计蓝图细节见 `scratchpad/task-cuda-throughput-bench/MULTI_CI_DESIGN.md`（git-ignored），分支 `feat/cuda-multi-ci-correctness`。
+
+- **多 CI（每层多晶体带 proportion）全量落地，对标 Metal 惰性-transit-per-CI 模型**（CUDA 此前是 single-CI MVP：BeginSession 只传 1 晶体、TraceLayer/Recombine/DrainExits 用 setting_[0]）。结构改动：
+  - 几何 per-CI：`UploadCrystalGeometry`/`EnsureGeomCapacity`（grow-only），对标 Metal `UploadCrystal`。
+  - cont 缓冲 ping-pong（`d_cont_*[2]`）；**transit 从 Recombine 移入 TraceLayer 惰性逐 CI**（读 cont[in_slot] 的 per-ci 切片过该 ci 晶体），Recombine 变薄（只 bump 层 + 返回 cont count）。
+  - TraceLayer per-CI 循环：`PartitionCrystalRayNum` 连续切片 → 每 CI MakeCrystal + 几何上传 + gen(首层)/transit(续传) + trace，exit(crystal_id=ci tag)/cont[out_slot] atomic 累加。RNG flat-seed + 每 CI 推进 monotone gen/gate/transit counter（不相交 PCG 区间，单 CI 行为不变）。
+  - final 层 DrainExits 按 `ExitRayRecord.crystal_id` 索引 per-CI FilterSpec/crystal；`EnsureContCapacity` 支持 3+ 层 cont/root grow（in_slot 不动，cont_cap_[2] 每槽）。
+  - kernel emit-gate filter slot 修为 `ms_layer*max_ci + crystal_id`（原缺 crystal_id=单 CI MVP 残留）。
+  - `ComputeExitCap/ComputeContCap` 去掉 64MiB silent-drop 硬顶，按解析上界 `n*(max_hits*2+4)` size（correctness > memory；OOM→优雅回退 legacy）。
+- **验证（dev49/44 RTX 4060 Ti，全对 legacy）**：parity-cross-backend 11/11（单MS / ms_prob05 2层 / ms_multi_crystal 2层多CI ds_corr 0.913→0.9998 / **ms3_multi_crystal 3层多CI [4,3,2] 含 final** / filter / cross-seed 自洽）；e2e-correctness 15/15（CUDA 路由确认）；ctest golden-analytic 100%。**未修前 ms_multi_crystal 静默错（ds_corr 0.913，energy+cross-seed 都掩盖）——parity 漏因只测了 single-CI 的 ms_prob05。**
+- **诚实吞吐基线（干净机 44-GPU，GPU 0%/CPU idle 99%）**：light_single_ms CUDA ≈ **0.10–0.12× legacy，flat（与 dispatch 无关）**；瓶颈 100% = **出射记录主机往返**（DrainExits D2H + 主机 filter + 下游 XYZ 累加，线性于 exit 数 ~54ns/exit），trace kernel 极小。
+  - ⚠️ **推翻 scrum-296 Step D（49-GPU 旧单 CI 代码）"大 dispatch 1.6–2.2×"**——那是 exit 64MiB 硬顶丢弃 87% exit 的假象（drain 被封顶→虚高）。处理全部 exit 后 = ~0.1× flat。**"加大 dispatch 让 CUDA 赢"失效。**
+  - 唯一有意义优化 = **device 侧 XYZ 累加**（不每 dispatch 把裸 records 过 PCIe+主机处理），非 dispatch/batch 调参。详见 `scratchpad/backlog.md` seam 条目（待单起 explore）。
+  - 仪表瑕疵待修：多 CI 重写把 cudaEvent `ev_end_kernel_` 记录点挪到 per-CI 循环外，TraceLayer kernel 计时失真（≈0ms 假象）；profiling 前先修 event placement。
+
 ## 1. 状态与目标（设计期原文）
 
 > **接手注意**：本节描述 scrum-267/268 之前的出发状态（设计期），已是历史。

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Committed throughput bench harness (task-270.6 / performance layer §1.5).
 
-Runs `Lumice --benchmark` across a 3-backend × heavy-config × Metal-dispatch
+Runs `Lumice --benchmark` across a 4-backend × heavy-config × GPU-dispatch
 matrix, reports median rays/s + CoV per cell, ratios against the legacy CPU
-baseline. Replaces the gitignored `scratchpad/bench/seam_exit_bench.py` (whose
+baseline. Backends: legacy CPU (baseline), cpu_backend (verify-only), Metal
+(Apple host only), CUDA (CUDA host only, e.g. dev49 — scrum-296 Step D). The
+host-incompatible GPU rows print as N/A. Replaces the gitignored `scratchpad/bench/seam_exit_bench.py` (whose
 LUMICE_BATCH_RAY_NUM knob was removed in scrum-268.4).
 
 Baseline policy: the denominator is always legacy CPU (env unset = the GUI's
@@ -38,17 +40,30 @@ import tempfile
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-BIN = PROJECT_ROOT / "build" / "cmake_install" / "Lumice"
+# BIN/lib are env-overridable so the same harness runs on dev49 (CUDA bench, Linux
+# docker: binary at /work/build/Release/bin/Lumice) as on a local Mac. Default is
+# the local install path.
+_BIN_ENV = os.environ.get("LUMICE_BENCH_BIN")
+BIN = Path(_BIN_ENV) if _BIN_ENV else PROJECT_ROOT / "build" / "cmake_install" / "Lumice"
 # rpath workaround for -sj shared-lib builds (backlog #345). Harmless for -j.
-DYLIB_DIRS = [
+# LUMICE_BENCH_LIBDIR prepends a dir (dev49: /work/build/Release/lib).
+_LIBDIR_ENV = os.environ.get("LUMICE_BENCH_LIBDIR")
+LIB_DIRS = ([Path(_LIBDIR_ENV)] if _LIBDIR_ENV else []) + [
     PROJECT_ROOT / "build" / "Release" / "lib",
     PROJECT_ROOT / "build" / "cmake_install" / "lib",
     PROJECT_ROOT / "build" / "RelWithDebInfo" / "lib",
 ]
+# Shared-lib search-path env var differs by platform: macOS=DYLD_, Linux=LD_.
+LIB_PATH_VAR = "DYLD_LIBRARY_PATH" if platform.system() == "Darwin" else "LD_LIBRARY_PATH"
 
 BENCH_RE = re.compile(r"\[BENCHMARK\]\s*(\{.*\})")
 ROUTE_METAL = "routing via MetalTraceBackend"
+ROUTE_CUDA = "routing via CudaTraceBackend"
 FALLBACK = "falling back"
+# GPU backends whose routing must be confirmed in the log (else the run silently
+# fell back to legacy CPU and the number is meaningless). legacy/cpu_backend are
+# not route-gated (cpu_backend is verify-only; legacy is the baseline path).
+GPU_ROUTE_STRINGS = {"metal": ROUTE_METAL, "cuda": ROUTE_CUDA}
 
 # Canonical throughput-regime scene set (light -> heavy). Mirrors the benchmark
 # scene registry in doc/performance-testing.md ("基准场景注册表") — keep the two
@@ -84,17 +99,22 @@ BACKENDS = [
     ("legacy", None),
     ("cpu_backend", "cpu_backend"),
     ("metal", "metal"),
+    ("cuda", "cuda"),
 ]
 
-# Dispatch sweep applies to Metal only — CPU paths ignore LUMICE_DISPATCH_RAY_NUM
-# for parity with how the GUI runs. `None` means "do NOT set the env var" — the
-# server picks its own backend-aware default (32768 for Metal, kDefaultRayNum for
-# CPU). Keeping `None` distinct from `32768` lets the table verify "default ==
-# 32768 today" without conflating intents if the default later moves.
+# Dispatch sweep applies to GPU backends (Metal, CUDA) — CPU paths ignore
+# LUMICE_DISPATCH_RAY_NUM for parity with how the GUI runs. `None` means "do NOT
+# set the env var" — the server picks its own backend-aware default (32768 for any
+# GPU route, kDefaultRayNum for CPU; server.cpp ResolveGpuRoute). Keeping `None`
+# distinct from `32768` lets the table verify "default == 32768 today" without
+# conflating intents if the default later moves. The small-batch points (128, 512)
+# characterize the "small dispatch starves the GPU" curve that motivates the
+# single-engine large-dispatch route (doc/seam-design.md §5).
 DISPATCH_PLAN = {
     "legacy": [None],
     "cpu_backend": [None],
     "metal": [None, 128, 512, 2048, 32768],
+    "cuda": [None, 128, 512, 2048, 32768],
 }
 
 N_REPS = 5
@@ -107,10 +127,44 @@ BASELINE_LABEL = "[BASELINE]"
 CPU_BACKEND_LABEL = "[verify-only]"  # not a baseline; see feedback_perf_baseline_is_legacy_cpu
 
 
+# --- Optional env-driven matrix narrowing (for focused / robust remote runs) ---
+# The committed defaults above run the full matrix. For a focused dev49 run (e.g.
+# scrum-296 Step D: legacy vs cuda only, fewer reps, larger dispatch probe) these
+# env knobs trim the matrix WITHOUT editing the committed defaults. Unset = full.
+#   LUMICE_BENCH_BACKENDS=legacy,cuda      # subset of backend labels (order kept)
+#   LUMICE_BENCH_CONFIGS=ms_multi_crystal  # subset of config labels
+#   LUMICE_BENCH_DISPATCH=default,32768,65536,131072  # GPU dispatch list ("default"->None)
+#   LUMICE_BENCH_NREPS=5                    # override N_REPS
+def _csv_env(name: str) -> list[str] | None:
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    return [tok.strip() for tok in raw.split(",") if tok.strip()]
+
+
+_sel_backends = _csv_env("LUMICE_BENCH_BACKENDS")
+if _sel_backends is not None:
+    BACKENDS = [b for b in BACKENDS if b[0] in _sel_backends]
+
+_sel_configs = _csv_env("LUMICE_BENCH_CONFIGS")
+if _sel_configs is not None:
+    CONFIGS = {k: v for k, v in CONFIGS.items() if k in _sel_configs}
+
+_sel_dispatch = _csv_env("LUMICE_BENCH_DISPATCH")
+if _sel_dispatch is not None:
+    _parsed = [None if tok == "default" else int(tok) for tok in _sel_dispatch]
+    for _gpu in ("metal", "cuda"):
+        DISPATCH_PLAN[_gpu] = _parsed
+
+_nreps_env = os.environ.get("LUMICE_BENCH_NREPS")
+if _nreps_env:
+    N_REPS = int(_nreps_env)
+
+
 def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) -> dict:
     """Execute one --benchmark invocation. Returns parsed result dict."""
     env = dict(os.environ)
-    env["DYLD_LIBRARY_PATH"] = ":".join(str(d) for d in DYLIB_DIRS)
+    env[LIB_PATH_VAR] = ":".join(str(d) for d in LIB_DIRS)
     if backend_env is None:
         env.pop("LUMICE_TRACE_BACKEND", None)
     else:
@@ -134,21 +188,22 @@ def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) ->
             pass  # malformed [BENCHMARK] line → INCOMPLETE note below
     by_mode = {b["mode"]: b["rays_per_sec"] for b in benches}
 
-    routed_metal = ROUTE_METAL in out
+    expected_route = GPU_ROUTE_STRINGS.get(backend_env)  # None for legacy/cpu_backend
+    routed_gpu = (expected_route in out) if expected_route else True
     fell_back = FALLBACK in out
     note = ""
-    if backend_env == "metal":
+    if expected_route is not None:  # metal or cuda — must confirm GPU routing
         if fell_back:
             note = "FELL_BACK"
-        elif not routed_metal:
-            note = f"NO_METAL_ROUTE(rc={proc.returncode})"
+        elif not routed_gpu:
+            note = f"NO_{backend_env.upper()}_ROUTE(rc={proc.returncode})"
         elif len(benches) < 2:
             note = f"INCOMPLETE(n={len(benches)},rc={proc.returncode})"
     else:
         if len(benches) < 2:
             note = f"INCOMPLETE(n={len(benches)},rc={proc.returncode})"
 
-    routed_ok = (backend_env != "metal") or (routed_metal and not fell_back)
+    routed_ok = (expected_route is None) or (routed_gpu and not fell_back)
     return {
         "single_rps": by_mode.get("single"),
         "multi_rps": by_mode.get("multi"),
@@ -219,6 +274,19 @@ def _fmt_dispatch(d):
     return "default" if d is None else str(d)
 
 
+def _backend_na_reason(backend_label: str, is_darwin: bool) -> str | None:
+    """Which backends are not runnable on this host (returns reason, else None).
+
+    Metal needs an Apple host; CUDA needs a CUDA-enabled build + NVIDIA device
+    (the dev49 Linux docker image), which is never the Mac dev host.
+    """
+    if backend_label == "metal" and not is_darwin:
+        return "Darwin only"
+    if backend_label == "cuda" and is_darwin:
+        return "CUDA host only"
+    return None
+
+
 def _preflight() -> list[str]:
     """Validate prerequisites; returns list of error strings (empty == OK)."""
     errs: list[str] = []
@@ -264,7 +332,10 @@ def main() -> int:
 
     is_darwin = platform.system() == "Darwin"
     if not is_darwin:
-        print("[bench_throughput] non-Darwin host: Metal rows will be reported as 'N/A'.",
+        print("[bench_throughput] non-Darwin host: Metal rows -> N/A; CUDA is the GPU backend.",
+              flush=True)
+    else:
+        print("[bench_throughput] Darwin host: CUDA rows -> N/A; Metal is the GPU backend.",
               flush=True)
 
     print(
@@ -291,11 +362,12 @@ def main() -> int:
         legacy_multi_median = None
 
         for backend_label, backend_env in BACKENDS:
-            if backend_label == "metal" and not is_darwin:
+            na_reason = _backend_na_reason(backend_label, is_darwin)
+            if na_reason is not None:
                 print(
                     f"{backend_label:<12s} {cfg_label:<34s} {'-':>9s} "
                     f"{'N/A':>15s} {'N/A':>15s} {'-':>6s} {'-':>6s} {'-':>10s} "
-                    f"<-- N/A (Darwin only)",
+                    f"<-- N/A ({na_reason})",
                     flush=True,
                 )
                 continue

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -161,6 +161,13 @@ constexpr uint32_t kCudaGenNonce     = 0x3C9A7F11u;
 // (mirrors Metal `impl_->rng` re-seeding semantics — see scrum-258 lesson on
 // BeginSession RNG resets being filter parity's hidden third rail).
 constexpr uint32_t kCudaDrainNonce   = 0xD5A1B3C7u;
+// Continuation-pool shuffle PCG nonce (task-gpu-backend-recombine-shuffle).
+// shuffle_cont_kernel decorrelates the per-parent-CI grouping the per-CI trace
+// kernels leave in cont[written_slot] before the next layer's per-CI slicing
+// consumes them (mirrors legacy host Fisher-Yates in simulator.cpp:946-950).
+// Layer-level seed = shuffle_seed_ ^ ms_layer_idx_ keeps each layer's Feistel
+// independent (Metal-side kMetalShuffleNonce takes the same value, symmetric).
+constexpr uint32_t kCudaShuffleNonce = 0xB17CA3D9u;
 
 // File-local mirror of Metal `ComputeJacobianEnvelopeForDeviceGen`
 // (metal_trace_backend.mm:259). The four branches MUST stay numerically
@@ -922,6 +929,40 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
   }
 }
 
+// --- shuffle_cont_kernel ---------------------------------------------------
+//
+// Continuation-pool decorrelation shuffle (task-gpu-backend-recombine-shuffle).
+// Gather-form Feistel permutation: each thread tid in [0, n) computes
+// `src = feistel_bijection(tid, n, seed)` (lm_pcg, shared with MSL) and copies
+// (d, w, wl_idx) from in[src] to out[tid]. The dest must NOT alias the source,
+// so the caller passes cont[other_slot] as the dest and swaps the slot pointers
+// afterwards (see Recombine).
+//
+// Why: when a multi-CI layer's per-CI trace_single_ms_kernel dispatches run on
+// the default stream, cont[written_slot] ends up grouped by parent CI. The next
+// layer's per-CI slicing then hands "parent-correlated" subsets to each child
+// CI, biasing the ray→crystal pairing. Legacy host Fisher-Yates breaks this
+// (simulator.cpp:946-950); explore-300 confirmed the GPU backends were missing
+// the same step.
+__global__ void shuffle_cont_kernel(const float* __restrict__    in_d,
+                                    const float* __restrict__    in_w,
+                                    const uint32_t* __restrict__ in_wl,
+                                    float* __restrict__          out_d,
+                                    float* __restrict__          out_w,
+                                    uint32_t* __restrict__       out_wl,
+                                    uint32_t n_rays, uint32_t seed) {
+  const uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= n_rays) {
+    return;
+  }
+  const uint32_t src = lm_pcg::feistel_bijection(tid, n_rays, seed);
+  out_d[tid * 3u + 0u] = in_d[src * 3u + 0u];
+  out_d[tid * 3u + 1u] = in_d[src * 3u + 1u];
+  out_d[tid * 3u + 2u] = in_d[src * 3u + 2u];
+  out_w[tid]  = in_w[src];
+  out_wl[tid] = in_wl[src];
+}
+
 }  // namespace
 
 bool CudaDeviceAvailable() {
@@ -1091,6 +1132,12 @@ struct CudaTraceBackend::Impl {
   size_t   gen_ray_count_ = 0;
   bool     gen_seeded_    = false;
   bool     disable_device_gen_ = false;
+
+  // --- Continuation-pool shuffle PCG state (task-gpu-backend-recombine-shuffle)
+  // shuffle_cont_kernel uses (shuffle_seed_ ^ ms_layer_idx_) as the per-layer
+  // Feistel seed; no monotone counter (the Feistel is keyed once per layer, not
+  // per ray, and each layer's seed is naturally disjoint).
+  uint32_t shuffle_seed_ = 0u;
 
   // --- MS layer tracking (296.4) -------------------------------------------
   // Populated by BeginSession from spec.scene->ms_.size() and advanced by
@@ -1810,6 +1857,7 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     impl_->transit_seed_ = spec.seed ^ kCudaTransitNonce;
     impl_->gate_seed_    = spec.seed ^ kCudaGateNonce;
     impl_->gen_seed_     = spec.seed ^ kCudaGenNonce;
+    impl_->shuffle_seed_ = spec.seed ^ kCudaShuffleNonce;
     if (!impl_->transit_seeded_) {
       impl_->transit_ray_count_ = 0;
       impl_->transit_seeded_ = true;
@@ -2164,7 +2212,6 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
 }
 
 RootRaySource CudaTraceBackend::Recombine(LayerHandlePtr handle, const RecombineSpec& spec) {
-  (void)spec;
   if (!impl_->in_session_) {
     throw BackendUnavailableError("CudaTraceBackend::Recombine called outside session");
   }
@@ -2181,6 +2228,71 @@ RootRaySource CudaTraceBackend::Recombine(LayerHandlePtr handle, const Recombine
   // here: the next TraceLayer zeroes its own out_slot before its ci-loop.
   const uint32_t cont_n = impl_->h_cont_count_;
   const int written_slot = static_cast<int>(impl_->ms_layer_idx_ & 1u);
+
+  // Continuation-pool decorrelation shuffle (task-gpu-backend-recombine-shuffle).
+  // Mirrors legacy host Fisher-Yates (simulator.cpp:946-950): per-CI trace
+  // dispatches leave cont[written_slot] grouped by parent CI; without this
+  // shuffle, the next layer's per-CI slicing would hand parent-correlated
+  // subsets to each child CI (explore-300 root cause).
+  //
+  // Slot accounting (cuda_trace_backend.cu:1930-1933 F-verify, plan §8):
+  //   - This layer wrote cont[out_slot = ms_layer_idx_ & 1u]; we are BEFORE
+  //     the ++ so written_slot above is exactly that out_slot.
+  //   - The next layer N+1 reads in_slot = ((N+1)-1) & 1 = N & 1 = written_slot.
+  //   - Gather READ cont[written_slot] (source), WRITE cont[other_slot] (dest),
+  //     then SWAP the slot pointers so cont[written_slot] holds the shuffled
+  //     data the next layer will consume.
+  //   - cont[other_slot] post-swap holds the stale source; the next layer will
+  //     overwrite it (out_slot = (N+1) & 1 = other_slot) — no aliasing.
+  if (spec.shuffle && cont_n > 1u) {
+    const int other_slot = 1 - written_slot;
+    // Ensure cont[other_slot] has capacity for cont_n entries. Mirrors the
+    // grow-on-overflow path in EnsureContCapacity (alloc d/w/wl together).
+    if (impl_->cont_cap_[other_slot] < cont_n) {
+      auto ck = [this](cudaError_t e, const char* ctx) {
+        if (e != cudaSuccess) {
+          impl_->Reset();
+          throw BackendUnavailableError(std::string{"CudaTraceBackend::Recombine: "} + ctx + ": " +
+                                        cudaGetErrorString(e));
+        }
+      };
+      cudaDeviceSynchronize();
+      cudaFree(impl_->d_cont_d_[other_slot]);      impl_->d_cont_d_[other_slot] = nullptr;
+      cudaFree(impl_->d_cont_w_[other_slot]);      impl_->d_cont_w_[other_slot] = nullptr;
+      cudaFree(impl_->d_cont_wl_idx_[other_slot]); impl_->d_cont_wl_idx_[other_slot] = nullptr;
+      ck(cudaMalloc(&impl_->d_cont_d_[other_slot],      3 * cont_n * sizeof(float)),
+         "cudaMalloc d_cont_d (shuffle grow)");
+      ck(cudaMalloc(&impl_->d_cont_w_[other_slot],      cont_n * sizeof(float)),
+         "cudaMalloc d_cont_w (shuffle grow)");
+      ck(cudaMalloc(&impl_->d_cont_wl_idx_[other_slot], cont_n * sizeof(uint32_t)),
+         "cudaMalloc d_cont_wl_idx (shuffle grow)");
+      impl_->cont_cap_[other_slot] = cont_n;
+    }
+    const uint32_t shuf_seed = impl_->shuffle_seed_ ^ static_cast<uint32_t>(impl_->ms_layer_idx_);
+    const uint32_t grid = (cont_n + 255u) / 256u;
+    shuffle_cont_kernel<<<grid, 256>>>(impl_->d_cont_d_[written_slot],
+                                       impl_->d_cont_w_[written_slot],
+                                       impl_->d_cont_wl_idx_[written_slot],
+                                       impl_->d_cont_d_[other_slot],
+                                       impl_->d_cont_w_[other_slot],
+                                       impl_->d_cont_wl_idx_[other_slot],
+                                       cont_n, shuf_seed);
+    cudaError_t launch_err = cudaPeekAtLastError();
+    if (launch_err != cudaSuccess) {
+      impl_->Reset();
+      throw BackendUnavailableError(std::string{"CudaTraceBackend::Recombine: shuffle_cont_kernel launch: "} +
+                                    cudaGetErrorString(launch_err));
+    }
+    // Swap ALL four parallel slot arrays so cont[written_slot] holds the
+    // shuffled data (next layer's in_slot = written_slot). Omitting wl_idx
+    // here would silently desynchronize per-ray wavelength tagging — Feistel /
+    // energy parity could not detect it.
+    std::swap(impl_->d_cont_d_[written_slot],      impl_->d_cont_d_[other_slot]);
+    std::swap(impl_->d_cont_w_[written_slot],      impl_->d_cont_w_[other_slot]);
+    std::swap(impl_->d_cont_wl_idx_[written_slot], impl_->d_cont_wl_idx_[other_slot]);
+    std::swap(impl_->cont_cap_[written_slot],      impl_->cont_cap_[other_slot]);
+  }
+
   impl_->ms_layer_idx_++;
 
   if (impl_->logger != nullptr) {

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -74,6 +74,7 @@
 #include "core/shared/pcg_shared.h"
 #include "core/shared/traversal_shared.h"
 #include "core/trace_ops.hpp"
+#include "core/simulator.hpp"  // PartitionCrystalRayNum (multi-CI per-layer partition)
 #include "util/logger.hpp"
 
 namespace lumice {
@@ -106,24 +107,35 @@ void CheckCuda(cudaError_t err, const char* ctx) {
 
 // Exit buffer capacity. Coefficient 2 = reflect+refract conservative upper
 // bound per hit; +4 = safety margin matching the Metal EnsureExitBuffers
-// constant. Capped at 64 MiB / sizeof(ExitRayRecord) ≈ 760k records.
+// constant.
+//
+// `n_roots * (max_hits*2 + 4)` is the ANALYTIC HARD upper bound on exit records
+// a layer can emit (every root emits at most that many), so sizing to it means
+// the kernel's `slot < exit_cap` append guard can never trip and no exit is ever
+// silently dropped. A former `std::min` with a 64 MiB cap (~762600 records) was
+// a memory optimization, but it CORRUPTED output for high-continuation configs
+// that exceed it even at the DEFAULT dispatch: scrum-296 Step D dig-out found
+// ms_multi_crystal's layer-1 emitted ~954k > 762k → tail dropped → ds_corr vs
+// legacy fell to 0.913, while total energy (1.02) and cross-seed self-corr
+// (0.9998) both stayed clean and MASKED the bug (only corr-vs-legacy caught it).
+// Correctness over memory: size to the true bound. A dispatch so large the
+// buffer cannot be allocated fails via cudaMalloc → BackendUnavailableError →
+// graceful legacy fallback — never silently-wrong output. (See the seam-design
+// follow-up: the exit-record host round-trip is the real CUDA throughput
+// bottleneck and wants device-side accumulation rather than a bigger buffer.)
 size_t ComputeExitCap(size_t n_roots, size_t max_hits) {
-  size_t cap = n_roots * (max_hits * 2u + 4u);
-  size_t hard_cap = (size_t{64u} * 1024u * 1024u) / sizeof(ExitRayRecord);
-  return std::min(cap, hard_cap);
+  return n_roots * (max_hits * 2u + 4u);
 }
 
 // Continuation buffer capacity (296.4). Each root may emit up to
 // (max_hits * 2 + 4) candidate continuations (matches ComputeExitCap upper
-// bound — every outward exit is a continuation candidate). Same 64 MiB hard
-// cap scaled by float[4] per slot (dir3 + weight) so the cont pool never
-// exceeds the exit-record pool's memory footprint by more than 1.
+// bound — every outward exit is a continuation candidate). Sized to the same
+// analytic hard upper bound (no silent-drop cap) for the same correctness
+// reason as ComputeExitCap: a dropped continuation loses a downstream ray's
+// entire sub-tree. Cont slots (~20B) are smaller than ExitRayRecord, so this
+// pool's footprint stays below the exit pool's.
 size_t ComputeContCap(size_t n_roots, size_t max_hits) {
-  size_t cap = n_roots * (max_hits * 2u + 4u);
-  // Each cont slot = 3 float dir + 1 float weight + 1 uint32 wl_idx = 20B,
-  // safely below ExitRayRecord (~36B). Reuse the exit-pool hard cap row.
-  size_t hard_cap = (size_t{64u} * 1024u * 1024u) / sizeof(ExitRayRecord);
-  return std::min(cap, hard_cap);
+  return n_roots * (max_hits * 2u + 4u);
 }
 
 // File-local mirror of Metal `kFaceCoplanarFloor` (metal_trace_backend.mm:1270)
@@ -469,7 +481,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
         // filter-fail → implicit drop (no buffer write), enforcing AC1
         // "filter-fail光线不跨MS层传播". exit_world is the WORLD-space ray
         // direction Metal/CPU FilterMatchDirection expects.
-        const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci;
+        const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
+                                   static_cast<uint32_t>(crystal_id);
         const bool filter_pass = lm_filter::DeviceFilterCheck(
             d_filter_desc[gate_slot], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot,
             exit_world, crystal_config_id);
@@ -627,7 +640,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           // Per-bounce refracted exit emit gate (296.5): same filter-then-prob
           // semantics as the entry-face emit above. path_rec already includes
           // hit_poly (appended at the top of this hit, before Fresnel).
-          const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci;
+          const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
+                                   static_cast<uint32_t>(crystal_id);
           const bool filter_pass = lm_filter::DeviceFilterCheck(
               d_filter_desc[gate_slot], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
               gate_slot, exit_world, crystal_config_id);
@@ -941,6 +955,16 @@ struct CudaTraceBackend::Impl {
   uint16_t* d_tri_to_poly_ = nullptr;  // tri_cnt (kInvalidId on coplanar miss)
   uint32_t  tri_cnt_       = 0;
 
+  // Grow-only physical capacities for the per-CI geometry re-upload path
+  // (UploadCrystalGeometry). Multi-CI mirrors Metal UploadCrystal: each ci in a
+  // layer re-uploads its own crystal's geometry into the SAME device buffers
+  // before its trace/transit dispatch (ci dispatches are serialized, so reuse is
+  // safe). poly_cnt_/tri_cnt_ track the currently-uploaded crystal's sizes;
+  // alloc_*_cap_ track the physically-allocated buffer sizes so a smaller ci
+  // does not realloc. Mirrors Metal EnsurePolyBuffers/EnsureTriBuffers.
+  uint32_t  alloc_poly_cap_ = 0;
+  uint32_t  alloc_tri_cap_  = 0;
+
   // Per-ray crystal->world rotation buffer (9 floats/ray, row-major
   // Rotation::mat_). Allocated in EnsureSessionBuffers; filled per TraceLayer
   // from InitRayFirstMs all_data[i].crystal_rot_ output (ms_mode==0 path) or
@@ -963,18 +987,34 @@ struct CudaTraceBackend::Impl {
   // (continuation pass-through) on subsequent layers.
   uint32_t* d_root_wl_idx_ = nullptr;
 
-  // --- Continuation ring (296.4) -------------------------------------------
-  // Single ping-pong slot (no multi-generation tracking required by seam
-  // lifetime contract: DeviceRayBatch::backend_ptr valid only until the next
-  // Recombine; see trace_backend.hpp). Written by trace_single_ms_kernel when
-  // ms_mode==1, consumed by transit_multi_ms_kernel.
-  float*    d_cont_d_       = nullptr;   // 3 × cont_cap (world-space dir)
-  float*    d_cont_w_       = nullptr;   // cont_cap (continuation weight)
-  uint32_t* d_cont_wl_idx_  = nullptr;   // cont_cap (wl pass-through; MVP always 0)
-  uint32_t* d_cont_count_   = nullptr;   // 1 uint32 (atomic, device)
-  size_t    cont_cap_       = 0;
+  // --- Continuation ring (296.4 + multi-CI 全量) ---------------------------
+  // PING-PONG (2 slots), mirroring Metal cont_d/cont_w[slot]. Multi-CI moved
+  // transit INTO TraceLayer (lazy, per-CI), so a continuation layer READS the
+  // previous layer's continuations from slot in=(ms_layer_idx_-1)&1 (slice per
+  // ci) while WRITING this layer's continuations to slot out=ms_layer_idx_&1.
+  // A single buffer would be a read-after-write hazard across the ci loop. Each
+  // slot is written by trace_single_ms_kernel (ms_mode==1) and read, per-ci-
+  // slice, by transit_multi_ms_kernel in the NEXT layer's TraceLayer.
+  float*    d_cont_d_[2]      = {nullptr, nullptr};  // 3 × cont_cap (world-space dir)
+  float*    d_cont_w_[2]      = {nullptr, nullptr};  // cont_cap (continuation weight)
+  uint32_t* d_cont_wl_idx_[2] = {nullptr, nullptr};  // cont_cap (per-ray wl pass-through)
+  uint32_t* d_cont_count_[2]  = {nullptr, nullptr};  // 1 uint32 each (atomic, device)
+  // Per-slot continuation capacity (multi-CI 3+ layer): a continuation layer
+  // grows ONLY its out_slot (the in_slot holds rays being read this layer and
+  // must not realloc). Each slot grows lazily when it becomes the out_slot, so
+  // the two slots may differ in size. root_cap_ tracks the root/rotation buffers
+  // (d_dirs_/d_pos_/d_ws_/d_from_poly_/d_root_wl_idx_/d_rot_c2w_) which hold this
+  // layer's per-ci gen/transit output (≤ n_in roots).
+  size_t    cont_cap_[2]    = {0, 0};
+  size_t    root_cap_       = 0;
   uint32_t  h_cont_count_   = 0;         // host snapshot after 4B D2H readback
   uint32_t* pinned_cont_count_ = nullptr;  // 1 uint32 pinned host (D2H staging)
+
+  // Per-(layer) per-ci ray-count partition carry (largest-remainder fractional
+  // remainder), persistent across batches within a session. Indexed by MS layer;
+  // each entry sized to that layer's crystal_cnt. Mirrors simulator.cpp:830
+  // ray_alloc_carry[mi]. Cleared per BeginSession.
+  std::vector<std::vector<double>> ray_alloc_carry_;
 
   // Session-level exit pool.
   ExitRayRecord* d_exit_ = nullptr;
@@ -1079,9 +1119,13 @@ struct CudaTraceBackend::Impl {
   // DrainExits applies FilterSpec::Check + prob to records tagged with the
   // final ms_layer_idx (mirrors Metal ReadbackExitRays:2447-2578). Captured in
   // BeginSession from the last ms_setting; single-CI MVP, multi-CI is 296.6.
-  FilterConfig     final_layer_filter_config_{};
-  Crystal          final_layer_crystal_{};
-  AxisDistribution final_layer_axis_dist_{};
+  // Multi-CI 全量: the final layer may hold several crystals; DrainExits indexes
+  // these per-exit by ExitRayRecord.crystal_id. Populated in BeginSession from
+  // the last MS layer's settings (proto crystals — filter only needs topology).
+  // Mirrors Metal last_layer_crystals_[ci] (metal_trace_backend.mm:2403-2409).
+  std::vector<FilterConfig>     final_layer_filter_configs_;
+  std::vector<Crystal>          final_layer_crystals_;
+  std::vector<AxisDistribution> final_layer_axis_dists_;
   uint8_t          final_ms_layer_idx_ = 0u;
   float            final_ms_prob_      = 0.0f;
   // `drain_rng_` is the host-side prob-draw RNG used by DrainExits. Seeded
@@ -1105,6 +1149,21 @@ struct CudaTraceBackend::Impl {
   // next TraceLayer. EnsureSessionBuffers must NOT run on the device-roots path:
   // its n_roots_!=n realloc would free those buffers mid-flight (296.4 root-cause).
   void EnsureExitCapacity(size_t n);
+
+  // Continuation-layer (3+ MS) capacity growth (grow-only). Grows the exit pool,
+  // the root/rotation buffers (to hold n_in transit outputs), and ONLY the given
+  // out_slot continuation buffer (to hold this layer's fan-out). The in_slot is
+  // left intact — it holds the previous layer's continuations being read this
+  // layer. Mirrors Metal EnsureRootBuffers(total)+EnsureContBuffer(out_slot).
+  void EnsureContCapacity(size_t n_in, int out_slot);
+
+  // Per-CI geometry (multi-CI, mirrors Metal UploadCrystal/Ensure*Buffers).
+  // EnsureGeomCapacity grows d_poly_*/d_tri_* (grow-only) to hold a crystal of
+  // the given size; UploadCrystalGeometry resizes + H2D-copies one crystal's
+  // polygon/triangle pool (incl. the tri_to_poly argmax map) and updates
+  // poly_cnt_/tri_cnt_. Call once per (layer,ci) before that ci's trace/transit.
+  void EnsureGeomCapacity(size_t poly_cnt, size_t tri_cnt);
+  void UploadCrystalGeometry(const Crystal& crystal);
 };
 
 void CudaTraceBackend::Impl::Reset() {
@@ -1123,6 +1182,13 @@ void CudaTraceBackend::Impl::Reset() {
   d_tri_area_ = nullptr;
   cudaFree(d_tri_to_poly_);
   d_tri_to_poly_ = nullptr;
+  // Grow-only geometry capacities track the freed buffers above; zero them so a
+  // fresh session re-allocates rather than reusing a dangling capacity.
+  alloc_poly_cap_ = 0;
+  alloc_tri_cap_ = 0;
+  poly_cnt_ = 0;
+  tri_cnt_ = 0;
+  ray_alloc_carry_.clear();
   cudaFree(d_rot_c2w_);
   d_rot_c2w_ = nullptr;
   cudaFree(d_dirs_);
@@ -1137,14 +1203,12 @@ void CudaTraceBackend::Impl::Reset() {
   d_root_wl_idx_ = nullptr;
   cudaFree(d_wl_pool_);
   d_wl_pool_ = nullptr;
-  cudaFree(d_cont_d_);
-  d_cont_d_ = nullptr;
-  cudaFree(d_cont_w_);
-  d_cont_w_ = nullptr;
-  cudaFree(d_cont_wl_idx_);
-  d_cont_wl_idx_ = nullptr;
-  cudaFree(d_cont_count_);
-  d_cont_count_ = nullptr;
+  for (int s = 0; s < 2; ++s) {
+    cudaFree(d_cont_d_[s]);      d_cont_d_[s] = nullptr;
+    cudaFree(d_cont_w_[s]);      d_cont_w_[s] = nullptr;
+    cudaFree(d_cont_wl_idx_[s]); d_cont_wl_idx_[s] = nullptr;
+    cudaFree(d_cont_count_[s]);  d_cont_count_[s] = nullptr;
+  }
   cudaFree(d_exit_);
   d_exit_ = nullptr;
   cudaFree(d_exit_count_);
@@ -1187,7 +1251,9 @@ void CudaTraceBackend::Impl::Reset() {
   tri_cnt_ = 0;
   exit_cap_ = 0;
   alloc_exit_cap_ = 0;
-  cont_cap_ = 0;
+  cont_cap_[0] = 0;
+  cont_cap_[1] = 0;
+  root_cap_ = 0;
   h_exit_count_ = 0;
   h_cont_count_ = 0;
   n_roots_ = 0;
@@ -1196,9 +1262,9 @@ void CudaTraceBackend::Impl::Reset() {
   filter_desc_max_ci_ = 0u;
   filter_n_slot_ = 0u;
   crystal_config_id_ = 0xFFFFu;
-  final_layer_filter_config_ = FilterConfig{};
-  final_layer_crystal_ = Crystal{};
-  final_layer_axis_dist_ = AxisDistribution{};
+  final_layer_filter_configs_.clear();
+  final_layer_crystals_.clear();
+  final_layer_axis_dists_.clear();
   final_ms_layer_idx_ = 0u;
   final_ms_prob_ = 0.0f;
   buffers_allocated_ = false;
@@ -1209,6 +1275,68 @@ void CudaTraceBackend::Impl::Reset() {
   // counterparts are deliberately NOT cleared — the first-seeding gate in
   // BeginSession resets the monotone counter exactly once per spec.seed,
   // matching the Metal `transit_ray_count_` discipline (scrum-267).
+}
+
+void CudaTraceBackend::Impl::EnsureGeomCapacity(size_t poly_cnt, size_t tri_cnt) {
+  // Grow-only: a ci whose crystal is smaller than a previously-uploaded one
+  // reuses the existing (larger) buffers. cudaFree(nullptr) is a no-op.
+  if (poly_cnt > alloc_poly_cap_) {
+    cudaFree(d_poly_n_); d_poly_n_ = nullptr;
+    cudaFree(d_poly_d_); d_poly_d_ = nullptr;
+    CheckCuda(cudaMalloc(&d_poly_n_, 3 * poly_cnt * sizeof(float)), "EnsureGeomCapacity cudaMalloc d_poly_n");
+    CheckCuda(cudaMalloc(&d_poly_d_, poly_cnt * sizeof(float)), "EnsureGeomCapacity cudaMalloc d_poly_d");
+    alloc_poly_cap_ = static_cast<uint32_t>(poly_cnt);
+  }
+  if (tri_cnt > alloc_tri_cap_) {
+    cudaFree(d_tri_vtx_);     d_tri_vtx_ = nullptr;
+    cudaFree(d_tri_norm_);    d_tri_norm_ = nullptr;
+    cudaFree(d_tri_area_);    d_tri_area_ = nullptr;
+    cudaFree(d_tri_to_poly_); d_tri_to_poly_ = nullptr;
+    CheckCuda(cudaMalloc(&d_tri_vtx_,     9 * tri_cnt * sizeof(float)),    "EnsureGeomCapacity cudaMalloc d_tri_vtx");
+    CheckCuda(cudaMalloc(&d_tri_norm_,    3 * tri_cnt * sizeof(float)),    "EnsureGeomCapacity cudaMalloc d_tri_norm");
+    CheckCuda(cudaMalloc(&d_tri_area_,    tri_cnt * sizeof(float)),        "EnsureGeomCapacity cudaMalloc d_tri_area");
+    CheckCuda(cudaMalloc(&d_tri_to_poly_, tri_cnt * sizeof(uint16_t)),     "EnsureGeomCapacity cudaMalloc d_tri_to_poly");
+    alloc_tri_cap_ = static_cast<uint32_t>(tri_cnt);
+  }
+}
+
+void CudaTraceBackend::Impl::UploadCrystalGeometry(const Crystal& crystal) {
+  // Per-CI geometry H2D, mirrors Metal UploadCrystal (metal_trace_backend.mm:1158).
+  // Polygon-face slab geometry + triangle pool (for transit entry-point sampling)
+  // + the tri_to_poly argmax map. Updates poly_cnt_/tri_cnt_ to this crystal.
+  size_t poly_cnt = crystal.PolygonFaceCount();
+  size_t tri_cnt  = crystal.TotalTriangles();
+  if (poly_cnt == 0) {
+    throw BackendUnavailableError("CudaTraceBackend::UploadCrystalGeometry: degenerate crystal geometry (0 polygons)");
+  }
+  if (tri_cnt == 0) {
+    throw BackendUnavailableError("CudaTraceBackend::UploadCrystalGeometry: degenerate crystal geometry (0 triangles)");
+  }
+  if (tri_cnt > static_cast<size_t>(lm_pcg::kMaxTriPerKernel)) {
+    throw BackendUnavailableError(
+        std::string{"CudaTraceBackend::UploadCrystalGeometry: tri_count="} + std::to_string(tri_cnt) +
+        " exceeds kMaxTriPerKernel=" + std::to_string(lm_pcg::kMaxTriPerKernel) +
+        " (gen/transit kernel proj_prob[] stack bound)");
+  }
+  EnsureGeomCapacity(poly_cnt, tri_cnt);
+
+  CheckCuda(cudaMemcpy(d_poly_n_, crystal.GetPolygonFaceNormal(), 3 * poly_cnt * sizeof(float),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_n");
+  CheckCuda(cudaMemcpy(d_poly_d_, crystal.GetPolygonFaceDist(), poly_cnt * sizeof(float),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_d");
+  CheckCuda(cudaMemcpy(d_tri_vtx_, crystal.GetTriangleVtx(), 9 * tri_cnt * sizeof(float),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_tri_vtx");
+  CheckCuda(cudaMemcpy(d_tri_norm_, crystal.GetTriangleNormal(), 3 * tri_cnt * sizeof(float),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_tri_norm");
+  CheckCuda(cudaMemcpy(d_tri_area_, crystal.GetTirangleArea(), tri_cnt * sizeof(float),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_tri_area");
+  std::vector<uint16_t> tri_to_poly_host;
+  FillTriToPoly(crystal, tri_to_poly_host);
+  CheckCuda(cudaMemcpy(d_tri_to_poly_, tri_to_poly_host.data(), tri_cnt * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_tri_to_poly");
+
+  poly_cnt_ = static_cast<uint32_t>(poly_cnt);
+  tri_cnt_  = static_cast<uint32_t>(tri_cnt);
 }
 
 void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
@@ -1231,10 +1359,12 @@ void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
   cudaFree(d_rot_c2w_);  d_rot_c2w_ = nullptr;
   cudaFree(d_exit_);     d_exit_ = nullptr;
   cudaFree(d_exit_count_); d_exit_count_ = nullptr;
-  cudaFree(d_cont_d_);      d_cont_d_ = nullptr;
-  cudaFree(d_cont_w_);      d_cont_w_ = nullptr;
-  cudaFree(d_cont_wl_idx_); d_cont_wl_idx_ = nullptr;
-  cudaFree(d_cont_count_);  d_cont_count_ = nullptr;
+  for (int s = 0; s < 2; ++s) {
+    cudaFree(d_cont_d_[s]);      d_cont_d_[s] = nullptr;
+    cudaFree(d_cont_w_[s]);      d_cont_w_[s] = nullptr;
+    cudaFree(d_cont_wl_idx_[s]); d_cont_wl_idx_[s] = nullptr;
+    cudaFree(d_cont_count_[s]);  d_cont_count_[s] = nullptr;
+  }
   cudaFreeHost(pinned_dirs_);     pinned_dirs_ = nullptr;
   cudaFreeHost(pinned_pos_);      pinned_pos_ = nullptr;
   cudaFreeHost(pinned_ws_);       pinned_ws_ = nullptr;
@@ -1246,16 +1376,15 @@ void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
 
   size_t max_hits = scene_ != nullptr ? scene_->max_hits_ : kMaxHits;
   exit_cap_ = ComputeExitCap(n, max_hits);
-  cont_cap_ = ComputeContCap(n, max_hits);
+  const size_t cont_cap0 = ComputeContCap(n, max_hits);
+  cont_cap_[0] = cont_cap0;
+  cont_cap_[1] = cont_cap0;
 
-  // Root / rotation / continuation buffers MUST be sized to cont_cap_, not n:
-  // the transit_multi_ms_kernel writes up to cont_cap_ roots in a single
-  // dispatch (the next-layer fan-out from this layer's continuation count).
-  // Sizing by n alone would overrun these buffers on layers where the
-  // continuation set exceeds the original root_ray_count. Pinned-staging
-  // counterparts (filled only on the ms_mode==0 first-layer ingest path)
-  // stay sized to n_roots since they back the host root-gen output only.
-  size_t buf_cap = std::max<size_t>(n, cont_cap_);
+  // Root / rotation / continuation buffers MUST be sized to cont_cap, not n:
+  // the per-ci transit writes up to n roots and the trace fan-out fills cont up
+  // to ComputeContCap. EnsureContCapacity grows these per continuation layer.
+  size_t buf_cap = std::max<size_t>(n, cont_cap0);
+  root_cap_ = buf_cap;
 
   // Check every CUDA allocation. On failure Reset() tears down all buffers
   // (including session-level geometry) and BackendUnavailableError propagates
@@ -1276,10 +1405,12 @@ void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
   ck(cudaMalloc(&d_rot_c2w_,     9 * buf_cap * sizeof(float)),             "cudaMalloc d_rot_c2w");
   ck(cudaMalloc(&d_exit_,        exit_cap_ * sizeof(ExitRayRecord)),       "cudaMalloc d_exit");
   ck(cudaMalloc(&d_exit_count_,  sizeof(uint32_t)),                        "cudaMalloc d_exit_count");
-  ck(cudaMalloc(&d_cont_d_,      3 * cont_cap_ * sizeof(float)),           "cudaMalloc d_cont_d");
-  ck(cudaMalloc(&d_cont_w_,      cont_cap_ * sizeof(float)),               "cudaMalloc d_cont_w");
-  ck(cudaMalloc(&d_cont_wl_idx_, cont_cap_ * sizeof(uint32_t)),            "cudaMalloc d_cont_wl_idx");
-  ck(cudaMalloc(&d_cont_count_,  sizeof(uint32_t)),                        "cudaMalloc d_cont_count");
+  for (int s = 0; s < 2; ++s) {
+    ck(cudaMalloc(&d_cont_d_[s],      3 * cont_cap0 * sizeof(float)),       "cudaMalloc d_cont_d");
+    ck(cudaMalloc(&d_cont_w_[s],      cont_cap0 * sizeof(float)),           "cudaMalloc d_cont_w");
+    ck(cudaMalloc(&d_cont_wl_idx_[s], cont_cap0 * sizeof(uint32_t)),        "cudaMalloc d_cont_wl_idx");
+    ck(cudaMalloc(&d_cont_count_[s],  sizeof(uint32_t)),                    "cudaMalloc d_cont_count");
+  }
 
   ck(cudaHostAlloc(&pinned_dirs_,     3 * n * sizeof(float),               cudaHostAllocDefault), "cudaHostAlloc pinned_dirs");
   ck(cudaHostAlloc(&pinned_pos_,      3 * n * sizeof(float),               cudaHostAllocDefault), "cudaHostAlloc pinned_pos");
@@ -1298,7 +1429,8 @@ void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
   // parity-battery cross-seed test. Per-layer recycling (after Recombine
   // drains the count) is owned by Recombine itself; here we only handle the
   // initial state.
-  ck(cudaMemset(d_cont_count_, 0, sizeof(uint32_t)), "cudaMemset d_cont_count_ (init)");
+  ck(cudaMemset(d_cont_count_[0], 0, sizeof(uint32_t)), "cudaMemset d_cont_count_[0] (init)");
+  ck(cudaMemset(d_cont_count_[1], 0, sizeof(uint32_t)), "cudaMemset d_cont_count_[1] (init)");
 
   n_roots_ = n;
   alloc_exit_cap_ = exit_cap_;  // track physical d_exit_ size for grow-only EnsureExitCapacity
@@ -1330,6 +1462,55 @@ void CudaTraceBackend::Impl::EnsureExitCapacity(size_t n) {
   ck(cudaHostAlloc(&pinned_exit_, need * sizeof(ExitRayRecord), cudaHostAllocDefault),
      "cudaHostAlloc pinned_exit (grow)");
   alloc_exit_cap_ = need;
+}
+
+void CudaTraceBackend::Impl::EnsureContCapacity(size_t n_in, int out_slot) {
+  // Exit pool grows for this layer's fan-out (also updates exit_cap_).
+  EnsureExitCapacity(n_in);
+  if (!buffers_allocated_) {
+    return;  // first layer hasn't allocated yet (shouldn't happen on the device-roots path)
+  }
+  auto ck = [this](cudaError_t e, const char* ctx) {
+    if (e != cudaSuccess) {
+      Reset();
+      throw BackendUnavailableError(std::string{"CudaTraceBackend::EnsureContCapacity: "} + ctx + ": " +
+                                    cudaGetErrorString(e));
+    }
+  };
+
+  // Grow the root/rotation buffers if this continuation layer's incoming count
+  // exceeds them (per-ci transit/trace reuse root buf [0, ci_n), ci_n ≤ n_in).
+  if (n_in > root_cap_) {
+    cudaDeviceSynchronize();  // a prior layer's transit/trace may still read roots.
+    cudaFree(d_dirs_);        d_dirs_ = nullptr;
+    cudaFree(d_pos_);         d_pos_ = nullptr;
+    cudaFree(d_ws_);          d_ws_ = nullptr;
+    cudaFree(d_from_poly_);   d_from_poly_ = nullptr;
+    cudaFree(d_root_wl_idx_); d_root_wl_idx_ = nullptr;
+    cudaFree(d_rot_c2w_);     d_rot_c2w_ = nullptr;
+    ck(cudaMalloc(&d_dirs_,        3 * n_in * sizeof(float)),   "cudaMalloc d_dirs (grow)");
+    ck(cudaMalloc(&d_pos_,         3 * n_in * sizeof(float)),   "cudaMalloc d_pos (grow)");
+    ck(cudaMalloc(&d_ws_,          n_in * sizeof(float)),       "cudaMalloc d_ws (grow)");
+    ck(cudaMalloc(&d_from_poly_,   n_in * sizeof(uint32_t)),    "cudaMalloc d_from_poly (grow)");
+    ck(cudaMalloc(&d_root_wl_idx_, n_in * sizeof(uint32_t)),    "cudaMalloc d_root_wl_idx (grow)");
+    ck(cudaMalloc(&d_rot_c2w_,     9 * n_in * sizeof(float)),   "cudaMalloc d_rot_c2w (grow)");
+    root_cap_ = n_in;
+  }
+
+  // Grow ONLY the out_slot continuation buffer to hold this layer's fan-out. The
+  // in_slot buffer holds the previous layer's continuations being READ this
+  // layer (per-ci slices) and must NOT be reallocated.
+  const size_t need = ComputeContCap(n_in, scene_ != nullptr ? scene_->max_hits_ : kMaxHits);
+  if (need > cont_cap_[out_slot]) {
+    cudaDeviceSynchronize();
+    cudaFree(d_cont_d_[out_slot]);      d_cont_d_[out_slot] = nullptr;
+    cudaFree(d_cont_w_[out_slot]);      d_cont_w_[out_slot] = nullptr;
+    cudaFree(d_cont_wl_idx_[out_slot]); d_cont_wl_idx_[out_slot] = nullptr;
+    ck(cudaMalloc(&d_cont_d_[out_slot],      3 * need * sizeof(float)),    "cudaMalloc d_cont_d (grow)");
+    ck(cudaMalloc(&d_cont_w_[out_slot],      need * sizeof(float)),        "cudaMalloc d_cont_w (grow)");
+    ck(cudaMalloc(&d_cont_wl_idx_[out_slot], need * sizeof(uint32_t)),     "cudaMalloc d_cont_wl_idx (grow)");
+    cont_cap_[out_slot] = need;
+  }
 }
 
 // EnsureFilterBuffers — mirror of Metal `EnsureFilterBuffers`
@@ -1468,26 +1649,36 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
        "cudaMemcpy d_complex_sub_desc");
   }
 
-  // Capture final-layer host filter state — DrainExits applies FilterSpec on
-  // records tagged with the final ms_layer_idx (mirrors Metal last_layer_*).
-  // Single-CI MVP: take setting_[0] of the last MS layer.
+  // Capture final-layer host filter state PER-CI — DrainExits applies FilterSpec
+  // on records tagged with the final ms_layer_idx, indexed by ExitRayRecord
+  // .crystal_id (mirrors Metal last_layer_crystals_[ci], metal:2403-2409). Proto
+  // crystals (deterministic rng) suffice: the host filter only needs the face
+  // topology (GetFn), which is param-determined, not the exact traced instance.
   const auto& last_ms_layer = spec.scene->ms_.back();
-  if (!last_ms_layer.setting_.empty()) {
-    const auto& last_setting = last_ms_layer.setting_[0];
-    final_layer_filter_config_ = last_setting.filter_;
-    RandomNumberGenerator drain_proto_rng(0xC0FEFEEDu);
-    final_layer_crystal_ = MakeCrystal(drain_proto_rng, last_setting.crystal_.param_);
-    final_layer_axis_dist_ = last_setting.crystal_.axis_;
+  const size_t last_ci_cnt = last_ms_layer.setting_.size();
+  RandomNumberGenerator drain_proto_rng(0xC0FEFEEDu);
+  final_layer_filter_configs_.clear();
+  final_layer_crystals_.clear();
+  final_layer_axis_dists_.clear();
+  final_layer_filter_configs_.reserve(last_ci_cnt);
+  final_layer_crystals_.reserve(last_ci_cnt);
+  final_layer_axis_dists_.reserve(last_ci_cnt);
+  for (size_t ci = 0; ci < last_ci_cnt; ++ci) {
+    const auto& s = last_ms_layer.setting_[ci];
+    final_layer_filter_configs_.push_back(s.filter_);
+    final_layer_crystals_.push_back(MakeCrystal(drain_proto_rng, s.crystal_.param_));
+    final_layer_axis_dists_.push_back(s.crystal_.axis_);
   }
   final_ms_layer_idx_ = static_cast<uint8_t>(n_layers - 1u);
   final_ms_prob_ = last_ms_layer.prob_;
 
-  // crystal_config_id_ for DeviceFilterMatchCrystal. Mirrors Metal line 1705-
-  // 1707: when the source crystal has no config_id (kInvalidId), surface
-  // 0xFFFFu so a Crystal-type filter never matches by accident.
-  crystal_config_id_ = (final_layer_crystal_.config_id_ == kInvalidId)
-                          ? 0xFFFFu
-                          : static_cast<uint32_t>(final_layer_crystal_.config_id_);
+  // crystal_config_id_ for DeviceFilterMatchCrystal. Per-ci config ids are passed
+  // inline to the trace kernel (ci_cfg_id); this session-level value mirrors the
+  // first final-layer crystal for any legacy single-value consumer.
+  crystal_config_id_ =
+      (!final_layer_crystals_.empty() && final_layer_crystals_[0].config_id_ != kInvalidId)
+          ? static_cast<uint32_t>(final_layer_crystals_[0].config_id_)
+          : 0xFFFFu;
 }
 
 CudaTraceBackend::CudaTraceBackend(Logger* logger) : impl_(std::make_unique<Impl>()) {
@@ -1517,6 +1708,7 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     impl_->render_ = spec.render;
     impl_->wl_ = spec.wl;
     impl_->rng_.SetSeed(spec.seed);
+    impl_->ray_alloc_carry_.clear();  // per-(layer,ci) partition carry — fresh per session
 
     // MVP: single MS, single crystal config — ms_[0].setting_[0].
     if (spec.scene == nullptr || spec.scene->ms_.empty() || spec.scene->ms_[0].setting_.empty()) {
@@ -1564,58 +1756,14 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
       }
     }
 
-    // Polygon-face geometry H2D: outward normals (3 × poly_cnt, AoS) +
-    // plane constants (poly_cnt). Layout matches Crystal::GetPolygonFace*
-    // contracts (crystal.cpp:191/574/578); the kernel reads them via
-    // `d_poly_n[fi*3 + {0,1,2}]` and `d_poly_d[fi]`, mirroring legacy
-    // `PropagateSlab` (optics.cpp:111-125).
-    CheckCuda(cudaMalloc(&impl_->d_poly_n_, 3 * poly_cnt * sizeof(float)), "BeginSession cudaMalloc d_poly_n");
-    CheckCuda(cudaMemcpy(impl_->d_poly_n_, crystal_for_geom.GetPolygonFaceNormal(),
-                         3 * poly_cnt * sizeof(float), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_poly_n");
-    CheckCuda(cudaMalloc(&impl_->d_poly_d_, poly_cnt * sizeof(float)), "BeginSession cudaMalloc d_poly_d");
-    CheckCuda(cudaMemcpy(impl_->d_poly_d_, crystal_for_geom.GetPolygonFaceDist(),
-                         poly_cnt * sizeof(float), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_poly_d");
-
-    // Triangle pool H2D for transit_multi_ms_kernel (296.4). vtx/norm/area
-    // come straight from Crystal; tri_to_poly is computed host-side via the
-    // argmax + coplanar-floor predicate (mirrors Metal UploadCrystal). The
-    // upload is session-scoped (single CI in MVP); multi-CI per-layer crystal
-    // pool is 296.6.
-    size_t tri_cnt = crystal_for_geom.TotalTriangles();
-    if (tri_cnt == 0) {
-      throw BackendUnavailableError("CudaTraceBackend::BeginSession: degenerate crystal geometry (0 triangles)");
-    }
-    if (tri_cnt > static_cast<size_t>(lm_pcg::kMaxTriPerKernel)) {
-      throw BackendUnavailableError(
-          std::string{"CudaTraceBackend::BeginSession: tri_count="} + std::to_string(tri_cnt) +
-          " exceeds kMaxTriPerKernel=" + std::to_string(lm_pcg::kMaxTriPerKernel) +
-          " (transit_multi_ms_kernel proj_prob[] stack bound)");
-    }
-    impl_->tri_cnt_ = static_cast<uint32_t>(tri_cnt);
-    CheckCuda(cudaMalloc(&impl_->d_tri_vtx_, 9 * tri_cnt * sizeof(float)),
-              "BeginSession cudaMalloc d_tri_vtx");
-    CheckCuda(cudaMemcpy(impl_->d_tri_vtx_, crystal_for_geom.GetTriangleVtx(),
-                         9 * tri_cnt * sizeof(float), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_tri_vtx");
-    CheckCuda(cudaMalloc(&impl_->d_tri_norm_, 3 * tri_cnt * sizeof(float)),
-              "BeginSession cudaMalloc d_tri_norm");
-    CheckCuda(cudaMemcpy(impl_->d_tri_norm_, crystal_for_geom.GetTriangleNormal(),
-                         3 * tri_cnt * sizeof(float), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_tri_norm");
-    CheckCuda(cudaMalloc(&impl_->d_tri_area_, tri_cnt * sizeof(float)),
-              "BeginSession cudaMalloc d_tri_area");
-    CheckCuda(cudaMemcpy(impl_->d_tri_area_, crystal_for_geom.GetTirangleArea(),
-                         tri_cnt * sizeof(float), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_tri_area");
-    std::vector<uint16_t> tri_to_poly_host;
-    FillTriToPoly(crystal_for_geom, tri_to_poly_host);
-    CheckCuda(cudaMalloc(&impl_->d_tri_to_poly_, tri_cnt * sizeof(uint16_t)),
-              "BeginSession cudaMalloc d_tri_to_poly");
-    CheckCuda(cudaMemcpy(impl_->d_tri_to_poly_, tri_to_poly_host.data(),
-                         tri_cnt * sizeof(uint16_t), cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_tri_to_poly");
+    // Polygon-face slab geometry + triangle pool H2D via the per-CI helper
+    // (mirrors Metal UploadCrystal). TraceLayer re-invokes UploadCrystalGeometry
+    // per (layer,ci) for multi-CI; here it primes the buffers with the first
+    // layer's first crystal so the BeginSession refractive-index log below and
+    // any single-CI fast path see a populated pool. poly_cnt_/tri_cnt_ are set
+    // by the helper. The kMaxTriPerKernel guard now lives inside the helper.
+    impl_->UploadCrystalGeometry(crystal_for_geom);
+    size_t tri_cnt = impl_->tri_cnt_;
 
     // Per-ray wavelength pool (296.6 DR-3). One session covers the whole
     // spectrum; build the WlEntry table (n_idx + spd_weight per sampled wl) from
@@ -1744,22 +1892,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     return std::make_unique<CudaLayerHandle>(0u, LayerStats{0u, 0.0f});
   }
 
-  if (roots.is_device) {
-    // Device-roots continuation layer: the root buffers were filled in-place by
-    // the previous Recombine's transit_multi_ms_kernel and are already sized by
-    // that layer. Running EnsureSessionBuffers here (n = cont_n != n_roots_)
-    // would free + realloc them mid-flight, destroying the continuation rays
-    // (296.4 root-cause: d_ws_/d_from_poly_ then read uninitialised → w=0 →
-    // every layer-1 ray skips entry → ~80% of multi-MS energy lost). Only the
-    // exit pool may need to grow for this layer's exits.
-    impl_->EnsureExitCapacity(n);
-  } else {
-    impl_->EnsureSessionBuffers(n);
-  }
-
-  // Local helper: Reset() + BackendUnavailableError for CUDA call failures
-  // inside TraceLayer. EnsureSessionBuffers has its own internal Reset path;
-  // this lambda is only for the CUDA calls after it returns.
+  // Local helper: Reset() + BackendUnavailableError for CUDA call failures.
   auto ck_reset = [this](cudaError_t e, const char* ctx) {
     if (e != cudaSuccess) {
       impl_->Reset();
@@ -1768,199 +1901,208 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     }
   };
 
-  // Per-session zero of d_cont_count_ at first layer: EnsureSessionBuffers
-  // zeroes on first alloc but skips zeroing when reusing buffers (fast-path).
-  // A prior session that ended without Recombine may leave a non-zero count;
-  // ms_layer_idx_==0 is the session-start sentinel (BeginSession resets it).
-  if (impl_->ms_layer_idx_ == 0) {
-    ck_reset(cudaMemset(impl_->d_cont_count_, 0, sizeof(uint32_t)),
-             "cudaMemset d_cont_count_ (session start)");
-  }
-
-  // Resolve current MS layer's setting + refractive index. MVP uses the first
-  // crystal_ of `ms_[ms_layer_idx_].setting_[0]` (single-CI assumption); multi-
-  // CI per-layer crystal pool is 296.6.
+  // Resolve current MS layer. Multi-CI (全量, owner 2026-06-27): a layer may hold
+  // several crystals (ScatteringSetting) each with a proportion; PartitionCrystal-
+  // RayNum splits this layer's rays into contiguous per-ci slices, and each ci is
+  // gen/transit'd + traced through ITS OWN crystal geometry. Mirrors Metal
+  // TraceLayer's ci-loop (metal_trace_backend.mm:2086-2288) and legacy
+  // simulator.cpp:826-940.
   if (impl_->ms_layer_idx_ >= impl_->n_ms_layers_) {
     throw BackendUnavailableError(
         std::string{"CudaTraceBackend::TraceLayer: ms_layer_idx_="} +
         std::to_string(impl_->ms_layer_idx_) + " >= n_ms_layers_=" +
         std::to_string(impl_->n_ms_layers_) + " (over-traced past final layer)");
   }
-  const auto& ms_layer   = impl_->scene_->ms_[impl_->ms_layer_idx_];
-  const auto& ms_setting = ms_layer.setting_[0];
+  const auto& ms_layer = impl_->scene_->ms_[impl_->ms_layer_idx_];
+  const size_t crystal_cnt = ms_layer.setting_.size();
+  const bool first_ms = !roots.is_device;
 
   // ms_mode = continuation iff this is NOT the final MS layer. Final layer
   // (ms_mode==0) writes every exit candidate to d_exit_; non-final layer
-  // (ms_mode==1) routes each candidate through the per-emit PCG gate (see
-  // trace_single_ms_kernel header comment).
+  // (ms_mode==1) routes each candidate through the per-emit PCG gate.
   const bool is_final_layer = (impl_->ms_layer_idx_ + 1u >= impl_->n_ms_layers_);
   const uint8_t ms_mode = is_final_layer ? 0u : 1u;
   const float ms_prob = is_final_layer ? 0.0f : ms_layer.prob_;
 
-  cudaEventRecord(impl_->ev_start_h2d_);
+  // Continuation ping-pong slots: this layer READS the previous layer's
+  // continuations from cont[in_slot] (per-ci slice) and WRITES its own to
+  // cont[out_slot]. Mirrors Metal slot = ms_idx & 1.
+  const int out_slot = static_cast<int>(impl_->ms_layer_idx_ & 1u);
+  const int in_slot = (impl_->ms_layer_idx_ == 0u)
+                          ? 0
+                          : static_cast<int>((impl_->ms_layer_idx_ - 1u) & 1u);
 
-  if (!roots.is_device && !impl_->disable_device_gen_) {
-    // ── Device root-gen path (296.6) ───────────────────────────────────────
-    // gen_root_kernel samples orientation, the sun-cone incident direction,
-    // entry point + per-ray wl on device and writes the root buffers directly —
-    // no host InitRayFirstMs, no H2D (host pointers do not cross the seam, §5
-    // 铁律). Geometry is the BeginSession-uploaded tri pool (tri_cnt ≤ 64 is
-    // enforced there). Mirrors Metal's device-gen GenerateFirstLayerRootsForCi.
-    // impl_->rng_ stays pristine — the device PCG stream owns the sampling.
-    lm_pcg::GenRootKernelParams gp =
-        BuildGenGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, static_cast<uint32_t>(n),
-                         impl_->scene_->light_source_.param_, impl_->wl_pool_size_);
-    gp.gen_seed     = impl_->gen_seed_;
-    gp.gen_ray_base = NarrowPcgRayBase(impl_->gen_ray_count_, n, "cuda-gen");
-    uint32_t grid = (static_cast<uint32_t>(n) + 255u) / 256u;
-    gen_root_kernel<<<grid, 256>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
-                                   impl_->d_rot_c2w_, impl_->d_root_wl_idx_, impl_->d_tri_vtx_, impl_->d_tri_norm_,
-                                   impl_->d_tri_area_, impl_->d_tri_to_poly_, impl_->d_wl_pool_, gp,
-                                   static_cast<uint32_t>(n));
-    ck_reset(cudaPeekAtLastError(), "gen_root_kernel launch");
-    impl_->gen_ray_count_ += n;  // monotone across batches (disjoint PCG ranges)
-  } else if (!roots.is_device) {
-    // ── Host-roots fallback (InitRayFirstMs + H2D; LUMICE_DISABLE_DEVICE_GEN) ─
-    // Host-side root-ray generation, mirroring cpu_trace_backend.cpp:135-140.
-    // Build a fresh Crystal per batch via MakeCrystal(rng_, param_) so the
-    // crystal-orientation RNG draw stays consistent with the CPU oracle's
-    // batch-by-batch ordering. Wrapped in try/catch: std::bad_alloc from
-    // RayBuffer growth or other C++ exceptions reset device state before
-    // propagating (mirrors BeginSession's exception-safety contract).
-    try {
-      Crystal crystal = MakeCrystal(impl_->rng_, ms_setting.crystal_.param_);
-      const auto& axis_dist = ms_setting.crystal_.axis_;
-
-      // Mirror the CPU pattern (cpu_trace_backend.cpp:107-108): workspace[0]/[1]
-      // capacities sized for the InitRay/HitSurface fan-out so EmplaceBack
-      // doesn't grow them mid-trace. We only consume workspace[0] (first-hit
-      // snapshot of d/p/w/crystal_rot_), but InitRayFirstMs writes both slots.
-      RayBuffer workspace[2]{};
-      workspace[0].Reset(n * 2);
-      workspace[1].Reset(n * 4);
-      // all_data is the per-batch RaySeg bookkeeping buffer. Use the same
-      // AllocateAllData sizing as the simulator (simulator.cpp:811) — overshoots
-      // for our single-MS use but keeps the capacity contract obviously safe.
-      RayBuffer all_data = AllocateAllData(*impl_->scene_, n);
-      InitRayFirstMs(impl_->rng_, impl_->scene_->light_source_.param_, impl_->wl_, n, crystal,
-                     impl_->ms_layer_idx_, axis_dist, workspace, all_data);
-
-      // Copy crystal-local d/p/w + per-ray crystal->world rotation into pinned
-      // staging. to_face_ is the InitRay_p_fid entry-face polygon id; the
-      // kernel needs it as the initial from_poly to suppress self-intersect on
-      // the first polygon-slab sweep (p sits exactly on this polygon).
-      // IdType (uint16_t per raypath.hpp) widens cleanly to uint32_t;
-      // kInvalidId (0xFFFFFFFFu after widening) maps to the kernel's "no
-      // previous face" sentinel. InitRayFirstMs samples an independent crystal
-      // orientation per root ray (halo-ring distribution comes from this); each
-      // RaySeg.crystal_rot_ is row-major 3x3. Aligns d_rot_c2w_ with d_dirs_'s
-      // crystal-local frame — frame invariant 6. Mirrors
-      // metal_trace_backend.mm:1375.
-      for (size_t i = 0; i < n; ++i) {
-        const auto& r = all_data[i];
-        impl_->pinned_dirs_[i * 3 + 0] = r.d_[0];
-        impl_->pinned_dirs_[i * 3 + 1] = r.d_[1];
-        impl_->pinned_dirs_[i * 3 + 2] = r.d_[2];
-        impl_->pinned_pos_[i * 3 + 0] = r.p_[0];
-        impl_->pinned_pos_[i * 3 + 1] = r.p_[1];
-        impl_->pinned_pos_[i * 3 + 2] = r.p_[2];
-        // Per-ray wavelength (296.6 DR-3): draw a wl_idx and take the weight from
-        // the pool's spd_weight. In per-ray (illuminant) mode InitRayFirstMs ran
-        // with the session's zero-wl WlParam, so r.w_ is NOT the spectral weight;
-        // the pool is the single source. In discrete mode the pool is degenerate
-        // (all entries == spec_wl) so this is identical to r.w_. Mirrors Metal's
-        // host-gen fallback (metal_trace_backend.mm:1377).
-        uint32_t wl_idx = static_cast<uint32_t>(impl_->rng_.GetUniform() * static_cast<float>(impl_->wl_pool_size_));
-        if (wl_idx >= impl_->wl_pool_size_) {
-          wl_idx = impl_->wl_pool_size_ - 1u;  // guard GetUniform()→1.0 rounding
-        }
-        impl_->pinned_root_wl_idx_[i] = wl_idx;
-        impl_->pinned_ws_[i] = impl_->wl_pool_host_[wl_idx].spd_weight;
-        impl_->pinned_from_poly_[i] =
-            (r.to_face_ == kInvalidId) ? 0xFFFFFFFFu : static_cast<uint32_t>(r.to_face_);
-        std::memcpy(impl_->pinned_rot_c2w_ + i * 9, r.crystal_rot_.GetMat(), 9 * sizeof(float));
-      }
-    } catch (...) {
-      impl_->Reset();
-      throw;
-    }
-
-    // H2D upload — all copies issue on the default stream; the synchronous
-    // cudaMemcpy(&h_exit_count_, ...) below is also default-stream and joins
-    // these copies before the host reads the count, so per-ray rot/dir/p/w/
-    // from_poly are guaranteed visible to the kernel launch.
-    cudaMemcpyAsync(impl_->d_rot_c2w_, impl_->pinned_rot_c2w_, 9 * n * sizeof(float),
-                    cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(impl_->d_dirs_, impl_->pinned_dirs_, 3 * n * sizeof(float), cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(impl_->d_pos_, impl_->pinned_pos_, 3 * n * sizeof(float), cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(impl_->d_ws_, impl_->pinned_ws_, n * sizeof(float), cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(impl_->d_from_poly_, impl_->pinned_from_poly_, n * sizeof(uint32_t),
-                    cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(impl_->d_root_wl_idx_, impl_->pinned_root_wl_idx_, n * sizeof(uint32_t),
-                    cudaMemcpyHostToDevice);
-    // Harvest any sticky async error from the H2D block.
-    ck_reset(cudaGetLastError(), "H2D batch");
+  // Buffer sizing. First layer allocates root + both cont slots (EnsureSession-
+  // Buffers). Continuation layers must NOT realloc the root/in_slot buffers
+  // (in_slot holds the device-resident continuations being read; 296.4 root-
+  // cause). Only the exit pool may grow. (3+ layer cont-out growth: see
+  // EnsureContCapacity follow-up; canonical 2-layer multi-CI fits cont_cap_.)
+  if (first_ms) {
+    impl_->EnsureSessionBuffers(n);
   } else {
-    // ── Device-roots path (continuation from previous Recombine) ───────────
-    // Root buffers (d_dirs_/d_pos_/d_ws_/d_from_poly_/d_rot_c2w_) were filled
-    // in-place by `transit_multi_ms_kernel` inside the previous Recombine
-    // dispatch; no H2D / pinned staging needed (host pointers do not cross
-    // the seam in this path — §5 铁律). Per-ray n_idx now comes from the device
-    // wl_pool via each ray's wl_idx (296.6 DR-3); the continuation rays carry
-    // their wl_idx in d_root_wl_idx_ (written by transit_multi_ms_kernel), so the
-    // device-roots path needs no host crystal / refractive-index resolution.
-    // backend_ptr sanity: not strictly required for correctness (the rays live
-    // in our own Impl buffers), but a NULL here means the caller forgot to
-    // pass back the Recombine result — flag it loudly.
-    if (roots.device.backend_ptr == nullptr) {
-      throw BackendUnavailableError(
-          "CudaTraceBackend::TraceLayer: device-roots path got NULL backend_ptr "
-          "(caller did not propagate the previous Recombine result)");
-    }
+    impl_->EnsureContCapacity(n, out_slot);
   }
 
-  cudaEventRecord(impl_->ev_end_h2d_);
+  // Partition this layer's `n` rays across its crystals by proportion. carry is
+  // per-(layer) persistent across batches (largest-remainder), mirroring
+  // simulator.cpp:830 ray_alloc_carry[mi].
+  std::vector<float> proportions;
+  proportions.reserve(crystal_cnt);
+  for (size_t ci = 0; ci < crystal_cnt; ci++) {
+    proportions.push_back(ms_layer.setting_[ci].crystal_proportion_);
+  }
+  if (impl_->ray_alloc_carry_.size() < impl_->n_ms_layers_) {
+    impl_->ray_alloc_carry_.resize(impl_->n_ms_layers_);
+  }
+  auto& carry = impl_->ray_alloc_carry_[impl_->ms_layer_idx_];
+  if (carry.size() != crystal_cnt) {
+    carry.assign(crystal_cnt, 0.0);
+  }
+  auto crystal_ray_num = PartitionCrystalRayNum(proportions, n, carry);
 
+  // Zero the layer's accumulators ONCE before the ci-loop: each ci's trace
+  // dispatch APPENDS to d_exit_ / cont[out_slot] via atomic counters.
+  cudaEventRecord(impl_->ev_start_h2d_);
   ck_reset(cudaMemset(impl_->d_exit_count_, 0, sizeof(uint32_t)), "cudaMemset d_exit_count");
+  ck_reset(cudaMemset(impl_->d_cont_count_[out_slot], 0, sizeof(uint32_t)),
+           "cudaMemset d_cont_count_[out_slot]");
 
-  uint32_t max_hits = static_cast<uint32_t>(impl_->scene_->max_hits_);
-  uint32_t grid = (static_cast<uint32_t>(n) + 255u) / 256u;
+  const uint32_t max_hits = static_cast<uint32_t>(impl_->scene_->max_hits_);
+  size_t ci_start = 0;  // running offset into cont[in_slot] for continuation slices
+  for (size_t ci = 0; ci < crystal_cnt; ci++) {
+    const size_t ci_n = crystal_ray_num[ci];
+    if (ci_n == 0u) {
+      continue;
+    }
+    const auto& ms_setting = ms_layer.setting_[ci];
+    const uint32_t cin = static_cast<uint32_t>(ci_n);
+    const uint32_t grid = (cin + 255u) / 256u;
 
-  // Splitting (deterministic per-bounce fan-out) — no per-thread RNG needed.
-  // The ms_mode/ms_prob/gate_* parameters route the kernel's emit gate (see
-  // trace_single_ms_kernel header for the per-emit gate semantics). Final-
-  // layer dispatches pass ms_mode=0 + nullptr cont buffers; non-final layers
-  // pass ms_mode=1 with the d_cont_* ring + gate PCG seed.
-  trace_single_ms_kernel<<<grid, 256>>>(
-      impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
-      static_cast<uint32_t>(n), impl_->d_poly_n_, impl_->d_poly_d_,
-      impl_->poly_cnt_, impl_->d_rot_c2w_, impl_->d_wl_pool_, impl_->d_root_wl_idx_,
-      max_hits, impl_->d_exit_,
-      static_cast<uint32_t>(impl_->exit_cap_), impl_->d_exit_count_,
-      /*crystal_id=*/0u, /*ms_layer_idx=*/impl_->ms_layer_idx_,
-      ms_mode, ms_prob,
-      ms_mode == 1u ? impl_->d_cont_d_       : nullptr,
-      ms_mode == 1u ? impl_->d_cont_w_       : nullptr,
-      ms_mode == 1u ? impl_->d_cont_wl_idx_  : nullptr,
-      ms_mode == 1u ? impl_->d_cont_count_   : nullptr,
-      ms_mode == 1u ? static_cast<uint32_t>(impl_->cont_cap_) : 0u,
-      impl_->gate_seed_,
-      NarrowPcgRayBase(impl_->gate_ray_count_, n, "cuda-gate"),
-      // 296.5 filter gate params. ms_mode==0 dispatches can pass these as
-      // nullptr/0 because the gate code is unreachable; we always pass real
-      // pointers to avoid undefined behaviour from null-pointer-arith warnings
-      // on stricter compilers — EnsureFilterBuffers guarantees they are
-      // non-null (1-byte dummies in the no-filter session case).
-      ms_mode == 1u ? impl_->d_filter_desc_       : nullptr,
-      ms_mode == 1u ? impl_->d_getfn_offsets_     : nullptr,
-      ms_mode == 1u ? impl_->d_getfn_bytes_       : nullptr,
-      ms_mode == 1u ? impl_->d_complex_sub_desc_  : nullptr,
-      ms_mode == 1u ? impl_->filter_desc_max_ci_  : 0u,
-      impl_->crystal_config_id_);
-  // Peek immediately after launch: illegal address / invalid config errors
-  // surface here before the synchronizing 4B readback, giving a precise
-  // error origin instead of a deferred cudaErrorLaunchFailure on Memcpy.
-  ck_reset(cudaPeekAtLastError(), "kernel launch");
+    // Per-ci crystal + geometry (mirrors Metal ResolveLayerCrystalForCi +
+    // UploadCrystal). MakeCrystal consumes impl_->rng_ once per (layer,ci,batch),
+    // matching legacy/Metal ordering.
+    Crystal ci_crystal = MakeCrystal(impl_->rng_, ms_setting.crystal_.param_);
+    impl_->UploadCrystalGeometry(ci_crystal);
+    const uint32_t ci_cfg_id = (ci_crystal.config_id_ == kInvalidId)
+                                   ? 0xFFFFu
+                                   : static_cast<uint32_t>(ci_crystal.config_id_);
+
+    // ── Generate / transit this ci's root rays into root buf [0, ci_n) ──────
+    if (first_ms && !impl_->disable_device_gen_) {
+      // Device root-gen (296.6): samples orientation + sun-cone dir + entry point
+      // + per-ray wl on device for THIS ci's crystal geometry. gen_ray_count_ is
+      // monotone so each (layer,ci,batch) consumes a disjoint PCG range.
+      lm_pcg::GenRootKernelParams gp =
+          BuildGenGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cin,
+                           impl_->scene_->light_source_.param_, impl_->wl_pool_size_);
+      gp.gen_seed     = impl_->gen_seed_;
+      gp.gen_ray_base = NarrowPcgRayBase(impl_->gen_ray_count_, ci_n, "cuda-gen");
+      gen_root_kernel<<<grid, 256>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
+                                     impl_->d_rot_c2w_, impl_->d_root_wl_idx_, impl_->d_tri_vtx_,
+                                     impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
+                                     impl_->d_wl_pool_, gp, cin);
+      ck_reset(cudaPeekAtLastError(), "gen_root_kernel launch");
+      impl_->gen_ray_count_ += ci_n;
+    } else if (first_ms) {
+      // Host-roots fallback (LUMICE_DISABLE_DEVICE_GEN): InitRayFirstMs for ci_n
+      // rays through ci_crystal, then H2D the staged root buffers [0, ci_n).
+      try {
+        const auto& axis_dist = ms_setting.crystal_.axis_;
+        RayBuffer workspace[2]{};
+        workspace[0].Reset(ci_n * 2);
+        workspace[1].Reset(ci_n * 4);
+        RayBuffer all_data = AllocateAllData(*impl_->scene_, ci_n);
+        InitRayFirstMs(impl_->rng_, impl_->scene_->light_source_.param_, impl_->wl_, ci_n, ci_crystal,
+                       impl_->ms_layer_idx_, axis_dist, workspace, all_data);
+        for (size_t i = 0; i < ci_n; ++i) {
+          const auto& r = all_data[i];
+          impl_->pinned_dirs_[i * 3 + 0] = r.d_[0];
+          impl_->pinned_dirs_[i * 3 + 1] = r.d_[1];
+          impl_->pinned_dirs_[i * 3 + 2] = r.d_[2];
+          impl_->pinned_pos_[i * 3 + 0] = r.p_[0];
+          impl_->pinned_pos_[i * 3 + 1] = r.p_[1];
+          impl_->pinned_pos_[i * 3 + 2] = r.p_[2];
+          uint32_t wl_idx = static_cast<uint32_t>(impl_->rng_.GetUniform() *
+                                                  static_cast<float>(impl_->wl_pool_size_));
+          if (wl_idx >= impl_->wl_pool_size_) {
+            wl_idx = impl_->wl_pool_size_ - 1u;
+          }
+          impl_->pinned_root_wl_idx_[i] = wl_idx;
+          impl_->pinned_ws_[i] = impl_->wl_pool_host_[wl_idx].spd_weight;
+          impl_->pinned_from_poly_[i] =
+              (r.to_face_ == kInvalidId) ? 0xFFFFFFFFu : static_cast<uint32_t>(r.to_face_);
+          std::memcpy(impl_->pinned_rot_c2w_ + i * 9, r.crystal_rot_.GetMat(), 9 * sizeof(float));
+        }
+      } catch (...) {
+        impl_->Reset();
+        throw;
+      }
+      cudaMemcpyAsync(impl_->d_rot_c2w_, impl_->pinned_rot_c2w_, 9 * ci_n * sizeof(float),
+                      cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(impl_->d_dirs_, impl_->pinned_dirs_, 3 * ci_n * sizeof(float), cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(impl_->d_pos_, impl_->pinned_pos_, 3 * ci_n * sizeof(float), cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(impl_->d_ws_, impl_->pinned_ws_, ci_n * sizeof(float), cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(impl_->d_from_poly_, impl_->pinned_from_poly_, ci_n * sizeof(uint32_t),
+                      cudaMemcpyHostToDevice);
+      cudaMemcpyAsync(impl_->d_root_wl_idx_, impl_->pinned_root_wl_idx_, ci_n * sizeof(uint32_t),
+                      cudaMemcpyHostToDevice);
+      ck_reset(cudaGetLastError(), "H2D batch");
+    } else {
+      // ── Continuation: transit cont[in_slot] slice [ci_start, ci_start+ci_n) ──
+      // into root buf [0, ci_n) using THIS ci's crystal (orientation resample +
+      // entry-point sample). Mirrors Metal EncodeTransitRoot's per-ci slice
+      // (metal_trace_backend.mm:2236-2248). Offset the in_slot cont pointers by
+      // ci_start; the kernel indexes tid in [0, ci_n). transit_ray_count_ is
+      // monotone → disjoint PCG range per (layer,ci,batch).
+      lm_pcg::GenRootKernelParams gp =
+          BuildTransitGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cin);
+      gp.gen_seed     = impl_->transit_seed_;
+      gp.gen_ray_base = NarrowPcgRayBase(impl_->transit_ray_count_, ci_n, "cuda-transit");
+      transit_multi_ms_kernel<<<grid, 256>>>(
+          impl_->d_cont_d_[in_slot] + ci_start * 3u, impl_->d_cont_w_[in_slot] + ci_start,
+          impl_->d_cont_wl_idx_[in_slot] + ci_start,
+          impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
+          impl_->d_rot_c2w_, impl_->d_root_wl_idx_,
+          impl_->d_tri_vtx_, impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
+          gp, cin);
+      ck_reset(cudaPeekAtLastError(), "transit kernel launch");
+      impl_->transit_ray_count_ += ci_n;
+      ci_start += ci_n;
+    }
+
+    // ── Trace this ci's ci_n root rays through ci_crystal geometry ──────────
+    // Exits APPEND to d_exit_ (crystal_id=ci tag); continuations APPEND to
+    // cont[out_slot] (atomic counters, zeroed once before the loop). The kernel
+    // computes its filter-desc slot as ms_layer_idx*max_ci + crystal_id, so
+    // passing crystal_id=ci selects this ci's per-(layer,ci) filter descriptor.
+    trace_single_ms_kernel<<<grid, 256>>>(
+        impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
+        cin, impl_->d_poly_n_, impl_->d_poly_d_,
+        impl_->poly_cnt_, impl_->d_rot_c2w_, impl_->d_wl_pool_, impl_->d_root_wl_idx_,
+        max_hits, impl_->d_exit_,
+        static_cast<uint32_t>(impl_->exit_cap_), impl_->d_exit_count_,
+        /*crystal_id=*/static_cast<uint32_t>(ci), /*ms_layer_idx=*/impl_->ms_layer_idx_,
+        ms_mode, ms_prob,
+        ms_mode == 1u ? impl_->d_cont_d_[out_slot]      : nullptr,
+        ms_mode == 1u ? impl_->d_cont_w_[out_slot]      : nullptr,
+        ms_mode == 1u ? impl_->d_cont_wl_idx_[out_slot] : nullptr,
+        ms_mode == 1u ? impl_->d_cont_count_[out_slot]  : nullptr,
+        ms_mode == 1u ? static_cast<uint32_t>(impl_->cont_cap_[out_slot]) : 0u,
+        impl_->gate_seed_,
+        NarrowPcgRayBase(impl_->gate_ray_count_, ci_n, "cuda-gate"),
+        ms_mode == 1u ? impl_->d_filter_desc_       : nullptr,
+        ms_mode == 1u ? impl_->d_getfn_offsets_     : nullptr,
+        ms_mode == 1u ? impl_->d_getfn_bytes_       : nullptr,
+        ms_mode == 1u ? impl_->d_complex_sub_desc_  : nullptr,
+        ms_mode == 1u ? impl_->filter_desc_max_ci_  : 0u,
+        ci_cfg_id);
+    ck_reset(cudaPeekAtLastError(), "kernel launch");
+    if (ms_mode == 1u) {
+      impl_->gate_ray_count_ += ci_n;  // monotone per (layer,ci,batch)
+    }
+  }  // ci-loop
+
+  cudaEventRecord(impl_->ev_end_h2d_);
   cudaEventRecord(impl_->ev_end_kernel_);
 
   // 4B readback (synchronous on the default stream — also the first sync
@@ -1994,29 +2136,23 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     impl_->h_exit_count_ = static_cast<uint32_t>(impl_->exit_cap_);
   }
 
-  // Advance gate PCG counter ONLY in ms_mode==1 (final-layer dispatches do
-  // not draw the gate PCG so they leave the counter undisturbed). Bumping
-  // by `n` (root-ray count) — each ray's emit draws share a single
-  // global_idx + advancing `slot`, so two batches with disjoint
-  // global_idx ranges have fully disjoint streams.
-  if (ms_mode == 1u) {
-    impl_->gate_ray_count_ += n;
-  }
+  // gate PCG counter was advanced per-ci inside the loop (monotone), so no
+  // layer-level advance here.
 
-  // Continuation-count readback (only meaningful for ms_mode==1; the kernel
-  // does not touch d_cont_count_ on the ms_mode==0 path so it stays at the
-  // value Recombine / EnsureSessionBuffers last zeroed it to).
+  // Continuation-count readback (only meaningful for ms_mode==1). Reads the OUT
+  // slot counter this layer's ci-loop appended into; the kernel leaves it
+  // untouched on the ms_mode==0 (final) path.
   size_t cont_count_for_handle = 0u;
   if (ms_mode == 1u) {
-    ck_reset(cudaMemcpy(&impl_->h_cont_count_, impl_->d_cont_count_, sizeof(uint32_t),
+    ck_reset(cudaMemcpy(&impl_->h_cont_count_, impl_->d_cont_count_[out_slot], sizeof(uint32_t),
                         cudaMemcpyDeviceToHost), "4B cont_count readback");
-    if (impl_->h_cont_count_ >= impl_->cont_cap_) {
+    if (impl_->h_cont_count_ >= impl_->cont_cap_[out_slot]) {
       if (impl_->logger != nullptr) {
         ILOG_WARN(*impl_->logger,
                   "CudaTraceBackend::TraceLayer: cont buffer overflow (count={} cap={}); tail dropped",
-                  impl_->h_cont_count_, impl_->cont_cap_);
+                  impl_->h_cont_count_, impl_->cont_cap_[out_slot]);
       }
-      impl_->h_cont_count_ = static_cast<uint32_t>(impl_->cont_cap_);
+      impl_->h_cont_count_ = static_cast<uint32_t>(impl_->cont_cap_[out_slot]);
     }
     cont_count_for_handle = impl_->h_cont_count_;
   } else {
@@ -2037,79 +2173,27 @@ RootRaySource CudaTraceBackend::Recombine(LayerHandlePtr handle, const Recombine
   // populated by TraceLayer's tail readback.
   handle.reset();
 
-  // Local error helper.
-  auto ck_reset = [this](cudaError_t e, const char* ctx) {
-    if (e != cudaSuccess) {
-      impl_->Reset();
-      throw BackendUnavailableError(std::string{"CudaTraceBackend::Recombine: "} + ctx + ": " +
-                                    cudaGetErrorString(e));
-    }
-  };
-
+  // Transit is now LAZY (multi-CI 全量): it is performed per-ci inside the NEXT
+  // TraceLayer's continuation branch (mirrors Metal — Recombine just advances
+  // the layer index and returns the continuation count). The continuations this
+  // just-traced layer produced live in cont[written_slot]; the next TraceLayer
+  // reads them per-ci-slice as in_slot. No transit kernel / cont_count zeroing
+  // here: the next TraceLayer zeroes its own out_slot before its ci-loop.
   const uint32_t cont_n = impl_->h_cont_count_;
-
-  // No continuations → nothing to transit. Bump ms_layer_idx_ so the next
-  // TraceLayer (if any) advances; return an empty DeviceRayBatch so the
-  // caller can short-circuit. Also zero d_cont_count_ for the next layer.
-  //
-  // Null guard: an n=0 first-layer TraceLayer early-returns before
-  // EnsureSessionBuffers runs, leaving d_cont_count_ == nullptr while the
-  // documented contract still allows a follow-up Recombine. cudaMemset(nullptr)
-  // returns cudaErrorInvalidValue → ck_reset would Reset + throw. When no
-  // buffers exist there is nothing to zero, so skip the memset. (296.4 review)
-  if (cont_n == 0u) {
-    if (impl_->d_cont_count_ != nullptr) {
-      ck_reset(cudaMemset(impl_->d_cont_count_, 0, sizeof(uint32_t)), "cudaMemset d_cont_count");
-    }
-    impl_->ms_layer_idx_++;
-    return RootRaySource::FromDevice(DeviceRayBatch{});
-  }
-
-  // Dispatch transit_multi_ms_kernel: read cont_d/cont_w/cont_wl_idx, write
-  // root_d/root_p/root_w/root_from_poly/root_rot/root_wl_idx into the
-  // Impl-owned root buffers (d_dirs_/d_pos_/d_ws_/d_from_poly_/d_rot_c2w_).
-  // wl_idx pass-through: d_cont_wl_idx_ is passed as both input and output
-  // (aliases). __restrict__ has been removed from those two kernel params to
-  // avoid C/CUDA UB (no-alias contract violation).
-  const auto& ms_setting = impl_->scene_->ms_[impl_->ms_layer_idx_].setting_[0];
-  lm_pcg::GenRootKernelParams gp =
-      BuildTransitGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cont_n);
-  gp.gen_seed     = impl_->transit_seed_;
-  gp.gen_ray_base = NarrowPcgRayBase(impl_->transit_ray_count_, cont_n, "cuda-transit");
-
-  uint32_t grid = (cont_n + 255u) / 256u;
-  transit_multi_ms_kernel<<<grid, 256>>>(
-      impl_->d_cont_d_, impl_->d_cont_w_, impl_->d_cont_wl_idx_,
-      impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
-      impl_->d_rot_c2w_, impl_->d_root_wl_idx_,  // 296.6 DR-3: pass per-ray wl_idx from continuation into the
-                                                 // next layer's root buffer (read by trace_single_ms_kernel)
-      impl_->d_tri_vtx_, impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
-      gp, cont_n);
-  ck_reset(cudaPeekAtLastError(), "transit kernel launch");
-  // Synchronize the default stream only — cudaDeviceSynchronize would block
-  // all streams (including potential future overlapping streams) unnecessarily.
-  ck_reset(cudaStreamSynchronize(cudaStreamDefault), "transit kernel sync");
-
-  // Advance PCG counter + MS layer index. transit_ray_count_ uses the
-  // continuation count (= number of kernel threads = number of unique PCG
-  // global_idx values consumed).
-  impl_->transit_ray_count_ += cont_n;
+  const int written_slot = static_cast<int>(impl_->ms_layer_idx_ & 1u);
   impl_->ms_layer_idx_++;
 
-  // Zero d_cont_count_ for the next layer's emit gate (the buffer is reused).
-  ck_reset(cudaMemset(impl_->d_cont_count_, 0, sizeof(uint32_t)), "cudaMemset d_cont_count");
-
   if (impl_->logger != nullptr) {
-    ILOG_DEBUG(*impl_->logger,
-               "CudaTraceBackend::Recombine: cont_n={} new_layer={} transit_ray_count={}",
-               cont_n, impl_->ms_layer_idx_, impl_->transit_ray_count_);
+    ILOG_DEBUG(*impl_->logger, "CudaTraceBackend::Recombine: cont_n={} new_layer={}",
+               cont_n, impl_->ms_layer_idx_);
   }
 
-  // backend_ptr cookie identifies "this is the Impl's root ring" — opaque to
-  // the caller, used only as a non-null sanity tag by the next TraceLayer's
-  // device-roots branch (the actual buffer addressing lives in Impl).
+  // backend_ptr is an opaque non-null sanity cookie (continuation rays live in
+  // Impl's cont[written_slot]); is_device=true routes the next TraceLayer into
+  // the continuation (per-ci transit) branch. When cont_n==0 the next
+  // TraceLayer's n==0 guard short-circuits regardless of the cookie.
   DeviceRayBatch batch{};
-  batch.backend_ptr = static_cast<void*>(impl_->d_dirs_);
+  batch.backend_ptr = static_cast<void*>(impl_->d_cont_d_[written_slot]);
   batch.count = cont_n;
   return RootRaySource::FromDevice(batch);
 }
@@ -2143,8 +2227,15 @@ size_t CudaTraceBackend::DrainExits(std::vector<ExitRayRecord>& out) {
   // layer records run FilterSpec::Check + a host RNG prob draw to enforce the
   // legacy CollectData per-layer semantics (simulator.cpp:425).
   const uint8_t final_layer = impl_->final_ms_layer_idx_;
-  std::unique_ptr<FilterSpec> spec = FilterSpec::Create(
-      impl_->final_layer_filter_config_, impl_->final_layer_crystal_, impl_->final_layer_axis_dist_);
+  // Per-ci FilterSpec cache for the final layer (mirrors Metal spec_per_ci,
+  // metal:2403-2409). The same crystal_id repeats across many exits; build once.
+  const size_t final_ci_cnt = impl_->final_layer_crystals_.size();
+  std::vector<std::unique_ptr<FilterSpec>> spec_per_ci(final_ci_cnt);
+  for (size_t k = 0; k < final_ci_cnt; ++k) {
+    spec_per_ci[k] = FilterSpec::Create(impl_->final_layer_filter_configs_[k],
+                                        impl_->final_layer_crystals_[k],
+                                        impl_->final_layer_axis_dists_[k]);
+  }
   std::uniform_real_distribution<float> prob_dist(0.0f, 1.0f);
 
   out.reserve(count);
@@ -2156,6 +2247,13 @@ size_t CudaTraceBackend::DrainExits(std::vector<ExitRayRecord>& out) {
       continue;
     }
 
+    // Resolve this exit's final-layer crystal by its per-ci tag (multi-CI).
+    const uint16_t cid = src.crystal_id;
+    if (cid >= final_ci_cnt) {
+      continue;  // safety: stray record from a malformed kernel run
+    }
+    const Crystal& final_crystal = impl_->final_layer_crystals_[cid];
+
     // Reconstruct {RaySeg, RaypathRecorder} for FilterSpec::Check.
     RaySeg r{};
     r.d_[0] = src.dir[0];
@@ -2164,7 +2262,7 @@ size_t CudaTraceBackend::DrainExits(std::vector<ExitRayRecord>& out) {
     r.w_ = src.weight;
     r.to_face_ = kInvalidId;
     r.is_continue_ = false;
-    r.crystal_config_id_ = impl_->final_layer_crystal_.config_id_;
+    r.crystal_config_id_ = final_crystal.config_id_;
 
     // GetFn remap: raw kernel path[] carries poly-face indices; FilterSpec
     // expects post-GetFn ids (mirrors Metal ReadbackExitRays:2539-2545). For
@@ -2179,14 +2277,14 @@ size_t CudaTraceBackend::DrainExits(std::vector<ExitRayRecord>& out) {
     const bool has_overflow = (seq_len > RaypathRecorder::kInlineCap);
     rec.overflow_idx_ = has_overflow ? 0u : RaypathRecorder::kNoOverflow;
     for (uint8_t k = 0; k < seq_len; ++k) {
-      const uint8_t v = static_cast<uint8_t>(impl_->final_layer_crystal_.GetFn(static_cast<IdType>(src.path.data_[k])));
+      const uint8_t v = static_cast<uint8_t>(final_crystal.GetFn(static_cast<IdType>(src.path.data_[k])));
       if (k < RaypathRecorder::kInlineCap) {
         rec.data_[k] = v;
       }
       local_arena[k] = v;
     }
     const uint8_t* arena_for_check = has_overflow ? local_arena : nullptr;
-    if (spec && !spec->Check(r, rec, arena_for_check)) {
+    if (spec_per_ci[cid] && !spec_per_ci[cid]->Check(r, rec, arena_for_check)) {
       continue;  // filter-fail → drop (Design A termination on final layer)
     }
     // Legacy mirror: rng<prob means "would have continued"; since there is no

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -67,8 +67,11 @@ class MetalLayerHandle : public LayerHandle {
 // v1 constraints:
 //   - kRectangular lens and zenith view (el≈90°) only.
 //   - Each MS layer must have exactly one crystal setting.
-//   - Device-side shuffle is not implemented; callers must set
-//     RecombineSpec.shuffle = false before calling Recombine().
+//
+// Recombine honors RecombineSpec.shuffle: when true, a device-side
+// shuffle_cont_kernel (Feistel gather) decorrelates the continuation pool's
+// per-parent-CI grouping, mirroring legacy host Fisher-Yates
+// (task-gpu-backend-recombine-shuffle). shuffle = false skips the permutation.
 class MetalTraceBackend : public TraceBackend {
  public:
   explicit MetalTraceBackend(Logger* logger = nullptr);

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -68,6 +68,13 @@ constexpr int kTraceKernelRecCap = 64;
 static_assert(kDevFilterMatchRecCap == kTraceKernelRecCap,
               "kDevRecCap (filter-match helper) and kRecCap (trace kernel) must match");
 
+// Continuation-pool shuffle PCG nonce (task-gpu-backend-recombine-shuffle).
+// MUST equal the CUDA-side kCudaShuffleNonce so the two backends derive the
+// same per-layer Feistel seed (spec.seed ^ nonce ^ ms_idx) — the shuffle only
+// needs statistical uniformity, not bit-match with legacy host Fisher-Yates,
+// but keeping the nonces identical keeps the two GPU backends in lock-step.
+constexpr uint32_t kMetalShuffleNonce = 0xB17CA3D9u;
+
 // Mirror of the Metal-side KernelParams (host layout MUST match the .metal
 // struct field-for-field — all 4-byte scalars, natural alignment).
 // NOTE: field order MUST match MSL KernelParams in src/core/metal/lumice_trace.metal — static_assert
@@ -454,6 +461,9 @@ struct MetalTraceBackend::Impl {
   // Device frame-transit PSO (scrum-267 task-device-resident-continuation).
   // Same compiled library as gen_root_pso_; nil until first BeginSession.
   id<MTLComputePipelineState> transit_root_pso_ = nil;
+  // Continuation-pool shuffle PSO (task-gpu-backend-recombine-shuffle).
+  // Same compiled library as the others; nil until first BeginSession.
+  id<MTLComputePipelineState> shuffle_pso_ = nil;
   // Captured from spec.seed by BeginSession. 0 → device gen disabled (host
   // fallback path). Non-zero implies single-worker determinism contract.
   uint32_t gen_seed_ = 0u;
@@ -710,6 +720,12 @@ struct MetalTraceBackend::Impl {
   // root_*_buf in lock-step with the trace kernel's input layout.
   void EncodeTransitRoot(id<MTLCommandBuffer> cb, const GenRootKernelParams& gp,
                          int in_slot, size_t ci_start);
+  // Encodes a shuffle_cont_kernel pass: gather-reads the full cont[in_slot]
+  // slice (n entries) and writes the Feistel permutation into cont[out_slot].
+  // The caller (Recombine) swaps the slot handles afterwards so cont[in_slot]
+  // ends up holding the shuffled data the next layer consumes.
+  void EncodeShuffleCont(id<MTLCommandBuffer> cb, int in_slot, int out_slot,
+                         uint32_t n, uint32_t seed);
   // DispatchLayer encodes the trace pass (and any pending gen_root) into either
   // a freshly-created command buffer or `existing_cb` (used by the non-first
   // MS path to share the CB with a preceding EncodeTransitRoot), commits the
@@ -831,6 +847,23 @@ void MetalTraceBackend::Impl::EnsurePso() {
                "MetalTraceBackend: transit_root pipeline state creation failed: {}",
                desc ? desc : "(no error)");
     throw BackendUnavailableError("MetalTraceBackend: transit_root pipeline state creation failed");
+  }
+
+  // Continuation-pool shuffle PSO (task-gpu-backend-recombine-shuffle). Shares
+  // the same compiled library so the kernel cache survives across BeginSession
+  // invocations alongside transit_root_pso_.
+  id<MTLFunction> shuffle_fn = [lib newFunctionWithName:@"shuffle_cont_kernel"];
+  if (shuffle_fn == nil) {
+    LogMissingFunction("shuffle_cont_kernel");
+    throw BackendUnavailableError("MetalTraceBackend: shuffle_cont_kernel entry point missing");
+  }
+  shuffle_pso_ = [device newComputePipelineStateWithFunction:shuffle_fn error:&err];
+  if (shuffle_pso_ == nil) {
+    const char* desc = err.localizedDescription.UTF8String;
+    ILOG_ERROR(EffectiveLogger(logger_),
+               "MetalTraceBackend: shuffle pipeline state creation failed: {}",
+               desc ? desc : "(no error)");
+    throw BackendUnavailableError("MetalTraceBackend: shuffle pipeline state creation failed");
   }
 }
 
@@ -1576,6 +1609,37 @@ void MetalTraceBackend::Impl::EncodeTransitRoot(
     NSUInteger groups  = (static_cast<NSUInteger>(gp.num_rays) + threads - 1) / threads;
     [enc dispatchThreadgroups:MTLSizeMake(groups, 1, 1)
         threadsPerThreadgroup:MTLSizeMake(threads, 1, 1)];
+    [enc endEncoding];
+  }
+}
+
+void MetalTraceBackend::Impl::EncodeShuffleCont(
+    id<MTLCommandBuffer> cb, int in_slot, int out_slot,
+    uint32_t n, uint32_t seed) {
+  assert(shuffle_pso_ != nil && "shuffle_pso_ nil in EncodeShuffleCont");
+  assert(cont_d[in_slot] != nil && cont_w[in_slot] != nil &&
+         cont_wl_idx_buf_[in_slot] != nil &&
+         "EncodeShuffleCont: source cont buffers must be allocated");
+  assert(cont_d[out_slot] != nil && cont_w[out_slot] != nil &&
+         cont_wl_idx_buf_[out_slot] != nil &&
+         "EncodeShuffleCont: dest cont buffers must be allocated (EnsureContBuffer)");
+  @autoreleasepool {
+    id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
+    [enc setComputePipelineState:shuffle_pso_];
+    [enc setBuffer:cont_d[in_slot]          offset:0 atIndex:0];
+    [enc setBuffer:cont_w[in_slot]          offset:0 atIndex:1];
+    [enc setBuffer:cont_wl_idx_buf_[in_slot] offset:0 atIndex:2];
+    [enc setBuffer:cont_d[out_slot]         offset:0 atIndex:3];
+    [enc setBuffer:cont_w[out_slot]         offset:0 atIndex:4];
+    [enc setBuffer:cont_wl_idx_buf_[out_slot] offset:0 atIndex:5];
+    [enc setBytes:&n    length:sizeof(uint32_t) atIndex:6];
+    [enc setBytes:&seed length:sizeof(uint32_t) atIndex:7];
+    // 256 to match the CUDA shuffle blockDim (cross-backend symmetry) and the
+    // trace kernel's dispatch, capped to the device ceiling. Non-uniform
+    // dispatchThreads handles the n % tg remainder; the kernel guards tid >= n.
+    NSUInteger tg = std::min<NSUInteger>(256, shuffle_pso_.maxTotalThreadsPerThreadgroup);
+    [enc dispatchThreads:MTLSizeMake(n, 1, 1)
+        threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
     [enc endEncoding];
   }
 }
@@ -2330,13 +2394,57 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
 RootRaySource MetalTraceBackend::Recombine(LayerHandlePtr handle, const RecombineSpec& spec) {
   assert(impl_->in_session);
   assert(handle != nullptr);
-  // v1 does not implement device-side shuffle; integration callers must opt
-  // out explicitly (RecombineSpec.shuffle = false). The default-true value is
-  // safe for the CPU backend only.
-  assert(!spec.shuffle &&
-         "MetalTraceBackend v1 does not implement device-side shuffle");
   size_t count = handle->ContinuationCount();
-  (void)spec;
+
+  // Continuation-pool decorrelation shuffle (task-gpu-backend-recombine-shuffle).
+  // Mirrors legacy host Fisher-Yates (simulator.cpp:946-950): the per-CI trace
+  // dispatches leave cont[written_slot] grouped by parent CI; without this
+  // shuffle, the next layer's per-CI slicing hands parent-correlated subsets to
+  // each child CI (explore-300 root cause).
+  //
+  // Slot accounting (mirrors TraceLayer's out_slot = ms_idx & 1 /
+  // in_slot = (ms_idx-1) & 1 at metal_trace_backend.mm:2105-2106; F-verified):
+  //   - This layer wrote cont[out_slot = ms_idx & 1]; we are BEFORE the ++ so
+  //     written_slot below is exactly that out_slot.
+  //   - The next layer N+1 reads in_slot = ((N+1)-1) & 1 = N & 1 = written_slot.
+  //   - Gather READ cont[written_slot] (source), WRITE cont[other_slot] (dest),
+  //     then SWAP the slot handles so cont[written_slot] holds the shuffled
+  //     data the next layer consumes; cont[other_slot] post-swap holds the
+  //     stale source the next layer overwrites (out_slot = (N+1) & 1) — no alias.
+  if (spec.shuffle && count > 1u) {
+    const int written_slot = static_cast<int>(impl_->ms_idx & 1u);
+    const int other_slot   = 1 - written_slot;
+    // Sync precondition: TraceLayer drained every trace CB via
+    // WaitAndReadbackLayer ([cb waitUntilCompleted]) at each ci-tail before
+    // returning the handle, so no CB is in flight against cont[other_slot] when
+    // we realloc it below (CUDA's equivalent guard is the default-stream
+    // cudaDeviceSynchronize before its grow path).
+    // Grow cont[other_slot] to the current fan-out bound. EnsureContBuffer sizes
+    // every slot to out_cap, and out_cap >= count by the fan-out invariant
+    // (WaitAndReadbackLayer asserts produced <= out_cap), so this guarantees
+    // capacity >= count. Assert makes the implicit invariant explicit, symmetric
+    // with CUDA's explicit cont_cap_[other_slot] < cont_n check.
+    impl_->EnsureContBuffer(other_slot);
+    assert(impl_->cont_capacity[other_slot] >= count &&
+           "shuffle: other_slot capacity must cover the continuation count");
+    // Per-layer Feistel seed: spec.seed ^ nonce ^ ms_idx. Matches the CUDA side
+    // (shuffle_seed_ ^ ms_layer_idx_, with shuffle_seed_ = spec.seed ^ nonce);
+    // inlined here rather than cached since Recombine is called rarely.
+    const uint32_t shuf_seed = impl_->spec.seed ^ kMetalShuffleNonce ^
+                               static_cast<uint32_t>(impl_->ms_idx);
+    id<MTLCommandBuffer> shuf_cb = [impl_->queue commandBuffer];
+    impl_->EncodeShuffleCont(shuf_cb, written_slot, other_slot,
+                             static_cast<uint32_t>(count), shuf_seed);
+    [shuf_cb commit];
+    [shuf_cb waitUntilCompleted];
+    // Swap ALL parallel slot arrays so cont[written_slot] holds the shuffled
+    // data. Omitting cont_wl_idx_buf_ would silently desynchronize per-ray
+    // wavelength tagging — Feistel / energy parity could not detect it.
+    std::swap(impl_->cont_d[written_slot],          impl_->cont_d[other_slot]);
+    std::swap(impl_->cont_w[written_slot],          impl_->cont_w[other_slot]);
+    std::swap(impl_->cont_wl_idx_buf_[written_slot], impl_->cont_wl_idx_buf_[other_slot]);
+    std::swap(impl_->cont_capacity[written_slot],   impl_->cont_capacity[other_slot]);
+  }
 
   impl_->ms_idx++;
 

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -312,11 +312,15 @@ using LayerHandlePtr = std::unique_ptr<LayerHandle>;
 // -----------------------------------------------------------------------------
 // RecombineSpec — declarative control for the inter-layer compaction stage.
 //
-// `shuffle`: for CPU backends, applies a Fisher-Yates shuffle to the
-// continuation set so per-crystal-batch ordering does not bias the next
-// layer's small-batch dispatch. GPU stream compaction is naturally unordered;
-// backends may interpret `shuffle` as a no-op when compaction already breaks
-// any locality assumptions.
+// `shuffle`: applies a random permutation to the continuation set so the
+// per-parent-crystal ordering left by the producing layer does not bias the
+// next layer's per-CI slicing / small-batch dispatch. CPU backends use a host
+// Fisher-Yates; GPU backends (Metal/CUDA) use a device-side Feistel gather
+// (`feistel_bijection`, task-gpu-backend-recombine-shuffle). The earlier
+// assumption that "GPU stream compaction is naturally unordered, so shuffle is
+// a no-op" held only for single-CI continuation layers; multi-CI continuation
+// layers group the pool by parent CI and DO need this decorrelation
+// (explore-300). `shuffle = false` skips the permutation on every backend.
 // -----------------------------------------------------------------------------
 struct RecombineSpec {
   bool shuffle = true;

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -1024,3 +1024,39 @@ kernel void transit_root_kernel(
   // scrum-268.8 (DR-3): pass-through wavelength index (photon lifetime tag).
   root_wl_idx_out[tid] = cont_wl_idx_in[tid];
 }
+
+// --- shuffle_cont_kernel ---------------------------------------------------
+//
+// Continuation-pool decorrelation shuffle (task-gpu-backend-recombine-shuffle).
+// Gather-form Feistel permutation: each thread tid in [0, n) computes
+// `src = feistel_bijection(tid, n, seed)` (shared lm_pcg, identical to the CUDA
+// shuffle_cont_kernel) and copies (d, w, wl_idx) from in[src] to out[tid]. The
+// dest must NOT alias the source, so the host passes cont[other_slot] as the
+// dest and swaps the slot handles afterwards (see MetalTraceBackend::Recombine).
+//
+// Why: when a multi-CI layer's per-CI trace dispatches run, cont[written_slot]
+// ends up grouped by parent CI. The next layer's per-CI slicing would then hand
+// "parent-correlated" subsets to each child CI, biasing the ray→crystal pairing.
+// Legacy host Fisher-Yates breaks this (simulator.cpp:946-950); explore-300
+// confirmed both GPU backends were missing the same decorrelation step.
+kernel void shuffle_cont_kernel(
+    device const float*  in_d   [[buffer(0)]],   // 3 × n
+    device const float*  in_w   [[buffer(1)]],   // n
+    device const uint*   in_wl  [[buffer(2)]],   // n
+    device float*        out_d  [[buffer(3)]],   // 3 × n
+    device float*        out_w  [[buffer(4)]],   // n
+    device uint*         out_wl [[buffer(5)]],   // n
+    constant uint&       n_rays [[buffer(6)]],
+    constant uint&       seed   [[buffer(7)]],
+    uint tid [[thread_position_in_grid]])
+{
+  if (tid >= n_rays) {
+    return;
+  }
+  uint src = feistel_bijection(tid, n_rays, seed);
+  out_d[tid * 3u + 0u] = in_d[src * 3u + 0u];
+  out_d[tid * 3u + 1u] = in_d[src * 3u + 1u];
+  out_d[tid * 3u + 2u] = in_d[src * 3u + 2u];
+  out_w[tid]  = in_w[src];
+  out_wl[tid] = in_wl[src];
+}

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -328,7 +328,13 @@ LM_FN void sample_sph_cap(LM_THREAD PcgStream& s, float lon, float lat, float ha
 //
 // Small-n special cases: n<=1 returns i (trivial); n==2 returns i^1 (the
 // p=h=1 case degenerates to all-zero output under the general Feistel form
-// because half-bit width = 0 — see review.md Minor#2).
+// because the half-bit width = 0). The n==2 permutation is seed-INDEPENDENT —
+// a 2-element set has exactly one non-trivial permutation (the swap), so this
+// is a mathematical limit, not a missing seed dependency.
+//
+// Supported domain: n up to 2^30 (~1.07e9), far above any continuation-pool
+// size (ray counts are in the millions at most). The bit-width loop is capped
+// at 30 to keep `1u << bits` clear of the uint32 shift-UB boundary (bits==32).
 LM_FN uint32_t feistel_bijection(uint32_t i, uint32_t n, uint32_t seed) {
   if (n <= 1u) {
     return i;
@@ -340,8 +346,11 @@ LM_FN uint32_t feistel_bijection(uint32_t i, uint32_t n, uint32_t seed) {
   // bit-width (else the split L|R wouldn't cover the whole p domain — e.g.
   // n=5 → next_pow2=8 has 3 bits, halves of 1+1=2 bits cover only 4 elements).
   // Round bit-width up to even (equivalent to next power-of-4 domain).
+  // Cap at 30 so `1u << bits` never reaches the uint32 shift-UB boundary
+  // (bits==32). n > 2^30 is unsupported (see domain note above); it would
+  // degrade gracefully to the cycle-walk fallback rather than invoke UB.
   uint32_t bits = 0u;
-  while ((1u << bits) < n) {
+  while (bits < 30u && (1u << bits) < n) {
     bits++;
   }
   if ((bits & 1u) != 0u) {
@@ -349,8 +358,6 @@ LM_FN uint32_t feistel_bijection(uint32_t i, uint32_t n, uint32_t seed) {
   }
   uint32_t half_bits = bits >> 1u;
   uint32_t hm = (1u << half_bits) - 1u;
-  uint32_t p = 1u << bits;
-  (void)p;
   uint32_t round_const[4] = { 0x9E3779B9u, 0x85EBCA6Bu, 0xC2B2AE35u, 0x27D4EB2Fu };
   uint32_t cur = i;
   // Cycle-walk: at most O(p/n) iterations expected (p ≤ 4n by pow-of-4 rounding;
@@ -372,7 +379,14 @@ LM_FN uint32_t feistel_bijection(uint32_t i, uint32_t n, uint32_t seed) {
     }
     cur = out;
   }
-  // Defensive: should be unreachable; return cur modulo n to keep within range.
+  // Defensive fallback: mathematically unreachable for supported n (a finite
+  // Feistel cycle always returns to [0,n); the Python harness measured a max
+  // cycle-walk depth of 26, well under the guard of 64). If it IS reached, the
+  // permutation contract is already broken — `cur % n` is NOT a bijection, so
+  // the shuffle would silently double-count / drop rays. We still clamp into
+  // [0,n) here (rather than return `cur`) so a broken state cannot cause an
+  // out-of-bounds gather read on the GPU; the energy imbalance would surface
+  // in parity tests.
   return cur % n;
 }
 

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -316,6 +316,66 @@ LM_FN void sample_sph_cap(LM_THREAD PcgStream& s, float lon, float lat, float ha
   out_d[2] = s_lat * x + c_lat * z;
 }
 
+// Device-side bijection on [0, n) — 4-round balanced Feistel with cycle-walk
+// for non-power-of-2 n. Used by Metal/CUDA continuation-pool shuffle to remove
+// the per-parent-CI correlation that legacy host Fisher-Yates breaks
+// (explore-300; task-gpu-backend-recombine-shuffle).
+//
+// Each thread `i in [0, n)` computes `src = feistel_bijection(i, n, seed)`
+// independently — no atomics, no host RNG, no sort. The output is a permutation
+// of [0, n). cycle-walk: when the Feistel domain p = next_pow2(n) > n, iterate
+// until the result falls in [0, n); for n in (p/2, p], expected iterations < 2.
+//
+// Small-n special cases: n<=1 returns i (trivial); n==2 returns i^1 (the
+// p=h=1 case degenerates to all-zero output under the general Feistel form
+// because half-bit width = 0 — see review.md Minor#2).
+LM_FN uint32_t feistel_bijection(uint32_t i, uint32_t n, uint32_t seed) {
+  if (n <= 1u) {
+    return i;
+  }
+  if (n == 2u) {
+    return i ^ 1u;
+  }
+  // Balanced Feistel needs an EVEN bit-width domain so each half has equal
+  // bit-width (else the split L|R wouldn't cover the whole p domain — e.g.
+  // n=5 → next_pow2=8 has 3 bits, halves of 1+1=2 bits cover only 4 elements).
+  // Round bit-width up to even (equivalent to next power-of-4 domain).
+  uint32_t bits = 0u;
+  while ((1u << bits) < n) {
+    bits++;
+  }
+  if ((bits & 1u) != 0u) {
+    bits++;
+  }
+  uint32_t half_bits = bits >> 1u;
+  uint32_t hm = (1u << half_bits) - 1u;
+  uint32_t p = 1u << bits;
+  (void)p;
+  uint32_t round_const[4] = { 0x9E3779B9u, 0x85EBCA6Bu, 0xC2B2AE35u, 0x27D4EB2Fu };
+  uint32_t cur = i;
+  // Cycle-walk: at most O(p/n) iterations expected (p ≤ 4n by pow-of-4 rounding;
+  // typical n=10^3-10^4 in our cont-pool use case gives ratio ≈ 1-1.6). Guard
+  // bound 64 chosen for statistical safety — verified by Python harness in
+  // scratchpad/task-gpu-backend-recombine-shuffle (n ∈ {2..100003}, 5 seeds).
+  for (uint32_t guard = 0u; guard < 64u; guard++) {
+    uint32_t L = (cur >> half_bits) & hm;
+    uint32_t R = cur & hm;
+    for (uint32_t k = 0u; k < 4u; k++) {
+      uint32_t f = pcg_hash(seed ^ R ^ round_const[k]) & hm;
+      uint32_t new_R = L ^ f;
+      L = R;
+      R = new_R;
+    }
+    uint32_t out = (L << half_bits) | R;
+    if (out < n) {
+      return out;
+    }
+    cur = out;
+  }
+  // Defensive: should be unreachable; return cur modulo n to keep within range.
+  return cur % n;
+}
+
 // RandomSample (geo3d.cpp:112-150) — categorical CDF with negative-weight clip.
 // Mirrors host behavior: non-positive total falls back to bin 0.
 LM_FN uint32_t categorical_sample(LM_THREAD const float* weights, uint32_t n, float u_in) {

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1057,10 +1057,12 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
       aborted = true;
       break;
     }
-    // Metal v1 does not implement device-side shuffle and asserts on shuffle=true.
-    // CpuTraceBackend tolerates either. Always disable to keep both paths uniform.
+    // Continuation-pool decorrelation shuffle (default shuffle = true). All
+    // backends now honor it: CpuTraceBackend via host Fisher-Yates, Metal/CUDA
+    // via a device-side Feistel gather (task-gpu-backend-recombine-shuffle).
+    // It removes the per-parent-CI grouping that biased multi-CI continuation
+    // layers' ray→crystal pairing (explore-300).
     RecombineSpec rspec{};
-    rspec.shuffle = false;
     roots = backend.Recombine(std::move(handle), rspec);
   }
 

--- a/test/parity-cross-backend/backend/test_cuda_multi_ms_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_multi_ms_parity.py
@@ -160,6 +160,111 @@ def test_cuda_multi_ms_image_parity_vs_legacy():
 
 
 # --------------------------------------------------------------------------- #
+# Exit-buffer overflow regression (scrum-296 Step D / task-cuda-throughput-bench)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.slow
+def test_cuda_high_continuation_no_exit_overflow_corruption():
+    """Guard: a HIGH-continuation config must not corrupt the image via the
+    CUDA exit-buffer cap.
+
+    ``ms_prob05`` (the parity config above) has low continuation and never fills
+    the exit pool, so it could not catch this: ``ComputeExitCap`` formerly capped
+    the per-layer exit buffer at 64 MiB (~762600 records). ``ms_multi_crystal``
+    emits ~954k layer-1 exits at the DEFAULT dispatch — over the old cap — and the
+    kernel silently dropped the tail. Total energy (~1.02) AND cross-seed
+    self-corr (~0.9998) both stayed clean and masked it; only corr-vs-legacy
+    exposed the spatial damage (ds_corr fell to 0.913 < the 0.95 floor). The fix
+    sizes the exit/cont buffers to the analytic upper bound `n*(max_hits*2+4)` so
+    no exit is ever dropped. This test pins ds_corr back at/above the floor on
+    exactly the config that overflowed.
+    """
+    cfg = "ms_multi_crystal"
+    legacy = _run(cfg, "legacy", seed=_SEED)
+    cuda = _run(cfg, "cuda", seed=_SEED)
+
+    _assert_routed(legacy, "legacy", cfg)
+    _assert_routed(cuda, "cuda", cfg)
+
+    corr = _raw_corr_ds(cuda, legacy)
+    cuda_Y = float(cuda.flt_buf[..., 1].sum())
+    legacy_Y = float(legacy.flt_buf[..., 1].sum())
+    assert legacy_Y > 0.0, f"{cfg}: legacy total Y == 0; cannot form energy ratio"
+    energy_ratio = cuda_Y / legacy_Y
+
+    print(
+        f"[parity] {cfg}: cuda ds_corr={corr:.4f} energy_ratio={energy_ratio:.4f} "
+        f"(floors corr≥{_T_RAW_CORR_DS}, |energy−1|≤{_T_ENERGY_TOL})"
+    )
+
+    # ds_corr is the discriminating metric: the dropped-tail damage is spatial,
+    # not energetic, so this is what regressed (0.913) under the old cap.
+    assert corr >= _T_RAW_CORR_DS, (
+        f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Exit/cont buffer cap "
+        "may have reintroduced silent exit-record dropping (ComputeExitCap / "
+        "ComputeContCap must size to the analytic upper bound, not a fixed cap)."
+    )
+    assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
+        f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
+        f"[1 ± {_T_ENERGY_TOL}]."
+    )
+
+
+@pytest.mark.slow
+def test_cuda_three_layer_multi_ci_parity_vs_legacy():
+    """Full multi-CI guard: a 3-MS config with multiple crystals on EVERY layer
+    (incl. the final layer) must match legacy.
+
+    ``ms3_multi_crystal`` has 3 scattering layers with per-layer crystal counts
+    [4, 3, 2]. It exercises the parts that 2-layer single-CI-final configs cannot:
+      - per-ci transit on CONTINUATION layers (layers 1,2 multi-CI),
+      - EnsureContCapacity growth across 3 layers (cont fan-out > layer-0 cap),
+      - multi-CI FINAL-layer DrainExits (crystal_id-indexed FilterSpec / GetFn).
+    A single-CI-only CUDA backend traces every ray through one crystal → ds_corr
+    collapses; this pins the full multi-CI path against legacy.
+    """
+    import json
+    import tempfile
+    cfg = "ms3_multi_crystal"
+    # The committed ms3_multi_crystal ships ray_num=5M (an e2e PSNR config); the
+    # legacy oracle runs single-worker under a fixed seed and times out at 5M ×
+    # 3-MS × max_hits=12. Reduce to 300K via a temp config — block-mean ds_corr is
+    # robust to the lower sample count, and the multi-CI structure (3 layers, CI
+    # [4,3,2]) is unchanged. Both backends run the SAME temp config.
+    src = json.loads((CONFIGS_DIR / f"{cfg}.json").read_text())
+    src["scene"]["ray_num"] = 300_000
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump(src, tmp)
+    tmp.flush()
+    tmp.close()
+
+    legacy = run_scene_capi_buffered(tmp.name, sim_seed=_SEED, backend="legacy", timeout_sec=_TIMEOUT)
+    cuda = run_scene_capi_buffered(tmp.name, sim_seed=_SEED, backend="cuda", timeout_sec=_TIMEOUT)
+
+    _assert_routed(legacy, "legacy", cfg)
+    _assert_routed(cuda, "cuda", cfg)
+
+    corr = _raw_corr_ds(cuda, legacy)
+    cuda_Y = float(cuda.flt_buf[..., 1].sum())
+    legacy_Y = float(legacy.flt_buf[..., 1].sum())
+    assert legacy_Y > 0.0, f"{cfg}: legacy total Y == 0; cannot form energy ratio"
+    energy_ratio = cuda_Y / legacy_Y
+
+    print(
+        f"[parity] {cfg}(300K): cuda ds_corr={corr:.4f} energy_ratio={energy_ratio:.4f} "
+        f"(floors corr≥{_T_RAW_CORR_DS}, |energy−1|≤{_T_ENERGY_TOL})"
+    )
+    assert corr >= _T_RAW_CORR_DS, (
+        f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Multi-CI path broken on a "
+        "continuation/final layer (per-ci transit / EnsureContCapacity / final-"
+        "layer crystal_id-indexed DrainExits)."
+    )
+    assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
+        f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside [1 ± {_T_ENERGY_TOL}]."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # AC2b — cross-seed self-consistency (the under-sampling guard)
 # --------------------------------------------------------------------------- #
 

--- a/test/regression-sentinel/test_metallib_no_source_compile.py
+++ b/test/regression-sentinel/test_metallib_no_source_compile.py
@@ -52,17 +52,19 @@ pytestmark = [
 
 # Marker emitted by LoadMetalLibrary in src/core/metal_trace_backend.mm.
 # Format: "MetalTraceBackend: loaded embedded metallib (N functions)".
-# Asserting both substrings (kernel marker AND the exact "3 functions" count
-# tied to the trace_layer / gen_root / transit_root entry points) gives early
-# warning on either:
+# Asserting both substrings (kernel marker AND the exact "4 functions" count
+# tied to the trace_layer / gen_root / transit_root / shuffle_cont entry points)
+# gives early warning on either:
 #   (a) silent regression to source-compile-only (marker absent), or
-#   (b) accidental drop of an entry point (count != 3).
+#   (b) accidental drop of an entry point (count != 4).
 _MARKER_RE = re.compile(
     r"MetalTraceBackend:\s+loaded\s+embedded\s+metallib\s+\((\d+)\s+functions\)"
 )
-# trace_layer_kernel + gen_root_kernel + transit_root_kernel.
+# trace_layer_kernel + gen_root_kernel + transit_root_kernel + shuffle_cont_kernel.
+# shuffle_cont_kernel added in task-gpu-backend-recombine-shuffle (continuation-
+# pool device-side Feistel shuffle).
 # Recount source of truth:  grep -c 'kernel void' src/core/metal/lumice_trace.metal
-_EXPECTED_FUNCTION_COUNT = 3
+_EXPECTED_FUNCTION_COUNT = 4
 
 
 def test_metal_runs_without_source_compile():
@@ -113,13 +115,13 @@ def test_metal_runs_without_source_compile():
         f"Captured {len(result.log_lines)} log lines."
     )
 
-    # 3. All three production entry points must resolve from the embedded
+    # 3. All four production entry points must resolve from the embedded
     #    metallib. If a future change adds a kernel, update the expected
     #    count in lock-step with the .metal source.
     counts = {int(m.group(1)) for m in matches}
     assert counts == {_EXPECTED_FUNCTION_COUNT}, (
         f"Expected exactly {_EXPECTED_FUNCTION_COUNT} entry points in the "
         f"embedded metallib (trace_layer_kernel / gen_root_kernel / "
-        f"transit_root_kernel); marker reported {counts}. "
+        f"transit_root_kernel / shuffle_cont_kernel); marker reported {counts}. "
         "If you added a new MSL kernel, update _EXPECTED_FUNCTION_COUNT."
     )


### PR DESCRIPTION
## 概述

两条相关的 GPU 后端正确性工作，同分支推进：

### 1. CUDA full multi-CI per-layer 支持 + exit-buffer 溢出修复（task-299）
- `6db5eb20` CUDA 完整 multi-CI 逐层支持 + exit-buffer 溢出修复
- `cf6a59b8` throughput bench harness 增 CUDA 行
- `19f5c71b` as-built 文档 + 诚实吞吐基线

### 2. Device 侧续传池去相关洗牌（task-301，本 PR 主修复）
Metal 与 CUDA 两个 GPU 后端都漏了 legacy 的"续传池去相关洗牌"。缝契约假设"GPU compaction 天然无序 → shuffle no-op"仅对**单 CI 续传层**成立；多 CI 续传层（`ms3_multi_crystal` [4,3,2]）per-ci kernel 串行启动使 cont 池按父晶体分组，下层 per-ci 切片把父相关子集分给各子晶体 → 出射方位角系统性偏移（explore-300 定根因，~0.0007 ds_corr 零重叠）。

- `1e5645fb` 共享 `lm_pcg::feistel_bijection`（4 轮平衡 Feistel + cycle-walk，单源供 MSL+CUDA）
- `cd76fba5` CUDA + Metal device 侧 `shuffle_cont_kernel`（gather Feistel + ping-pong slot swap）；`simulator.cpp` 恢复默认 `RecombineSpec.shuffle=true`；纠正 `trace_backend.hpp` / `metal_trace_backend.hpp` 错误注释

## 验证
- **AC1（Metal 噪声受控）**：cross(legacy×metal) ds_corr 0.99845→**0.99908**（与 self floor 重叠），SIGNAL 0.00060→0.00000。
- **AC2（CUDA dev49 parity）**：`test_cuda_*` `-m slow` battery **10/10 passed**，含 `test_cuda_three_layer_multi_ci_parity_vs_legacy` + cross-seed 自洽。
- **AC3（Mac 无回归）**：ctest 4/4 + fast e2e 54 passed + format/policy OK。
- **AC4（owner 肉眼）**：legacy vs Metal / legacy vs CUDA 渲染 ms3 方位角 fade 差异消除，已确认。
- code-review 2 轮 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)