### PR TITLE
fix(geo3d): RandomSample no-match fallback for MSVC 77H light leak (curr_p==0.0 → entry-face bug)

### DIFF
--- a/src/core/geo3d.cpp
+++ b/src/core/geo3d.cpp
@@ -164,6 +164,9 @@ int RandomSampleSelectBin(float curr_p, const float* p, int pop_size) {
       return j;
     }
   }
+  // Unreachable under a valid cumulative array (p[pop_size]==1 guarantees at least one
+  // positive-weight bin). Only an all-zero-weight input (p[pop_size]==0) reaches here;
+  // that violates the caller contract, so we fall back to bin 0 defensively.
   return 0;
 }
 }  // namespace detail

--- a/src/core/geo3d.cpp
+++ b/src/core/geo3d.cpp
@@ -142,14 +142,31 @@ void RandomSample(int pop_size, const float* weight, int* out, size_t sample_num
   auto& rng = RandomNumberGenerator::GetInstance();
   for (size_t i = 0; i < sample_num; i++) {
     auto curr_p = rng.GetUniform();
-    for (int j = 0; j < pop_size; j++) {
-      if (p[j] < curr_p && curr_p <= p[j + 1]) {
-        out[i] = j;
-        break;
-      }
-    }
+    out[i] = detail::RandomSampleSelectBin(curr_p, p, pop_size);
   }
 }
+
+namespace detail {
+int RandomSampleSelectBin(float curr_p, const float* p, int pop_size) {
+  for (int j = 0; j < pop_size; j++) {
+    if (p[j] < curr_p && curr_p <= p[j + 1]) {
+      return j;
+    }
+  }
+  // No-match fallback: curr_p == 0.0 is the only path here (intervals cover (0, 1]).
+  // MSVC STL uniform_real_distribution<float> can return exactly 0.0; libc++/libstdc++
+  // do not, so this branch is inert on Mac/gcc (parity zero risk). The first j with
+  // p[j+1] > p[j] is the first positive-weight bin, which equals the inverse-CDF limit
+  // at x=0. Without this, callers would silently keep their default index (e.g.
+  // InitRay_p_fid leaving tri_id=0), which can pick a zero-weight bin (the 77H leak).
+  for (int j = 0; j < pop_size; j++) {
+    if (p[j + 1] > p[j]) {
+      return j;
+    }
+  }
+  return 0;
+}
+}  // namespace detail
 
 
 void SampleTrianglePoint(const float* vertices, float* out_pt, size_t sample_num) {

--- a/src/core/geo3d.hpp
+++ b/src/core/geo3d.hpp
@@ -35,6 +35,16 @@ class Rotation {
 
 void RandomSample(int pop_size, const float* weight, int* out, size_t sample_num = 1);
 
+namespace detail {
+// Pure bin-selection step used by RandomSample. Exposed for deterministic unit testing of
+// the curr_p==0.0 no-match boundary (MSVC STL uniform_real_distribution<float> can return
+// 0.0; libc++/libstdc++ do not). Given normalized cumulative array p of length pop_size+1
+// with p[0]=0, p[pop_size]=1, returns bin j satisfying p[j] < curr_p <= p[j+1], or — when
+// no interval matches (curr_p==0.0) — the first j with p[j+1] > p[j] (first positive-weight
+// bin), i.e. the inverse-CDF limit at x=0.
+int RandomSampleSelectBin(float curr_p, const float* p, int pop_size);
+}  // namespace detail
+
 void SampleTrianglePoint(const float* vertices, float* out_pt, size_t sample_num = 1);
 
 void SampleSphCapPoint(float lon, float lat, float cap_radii, float* out_pt,    //

--- a/src/core/geo3d.hpp
+++ b/src/core/geo3d.hpp
@@ -38,8 +38,8 @@ void RandomSample(int pop_size, const float* weight, int* out, size_t sample_num
 namespace detail {
 // Pure bin-selection step used by RandomSample. Exposed for deterministic unit testing of
 // the curr_p==0.0 no-match boundary (MSVC STL uniform_real_distribution<float> can return
-// 0.0; libc++/libstdc++ do not). Given normalized cumulative array p of length pop_size+1
-// with p[0]=0, p[pop_size]=1, returns bin j satisfying p[j] < curr_p <= p[j+1], or — when
+// 0.0; libc++/libstdc++ do not). p is the normalized **cumulative** array (NOT raw weights)
+// of length pop_size+1 with p[0]=0, p[pop_size]=1; returns bin j satisfying p[j] < curr_p <= p[j+1], or — when
 // no interval matches (curr_p==0.0) — the first j with p[j+1] > p[j] (first positive-weight
 // bin), i.e. the inverse-CDF limit at x=0.
 int RandomSampleSelectBin(float curr_p, const float* p, int pop_size);

--- a/test/unit-correctness/core/test_geo3d.cpp
+++ b/test/unit-correctness/core/test_geo3d.cpp
@@ -17,6 +17,73 @@ class Geo3dTest : public ::testing::Test {
 
 
 // ============================================================================
+// RandomSample (no-match / zero-weight bin coverage; see task-fix-randomsample-nomatch-entry-leak)
+// ============================================================================
+
+TEST_F(Geo3dTest, RandomSample_NoMatchFallbackToFirstPositiveWeightBin) {
+  // Deterministic AC3 coverage: drives the curr_p == 0.0 no-match path directly through
+  // detail::RandomSampleSelectBin. MSVC STL uniform_real_distribution<float> can return
+  // exactly 0.0; libc++/libstdc++ do not — so the production RNG path on Mac/gcc never
+  // exercises the fallback. We construct the normalized cumulative array p[] by hand and
+  // assert the helper returns the first positive-weight bin (i.e. the inverse-CDF limit
+  // at x=0), never the zero-weight bin 0.
+
+  // weight = [0, 1, 0, 0]: bin 0 zero-weight, bin 1 carries all mass.
+  // After normalization: p = [0, 0, 1, 1, 1] (intervals: (0,0],(0,1],(1,1],(1,1]).
+  // curr_p == 0.0 satisfies no interval (j=0: p[0]=0 < 0 is false) → fallback path.
+  {
+    const float p[] = { 0.0f, 0.0f, 1.0f, 1.0f, 1.0f };
+    EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.0f, p, 4), 1) << "no-match must pick first positive bin (1)";
+  }
+
+  // weight = [0, 0, 2, 1]: first positive bin is j=2.
+  // After normalization: p = [0, 0, 0, 2/3, 1].
+  {
+    const float p[] = { 0.0f, 0.0f, 0.0f, 2.0f / 3.0f, 1.0f };
+    EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.0f, p, 4), 2) << "no-match skips zero-weight bins 0,1";
+  }
+
+  // Single-bin pop (pop_size=2 with weight=[0,1]): no-match must pick j=1, never 0.
+  {
+    const float p[] = { 0.0f, 0.0f, 1.0f };
+    EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.0f, p, 2), 1) << "single positive bin selected on no-match";
+  }
+}
+
+TEST_F(Geo3dTest, RandomSample_SelectBin_MatchPathUnchanged) {
+  // Belt-and-suspenders: the match path (curr_p > 0) must keep the half-open interval
+  // (p[j], p[j+1]] convention so Mac/gcc parity remains byte-identical after the refactor.
+  const float p[] = { 0.0f, 0.25f, 0.75f, 1.0f };
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.10f, p, 3), 0);
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.25f, p, 3), 0) << "boundary belongs to lower bin";
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.50f, p, 3), 1);
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.75f, p, 3), 1) << "boundary belongs to lower bin";
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.90f, p, 3), 2);
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(1.00f, p, 3), 2) << "upper boundary belongs to last bin";
+}
+
+TEST_F(Geo3dTest, RandomSample_ZeroWeightBinNeverSelectedViaPublicApi) {
+  // Belt-and-suspenders contract test (NOT primary AC3 coverage — see NoMatchFallback test
+  // above for the direct no-match path proof). On Mac/gcc the production RNG never returns
+  // 0.0, so this exercises only the main loop; the assertion still guards against any
+  // future regression (e.g. silent default-write or interval-coverage change) that would
+  // let a zero-weight bin slip through.
+  constexpr int kPop = 4;
+  constexpr float kWeight[kPop] = { 0.0f, 1.0f, 0.0f, 0.0f };  // only bin 1 has weight
+  constexpr size_t kN = 10000;
+  int out[kN];
+  for (size_t i = 0; i < kN; i++) {
+    out[i] = -1;  // sentinel: must be overwritten
+  }
+  lumice::RandomSample(kPop, kWeight, out, kN);
+  for (size_t i = 0; i < kN; i++) {
+    EXPECT_NE(out[i], -1) << "sample " << i << " left as sentinel (RandomSample failed to write)";
+    EXPECT_EQ(out[i], 1) << "sample " << i << " selected zero-weight bin " << out[i];
+  }
+}
+
+
+// ============================================================================
 // SampleTrianglePoint
 // ============================================================================
 

--- a/test/unit-correctness/core/test_geo3d.cpp
+++ b/test/unit-correctness/core/test_geo3d.cpp
@@ -55,9 +55,9 @@ TEST_F(Geo3dTest, RandomSample_SelectBin_MatchPathUnchanged) {
   // (p[j], p[j+1]] convention so Mac/gcc parity remains byte-identical after the refactor.
   const float p[] = { 0.0f, 0.25f, 0.75f, 1.0f };
   EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.10f, p, 3), 0);
-  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.25f, p, 3), 0) << "boundary belongs to lower bin";
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.25f, p, 3), 0) << "upper boundary belongs to the bin it closes";
   EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.50f, p, 3), 1);
-  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.75f, p, 3), 1) << "boundary belongs to lower bin";
+  EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.75f, p, 3), 1) << "upper boundary belongs to the bin it closes";
   EXPECT_EQ(lumice::detail::RandomSampleSelectBin(0.90f, p, 3), 2);
   EXPECT_EQ(lumice::detail::RandomSampleSelectBin(1.00f, p, 3), 2) << "upper boundary belongs to last bin";
 }


### PR DESCRIPTION
## Summary

修 `RandomSample`(src/core/geo3d.cpp) 在 `curr_p==0.0` 时 no-match → `out` 未写 → 调用方默认 `tri_id=0` 选到零权重背光入射面，导致 Windows/MSVC 内测用户在 77H 场景偶发"偏离地平 10-18° 异色离群光点"漏光（Mac/libc++/gcc/libstdc++ 不复现）。

根因（explore-77h-light-leak 两平台插桩铁证，详见 issue.md / explore-77h-light-leak SUMMARY）:
- MSVC STL `uniform_real_distribution<float>` 偶发返回精确 `0.0`（libc++/libstdc++ 不会），实测 2e9 抽样 115 次
- `RandomSample` 累积区间 `(0,1]` 半开，`curr_p==0` 时无任何 j 命中 → `out[i]` 保留调用方原值（`InitRay_p_fid` 传入 `tri_id=0`）
- 入射面变成零权重的背光面 13 → 入射 `d·n>0` → 被 `HitSurface` 误判 ice→air、入射角 > 临界角 50° → 全反射(w=1) → 反射光乱窜 → off-band 高权重出射

修复（最小、对 Mac 字节不变）:
- 抽 `lumice::detail::RandomSampleSelectBin(curr_p, p, pop_size)`（review Suggestion #1 锁定的 `detail::` 命名空间方案，便于确定性单测）
- no-match 时兜底选首个正权重 bin（`p[j+1] > p[j]`），等价 inverse-CDF 在 x=0 的极限
- `curr_p ∈ (0,1]` 路径逐字保持 → Mac/gcc 输出字节一致（实测见 AC2）

## Verification

- **AC1 — MSVC oracle（win-builder, 77H 2e9 单波长红 650nm）✅**
  ```
  [LEAK-SUMMARY] total=49732 in_band[8.0,20.0]=49732 outliers=0 big(>25deg)=0
  [LEAK-HIST] elev 5deg bins (-90..90):
    [ -15, -10): 49731
    [ -10,  -5): 1
  ```
  修复前（同场景同光线数）: ~5/50K filtered 散到 -78°~+23°；修复后 49732/49732 全 in-band，histogram 紧贴预期 Liljequist halo elevation 带。
- **AC2 — Mac/gcc 全 parity battery ✅** `./scripts/build.sh -tj release` ctest 4/4 全绿；`./scripts/build.sh -sj release && pytest -v -m slow` 24 passed / 10 skipped (CUDA-only on Mac) / 0 failed（412s）；含全部 Metal/CPU exit-seam parity + filter parity + batch invariance + golden + regression-sentinel
- **AC3 — 确定性回归测试 ✅** 新增 3 个 `Geo3dTest` TEST_F 覆盖 no-match 边界 / 主路径区间归属 / public-API 端到端 + sentinel；3/3 PASS
- **AC4 — Windows 视觉验收 ⏳ 待 owner / 内测用户确认 77H.lmc 在合并后无异色离群点**

## Test plan

- [x] `./scripts/build.sh -tj release` — ctest 全绿（Mac local）
- [x] `./scripts/build.sh -sj release && pytest -v -m slow` — slow parity battery 全绿（Mac local）
- [x] `./scripts/format.sh --check` + `python3 scripts/check_policies.py` — clean
- [x] win-builder MSVC 14.51 incremental rebuild + 77H 2e9 oracle — leak.txt outliers=0
- [ ] CI build + unit tests on PR push
- [ ] AC4: owner / 内测用户 Windows 端 77H.lmc 视觉验收

Closes scratchpad task #308 (`fix-randomsample-nomatch-entry-leak`); follow-up `audit-getuniform-zero-assumptions` 归 backlog（审计其他 `GetUniform()` 消费方是否潜在假设抽样 ∈ (0,1)）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)