### PR TITLE
perf(scrum-304): persist CUDA buffers across sessions — CUDA throughput competitive + bench standardized

### DIFF
--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -180,16 +180,32 @@ not "× legacy", when judging GPU throughput):
   compute to the M2 Max GPU); the remaining CUDA gap is execution-model, not a
   fundamental kernel limit.
 
-#### Linux — dev49 RTX 4060 Ti (AMD Zen5 9950X 16C/32T host) · legacy vs CUDA · TODO (dev49 occupied)
+#### Linux — dev49 RTX 4060 Ti (AMD Zen5 9950X 16C/32T host) · legacy vs CUDA · 2026-06-29
 
-Not yet measured this round. Run when dev49 is idle (after the scrum-304 buffer-persist
-build), fill the same table shape, and compare CUDA's light-scene number against both
-the 25 M/s target and the Metal ~28 M/s reference above:
+After scrum-304.2 buffer-persist, GPU-idle-gated (`nvidia-smi` 0% verified before run),
+`scripts/bench_throughput.py` default dispatch (=32768), ray_num=20M, N≥5 (N=9 on CoV>15%).
 
-```bash
-LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
-LUMICE_BENCH_BACKENDS=legacy,cuda python3 scripts/bench_throughput.py
-```
+| config | legacy single | legacy multi | CUDA single | CUDA multi | CUDA/legacy (multi) |
+|---|---|---|---|---|---|
+| `bench_light_single_ms` (轻·单MS) | 744 K/s | 8.98 M/s | **35.2 M/s** | **55.9 M/s** | 6.23× |
+| `ms_multi_crystal` (中·无filter) | 126 K/s | 1.44 M/s | 9.67 M/s | 13.7 M/s | 9.55× |
+| `ms_multi_crystal_complex_filter` (重·标准) | 471 K/s | 6.26 M/s | 38.0 M/s | 60.3 M/s | 9.63× |
+| `ms_multi_crystal_filtered_bd` (重·bd) | 510 K/s | 6.73 M/s | 39.1 M/s | 61.9 M/s | 9.19× |
+
+- **Competitive bar MET**: the comparable light single-MS scene is **35–56 M/s**, at/above
+  the 25 M/s competitor target AND above the Mac Metal reference (28–30 M/s). buffer-persist
+  alone (scrum-304.2) got CUDA here; the earlier "0.16–0.40× / 1.5M" pessimism was a
+  measurement artifact — ad-hoc non-idle-gated runs on the heavier `ms_multi_crystal`, the
+  wrong yardstick. Always idle-gate + use the canonical harness + the comparable scene.
+- **GPU not yet saturated**: nsys on the light scene (50M-ray plain run) = GPU active 17.6%
+  (JIT/setup-included); benchmark steady-window active ≈ 43%. trace_single_ms_kernel is 95%
+  of GPU time. The fully-fed kernel ceiling is ~129 M rays/s (50M / 386 ms kernel), so the
+  current 56 M is ~43% of ceiling — **~2.3× headroom remains**, locked behind per-dispatch
+  host serialization (default stream + per-layer sync; explore-303, untouched by 304.2).
+  Pursuing it is the async-engine work — now justified by the active% data, not speculation.
+- Caveat: the competitor's exact config (spectrum / max_hits) is unknown; our scene is a
+  reasonable single-crystal single-MS proxy (prism, D65, max_hits 7). Align if a precise
+  apples-to-apples is needed.
 
 ### macOS
 

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -128,6 +128,69 @@ Notes:
 - `bench_throughput.py` overrides `ray_num` to a large value per run (temp config,
   committed files untouched) so the steady window is long enough to be stable.
 
+#### Acceptance yardstick: hardware capability, NOT just "× legacy CPU"
+
+> **The `× legacy CPU` ratio is a FLOOR, not the success bar.** Beating the
+> legacy CPU is a necessary gate, never the goal — a GPU backend can "win × legacy"
+> while running the device at 1–2% utilization (this exact trap cost a day in
+> scrum-304: a CUDA number reported as "~1.7× legacy 16-core" was actually a
+> starved GPU on a heavier-than-comparable scene). For GPU backends the real bar
+> is the **device's hardware capability**, anchored to a comparable workload and
+> a known external reference.
+
+**Registered hardware-capability targets** (absolute, scene-anchored — cite these,
+not "× legacy", when judging GPU throughput):
+
+| scene | comparable workload | hardware-capability target | source |
+|---|---|---|---|
+| `bench_light_single_ms` (轻·单MS) | single crystal, single MS, no continuation | **≥ 25M rays/s on RTX 4060 Ti** | competitor product (measured) — the light single-MS scene is the apples-to-apples comparison |
+
+- Always benchmark the **comparable** scene against an external target — do NOT
+  cite a heavy multi-crystal / multi-MS number (e.g. `ms_multi_crystal`) when
+  the reference is single-crystal single-MS. They differ by an order of magnitude
+  in per-ray work.
+- When a GPU backend lands far below its hardware-capability target, the throughput
+  number is **not** a success regardless of the legacy ratio — investigate
+  utilization (see the CUDA active% diagnostic below) and the mechanism, do not
+  close out.
+- If a target genuinely cannot be reached, the acceptance artifact must be a
+  **profiler-grounded mechanism explanation** (where the time goes), not a black-box
+  "GPU doesn't naturally win" claim.
+
+### Latest measured results (per-run log)
+
+> Append the newest numbers here each time the bench is re-run. Record **absolute
+> rays/sec** (not just × legacy), per config, with a hardware summary. **Cross-hardware
+> numbers are NOT comparable** — always read within one host block; never compare a
+> Mac row against a Linux row. Source: `scripts/bench_throughput.py` (default dispatch,
+> `ray_num`=20M, N≥5 reps, N=9 re-run on CoV>15%).
+
+#### Mac — Apple M2 Max (12-core: 8P+4E, 32 GB, macOS 14.7) · legacy vs Metal · 2026-06-28
+
+| config | legacy single | legacy multi | Metal single | Metal multi | Metal/legacy (multi) |
+|---|---|---|---|---|---|
+| `bench_light_single_ms` (轻·单MS) | 573 K/s | 4.62 M/s | **27.8 M/s** | **30.6 M/s** | 6.62× |
+| `ms_multi_crystal` (中·无filter) | 94 K/s | 759 K/s | 7.08 M/s | 7.66 M/s | 10.08× |
+| `ms_multi_crystal_complex_filter` (重·标准) | 333 K/s | 1.54 M/s | 12.4 M/s | 12.8 M/s | 8.33× |
+| `ms_multi_crystal_filtered_bd` (重·bd) | 368 K/s | 1.62 M/s | 13.7 M/s | 14.0 M/s | 8.59× |
+
+- **Metal on the comparable light single-MS scene already hits ~28–30 M/s — at/above
+  the 25 M/s hardware-capability target.** This proves the bar is reachable on this
+  codebase and gives CUDA a same-engine target (the RTX 4060 Ti is comparable raw
+  compute to the M2 Max GPU); the remaining CUDA gap is execution-model, not a
+  fundamental kernel limit.
+
+#### Linux — dev49 RTX 4060 Ti (AMD Zen5 9950X 16C/32T host) · legacy vs CUDA · TODO (dev49 occupied)
+
+Not yet measured this round. Run when dev49 is idle (after the scrum-304 buffer-persist
+build), fill the same table shape, and compare CUDA's light-scene number against both
+the 25 M/s target and the Metal ~28 M/s reference above:
+
+```bash
+LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
+LUMICE_BENCH_BACKENDS=legacy,cuda python3 scripts/bench_throughput.py
+```
+
 ### macOS
 
 ```bash
@@ -168,6 +231,50 @@ scp examples/bench_config.json <windows-host>:<path>/
 
 # Manual mode (PowerShell wall time)
 Measure-Command { .\Lumice.exe -f bench_config.json -o . 2>&1 | Out-Null } | Select-Object TotalSeconds
+```
+
+### Linux / CUDA (dev49)
+
+CUDA throughput is measured on the dev49 bench box (NVIDIA RTX 4060 Ti, Linux,
+CUDA docker — see `reference_dev49_linux_bench` / `explore-cuda-step2-derisk/TOOLCHAIN.md`).
+**Do NOT improvise per-task bench scripts.** Use the committed harness
+`scripts/bench_throughput.py` — it already supports CUDA via env overrides, runs
+the canonical scene set (including the comparable `bench_light_single_ms`),
+confirms GPU routing (a silent fallback to legacy is flagged, not reported as a
+GPU number), and reports median + CoV with thermal re-runs.
+
+```bash
+# On dev49, inside the CUDA docker (build first: -DLUMICE_CUDA_ENABLED=ON
+# -DBUILD_SHARED_LIBS=ON -> build/Release/{bin/Lumice, lib/liblumice.so}).
+# Canonical CUDA throughput run (legacy baseline + CUDA, full canonical scene set):
+LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice \
+LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
+LUMICE_BENCH_BACKENDS=legacy,cuda \
+  python3 scripts/bench_throughput.py
+# Narrow to the comparable light scene only (vs the 25M/s hardware-capability target):
+#   LUMICE_BENCH_CONFIGS=bench_light_single_ms
+# Idle-gate: dev49 is shared (load often high); take strict throughput numbers in
+# an idle window only. Clean up your processes when done (do not leave Lumice /
+# detached bench running on the shared box).
+```
+
+#### GPU active% diagnostic (CUDA only — Metal/Mac has no equivalent CLI path)
+
+A throughput number alone cannot tell you whether the GPU is fed or starved.
+On CUDA/dev49, pair the bench with an `nsys` capture to read GPU utilization —
+this is the diagnostic that distinguishes a real win from a "beat the CPU while
+the GPU idles" false win. Profiler is already de-risked on dev49 (nsys 2023.4.4 +
+ncu 2024.1.1; install + usage recipe in `explore-cuda-step2-derisk/TOOLCHAIN.md`
+§"Profiler 可用性"). active% is **not a hard universal gate** — Metal on macOS has
+no comparable CLI active% path, so the cross-platform acceptance criterion stays
+the absolute hardware-capability target above; active% is a CUDA-side corroborating
+diagnostic for *why* a number is high or low.
+
+```bash
+# GPU active% = (sum of cuda_gpu_kern_sum) / wall, from an nsys timeline of one
+# representative run. Low active% (e.g. 1–2%) => GPU starved => the throughput
+# number is host-bound, not a hardware-capability result.
+nsys profile --trace=cuda --stats=true -o /tmp/rep <Lumice ...>   # see TOOLCHAIN.md
 ```
 
 ### CI Automated Benchmark

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -85,14 +85,20 @@ benchmark 模式的行为差异：
 
 - **Metal 在可比的轻·单MS 场景已 ~28–30 M/s,达到/超过 25 M/s 硬件能力目标。** 证明这个标尺在本 codebase 够得着,给 CUDA 一个同引擎目标(4060 Ti 与 M2 Max GPU 算力同级);CUDA 剩余差距是执行模型,不是 kernel 根本极限。
 
-#### Linux — dev49 RTX 4060 Ti(AMD Zen5 9950X 16C/32T host）· legacy vs CUDA · TODO（dev49 被占）
+#### Linux — dev49 RTX 4060 Ti(AMD Zen5 9950X 16C/32T host）· legacy vs CUDA · 2026-06-29
 
-本轮未测。dev49 空闲后跑(scrum-304 buffer-persist 构建),填同样表格,CUDA 轻场景数对标 25 M/s + 上面 Metal ~28 M/s 参照:
+scrum-304.2 buffer-persist 后,GPU idle-gate(跑前 `nvidia-smi` 实测 0%),`scripts/bench_throughput.py` 默认 dispatch(=32768),ray_num=20M,N≥5(CoV>15% 重跑 N=9)。
 
-```bash
-LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
-LUMICE_BENCH_BACKENDS=legacy,cuda python3 scripts/bench_throughput.py
-```
+| config | legacy single | legacy multi | CUDA single | CUDA multi | CUDA/legacy(multi) |
+|---|---|---|---|---|---|
+| `bench_light_single_ms`（轻·单MS） | 744 K/s | 8.98 M/s | **35.2 M/s** | **55.9 M/s** | 6.23× |
+| `ms_multi_crystal`（中·无filter） | 126 K/s | 1.44 M/s | 9.67 M/s | 13.7 M/s | 9.55× |
+| `ms_multi_crystal_complex_filter`（重·标准） | 471 K/s | 6.26 M/s | 38.0 M/s | 60.3 M/s | 9.63× |
+| `ms_multi_crystal_filtered_bd`（重·bd） | 510 K/s | 6.73 M/s | 39.1 M/s | 61.9 M/s | 9.19× |
+
+- **竞品线 25M 已达到/超过**:可比轻·单MS 场景 **35–56 M/s**,≥ 25M 竞品目标,也 > Mac Metal 参照(28–30M)。仅 buffer-persist(304.2)就到这了;之前"0.16–0.40× / 1.5M"的悲观是**测量假象**——ad-hoc 非 idle-gate 在重场景 `ms_multi_crystal` 上测、用错标尺。务必 idle-gate + 用 canonical harness + 可比场景。
+- **GPU 尚未满载**:nsys 轻场景(50M plain run)GPU active 17.6%(含 JIT/setup);benchmark steady 窗口 active ≈ 43%。trace kernel 占 GPU 95%。满载天花板 ≈ 129M rays/s(50M / 386ms kernel),现在 56M ≈ 43% → **还剩 ~2.3× headroom**,锁在每-dispatch host 串行(默认流 + per-layer 同步;explore-303 找到,304.2 未动)。要拿这部分=async-engine 工作,**现由 active% 数据支撑,非猜测**。
+- 注:竞品确切配置(光谱/max_hits)未知,我们场景是合理的单晶单MS 代理(prism,D65,max_hits 7)。需精确 apples-to-apples 时对齐。
 
 ### macOS
 

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -70,6 +70,30 @@ benchmark 模式的行为差异：
 - **不写图片**：跳过 `SaveRenderResults`，`wall_sec` 纯反映模拟耗时
 - **100ms 轮询间隔**（默认 1s）：将计时量化误差降至 ~0.1s
 
+### 最新实测结果（每次更新追加）
+
+> 每次重跑 bench 把最新数字追加这里。记**绝对 rays/sec**(不止倍数)、各 config 都有、附硬件摘要。**跨硬件数字不可比**——只在同一 host 块内读,别拿 Mac 行比 Linux 行。来源:`scripts/bench_throughput.py`(默认 dispatch,`ray_num`=20M,N≥5,CoV>15% 重跑 N=9)。
+
+#### Mac — Apple M2 Max(12 核 8P+4E,32GB,macOS 14.7)· legacy vs Metal · 2026-06-28
+
+| config | legacy single | legacy multi | Metal single | Metal multi | Metal/legacy(multi) |
+|---|---|---|---|---|---|
+| `bench_light_single_ms`（轻·单MS） | 573 K/s | 4.62 M/s | **27.8 M/s** | **30.6 M/s** | 6.62× |
+| `ms_multi_crystal`（中·无filter） | 94 K/s | 759 K/s | 7.08 M/s | 7.66 M/s | 10.08× |
+| `ms_multi_crystal_complex_filter`（重·标准） | 333 K/s | 1.54 M/s | 12.4 M/s | 12.8 M/s | 8.33× |
+| `ms_multi_crystal_filtered_bd`（重·bd） | 368 K/s | 1.62 M/s | 13.7 M/s | 14.0 M/s | 8.59× |
+
+- **Metal 在可比的轻·单MS 场景已 ~28–30 M/s,达到/超过 25 M/s 硬件能力目标。** 证明这个标尺在本 codebase 够得着,给 CUDA 一个同引擎目标(4060 Ti 与 M2 Max GPU 算力同级);CUDA 剩余差距是执行模型,不是 kernel 根本极限。
+
+#### Linux — dev49 RTX 4060 Ti(AMD Zen5 9950X 16C/32T host）· legacy vs CUDA · TODO（dev49 被占）
+
+本轮未测。dev49 空闲后跑(scrum-304 buffer-persist 构建),填同样表格,CUDA 轻场景数对标 25 M/s + 上面 Metal ~28 M/s 参照:
+
+```bash
+LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
+LUMICE_BENCH_BACKENDS=legacy,cuda python3 scripts/bench_throughput.py
+```
+
 ### macOS
 
 ```bash
@@ -110,6 +134,30 @@ scp examples/bench_config.json <windows-host>:<path>/
 # 手动模式（PowerShell 墙钟时间）
 Measure-Command { .\Lumice.exe -f bench_config.json -o . 2>&1 | Out-Null } | Select-Object TotalSeconds
 ```
+
+### Linux / CUDA（dev49）
+
+CUDA 吞吐在 dev49（RTX 4060 Ti，Linux，CUDA docker）测。**禁止每个 task 自己写 bench 脚本**——用 committed harness `scripts/bench_throughput.py`（已支持 CUDA env 覆盖、跑 canonical 场景集含可比的 `bench_light_single_ms`、确认 GPU 路由、median+CoV）。详见英文版 `performance-testing.md` 同名节 + `explore-cuda-step2-derisk/TOOLCHAIN.md`。
+
+```bash
+# dev49 CUDA docker 内（先 build -DLUMICE_CUDA_ENABLED=ON -DBUILD_SHARED_LIBS=ON）
+LUMICE_BENCH_BIN=/work/build/Release/bin/Lumice \
+LUMICE_BENCH_LIBDIR=/work/build/Release/lib \
+LUMICE_BENCH_BACKENDS=legacy,cuda \
+  python3 scripts/bench_throughput.py
+# 只跑可比轻场景（对标 25M/s）：LUMICE_BENCH_CONFIGS=bench_light_single_ms
+# dev49 共享机：严格吞吐须 idle 窗口；用完立刻清自己进程，别占机。
+```
+
+**⭐ 验收标尺 = 硬件能力,不是"× legacy CPU"。** 打过 legacy 只是必要门槛（floor），不是成功——GPU 可以"× legacy 赢"却只用 1–2% 利用率（scrum-304 踩过这坑）。GPU 后端真正的标尺是**这块卡的硬件能力**，锚到**可比工作负载 + 外部参照**：
+
+| 场景 | 可比负载 | 硬件能力目标 | 来源 |
+|---|---|---|---|
+| `bench_light_single_ms`（轻·单MS） | 单晶 + 单 MS + 无续传 | **4060 Ti ≥ 25M rays/s** | 竞品实测 |
+
+- 别拿重场景（多晶/多 MS）的数对标单晶单散射——逐光线工作量差一个数量级。
+- GPU 数远低于硬件能力目标时,**无论对 legacy 比值多少都不算成功**;查利用率（CUDA 可用 nsys active%；Mac/Metal 无同口径 CLI 路径,故 active% 非硬性普适门,跨平台判据仍是绝对能力目标）+ 机制,别收尾。
+- 到不了目标,交付物必须是 **profiler 落地的机制解释**（时间花哪了），不是"GPU 非天然胜"的黑盒话术。
 
 ### CI 自动化基准测试
 

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1337,7 +1337,10 @@ struct CudaTraceBackend::Impl {
   std::mt19937 drain_rng_{0u};
   bool         drain_seeded_ = false;
 
-  void Reset();
+  // keep_persistent_buffers=true (per-batch EndSession) preserves the large
+  // device + pinned buffers across sessions to avoid per-batch alloc churn;
+  // false (error paths + destructor) is full teardown. See definition.
+  void Reset(bool keep_persistent_buffers = false);
   void EnsureSessionBuffers(size_t n);
   void EnsureFilterBuffers(const SessionSpec& spec);
   // Grow ONLY the exit buffer for a device-roots continuation layer, leaving the
@@ -1363,102 +1366,99 @@ struct CudaTraceBackend::Impl {
   void UploadCrystalGeometry(const Crystal& crystal);
 };
 
-void CudaTraceBackend::Impl::Reset() {
+void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
   // cudaFree / cudaFreeHost on nullptr are no-ops per CUDA spec, so we don't
   // need explicit allocated-flag guards. Errors are intentionally ignored —
   // teardown must not throw.
-  cudaFree(d_poly_n_);
-  d_poly_n_ = nullptr;
-  cudaFree(d_poly_d_);
-  d_poly_d_ = nullptr;
-  cudaFree(d_tri_vtx_);
-  d_tri_vtx_ = nullptr;
-  cudaFree(d_tri_norm_);
-  d_tri_norm_ = nullptr;
-  cudaFree(d_tri_area_);
-  d_tri_area_ = nullptr;
-  cudaFree(d_tri_to_poly_);
-  d_tri_to_poly_ = nullptr;
-  // Grow-only geometry capacities track the freed buffers above; zero them so a
-  // fresh session re-allocates rather than reusing a dangling capacity.
-  alloc_poly_cap_ = 0;
-  alloc_tri_cap_ = 0;
-  poly_cnt_ = 0;
-  tri_cnt_ = 0;
+  //
+  // scrum-cuda-async-engine-port (304.2): per-batch EndSession passes
+  // keep_persistent_buffers=true so the large device + pinned buffers
+  // (ray/cont/exit/geometry/xyz/wl-pool) and their capacity trackers PERSIST
+  // across sessions, reused via the idempotent EnsureSessionBuffers fast-path
+  // (buffers_allocated_ && n_roots_ == n) + grow-only EnsureGeomCapacity. This
+  // mirrors Metal's Reset() which never frees MTLBuffers between sessions
+  // (metal_trace_backend.mm:1807) and eliminates the per-batch cudaMalloc +
+  // cudaHostAlloc churn that pinned CUDA throughput to GPU ~1-2% utilization
+  // (root cause: explore-303). Full teardown (keep_persistent_buffers=false)
+  // runs on error paths + the destructor.
+
+  // Filter descriptor buffers are reallocated UNCONDITIONALLY by
+  // EnsureFilterBuffers every BeginSession (no nullptr guard) — so they must be
+  // freed on EVERY session end, including the persistent path, or they leak.
+  cudaFree(d_filter_desc_);      d_filter_desc_ = nullptr;
+  cudaFree(d_getfn_offsets_);    d_getfn_offsets_ = nullptr;
+  cudaFree(d_getfn_bytes_);      d_getfn_bytes_ = nullptr;
+  cudaFree(d_complex_sub_desc_); d_complex_sub_desc_ = nullptr;
+
+  if (!keep_persistent_buffers) {
+    cudaFree(d_poly_n_);     d_poly_n_ = nullptr;
+    cudaFree(d_poly_d_);     d_poly_d_ = nullptr;
+    cudaFree(d_tri_vtx_);    d_tri_vtx_ = nullptr;
+    cudaFree(d_tri_norm_);   d_tri_norm_ = nullptr;
+    cudaFree(d_tri_area_);   d_tri_area_ = nullptr;
+    cudaFree(d_tri_to_poly_); d_tri_to_poly_ = nullptr;
+    // Grow-only geometry capacities track the freed buffers above; zero them so
+    // a fresh session re-allocates rather than reusing a dangling capacity.
+    alloc_poly_cap_ = 0;
+    alloc_tri_cap_ = 0;
+    cudaFree(d_rot_c2w_);      d_rot_c2w_ = nullptr;
+    cudaFree(d_dirs_);         d_dirs_ = nullptr;
+    cudaFree(d_pos_);          d_pos_ = nullptr;
+    cudaFree(d_ws_);           d_ws_ = nullptr;
+    cudaFree(d_from_poly_);    d_from_poly_ = nullptr;
+    cudaFree(d_root_wl_idx_);  d_root_wl_idx_ = nullptr;
+    cudaFree(d_wl_pool_);      d_wl_pool_ = nullptr;
+    for (int s = 0; s < 2; ++s) {
+      cudaFree(d_cont_d_[s]);      d_cont_d_[s] = nullptr;
+      cudaFree(d_cont_w_[s]);      d_cont_w_[s] = nullptr;
+      cudaFree(d_cont_wl_idx_[s]); d_cont_wl_idx_[s] = nullptr;
+      cudaFree(d_cont_count_[s]);  d_cont_count_[s] = nullptr;
+    }
+    cudaFree(d_exit_);         d_exit_ = nullptr;
+    cudaFree(d_exit_count_);   d_exit_count_ = nullptr;
+    // S2 device-fused XYZ accumulation buffers.
+    cudaFree(d_xyz_buf_);      d_xyz_buf_ = nullptr;
+    cudaFree(d_landed_weight_); d_landed_weight_ = nullptr;
+
+    cudaFreeHost(pinned_dirs_);        pinned_dirs_ = nullptr;
+    cudaFreeHost(pinned_pos_);         pinned_pos_ = nullptr;
+    cudaFreeHost(pinned_ws_);          pinned_ws_ = nullptr;
+    cudaFreeHost(pinned_from_poly_);   pinned_from_poly_ = nullptr;
+    cudaFreeHost(pinned_root_wl_idx_); pinned_root_wl_idx_ = nullptr;
+    cudaFreeHost(pinned_rot_c2w_);     pinned_rot_c2w_ = nullptr;
+    cudaFreeHost(pinned_cont_count_);  pinned_cont_count_ = nullptr;
+    cudaFreeHost(pinned_exit_);        pinned_exit_ = nullptr;
+
+    if (events_created_) {
+      cudaEventDestroy(ev_start_h2d_);
+      cudaEventDestroy(ev_end_h2d_);
+      cudaEventDestroy(ev_end_kernel_);
+      cudaEventDestroy(ev_end_d2h_);
+      events_created_ = false;
+    }
+
+    // Capacity trackers tied to the freed persistent buffers + the
+    // EnsureSessionBuffers idempotent-fastpath key (buffers_allocated_/n_roots_)
+    // are zeroed ONLY here — leaving them intact on the persistent path is what
+    // lets the next BeginSession skip re-allocation.
+    exit_cap_ = 0;
+    alloc_exit_cap_ = 0;
+    cont_cap_[0] = 0;
+    cont_cap_[1] = 0;
+    root_cap_ = 0;
+    n_roots_ = 0;
+    buffers_allocated_ = false;
+  }
+
+  // Session state — always reset. The next BeginSession re-initialises these;
+  // clearing here matches the prior Reset() contract and keeps accumulators /
+  // RAII vectors clean. (poly_cnt_/tri_cnt_ describe the current crystal and are
+  // re-set by BeginSession's UploadCrystalGeometry before any read.)
   ray_alloc_carry_.clear();
-  cudaFree(d_rot_c2w_);
-  d_rot_c2w_ = nullptr;
-  cudaFree(d_dirs_);
-  d_dirs_ = nullptr;
-  cudaFree(d_pos_);
-  d_pos_ = nullptr;
-  cudaFree(d_ws_);
-  d_ws_ = nullptr;
-  cudaFree(d_from_poly_);
-  d_from_poly_ = nullptr;
-  cudaFree(d_root_wl_idx_);
-  d_root_wl_idx_ = nullptr;
-  cudaFree(d_wl_pool_);
-  d_wl_pool_ = nullptr;
-  for (int s = 0; s < 2; ++s) {
-    cudaFree(d_cont_d_[s]);      d_cont_d_[s] = nullptr;
-    cudaFree(d_cont_w_[s]);      d_cont_w_[s] = nullptr;
-    cudaFree(d_cont_wl_idx_[s]); d_cont_wl_idx_[s] = nullptr;
-    cudaFree(d_cont_count_[s]);  d_cont_count_[s] = nullptr;
-  }
-  cudaFree(d_exit_);
-  d_exit_ = nullptr;
-  cudaFree(d_exit_count_);
-  d_exit_count_ = nullptr;
-  cudaFree(d_filter_desc_);
-  d_filter_desc_ = nullptr;
-  cudaFree(d_getfn_offsets_);
-  d_getfn_offsets_ = nullptr;
-  cudaFree(d_getfn_bytes_);
-  d_getfn_bytes_ = nullptr;
-  cudaFree(d_complex_sub_desc_);
-  d_complex_sub_desc_ = nullptr;
-  // S2 device-fused XYZ accumulation buffers.
-  cudaFree(d_xyz_buf_);
-  d_xyz_buf_ = nullptr;
-  cudaFree(d_landed_weight_);
-  d_landed_weight_ = nullptr;
-
-  cudaFreeHost(pinned_dirs_);
-  pinned_dirs_ = nullptr;
-  cudaFreeHost(pinned_pos_);
-  pinned_pos_ = nullptr;
-  cudaFreeHost(pinned_ws_);
-  pinned_ws_ = nullptr;
-  cudaFreeHost(pinned_from_poly_);
-  pinned_from_poly_ = nullptr;
-  cudaFreeHost(pinned_root_wl_idx_);
-  pinned_root_wl_idx_ = nullptr;
-  cudaFreeHost(pinned_rot_c2w_);
-  pinned_rot_c2w_ = nullptr;
-  cudaFreeHost(pinned_cont_count_);
-  pinned_cont_count_ = nullptr;
-  cudaFreeHost(pinned_exit_);
-  pinned_exit_ = nullptr;
-
-  if (events_created_) {
-    cudaEventDestroy(ev_start_h2d_);
-    cudaEventDestroy(ev_end_h2d_);
-    cudaEventDestroy(ev_end_kernel_);
-    cudaEventDestroy(ev_end_d2h_);
-    events_created_ = false;
-  }
-
   poly_cnt_ = 0;
   tri_cnt_ = 0;
-  exit_cap_ = 0;
-  alloc_exit_cap_ = 0;
-  cont_cap_[0] = 0;
-  cont_cap_[1] = 0;
-  root_cap_ = 0;
   h_exit_count_ = 0;
   h_cont_count_ = 0;
-  n_roots_ = 0;
   ms_layer_idx_ = 0u;
   n_ms_layers_ = 0u;
   filter_desc_max_ci_ = 0u;
@@ -1475,7 +1475,6 @@ void CudaTraceBackend::Impl::Reset() {
   max_abs_dz_ = 0.0f;
   img_w_ = 0u;
   img_h_ = 0u;
-  buffers_allocated_ = false;
   in_session_ = false;
   scene_ = nullptr;
   render_ = nullptr;
@@ -2675,7 +2674,13 @@ void CudaTraceBackend::EndSession() {
     return;
   }
   cudaDeviceSynchronize();
-  impl_->Reset();
+  // scrum-cuda-async-engine-port (304.2): keep the large device + pinned
+  // buffers allocated across the per-batch session boundary (mirrors Metal's
+  // Reset(), metal_trace_backend.mm:1807). The next BeginSession reuses them via
+  // the idempotent EnsureSessionBuffers fast-path, eliminating per-batch
+  // cudaMalloc + cudaHostAlloc churn. Full teardown happens on the destructor /
+  // error paths (Reset() default arg).
+  impl_->Reset(/*keep_persistent_buffers=*/true);
 }
 
 // S2 device-fused XYZ accumulation: mirrors MetalTraceBackend::HasDeviceXyzAccum.


### PR DESCRIPTION
## Summary

Resolves the "CUDA device-fused throughput 0.16–0.40× legacy" concern (scrum-302 S2). Two findings:

1. **Real fix (commit 1)**: the throughput deficit's root cause was **per-batch buffer churn** — `EndSession→Reset()` freed ALL device + pinned buffers every per-batch session, then `BeginSession` re-allocated them (pinned `cudaHostAlloc` page-locking dominated wall time). Mirrors Metal's `Reset()`, which never frees buffers between sessions. Fix: `Reset(bool keep_persistent_buffers)` — per-batch `EndSession` keeps the large ray/cont/exit/geometry/xyz/wl buffers, reusing the existing idempotent `EnsureSessionBuffers` fast-path. Small filter buffers still freed (reallocated unconditionally). Backend-internal; seam contract unchanged.

2. **Measurement correction (commits 2–3, docs)**: the "0.16–0.40×" was largely a **measurement artifact** — ad-hoc non-idle-gated runs on the heavier `ms_multi_crystal`, the wrong comparison scene. Idle-gated `scripts/bench_throughput.py` on the **comparable light single-MS scene** shows CUDA single-engine at **35.2M / 55.9M rays/s** — at/above the 25M competitor target AND above the Mac Metal reference (28–30M). **Competitive bar met.**

## Verification (dev49 RTX 4060 Ti, idle-gated)

- **Correctness**: CUDA parity battery 10/10 (single/multi MS × filter × multi-CI × cross-seed); CUDA-build `ctest` 4/4 (Unit/Parity/Golden/CudaMultiMsParity). Default dispatch, energy-conserving.
- **Throughput** (`bench_throughput.py`, default dispatch):

  | config | CUDA single | CUDA multi | ×legacy |
  |---|---|---|---|
  | bench_light_single_ms (comparable) | 35.2M | 55.9M | 6.23× |
  | ms_multi_crystal | 9.67M | 13.7M | 9.55× |
  | complex_filter | 38.0M | 60.3M | 9.63× |
  | filtered_bd | 39.1M | 61.9M | 9.19× |

## Docs

`doc/performance-testing.md` (+`_zh`): hardware-capability acceptance yardstick (not "× legacy"), Linux/CUDA canonical procedure (use the committed harness, never ad-hoc), GPU active% diagnostic, and a per-run measured-results log (Mac Metal + Linux CUDA).

## Follow-ups (out of scope, tracked)

- GPU still ~43% utilized; ~2.3× headroom behind per-dispatch host serialization → **async-engine** (separate task). NOT via larger dispatch: dispatch=131072 hits 82–122M but **silently drops ~11% energy** (parity energy_ratio 0.89) — a correctness regression, logged as a backlog bug.
- Full e2e/GUI suite under the CUDA build not run here (not CUDA-specific behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)