### PR TITLE
perf(scrum-306): CUDA throughput 37M→~114M (dispatch default + dead-buffer cap)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ option(LUMICE_NATIVE_ARCH "Enable -march=native for release builds (GCC/Clang)" 
 # Mac/Windows host builds without nvcc must stay zero-regress when this is OFF.
 option(LUMICE_CUDA_ENABLED "Enable CUDA backend (requires nvcc / CUDAToolkit)" OFF)
 
+# scrum-306.1 (explore-async-evidence, H7): embed Metal shader sources + line
+# tables into the metallib so Xcode/Instruments GPU shader profiler maps occupancy
+# / per-line ALU cost back to lumice_trace.metal. No runtime perf impact (only a
+# slightly larger embedded metallib blob); keep OFF for release/CI. Turn ON for
+# the Xcode profiling build (build/xcode) used to measure Metal kernel occupancy.
+option(LUMICE_METAL_SHADER_PROFILE "Embed Metal shader source + line tables for GPU shader profiler" OFF)
+
 if(MSVC)
   add_definitions(-DNOMINMAX)
   set(CMAKE_DEBUG_POSTFIX "d")
@@ -264,6 +271,13 @@ if(APPLE)
       "${PROJ_SRC_DIR}/core/shared/pcg_shared.h"
       "${PROJ_SRC_DIR}/core/shared/accum_shared.h")
 
+  # scrum-306.1 H7: optional shader debug info for the GPU profiler (off by default).
+  set(LUMICE_METAL_DEBUG_FLAGS "")
+  if(LUMICE_METAL_SHADER_PROFILE)
+    set(LUMICE_METAL_DEBUG_FLAGS -frecord-sources -gline-tables-only)
+    message(STATUS "[metal] LUMICE_METAL_SHADER_PROFILE=ON → embedding shader sources/line-tables for GPU profiler")
+  endif()
+
   add_custom_command(
     OUTPUT  "${LUMICE_METAL_AIR}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${LUMICE_METAL_GEN_DIR}"
@@ -272,6 +286,7 @@ if(APPLE)
             -std=metal3.0
             -fno-fast-math
             -mmacosx-version-min=13.0
+            ${LUMICE_METAL_DEBUG_FLAGS}
             -c "${LUMICE_METAL_SRC}"
             -o "${LUMICE_METAL_AIR}"
     DEPENDS "${LUMICE_METAL_SRC}" ${LUMICE_METAL_SHARED_HDRS}

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -192,17 +192,47 @@ After scrum-304.2 buffer-persist, GPU-idle-gated (`nvidia-smi` 0% verified befor
 | `ms_multi_crystal_complex_filter` (重·标准) | 471 K/s | 6.26 M/s | 38.0 M/s | 60.3 M/s | 9.63× |
 | `ms_multi_crystal_filtered_bd` (重·bd) | 510 K/s | 6.73 M/s | 39.1 M/s | 61.9 M/s | 9.19× |
 
+##### Rebench at the new CUDA default (262144) — scrum-306.3 (2026-06-29, dev49 idle-gated, 20M rays, 3 reps median)
+
+| config | legacy multi | CUDA multi (default=262144) | CUDA/legacy | vs old 32768 default |
+|---|---|---|---|---|
+| `bench_light_single_ms` (轻·单MS) | 6.2 M/s | **~87 M/s** | ~14× | 56→87 (1.6×) |
+| `ms_multi_crystal` (中·无filter) | 0.93 M/s | ~19.7 M/s | ~21× | 13.7→19.7 (1.4×) |
+| `ms_multi_crystal_complex_filter` (重·标准) | 3.2 M/s | ~178 M/s | ~56× | 60→178 (3.0×) |
+| `ms_multi_crystal_filtered_bd` (重·bd) | 2.7 M/s | ~232 M/s | ~85× | 62→232 (3.7×) |
+
+- **Out-of-box CUDA improved 1.4–3.7× by the new default dispatch + exit-cap** (scrum-306.2). The
+  filtered configs run *faster* than the light scene (178/232 vs 87 M/s) because the filter
+  terminates most rays early (rays/s counts root rays) — NOT a higher kernel throughput; the light
+  single-MS scene (~87 M/s here, ~114 M/s in the dedicated quiet-machine interleaved sweep) is the
+  honest comparable-load figure.
+- **⚠️ Absolute-number caveat (shared dev49 CPU contention):** CUDA is host-bound and legacy is
+  CPU-bound, so even with the GPU idle-gated (0%), co-tenant **CPU** load depresses both columns and
+  shifts run-to-run (the same bench_light CUDA cell read 87 M here vs 114 M in a quieter window).
+  Trust the **ratios** and the **new-vs-old-default** deltas (intra-run, robust); treat the absolute
+  M/s as indicative. Only per-run **interleaved** comparison (A,B,C,A,B,C…) is drift-proof — see the
+  scrum-306.2 methodology note below. The legacy column is also lower than the pre-306.2 table above
+  for the same reason (CPU contention at measurement time), which inflates the ratios — do not read
+  the ratio jump as pure CUDA gain.
+
 - **Competitive bar MET**: the comparable light single-MS scene is **35–56 M/s**, at/above
   the 25 M/s competitor target AND above the Mac Metal reference (28–30 M/s). buffer-persist
   alone (scrum-304.2) got CUDA here; the earlier "0.16–0.40× / 1.5M" pessimism was a
   measurement artifact — ad-hoc non-idle-gated runs on the heavier `ms_multi_crystal`, the
   wrong yardstick. Always idle-gate + use the canonical harness + the comparable scene.
-- **GPU not yet saturated**: nsys on the light scene (50M-ray plain run) = GPU active 17.6%
-  (JIT/setup-included); benchmark steady-window active ≈ 43%. trace_single_ms_kernel is 95%
-  of GPU time. The fully-fed kernel ceiling is ~129 M rays/s (50M / 386 ms kernel), so the
-  current 56 M is ~43% of ceiling — **~2.3× headroom remains**, locked behind per-dispatch
-  host serialization (default stream + per-layer sync; explore-303, untouched by 304.2).
-  Pursuing it is the async-engine work — now justified by the active% data, not speculation.
+- **GPU not yet saturated** (at the 32768 default this table used): nsys = benchmark steady-window
+  active ≈ 43%; trace_single_ms_kernel is 95% of GPU time; intrinsic kernel ceiling ≈ 134 M/s, so
+  the 56 M here was ~43% of ceiling. **⚠️ SUPERSEDED by scrum-306.2** (see the resolution subsection
+  below): the headroom was NOT locked behind async (per-dispatch sync was 0.3% of host time) but
+  behind per-batch host overhead + a dead `d_exit_` buffer. With those fixed and the CUDA default
+  dispatch raised to 262144, **out-of-box CUDA now reaches ~114 M/s** (= 85% of the 134 M intrinsic
+  rate) on the comparable light scene — these 35–56 M numbers are the pre-306.2 figures at the old
+  32768 default and are retained only as the baseline the 306.2 work improved on.
+- **The GPU route has no true multi-worker parallelism** (worker_count=1, server.cpp:275). The
+  benchmark's "single" and "multi" passes BOTH run on the single GPU engine; their difference is a
+  JIT-warmup + ray-count artifact, not parallelism (explore-306.1 E1: worker_count=1 is the铁证).
+  The "workers":N field in a GPU [BENCHMARK] line is the configured core count, NOT GPU engines.
+  Only the legacy CPU route is genuinely multi-worker (N = PhysicalCoreCount).
 - Caveat: the competitor's exact config (spectrum / max_hits) is unknown; our scene is a
   reasonable single-crystal single-MS proxy (prism, D65, max_hits 7). Align if a precise
   apples-to-apples is needed.

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -249,6 +249,28 @@ above was **half wrong**, corrected by profiling:
 - **Profile before coding a fix.** A fully-designed stream-deferral increment was abandoned once
   nsys showed it was worth <1%.
 
+##### scrum-306.6 (Metal kernel lever) + 306.7 (legacy energy) — both converged, no code change (2026-06-29)
+
+- **306.6 Metal kernel lever probe → NO cheap lever.** The path_rec spike (remove the per-bounce
+  `path[]` store + the `rec_csum`/`rec_sink` checksum, rebuild, idle-gated interleaved Metal multi
+  bench) gave **0 throughput change** (BASE ≈ SPIKE ≈ 30 M/s) — exactly like the CUDA path_rec
+  spike. Metal `trace_layer_kernel` dominates (~143–214µs/dispatch, ~80% of GPU time, from the
+  `xctrace export` of the Metal System Trace) and is ALU-bound (occ ~29% / ALU 63–73%, prior E7) —
+  the *hard* case: no cheap occupancy/memory knob, only algorithmic ALU reduction. Same bucket as
+  CUDA (latency-bound, 3 spikes all 0) → folded into the far-future algorithmic-kernel backlog, not
+  a standalone task. (The precise which-ALU breakdown / occupancy-limiter reason needs a
+  counter-enabled Xcode GPU frame capture — interactive, not headless-driveable; the existing
+  `metal-profile.trace` lacks hardware counters.)
+- **306.7 legacy energy "dispatch dependence" → NOT a bug (MC variance).** Legacy ΣY drifts with
+  `LUMICE_DISPATCH_RAY_NUM` because the legacy/illuminant path samples **one wavelength per
+  SimBatch** (`simulator.cpp`): wl-samples = ray_num/dispatch (128 → 78125 samples, converged;
+  131072 → ~77, high variance). `sim_ray_num`/`ray_seg_num` are invariant (10M/150M) — it is NOT a
+  ray-count or normalization bug. The per-batch-wl estimator has the **same expectation** as
+  per-ray wl (unbiased); only variance differs (cross-seed CV 0.3% @128 vs 8.6% @131072 = √(1024×
+  fewer samples)). Legacy at its default (128) is well-converged and correct; 306.4 already strips
+  the GPU-only knob from legacy. A root-cause change (per-ray or per-fixed-chunk wl) would touch the
+  legacy **reference oracle** (re-baseline risk) for zero real-world benefit → not pursued.
+
 > #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` is a GPU-only knob — never apply it to legacy in a comparison (scrum-306.1/306.4)
 >
 > `LUMICE_DISPATCH_RAY_NUM` sizes the GPU engine's per-dispatch grid. **CUDA total

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -207,6 +207,37 @@ After scrum-304.2 buffer-persist, GPU-idle-gated (`nvidia-smi` 0% verified befor
   reasonable single-crystal single-MS proxy (prism, D65, max_hits 7). Align if a precise
   apples-to-apples is needed.
 
+> #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` is a GPU-only knob — never apply it to legacy in a comparison (scrum-306.1/306.4)
+>
+> `LUMICE_DISPATCH_RAY_NUM` sizes the GPU engine's per-dispatch grid. **CUDA total
+> energy is dispatch-invariant** (verified: ΣY = 261.29 M ±0.001% across dispatch
+> ∈ {128, 8192, 32768, 131072} on `dual_fisheye_ref`) — i.e. the GPU result is
+> correct at any dispatch. **Legacy (CPU) total energy is NOT dispatch-invariant**:
+> the same knob (which overrides legacy's `kDefaultRayNum`=128) swings legacy ΣY
+> **−5 %..+13 %** (259.65 M @128 / 245.5 M @8192 / 275.5 M @32768 / 292.9 M @131072).
+> This is a real legacy correctness bug tracked in **scrum-306.7** (energy must be
+> batch-size invariant; mechanism TBD — normalization / ray-count / RNG-per-batch).
+>
+> **Consequence / historical misdiagnosis to NOT repeat**: setting
+> `LUMICE_DISPATCH_RAY_NUM=131072` globally to probe CUDA made
+> `test_cuda_single_ms_no_filter_parity` report `energy_ratio=0.8922` — this was
+> **mis-attributed to a "CUDA exit-cap/cont-cap silent energy loss"** (the original
+> scrum-304.3 backlog entry). It is NOT a CUDA bug: the knob leaked into the legacy
+> reference run and inflated the **denominator** (legacy_Y), `261.29/292.87 = 0.892`.
+> The parity harness now strips `LUMICE_DISPATCH_RAY_NUM` for the `legacy` backend
+> (`test/e2e/capi_runner.py`, scrum-306.4) so the oracle stays at its canonical
+> default and `energy_ratio` reflects the GPU backend's correctness alone
+> (re-verified: @131072 0.8922 FAIL → 1.0063 PASS). `bench_throughput.py` already
+> excludes legacy from the dispatch sweep (`DISPATCH_PLAN["legacy"]=[None]`).
+>
+> **Process lesson (why this is documented here, tracked)**: the 304.3 correctness
+> claim lived only as a backlog one-liner with no preserved script → a wrong
+> diagnosis (CUDA) propagated and could not be re-aligned. Correctness assertions
+> must land in a tracked doc with a reproducible recipe. Reproduce recipe: container
+> `pip install pytest numpy`, `LUMICE_HAS_CUDA=1`, then
+> `LUMICE_DISPATCH_RAY_NUM=131072 pytest -m slow test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py::test_cuda_single_ms_no_filter_parity`;
+> per-dispatch ΣY split via `bench_work/harness2.cpp` (dev49).
+
 ### macOS
 
 ```bash

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -207,6 +207,48 @@ After scrum-304.2 buffer-persist, GPU-idle-gated (`nvidia-smi` 0% verified befor
   reasonable single-crystal single-MS proxy (prism, D65, max_hits 7). Align if a precise
   apples-to-apples is needed.
 
+##### scrum-306.2 resolution: the 2.3× headroom was unlocked by dispatch size + exit-cap, NOT async (2026-06-29)
+
+The "~2.3× headroom locked behind per-dispatch host serialization → pursue async" framing
+above was **half wrong**, corrected by profiling:
+
+- **async (stream deferral) was the wrong lever.** nsys CUDA-API summary after the geometry
+  pool: `cudaEventSynchronize` / `cudaDeviceSynchronize` were **0.3% / 0.4%** of host-API
+  time — deferring them buys <1%. The originally-planned increment-2 (mirror Metal
+  `pending_cb_`/`WaitAndReadbackLayer`) was dropped.
+- **The GPU was host-bound, not sync-bound.** nsys GPU-side: `trace_single_ms_kernel` =
+  44.8 ms / 185 dispatches for 6M rays → **~134 M/s intrinsic kernel rate**; the GPU sat ~70%
+  idle waiting on **per-batch host overhead** (BeginSession + XYZ readback + orchestration),
+  which is **common to every variant** and amortizes with **fewer, bigger batches**.
+- **The lever = `LUMICE_DISPATCH_RAY_NUM`** (the default was raised for the CUDA route:
+  `kDefaultCudaDispatchRayNum = 262144`). Idle-gated **interleaved** sweep (cfg_50m, 50M
+  multi): 37M @32768 → **~114M @262144** (= 85% of the 134M ceiling) → ~115M @1M, then
+  declining (2M→106M, 4M→97M) as the continuation/root buffers grow.
+- **exit-cap was the enabler.** CUDA's `HasDeviceXyzAccum()` is unconditionally true, so the
+  trace kernel writes nothing to `d_exit_` (all exits go to `d_xyz_buf_` via `EmitToDeviceXyz`;
+  `DrainExits` reads 0 records). `d_exit_` sized `ComputeExitCap = n·(2·max_hits+4)` was dead
+  weight that ballooned to GBs at large dispatch — causing both the big-dispatch throughput
+  collapse and a parity OOM. Capping it (`kCudaDeadExitCap`) unlocked the dispatch sweep.
+- **The geometry pool (upload-once) + filter/wl persist were throughput-NEUTRAL** (interleaved
+  round-robin: pre ≈ pool ≈ pool+persist). They are correct, parity-clean structural changes
+  (remove per-batch H2D churn, align with seam-design §5) but the churn they removed overlaps
+  GPU compute / sits in setup — NOT on the steady-state critical path. Do not cite them as the
+  speedup source.
+- **Result**: out-of-box (no env knob) CUDA reaches **~114 M/s**, idle-gated, with the full
+  parity suite 10/10 at the new default AND at 524288/1048576. CUDA energy stays
+  dispatch-invariant; `kCommitCap=128` keeps the GUI snapshot cadence decoupled.
+
+**Methodology lessons (shared dev49 is CPU-contended → host-bound CUDA throughput is noisy):**
+- Same binary + same dispatch swung **33M ↔ 114M** with machine load. `nvidia-smi` GPU 0%
+  gate is necessary but NOT sufficient — it doesn't show CPU contention from co-tenant
+  containers. **Only trust per-run interleaved comparison** (A,B,C,A,B,C…), never cross-session,
+  and never even "back-to-back phases" (minute-scale drift between phases faked a 1.9× win once).
+- Use nsys **GPU-side** (`gpukernsum`: kernel time vs wall) to classify GPU-bound vs host-bound.
+  The CUDA-API summary (cudaMemcpy/cudaFree) is host time that may overlap compute — not the
+  bottleneck by itself.
+- **Profile before coding a fix.** A fully-designed stream-deferral increment was abandoned once
+  nsys showed it was worth <1%.
+
 > #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` is a GPU-only knob — never apply it to legacy in a comparison (scrum-306.1/306.4)
 >
 > `LUMICE_DISPATCH_RAY_NUM` sizes the GPU engine's per-dispatch grid. **CUDA total

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -104,17 +104,18 @@ BACKENDS = [
 
 # Dispatch sweep applies to GPU backends (Metal, CUDA) — CPU paths ignore
 # LUMICE_DISPATCH_RAY_NUM for parity with how the GUI runs. `None` means "do NOT
-# set the env var" — the server picks its own backend-aware default (32768 for any
-# GPU route, kDefaultRayNum for CPU; server.cpp ResolveGpuRoute). Keeping `None`
-# distinct from `32768` lets the table verify "default == 32768 today" without
-# conflating intents if the default later moves. The small-batch points (128, 512)
-# characterize the "small dispatch starves the GPU" curve that motivates the
-# single-engine large-dispatch route (doc/seam-design.md §5).
+# set the env var" — the server picks its own backend-aware default (Metal 32768,
+# CUDA 262144 since scrum-306.2, kDefaultRayNum for CPU; server.cpp ResolveGpuRoute).
+# Keeping `None` distinct from the explicit value lets the table verify "default ==
+# the resolved per-backend value" without conflating intents. The small-batch points
+# (128, 512) characterize the "small dispatch starves the GPU" curve; CUDA adds 262144
+# (the scrum-306.2 plateau ≈ 85% of the 134M intrinsic kernel rate, after capping the
+# dead d_exit_ buffer) so the sweep brackets its real operating point.
 DISPATCH_PLAN = {
     "legacy": [None],
     "cpu_backend": [None],
     "metal": [None, 128, 512, 2048, 32768],
-    "cuda": [None, 128, 512, 2048, 32768],
+    "cuda": [None, 128, 512, 2048, 32768, 262144],
 }
 
 N_REPS = 5

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1166,6 +1166,13 @@ struct CudaTraceBackend::Impl {
   std::vector<Crystal>  pool_crystals_;     // host slot crystals (config_id; wl-pool repr)
   bool        geom_pool_built_ = false;
   const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
+  // scrum-306.2 increment 4: filter descriptors + wl pool are per-session-CONSTANT
+  // (config + crystal n_idx fixed across batches) — persist them across the
+  // per-batch cycle instead of free+malloc+H2D every BeginSession (post-pool the
+  // dominant host-API cost: cudaFree 40% + cudaMemcpy 43%, nsys 4M-run). Rebuilt
+  // only on scene change (pool_scene_ sentinel) or full teardown.
+  bool        filter_built_      = false;
+  bool        wl_pool_uploaded_  = false;
 
   // Per-ray crystal->world rotation buffer (9 floats/ray, row-major
   // Rotation::mat_). Allocated in EnsureSessionBuffers; filled per TraceLayer
@@ -1426,13 +1433,9 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
   // (root cause: explore-303). Full teardown (keep_persistent_buffers=false)
   // runs on error paths + the destructor.
 
-  // Filter descriptor buffers are reallocated UNCONDITIONALLY by
-  // EnsureFilterBuffers every BeginSession (no nullptr guard) — so they must be
-  // freed on EVERY session end, including the persistent path, or they leak.
-  cudaFree(d_filter_desc_);      d_filter_desc_ = nullptr;
-  cudaFree(d_getfn_offsets_);    d_getfn_offsets_ = nullptr;
-  cudaFree(d_getfn_bytes_);      d_getfn_bytes_ = nullptr;
-  cudaFree(d_complex_sub_desc_); d_complex_sub_desc_ = nullptr;
+  // scrum-306.2 increment 4: filter descriptors are now PERSISTED across the
+  // per-batch keep path (EnsureFilterBuffers is idempotent on filter_built_), so
+  // they are freed only on full teardown below — not every session end.
 
   if (!keep_persistent_buffers) {
     cudaFree(d_poly_n_);     d_poly_n_ = nullptr;
@@ -1454,6 +1457,22 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     layer_slot_base_.clear(); pool_crystals_.clear();
     geom_pool_built_ = false;
     pool_scene_ = nullptr;
+    // increment 4: filter descriptors + wl pool persist across the keep path;
+    // free + invalidate them only here on full teardown (d_wl_pool_ freed below).
+    cudaFree(d_filter_desc_);      d_filter_desc_ = nullptr;
+    cudaFree(d_getfn_offsets_);    d_getfn_offsets_ = nullptr;
+    cudaFree(d_getfn_bytes_);      d_getfn_bytes_ = nullptr;
+    cudaFree(d_complex_sub_desc_); d_complex_sub_desc_ = nullptr;
+    filter_built_ = false;
+    wl_pool_uploaded_ = false;
+    filter_desc_max_ci_ = 0u;
+    filter_n_slot_ = 0u;
+    crystal_config_id_ = 0xFFFFu;
+    final_layer_filter_configs_.clear();
+    final_layer_crystals_.clear();
+    final_layer_axis_dists_.clear();
+    final_ms_layer_idx_ = 0u;
+    final_ms_prob_ = 0.0f;
     // Grow-only geometry capacities track the freed buffers above; zero them so
     // a fresh session re-allocates rather than reusing a dangling capacity.
     alloc_poly_cap_ = 0;
@@ -1522,14 +1541,10 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
   h_cont_count_ = 0;
   ms_layer_idx_ = 0u;
   n_ms_layers_ = 0u;
-  filter_desc_max_ci_ = 0u;
-  filter_n_slot_ = 0u;
-  crystal_config_id_ = 0xFFFFu;
-  final_layer_filter_configs_.clear();
-  final_layer_crystals_.clear();
-  final_layer_axis_dists_.clear();
-  final_ms_layer_idx_ = 0u;
-  final_ms_prob_ = 0.0f;
+  // increment 4: filter-descriptor state (filter_desc_max_ci_/filter_n_slot_/
+  // crystal_config_id_/final_layer_*/final_ms_*) is produced by EnsureFilterBuffers
+  // and now PERSISTS across the per-batch keep path — reset only on full teardown
+  // (keep=false block above), not here, or the idempotent-skip path reads zeros.
   proj_type_ = 0u;
   az0_ = 0.0f;
   r_scale_ = 1.0f;
@@ -1878,6 +1893,13 @@ void CudaTraceBackend::Impl::EnsureContCapacity(size_t n_in, int out_slot) {
 // Single-CI MVP: max_ci is structurally 1, so `gate_slot = ms_layer_idx`.
 // Multi-CI per-layer crystal pool is 296.6.
 void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
+  // scrum-306.2 increment 4: filter descriptors are per-session-constant (config
+  // fixed across batches) — built once per scene and persisted (filter_built_,
+  // reset on scene change / full teardown). Skips the free+malloc+H2D churn that
+  // ran every BeginSession (post-pool the dominant host-API cost).
+  if (filter_built_) {
+    return;
+  }
   // Free any prior session's filter buffers (cudaFree on nullptr is a no-op).
   cudaFree(d_filter_desc_);       d_filter_desc_       = nullptr;
   cudaFree(d_getfn_offsets_);     d_getfn_offsets_     = nullptr;
@@ -1908,6 +1930,7 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
     ck(cudaMalloc(&d_complex_sub_desc_, sizeof(DeviceFilterDesc)), "cudaMalloc d_complex_sub_desc (dummy)");
     filter_desc_max_ci_ = 1u;
     filter_n_slot_      = 1u;
+    filter_built_       = true;
   };
 
   if (spec.scene == nullptr || spec.scene->ms_.empty()) {
@@ -2033,6 +2056,7 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
       (!final_layer_crystals_.empty() && final_layer_crystals_[0].config_id_ != kInvalidId)
           ? static_cast<uint32_t>(final_layer_crystals_[0].config_id_)
           : 0xFFFFu;
+  filter_built_ = true;
 }
 
 CudaTraceBackend::CudaTraceBackend(Logger* logger) : impl_(std::make_unique<Impl>()) {
@@ -2063,6 +2087,16 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     impl_->wl_ = spec.wl;
     impl_->rng_.SetSeed(spec.seed);
     impl_->ray_alloc_carry_.clear();  // per-(layer,ci) partition carry — fresh per session
+
+    // scrum-306.2 increment 4: a scene change invalidates every per-session-constant
+    // cache (geometry pool, filter descriptors, wl pool). Within one scene these are
+    // built/uploaded ONCE and reused across the per-batch BeginSession cycle.
+    if (impl_->pool_scene_ != static_cast<const void*>(spec.scene)) {
+      impl_->geom_pool_built_   = false;
+      impl_->filter_built_      = false;
+      impl_->wl_pool_uploaded_  = false;
+      impl_->pool_scene_        = static_cast<const void*>(spec.scene);
+    }
 
     // MVP: single MS, single crystal config — ms_[0].setting_[0].
     if (spec.scene == nullptr || spec.scene->ms_.empty() || spec.scene->ms_[0].setting_.empty()) {
@@ -2112,10 +2146,8 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     // crystal_for_geom (dummy_rng; shape-independent refractive index) still
     // feeds the wl pool + refractive-index log below in both paths.
     if (!impl_->disable_device_gen_) {
-      if (!impl_->geom_pool_built_ ||
-          impl_->pool_scene_ != static_cast<const void*>(spec.scene)) {
-        impl_->BuildGeomPool(*spec.scene);
-        impl_->pool_scene_ = static_cast<const void*>(spec.scene);
+      if (!impl_->geom_pool_built_) {
+        impl_->BuildGeomPool(*spec.scene);  // sets geom_pool_built_
       }
       impl_->poly_cnt_ = impl_->pool_poly_cnt_[0];
       impl_->tri_cnt_  = impl_->pool_tri_cnt_[0];
@@ -2133,20 +2165,26 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     // (simulator.cpp). Mirrors Metal ComputeWlPool + EnsureWlPoolBuffer. The
     // buffer is allocated once (size = env-resolved M, stable per process) and
     // re-uploaded each BeginSession since the crystal n_idx is scene-dependent.
+    // scrum-306.2 increment 4: the wl pool (n_idx + spd_weight per sampled wl) is
+    // per-session-constant (crystal n_idx + spectrum fixed across batches), so
+    // compute + upload it ONCE per scene rather than every BeginSession.
     Logger& wl_logger = impl_->logger != nullptr ? *impl_->logger : GetGlobalLogger();
-    impl_->wl_pool_size_ = ResolveWlPoolSize(wl_logger);
-    const auto& spectrum = spec.scene->light_source_.spectrum_;
-    impl_->illuminant_mode_ = std::holds_alternative<IlluminantType>(spectrum);
-    impl_->illuminant_ = impl_->illuminant_mode_ ? std::get<IlluminantType>(spectrum) : IlluminantType{};
-    ComputeWlPool(crystal_for_geom, impl_->illuminant_mode_, impl_->illuminant_, spec.wl.wl_, spec.wl.weight_,
-                  impl_->wl_pool_size_, impl_->wl_pool_host_);
-    if (impl_->d_wl_pool_ == nullptr) {
-      CheckCuda(cudaMalloc(&impl_->d_wl_pool_, impl_->wl_pool_size_ * sizeof(WlEntry)),
-                "BeginSession cudaMalloc d_wl_pool");
+    if (!impl_->wl_pool_uploaded_) {
+      impl_->wl_pool_size_ = ResolveWlPoolSize(wl_logger);
+      const auto& spectrum = spec.scene->light_source_.spectrum_;
+      impl_->illuminant_mode_ = std::holds_alternative<IlluminantType>(spectrum);
+      impl_->illuminant_ = impl_->illuminant_mode_ ? std::get<IlluminantType>(spectrum) : IlluminantType{};
+      ComputeWlPool(crystal_for_geom, impl_->illuminant_mode_, impl_->illuminant_, spec.wl.wl_, spec.wl.weight_,
+                    impl_->wl_pool_size_, impl_->wl_pool_host_);
+      if (impl_->d_wl_pool_ == nullptr) {
+        CheckCuda(cudaMalloc(&impl_->d_wl_pool_, impl_->wl_pool_size_ * sizeof(WlEntry)),
+                  "BeginSession cudaMalloc d_wl_pool");
+      }
+      CheckCuda(cudaMemcpy(impl_->d_wl_pool_, impl_->wl_pool_host_.data(), impl_->wl_pool_size_ * sizeof(WlEntry),
+                           cudaMemcpyHostToDevice),
+                "BeginSession cudaMemcpy d_wl_pool");
+      impl_->wl_pool_uploaded_ = true;
     }
-    CheckCuda(cudaMemcpy(impl_->d_wl_pool_, impl_->wl_pool_host_.data(), impl_->wl_pool_size_ * sizeof(WlEntry),
-                         cudaMemcpyHostToDevice),
-              "BeginSession cudaMemcpy d_wl_pool");
 
     // MS layer count + initial layer index. Used by TraceLayer to derive
     // ms_mode (continuation vs final exit) when Step 5 lands. n_ms_layers_

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -134,6 +134,16 @@ size_t ComputeExitCap(size_t n_roots, size_t max_hits) {
   return n_roots * (max_hits * 2u + 4u);
 }
 
+// scrum-306.2: CUDA's HasDeviceXyzAccum() is unconditionally true, so every exit
+// is accumulated into d_xyz_buf_ via EmitToDeviceXyz — the trace kernel writes
+// NOTHING to d_exit_ / d_exit_count_ (DrainExits always reads 0 records). The
+// d_exit_/pinned_exit_ pool is therefore dead weight; sizing it to ComputeExitCap
+// (n × (2·max_hits+4)) ballooned to GBs at large LUMICE_DISPATCH_RAY_NUM, causing
+// the big-dispatch throughput collapse + parity OOM. Allocate a token slot so the
+// kernel's (unused) d_exit pointer stays bindable. If HasDeviceXyzAccum ever goes
+// false, restore ComputeExitCap sizing AND the kernel's d_exit write path together.
+constexpr size_t kCudaDeadExitCap = 256u;
+
 // Continuation buffer capacity (296.4). Each root may emit up to
 // (max_hits * 2 + 4) candidate continuations (matches ComputeExitCap upper
 // bound — every outward exit is a continuation candidate). Sized to the same
@@ -1744,7 +1754,7 @@ void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
   cudaFreeHost(pinned_cont_count_); pinned_cont_count_ = nullptr;
 
   size_t max_hits = scene_ != nullptr ? scene_->max_hits_ : kMaxHits;
-  exit_cap_ = ComputeExitCap(n, max_hits);
+  exit_cap_ = kCudaDeadExitCap;  // d_exit_ is dead (device-fused XYZ); see kCudaDeadExitCap
   const size_t cont_cap0 = ComputeContCap(n, max_hits);
   cont_cap_[0] = cont_cap0;
   cont_cap_[1] = cont_cap0;
@@ -1812,25 +1822,11 @@ void CudaTraceBackend::Impl::EnsureExitCapacity(size_t n) {
   // the exit pool may need to grow for this layer's fan-out. exit_cap_ tracks the
   // logical cap used by the kernel/overflow-clamp; alloc_exit_cap_ tracks the
   // physical d_exit_ allocation so we realloc only when genuinely insufficient.
-  const size_t need = ComputeExitCap(n, scene_ != nullptr ? scene_->max_hits_ : kMaxHits);
-  exit_cap_ = need;
-  if (!buffers_allocated_ || need <= alloc_exit_cap_) {
-    return;  // existing d_exit_ already holds `need` records.
-  }
-  cudaDeviceSynchronize();  // a prior layer's kernel may still be writing d_exit_.
-  auto ck = [this](cudaError_t e, const char* ctx) {
-    if (e != cudaSuccess) {
-      Reset();
-      throw BackendUnavailableError(std::string{"CudaTraceBackend::EnsureExitCapacity: "} + ctx + ": " +
-                                    cudaGetErrorString(e));
-    }
-  };
-  cudaFree(d_exit_);            d_exit_ = nullptr;
-  cudaFreeHost(pinned_exit_);   pinned_exit_ = nullptr;
-  ck(cudaMalloc(&d_exit_, need * sizeof(ExitRayRecord)), "cudaMalloc d_exit (grow)");
-  ck(cudaHostAlloc(&pinned_exit_, need * sizeof(ExitRayRecord), cudaHostAllocDefault),
-     "cudaHostAlloc pinned_exit (grow)");
-  alloc_exit_cap_ = need;
+  // scrum-306.2: d_exit_ is dead (device-fused XYZ; HasDeviceXyzAccum() always
+  // true → the kernel never writes d_exit_/d_exit_count_). It never needs to grow;
+  // keep the token capacity. See kCudaDeadExitCap.
+  (void)n;
+  exit_cap_ = kCudaDeadExitCap;
 }
 
 void CudaTraceBackend::Impl::EnsureContCapacity(size_t n_in, int out_slot) {

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1140,6 +1140,33 @@ struct CudaTraceBackend::Impl {
   uint32_t  alloc_poly_cap_ = 0;
   uint32_t  alloc_tri_cap_  = 0;
 
+  // --- scrum-306.2 geometry pool (device-gen path) -------------------------
+  // Per-(layer,ci) crystal geometry uploaded ONCE per scene and PERSISTED
+  // across the per-batch BeginSession/EndSession cycle (geom_pool_built_ guard).
+  // Replaces the per-batch MakeCrystal + 6×blocking-H2D re-upload of IDENTICAL
+  // geometry: rng_ is reset to the constant effective_seed_ every BeginSession
+  // (worker_count=1 GPU route) → MakeCrystal yields the same shapes every batch,
+  // so the prior path re-uploaded the same bytes per batch — the dominant
+  // per-dispatch host-sync memcpy (explore-async E2). K=1 shape per (layer,ci):
+  // PARITY-EXACT with the prior per-batch path (current path already traces one
+  // shape/(layer,ci)/session); the §5 per-ray K-shape pool is a later
+  // statistical refinement, not needed for parity. Buffers concatenate all
+  // slots; pool_*_off_/pool_*_cnt_ index each slot (slot = layer_slot_base_[mi]+ci).
+  float*    d_pool_poly_n_      = nullptr;  // 3 × Σ poly_cnt
+  float*    d_pool_poly_d_      = nullptr;  //     Σ poly_cnt
+  float*    d_pool_tri_vtx_     = nullptr;  // 9 × Σ tri_cnt
+  float*    d_pool_tri_norm_    = nullptr;  // 3 × Σ tri_cnt
+  float*    d_pool_tri_area_    = nullptr;  //     Σ tri_cnt
+  uint16_t* d_pool_tri_to_poly_ = nullptr;  //     Σ tri_cnt
+  std::vector<uint32_t> pool_poly_off_;
+  std::vector<uint32_t> pool_poly_cnt_;
+  std::vector<uint32_t> pool_tri_off_;
+  std::vector<uint32_t> pool_tri_cnt_;
+  std::vector<uint32_t> layer_slot_base_;   // ms layer mi → first slot index
+  std::vector<Crystal>  pool_crystals_;     // host slot crystals (config_id; wl-pool repr)
+  bool        geom_pool_built_ = false;
+  const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
+
   // Per-ray crystal->world rotation buffer (9 floats/ray, row-major
   // Rotation::mat_). Allocated in EnsureSessionBuffers; filled per TraceLayer
   // from InitRayFirstMs all_data[i].crystal_rot_ output (ms_mode==0 path) or
@@ -1376,6 +1403,11 @@ struct CudaTraceBackend::Impl {
   // poly_cnt_/tri_cnt_. Call once per (layer,ci) before that ci's trace/transit.
   void EnsureGeomCapacity(size_t poly_cnt, size_t tri_cnt);
   void UploadCrystalGeometry(const Crystal& crystal);
+
+  // scrum-306.2: build the per-(layer,ci) geometry pool once (device-gen path).
+  // Consumes rng_ via MakeCrystal in the EXACT ci-loop order (layers outer, ci
+  // inner) so pooled shapes are byte-identical to the prior per-batch upload.
+  void BuildGeomPool(const SceneConfig& scene);
 };
 
 void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
@@ -1409,6 +1441,19 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     cudaFree(d_tri_norm_);   d_tri_norm_ = nullptr;
     cudaFree(d_tri_area_);   d_tri_area_ = nullptr;
     cudaFree(d_tri_to_poly_); d_tri_to_poly_ = nullptr;
+    // scrum-306.2 geometry pool — freed only on full teardown (persists across
+    // the per-batch keep_persistent path so it is uploaded once per scene).
+    cudaFree(d_pool_poly_n_);      d_pool_poly_n_ = nullptr;
+    cudaFree(d_pool_poly_d_);      d_pool_poly_d_ = nullptr;
+    cudaFree(d_pool_tri_vtx_);     d_pool_tri_vtx_ = nullptr;
+    cudaFree(d_pool_tri_norm_);    d_pool_tri_norm_ = nullptr;
+    cudaFree(d_pool_tri_area_);    d_pool_tri_area_ = nullptr;
+    cudaFree(d_pool_tri_to_poly_); d_pool_tri_to_poly_ = nullptr;
+    pool_poly_off_.clear(); pool_poly_cnt_.clear();
+    pool_tri_off_.clear();  pool_tri_cnt_.clear();
+    layer_slot_base_.clear(); pool_crystals_.clear();
+    geom_pool_built_ = false;
+    pool_scene_ = nullptr;
     // Grow-only geometry capacities track the freed buffers above; zero them so
     // a fresh session re-allocates rather than reusing a dangling capacity.
     alloc_poly_cap_ = 0;
@@ -1560,6 +1605,92 @@ void CudaTraceBackend::Impl::UploadCrystalGeometry(const Crystal& crystal) {
 
   poly_cnt_ = static_cast<uint32_t>(poly_cnt);
   tri_cnt_  = static_cast<uint32_t>(tri_cnt);
+}
+
+void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene) {
+  // Build the per-(layer,ci) geometry pool ONCE. MakeCrystal is consumed from
+  // rng_ in the EXACT order the per-batch ci-loop used it (layers outer, ci
+  // inner; rng_ freshly re-seeded to spec.seed in BeginSession), so the pooled
+  // shapes are byte-identical to the prior per-batch upload. The pool then
+  // persists across batches (geom_pool_built_) — eliminating the per-batch 6×
+  // H2D re-upload of identical geometry.
+  pool_crystals_.clear();
+  pool_poly_off_.clear(); pool_poly_cnt_.clear();
+  pool_tri_off_.clear();  pool_tri_cnt_.clear();
+  layer_slot_base_.clear();
+
+  std::vector<float>    h_poly_n, h_poly_d, h_tri_vtx, h_tri_norm, h_tri_area;
+  std::vector<uint16_t> h_tri2poly;
+  uint32_t poly_acc = 0u, tri_acc = 0u;
+
+  for (size_t mi = 0; mi < scene.ms_.size(); ++mi) {
+    layer_slot_base_.push_back(static_cast<uint32_t>(pool_crystals_.size()));
+    const auto& settings = scene.ms_[mi].setting_;
+    for (size_t ci = 0; ci < settings.size(); ++ci) {
+      Crystal crystal = MakeCrystal(rng_, settings[ci].crystal_.param_);
+      size_t poly_cnt = crystal.PolygonFaceCount();
+      size_t tri_cnt  = crystal.TotalTriangles();
+      if (poly_cnt == 0 || tri_cnt == 0) {
+        throw BackendUnavailableError("CudaTraceBackend::BuildGeomPool: degenerate crystal geometry");
+      }
+      if (tri_cnt > static_cast<size_t>(lm_pcg::kMaxTriPerKernel)) {
+        throw BackendUnavailableError(
+            std::string{"CudaTraceBackend::BuildGeomPool: tri_count="} + std::to_string(tri_cnt) +
+            " exceeds kMaxTriPerKernel=" + std::to_string(lm_pcg::kMaxTriPerKernel));
+      }
+      const float* pn = crystal.GetPolygonFaceNormal();
+      const float* pd = crystal.GetPolygonFaceDist();
+      h_poly_n.insert(h_poly_n.end(), pn, pn + 3 * poly_cnt);
+      h_poly_d.insert(h_poly_d.end(), pd, pd + poly_cnt);
+      const float* tv = crystal.GetTriangleVtx();
+      const float* tn = crystal.GetTriangleNormal();
+      const float* ta = crystal.GetTirangleArea();
+      h_tri_vtx.insert(h_tri_vtx.end(), tv, tv + 9 * tri_cnt);
+      h_tri_norm.insert(h_tri_norm.end(), tn, tn + 3 * tri_cnt);
+      h_tri_area.insert(h_tri_area.end(), ta, ta + tri_cnt);
+      std::vector<uint16_t> t2p;
+      FillTriToPoly(crystal, t2p);
+      h_tri2poly.insert(h_tri2poly.end(), t2p.begin(), t2p.end());
+
+      pool_poly_off_.push_back(poly_acc);
+      pool_poly_cnt_.push_back(static_cast<uint32_t>(poly_cnt));
+      pool_tri_off_.push_back(tri_acc);
+      pool_tri_cnt_.push_back(static_cast<uint32_t>(tri_cnt));
+      poly_acc += static_cast<uint32_t>(poly_cnt);
+      tri_acc  += static_cast<uint32_t>(tri_cnt);
+      pool_crystals_.push_back(std::move(crystal));
+    }
+  }
+
+  // Free any prior pool (scene change), then allocate + H2D-upload once.
+  cudaFree(d_pool_poly_n_);      d_pool_poly_n_ = nullptr;
+  cudaFree(d_pool_poly_d_);      d_pool_poly_d_ = nullptr;
+  cudaFree(d_pool_tri_vtx_);     d_pool_tri_vtx_ = nullptr;
+  cudaFree(d_pool_tri_norm_);    d_pool_tri_norm_ = nullptr;
+  cudaFree(d_pool_tri_area_);    d_pool_tri_area_ = nullptr;
+  cudaFree(d_pool_tri_to_poly_); d_pool_tri_to_poly_ = nullptr;
+
+  CheckCuda(cudaMalloc(&d_pool_poly_n_,      3 * poly_acc * sizeof(float)),    "BuildGeomPool malloc pool_poly_n");
+  CheckCuda(cudaMalloc(&d_pool_poly_d_,          poly_acc * sizeof(float)),    "BuildGeomPool malloc pool_poly_d");
+  CheckCuda(cudaMalloc(&d_pool_tri_vtx_,     9 * tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_vtx");
+  CheckCuda(cudaMalloc(&d_pool_tri_norm_,    3 * tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_norm");
+  CheckCuda(cudaMalloc(&d_pool_tri_area_,        tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_area");
+  CheckCuda(cudaMalloc(&d_pool_tri_to_poly_,     tri_acc * sizeof(uint16_t)),  "BuildGeomPool malloc pool_tri_to_poly");
+
+  CheckCuda(cudaMemcpy(d_pool_poly_n_, h_poly_n.data(), h_poly_n.size() * sizeof(float),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_poly_n");
+  CheckCuda(cudaMemcpy(d_pool_poly_d_, h_poly_d.data(), h_poly_d.size() * sizeof(float),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_poly_d");
+  CheckCuda(cudaMemcpy(d_pool_tri_vtx_, h_tri_vtx.data(), h_tri_vtx.size() * sizeof(float),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_tri_vtx");
+  CheckCuda(cudaMemcpy(d_pool_tri_norm_, h_tri_norm.data(), h_tri_norm.size() * sizeof(float),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_tri_norm");
+  CheckCuda(cudaMemcpy(d_pool_tri_area_, h_tri_area.data(), h_tri_area.size() * sizeof(float),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_tri_area");
+  CheckCuda(cudaMemcpy(d_pool_tri_to_poly_, h_tri2poly.data(), h_tri2poly.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_tri_to_poly");
+
+  geom_pool_built_ = true;
 }
 
 void CudaTraceBackend::Impl::EnsureSessionBuffers(size_t n) {
@@ -1964,28 +2095,33 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     }
     impl_->poly_cnt_ = static_cast<uint32_t>(poly_cnt);
 
-    // Detect stochastic CrystalParam: if a Crystal built with the session
-    // seed differs in polygon count from dummy_rng's crystal, the uploaded
-    // geometry will diverge from per-batch TraceLayer crystals and G1 parity
-    // may fail. MVP dual_fisheye_ref uses deterministic prism/pyramid shapes.
-    if (impl_->logger != nullptr) {
-      RandomNumberGenerator probe_rng{spec.seed};
-      Crystal probe_crystal = MakeCrystal(probe_rng, ms_setting.crystal_.param_);
-      if (probe_crystal.PolygonFaceCount() != poly_cnt) {
-        ILOG_WARN(*impl_->logger,
-                  "CudaTraceBackend::BeginSession: stochastic CrystalParam detected — "
-                  "uploaded geometry may diverge from per-batch TraceLayer crystals; "
-                  "G1 parity may fail for non-deterministic crystal shapes");
-      }
+    // scrum-306.2: resolve the device-gen escape hatch (idempotent env read,
+    // once per Run via the gen_seeded_ guard) BEFORE geometry setup so the
+    // pool-vs-legacy upload path can branch on it. Resolved here instead of the
+    // later seed block; the duplicate read there is removed.
+    Logger& geom_logger = impl_->logger != nullptr ? *impl_->logger : GetGlobalLogger();
+    if (!impl_->gen_seeded_) {
+      impl_->disable_device_gen_ = env::DisableDeviceGen(geom_logger);
     }
 
-    // Polygon-face slab geometry + triangle pool H2D via the per-CI helper
-    // (mirrors Metal UploadCrystal). TraceLayer re-invokes UploadCrystalGeometry
-    // per (layer,ci) for multi-CI; here it primes the buffers with the first
-    // layer's first crystal so the BeginSession refractive-index log below and
-    // any single-CI fast path see a populated pool. poly_cnt_/tri_cnt_ are set
-    // by the helper. The kMaxTriPerKernel guard now lives inside the helper.
-    impl_->UploadCrystalGeometry(crystal_for_geom);
+    // Geometry to device. Device-gen path: build the per-(layer,ci) pool ONCE
+    // and persist it across the per-batch cycle (parity-exact — same shapes in
+    // the same rng_ order; eliminates the per-batch 6×blocking-H2D re-upload of
+    // identical geometry). Host-roots fallback keeps the legacy per-batch
+    // single-crystal upload (byte-exact rng_ interleaving with InitRayFirstMs).
+    // crystal_for_geom (dummy_rng; shape-independent refractive index) still
+    // feeds the wl pool + refractive-index log below in both paths.
+    if (!impl_->disable_device_gen_) {
+      if (!impl_->geom_pool_built_ ||
+          impl_->pool_scene_ != static_cast<const void*>(spec.scene)) {
+        impl_->BuildGeomPool(*spec.scene);
+        impl_->pool_scene_ = static_cast<const void*>(spec.scene);
+      }
+      impl_->poly_cnt_ = impl_->pool_poly_cnt_[0];
+      impl_->tri_cnt_  = impl_->pool_tri_cnt_[0];
+    } else {
+      impl_->UploadCrystalGeometry(crystal_for_geom);
+    }
     size_t tri_cnt = impl_->tri_cnt_;
 
     // Per-ray wavelength pool (296.6 DR-3). One session covers the whole
@@ -2045,9 +2181,8 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     if (!impl_->gen_seeded_) {
       impl_->gen_ray_count_ = 0;
       impl_->gen_seeded_ = true;
-      // LUMICE_DISABLE_DEVICE_GEN escape hatch — resolve once per session start
-      // (host InitRayFirstMs fallback). Mirrors Metal's disable_device_gen_.
-      impl_->disable_device_gen_ = env::DisableDeviceGen(wl_logger);
+      // disable_device_gen_ is resolved earlier (geometry-setup block) so the
+      // pool-vs-legacy upload path can branch on it before BuildGeomPool.
     }
     // Drain RNG: seed ONCE per Run() and advance across all per-wavelength-batch
     // BeginSession calls, exactly like the transit_/gate_ counters above. The
@@ -2263,14 +2398,40 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     const uint32_t cin = static_cast<uint32_t>(ci_n);
     const uint32_t grid = (cin + 255u) / 256u;
 
-    // Per-ci crystal + geometry (mirrors Metal ResolveLayerCrystalForCi +
-    // UploadCrystal). MakeCrystal consumes impl_->rng_ once per (layer,ci,batch),
-    // matching legacy/Metal ordering.
-    Crystal ci_crystal = MakeCrystal(impl_->rng_, ms_setting.crystal_.param_);
-    impl_->UploadCrystalGeometry(ci_crystal);
-    const uint32_t ci_cfg_id = (ci_crystal.config_id_ == kInvalidId)
-                                   ? 0xFFFFu
-                                   : static_cast<uint32_t>(ci_crystal.config_id_);
+    // Per-ci geometry. Device-gen path (default): point at this (layer,ci)'s
+    // pre-uploaded pool slot — built ONCE in BeginSession, persisted across
+    // batches, no per-batch MakeCrystal / 6×H2D (scrum-306.2; parity-exact since
+    // rng_ is reset to the constant effective_seed_ every batch → same shapes).
+    // Host-roots fallback (disable_device_gen_): per-batch MakeCrystal + legacy
+    // single-crystal upload (byte-exact rng_ interleaving with InitRayFirstMs).
+    // gen/transit read the slot's triangle pool, trace its polygon-slab — all via
+    // geom_* below, so the kernels themselves are unchanged.
+    std::unique_ptr<Crystal> ci_crystal_fb;  // fallback path only (avoids Crystal default-ctor)
+    uint32_t ci_cfg_id;
+    const float* geom_poly_n; const float* geom_poly_d; uint32_t geom_poly_cnt;
+    const float* geom_tri_vtx; const float* geom_tri_norm; const float* geom_tri_area;
+    const uint16_t* geom_tri_to_poly; uint32_t geom_tri_cnt;
+    if (impl_->disable_device_gen_) {
+      ci_crystal_fb = std::make_unique<Crystal>(MakeCrystal(impl_->rng_, ms_setting.crystal_.param_));
+      impl_->UploadCrystalGeometry(*ci_crystal_fb);
+      ci_cfg_id = (ci_crystal_fb->config_id_ == kInvalidId)
+                      ? 0xFFFFu : static_cast<uint32_t>(ci_crystal_fb->config_id_);
+      geom_poly_n = impl_->d_poly_n_; geom_poly_d = impl_->d_poly_d_; geom_poly_cnt = impl_->poly_cnt_;
+      geom_tri_vtx = impl_->d_tri_vtx_; geom_tri_norm = impl_->d_tri_norm_;
+      geom_tri_area = impl_->d_tri_area_; geom_tri_to_poly = impl_->d_tri_to_poly_;
+      geom_tri_cnt = impl_->tri_cnt_;
+    } else {
+      const uint32_t slot = impl_->layer_slot_base_[impl_->ms_layer_idx_] + static_cast<uint32_t>(ci);
+      const Crystal& pc = impl_->pool_crystals_[slot];
+      ci_cfg_id = (pc.config_id_ == kInvalidId) ? 0xFFFFu : static_cast<uint32_t>(pc.config_id_);
+      const uint32_t po = impl_->pool_poly_off_[slot];
+      const uint32_t to = impl_->pool_tri_off_[slot];
+      geom_poly_n = impl_->d_pool_poly_n_ + 3u * po; geom_poly_d = impl_->d_pool_poly_d_ + po;
+      geom_poly_cnt = impl_->pool_poly_cnt_[slot];
+      geom_tri_vtx = impl_->d_pool_tri_vtx_ + 9u * to; geom_tri_norm = impl_->d_pool_tri_norm_ + 3u * to;
+      geom_tri_area = impl_->d_pool_tri_area_ + to; geom_tri_to_poly = impl_->d_pool_tri_to_poly_ + to;
+      geom_tri_cnt = impl_->pool_tri_cnt_[slot];
+    }
 
     // ── Generate / transit this ci's root rays into root buf [0, ci_n) ──────
     if (first_ms && !impl_->disable_device_gen_) {
@@ -2278,13 +2439,13 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       // + per-ray wl on device for THIS ci's crystal geometry. gen_ray_count_ is
       // monotone so each (layer,ci,batch) consumes a disjoint PCG range.
       lm_pcg::GenRootKernelParams gp =
-          BuildGenGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cin,
+          BuildGenGpParams(ms_setting.crystal_.axis_, geom_tri_cnt, cin,
                            impl_->scene_->light_source_.param_, impl_->wl_pool_size_);
       gp.gen_seed     = impl_->gen_seed_;
       gp.gen_ray_base = NarrowPcgRayBase(impl_->gen_ray_count_, ci_n, "cuda-gen");
       gen_root_kernel<<<grid, 256, 0, impl_->stream_>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
-                                     impl_->d_rot_c2w_, impl_->d_root_wl_idx_, impl_->d_tri_vtx_,
-                                     impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
+                                     impl_->d_rot_c2w_, impl_->d_root_wl_idx_, geom_tri_vtx,
+                                     geom_tri_norm, geom_tri_area, geom_tri_to_poly,
                                      impl_->d_wl_pool_, gp, cin);
       ck_reset(cudaPeekAtLastError(), "gen_root_kernel launch");
       impl_->gen_ray_count_ += ci_n;
@@ -2297,7 +2458,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
         workspace[0].Reset(ci_n * 2);
         workspace[1].Reset(ci_n * 4);
         RayBuffer all_data = AllocateAllData(*impl_->scene_, ci_n);
-        InitRayFirstMs(impl_->rng_, impl_->scene_->light_source_.param_, impl_->wl_, ci_n, ci_crystal,
+        InitRayFirstMs(impl_->rng_, impl_->scene_->light_source_.param_, impl_->wl_, ci_n, *ci_crystal_fb,
                        impl_->ms_layer_idx_, axis_dist, workspace, all_data);
         for (size_t i = 0; i < ci_n; ++i) {
           const auto& r = all_data[i];
@@ -2340,7 +2501,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       // ci_start; the kernel indexes tid in [0, ci_n). transit_ray_count_ is
       // monotone → disjoint PCG range per (layer,ci,batch).
       lm_pcg::GenRootKernelParams gp =
-          BuildTransitGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cin);
+          BuildTransitGpParams(ms_setting.crystal_.axis_, geom_tri_cnt, cin);
       gp.gen_seed     = impl_->transit_seed_;
       gp.gen_ray_base = NarrowPcgRayBase(impl_->transit_ray_count_, ci_n, "cuda-transit");
       transit_multi_ms_kernel<<<grid, 256, 0, impl_->stream_>>>(
@@ -2348,7 +2509,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
           impl_->d_cont_wl_idx_[in_slot] + ci_start,
           impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
           impl_->d_rot_c2w_, impl_->d_root_wl_idx_,
-          impl_->d_tri_vtx_, impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
+          geom_tri_vtx, geom_tri_norm, geom_tri_area, geom_tri_to_poly,
           gp, cin);
       ck_reset(cudaPeekAtLastError(), "transit kernel launch");
       impl_->transit_ray_count_ += ci_n;
@@ -2371,8 +2532,8 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     // shortcut would make the new ms_mode==0 emit gate deref nullptr.
     trace_single_ms_kernel<<<grid, 256, 0, impl_->stream_>>>(
         impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
-        cin, impl_->d_poly_n_, impl_->d_poly_d_,
-        impl_->poly_cnt_, impl_->d_rot_c2w_, impl_->d_wl_pool_, impl_->d_root_wl_idx_,
+        cin, geom_poly_n, geom_poly_d,
+        geom_poly_cnt, impl_->d_rot_c2w_, impl_->d_wl_pool_, impl_->d_root_wl_idx_,
         max_hits, impl_->d_exit_,
         static_cast<uint32_t>(impl_->exit_cap_), impl_->d_exit_count_,
         /*crystal_id=*/static_cast<uint32_t>(ci), /*ms_layer_idx=*/impl_->ms_layer_idx_,

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1235,6 +1235,18 @@ struct CudaTraceBackend::Impl {
   cudaEvent_t ev_end_d2h_{};
   bool events_created_ = false;
 
+  // scrum-306.2 async-stream port (increment 1): all per-dispatch GPU work
+  // (kernels / memcpy / memset / events) runs on this dedicated non-default
+  // stream instead of the legacy default stream. Increment 1 keeps host-blocking
+  // at the SAME logical points (every former cudaDeviceSynchronize / blocking
+  // cudaMemcpy → cudaStreamSynchronize(stream_)), so semantics are preserved and
+  // parity must stay 10/10; it only establishes the stream infrastructure.
+  // Increment 2 then defers the count-readback waits to overlap D2H with compute.
+  // Created once (gated by stream_created_), destroyed in full Reset() / dtor —
+  // persists across the per-batch keep_persistent_buffers path like the events.
+  cudaStream_t stream_{};
+  bool stream_created_ = false;
+
   // --- Transit-kernel PCG state (296.4) ------------------------------------
   // Independent PCG stream for the device-resident continuation engine. The
   // counter is monotone across the whole session (NOT reset across batches /
@@ -1435,6 +1447,10 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
       cudaEventDestroy(ev_end_kernel_);
       cudaEventDestroy(ev_end_d2h_);
       events_created_ = false;
+    }
+    if (stream_created_) {  // scrum-306.2 async-stream
+      cudaStreamDestroy(stream_);
+      stream_created_ = false;
     }
 
     // Capacity trackers tied to the freed persistent buffers + the
@@ -2124,6 +2140,10 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
       CheckCuda(cudaEventCreate(&impl_->ev_end_d2h_),     "BeginSession cudaEventCreate ev_end_d2h");
       impl_->events_created_ = true;
     }
+    if (!impl_->stream_created_) {  // scrum-306.2 async-stream
+      CheckCuda(cudaStreamCreate(&impl_->stream_), "BeginSession cudaStreamCreate");
+      impl_->stream_created_ = true;
+    }
 
     impl_->in_session_ = true;
     if (impl_->logger != nullptr) {
@@ -2227,7 +2247,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
 
   // Zero the layer's accumulators ONCE before the ci-loop: each ci's trace
   // dispatch APPENDS to d_exit_ / cont[out_slot] via atomic counters.
-  cudaEventRecord(impl_->ev_start_h2d_);
+  cudaEventRecord(impl_->ev_start_h2d_, impl_->stream_);
   ck_reset(cudaMemset(impl_->d_exit_count_, 0, sizeof(uint32_t)), "cudaMemset d_exit_count");
   ck_reset(cudaMemset(impl_->d_cont_count_[out_slot], 0, sizeof(uint32_t)),
            "cudaMemset d_cont_count_[out_slot]");
@@ -2262,7 +2282,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
                            impl_->scene_->light_source_.param_, impl_->wl_pool_size_);
       gp.gen_seed     = impl_->gen_seed_;
       gp.gen_ray_base = NarrowPcgRayBase(impl_->gen_ray_count_, ci_n, "cuda-gen");
-      gen_root_kernel<<<grid, 256>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
+      gen_root_kernel<<<grid, 256, 0, impl_->stream_>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
                                      impl_->d_rot_c2w_, impl_->d_root_wl_idx_, impl_->d_tri_vtx_,
                                      impl_->d_tri_norm_, impl_->d_tri_area_, impl_->d_tri_to_poly_,
                                      impl_->d_wl_pool_, gp, cin);
@@ -2323,7 +2343,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
           BuildTransitGpParams(ms_setting.crystal_.axis_, impl_->tri_cnt_, cin);
       gp.gen_seed     = impl_->transit_seed_;
       gp.gen_ray_base = NarrowPcgRayBase(impl_->transit_ray_count_, ci_n, "cuda-transit");
-      transit_multi_ms_kernel<<<grid, 256>>>(
+      transit_multi_ms_kernel<<<grid, 256, 0, impl_->stream_>>>(
           impl_->d_cont_d_[in_slot] + ci_start * 3u, impl_->d_cont_w_[in_slot] + ci_start,
           impl_->d_cont_wl_idx_[in_slot] + ci_start,
           impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
@@ -2344,12 +2364,12 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     // right AFTER, both inside the loop. The LAST iteration's pair wins.
     // Stream order is strict (default stream) so end_h2d → kernel → end_kernel,
     // and kernel_ms = elapsed(end_h2d, end_kernel) is positive and meaningful.
-    cudaEventRecord(impl_->ev_end_h2d_);
+    cudaEventRecord(impl_->ev_end_h2d_, impl_->stream_);
     // Filter / gate buffers are passed unconditionally (S2): the ms_mode==0
     // device-fused emit gate also calls DeviceFilterCheck. Previously these
     // were short-circuited to nullptr on ms_mode==0 dispatches — keeping that
     // shortcut would make the new ms_mode==0 emit gate deref nullptr.
-    trace_single_ms_kernel<<<grid, 256>>>(
+    trace_single_ms_kernel<<<grid, 256, 0, impl_->stream_>>>(
         impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
         cin, impl_->d_poly_n_, impl_->d_poly_d_,
         impl_->poly_cnt_, impl_->d_rot_c2w_, impl_->d_wl_pool_, impl_->d_root_wl_idx_,
@@ -2382,7 +2402,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     // The original outside-loop placement (right next to ev_end_h2d_) collapsed
     // kernel_ms to ~0ms after the multi-CI rewrite — they recorded back-to-back
     // before any compute observed by the timer.
-    cudaEventRecord(impl_->ev_end_kernel_);
+    cudaEventRecord(impl_->ev_end_kernel_, impl_->stream_);
     // S2: gate_ray_count_ is advanced for BOTH ms_modes now — the ms_mode==0
     // path also draws prob via the gate stream so every dispatch (final or
     // not) must consume a disjoint global_idx range to avoid stream collision
@@ -2394,7 +2414,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
   // point that surfaces async kernel errors: check the return value).
   ck_reset(cudaMemcpy(&impl_->h_exit_count_, impl_->d_exit_count_, sizeof(uint32_t),
                       cudaMemcpyDeviceToHost), "4B readback");
-  cudaEventRecord(impl_->ev_end_d2h_);
+  cudaEventRecord(impl_->ev_end_d2h_, impl_->stream_);
   cudaEventSynchronize(impl_->ev_end_d2h_);
 
   float h2d_ms = 0.0f;
@@ -2507,7 +2527,7 @@ RootRaySource CudaTraceBackend::Recombine(LayerHandlePtr handle, const Recombine
     }
     const uint32_t shuf_seed = impl_->shuffle_seed_ ^ static_cast<uint32_t>(impl_->ms_layer_idx_);
     const uint32_t grid = (cont_n + 255u) / 256u;
-    shuffle_cont_kernel<<<grid, 256>>>(impl_->d_cont_d_[written_slot],
+    shuffle_cont_kernel<<<grid, 256, 0, impl_->stream_>>>(impl_->d_cont_d_[written_slot],
                                        impl_->d_cont_w_[written_slot],
                                        impl_->d_cont_wl_idx_[written_slot],
                                        impl_->d_cont_d_[other_slot],

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -90,6 +90,17 @@ class ServerImpl {
   // geometry-sampling cadence). Commit granularity (kCommitCap) stays fine
   // regardless, so "feed the GPU big, refresh the UI small" is one tunable.
   static constexpr size_t kDefaultMetalDispatchRayNum = 32768;
+  // scrum-306.2: CUDA's optimum sits much higher than Metal's. After capping the
+  // dead d_exit_ buffer (cuda_trace_backend.cu kCudaDeadExitCap), a large dispatch
+  // amortizes the per-batch host stall (BeginSession/XYZ-readback/sync) that left
+  // the GPU ~70% idle: dev49 idle-gated interleaved sweep on cfg_50m (50M-ray
+  // multi) climbs 37M @32768 -> ~114M @262144 (= 85% of the 134M intrinsic kernel
+  // rate, nsys), plateauing/declining beyond (~115M @1M, then cont/root-buffer
+  // pressure). 262144 is the throughput plateau at modest memory. CUDA energy is
+  // dispatch-invariant (scrum-306.4), and parity holds at this dispatch (full
+  // suite 10/10 @262144/524288). Kept separate from the Metal default (Metal's own
+  // optimum is unchanged; not re-measured here).
+  static constexpr size_t kDefaultCudaDispatchRayNum = 262144;
 
   void ConsumeData();
   void GenerateScene();
@@ -940,9 +951,22 @@ void ServerImpl::GenerateScene() {
   // CPU/legacy keeps the small kDefaultRayNum. An explicit LUMICE_DISPATCH_RAY_NUM
   // always wins. NOT static: a server reconstructed on a GUI backend toggle must
   // re-resolve the default for the new backend (commit↔batch decoupling, 268.4).
-  const size_t kDefaultDispatch = ResolveGpuRoute(preferred_backend_.load(std::memory_order_acquire), logger_) ?
-                                      kDefaultMetalDispatchRayNum :
-                                      kDefaultRayNum;
+  // scrum-306.2: CUDA's dispatch optimum (262144) is much higher than Metal's
+  // (32768) once the dead exit buffer is capped — select per backend so each GPU
+  // route gets its own measured plateau. ResolveGpuRoute is env-override-aware
+  // (LUMICE_TRACE_BACKEND wins over preferred_backend_, so keying on the latter
+  // misses the --benchmark/CLI env path). Metal is Apple-only; CUDA is the only
+  // GPU route on a non-Apple CUDA build — so there a true GPU route IS CUDA.
+  const BackendKind kPref = preferred_backend_.load(std::memory_order_acquire);
+  const bool kGpuRoute = ResolveGpuRoute(kPref, logger_);
+#if defined(LUMICE_CUDA_ENABLED) && !defined(__APPLE__)
+  const bool kIsCudaRoute = kGpuRoute;
+#else
+  const bool kIsCudaRoute = false;  // Apple GPU route is Metal; non-CUDA build has none
+#endif
+  const size_t kDefaultDispatch = kIsCudaRoute ? kDefaultCudaDispatchRayNum :
+                                  kGpuRoute    ? kDefaultMetalDispatchRayNum :
+                                                 kDefaultRayNum;
   const size_t kDispatchCap = env::DispatchRayNum(logger_, kDefaultDispatch);
   const size_t kBatchCap = kDispatchCap;  // local alias for the loop below
 

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -427,6 +427,20 @@ def run_scene_capi_buffered(
         # Caller's env would override our SetPreferredBackend — strip it.
         del os.environ["LUMICE_TRACE_BACKEND"]
 
+    # scrum-306.4: LUMICE_DISPATCH_RAY_NUM is a GPU-engine dispatch-sizing knob.
+    # The legacy (CPU) parity oracle's total energy is NOT invariant to it
+    # (explore-306.1: legacy Y swings −5%..+13% across dispatch sizes; a separate
+    # legacy bug tracked in scrum-306.7). When a dev sets LUMICE_DISPATCH_RAY_NUM
+    # globally to probe a GPU backend at a large dispatch, it leaks into the legacy
+    # reference run and inflates legacy_Y → a FALSE energy_ratio failure that was
+    # historically misattributed to a CUDA "silent energy loss". Pin the oracle to
+    # its canonical default by stripping the knob for the legacy run so the ratio
+    # reflects the GPU backend's correctness alone.
+    disp_was_set = "LUMICE_DISPATCH_RAY_NUM" in os.environ
+    disp_old = os.environ.get("LUMICE_DISPATCH_RAY_NUM")
+    if backend == "legacy" and disp_was_set:
+        del os.environ["LUMICE_DISPATCH_RAY_NUM"]
+
     capture = _LogCapture()
 
     try:
@@ -568,3 +582,9 @@ def run_scene_capi_buffered(
         else:
             if env_was_set:
                 os.environ["LUMICE_TRACE_BACKEND"] = env_old
+        # scrum-306.4: restore LUMICE_DISPATCH_RAY_NUM (only the legacy branch
+        # strips it; restore symmetrically regardless of backend).
+        if disp_was_set:
+            os.environ["LUMICE_DISPATCH_RAY_NUM"] = disp_old
+        else:
+            os.environ.pop("LUMICE_DISPATCH_RAY_NUM", None)


### PR DESCRIPTION
## scrum-306 cuda-async-engine — CUDA throughput to the hardware limit

**Result: out-of-box CUDA throughput 37M → ~114M rays/s** (dev49 RTX 4060 Ti, idle-gated; = 85% of the 134M intrinsic kernel rate). Clears the 90M floor, approaches the 120M target. **Full CUDA parity suite 10/10** at the new default AND at 524288/1048576.

### The honest story (the scrum's "async" premise was wrong)
Profiling (nsys) redirected the work twice:
- **async/stream-deferral was the wrong lever** — per-dispatch sync was 0.3% of host time; the fully-designed increment-2 was dropped.
- The GPU was **host-bound** (~70% idle), not sync-bound. The real levers:
  1. **`d_exit_` is dead on CUDA** (`HasDeviceXyzAccum()` always true → all exits go to the device XYZ buffer; the kernel never writes `d_exit_`). It was sized `n×(2·max_hits+4)` and ballooned to GBs at large dispatch — causing both the throughput collapse and a parity OOM. Capped to a token (`kCudaDeadExitCap`).
  2. **Dispatch size** — bigger batches amortize the per-batch host overhead. CUDA default raised 32768 → **262144** (keyed on the env-aware resolved route; Metal's default untouched). Energy is dispatch-invariant (306.4).
- The **geometry pool (upload-once)** + **filter/wl persist** are parity-clean structural improvements (align with seam-design §5, remove per-batch H2D churn) but **throughput-neutral** — interleaved round-robin proved pre ≈ pool ≈ pool+persist. Not cited as the speedup.

### Commits
- 306.1 `LUMICE_METAL_SHADER_PROFILE` build option
- 306.4 strip `LUMICE_DISPATCH_RAY_NUM` from the legacy parity oracle + misdiagnosis correction
- 306.2 increments: stream infra (1) · geometry pool (3) · filter/wl persist (4) · **dead `d_exit_` cap (5)** · **CUDA default dispatch 262144**
- 306.3 docs: rebench at the new default + 固化 "GPU has no true multi-worker" + corrected framing
- 306.6/306.7 docs: both investigations converged with no code change (see below)

### No-op investigations (recorded for retrieval)
- **306.6 Metal kernel lever** → no cheap lever (path_rec spike 0 change like CUDA; Metal is ALU-bound = algorithmic-only) → folded into the far-future algorithmic-kernel backlog.
- **306.7 legacy energy "dispatch dependence"** → not a bug; it's MC variance from per-batch wavelength sampling (unbiased; `sim_ray_num` invariant). Legacy default is correct; not pursued (would touch the reference oracle for zero benefit).

### Backlog
- 306.8 cont/root buffer cap (single-MS those buffers are also dead) — could unlock >1M dispatch toward the full 134M; low priority since 90M is met.

### Methodology note (in `doc/performance-testing.md`)
Shared dev49 is CPU-contended → host-bound CUDA throughput is noisy (same binary swung 33M↔114M). Only **per-run interleaved** comparison is trustworthy; GPU idle-gate is necessary but not sufficient. nsys GPU-side classifies host- vs GPU-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)