### PR TITLE
chore(cleanup): CUDA dead-code + CI Node24 bump + exit-seam crystals stat fix (scrum-311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
       # mechanism for partial installs — if the action ever changes that
       # contract, the install-size diagnostic step below will catch it.
       - name: Install CUDA toolkit (nvcc + cudart_dev)
-        uses: Jimver/cuda-toolkit@v0.2.23
+        uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: '12.6.3'
           method: 'network'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       # fatbin (compute_61 PTX + sm_75/86/89 SASS, see CMakeLists.txt).
       - name: Install CUDA toolkit (Windows CUDA artifact)
         if: matrix.cuda == 'ON'
-        uses: Jimver/cuda-toolkit@v0.2.23
+        uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: '12.6.3'
           method: 'network'

--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -24,8 +24,10 @@ namespace lumice {
 // vestigial outgoing_indices_ (vector<size_t>, 24B) — its content was never
 // read; the consumer's outgoing-ray count is outgoing_w_.size() — shrinking 240 → 216.
 // S1 device-fused: adds xyz_pixel_data_ (vector<float>, 24B) + xyz_landed_weight_
-// (float, 4B) + 4B padding = 32B total, bumping 216 → 248.
-static_assert(sizeof(SimData) == 248, "SimData size changed — update copy/move ctors and operators");
+// (float, 4B) + 4B padding = 32B total, bumping 216 → 248. task-exit-seam-
+// crystal-count adds crystal_count_ (size_t, 8B) for exit-seam stats, bumping
+// 248 → 256.
+static_assert(sizeof(SimData) == 256, "SimData size changed — update copy/move ctors and operators");
 
 namespace {
 
@@ -313,7 +315,8 @@ SimData::SimData(const SimData& other)
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(other.rays_), crystals_(other.crystals_),
       crystal_axis_dists_(other.crystal_axis_dists_), outgoing_d_(other.outgoing_d_), outgoing_w_(other.outgoing_w_),
       outgoing_wl_(other.outgoing_wl_), exit_records_(other.exit_records_), xyz_pixel_data_(other.xyz_pixel_data_),
-      xyz_landed_weight_(other.xyz_landed_weight_), root_ray_count_(other.root_ray_count_) {}
+      xyz_landed_weight_(other.xyz_landed_weight_), root_ray_count_(other.root_ray_count_),
+      crystal_count_(other.crystal_count_) {}
 
 SimData::SimData(SimData&& other) noexcept
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(std::move(other.rays_)),
@@ -321,7 +324,7 @@ SimData::SimData(SimData&& other) noexcept
       outgoing_d_(std::move(other.outgoing_d_)), outgoing_w_(std::move(other.outgoing_w_)),
       outgoing_wl_(std::move(other.outgoing_wl_)), exit_records_(std::move(other.exit_records_)),
       xyz_pixel_data_(std::move(other.xyz_pixel_data_)), xyz_landed_weight_(other.xyz_landed_weight_),
-      root_ray_count_(other.root_ray_count_) {}
+      root_ray_count_(other.root_ray_count_), crystal_count_(other.crystal_count_) {}
 
 SimData& SimData::operator=(const SimData& other) {
   if (&other == this) {
@@ -340,6 +343,7 @@ SimData& SimData::operator=(const SimData& other) {
   xyz_pixel_data_ = other.xyz_pixel_data_;
   xyz_landed_weight_ = other.xyz_landed_weight_;
   root_ray_count_ = other.root_ray_count_;
+  crystal_count_ = other.crystal_count_;
   return *this;
 }
 
@@ -366,6 +370,7 @@ SimData& SimData::operator=(SimData&& other) noexcept {
   xyz_pixel_data_ = std::move(other.xyz_pixel_data_);
   xyz_landed_weight_ = other.xyz_landed_weight_;
   root_ray_count_ = other.root_ray_count_;
+  crystal_count_ = other.crystal_count_;
   return *this;
 }
 

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -163,6 +163,12 @@ struct SimData {
   float xyz_landed_weight_ = 0.0f;
 
   size_t root_ray_count_ = 0;  // Count of root rays (prev_ray_idx_ == kInfSize)
+
+  // Crystal count for stats reporting. Populated by legacy path from
+  // all_crystals.size() and by exit-seam path from
+  // TraceBackend::GetLastBatchCrystalCount() (== final-layer setting count).
+  // See scrum-cleanup-cuda-ci-misc/task-exit-seam-crystal-count.
+  size_t crystal_count_ = 0;
 };
 
 using SimDataPtrS = std::shared_ptr<SimData>;

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -477,6 +477,7 @@ void CpuTraceBackend::EndSession() {
   in_session_ = false;
   ms_idx_ = 0;
   root_ray_count_ = 0;
+  last_layer_crystal_count_ = 0;  // task-exit-seam-crystal-count: lifecycle symmetry with BeginSession
   total_landed_weight_ = 0.0f;
   xyz_buf_.reset();
   continuation_buf_ = RayBuffer{};

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -242,6 +242,7 @@ void CpuTraceBackend::BeginSession(const SessionSpec& spec) {
 
   continuation_buf_ = RayBuffer{};
   exit_records_.clear();
+  last_layer_crystal_count_ = 0;
 }
 
 
@@ -268,6 +269,13 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
   // proportions from setting_[ci].crystal_proportion_ + zeros carry (one
   // session = one wavelength here, no cross-wavelength accumulation).
   size_t crystal_cnt = ms_info.setting_.size();
+  // task-exit-seam-crystal-count: record final MS layer setting count for
+  // Simulator to feed SimData.crystal_count_. Semantics: last layer only,
+  // not cross-layer sum (mirrors Metal `last_layer_crystals_` /
+  // CUDA `final_layer_crystals_`).
+  if (ms_idx_ + 1 == spec_.scene->ms_.size()) {
+    last_layer_crystal_count_ = crystal_cnt;
+  }
   std::vector<float> proportions;
   proportions.reserve(crystal_cnt);
   for (size_t ci = 0; ci < crystal_cnt; ci++) {

--- a/src/core/backend/cpu_trace_backend.hpp
+++ b/src/core/backend/cpu_trace_backend.hpp
@@ -68,6 +68,10 @@ class CpuTraceBackend : public TraceBackend {
   size_t RootRayCount() const { return root_ray_count_; }
   float TotalLandedWeight() const { return total_landed_weight_; }
 
+  // task-exit-seam-crystal-count: setting count of the final MS layer for the
+  // current session. Set by TraceLayer when processing the last layer.
+  size_t GetLastBatchCrystalCount() const override { return last_layer_crystal_count_; }
+
  private:
   SessionSpec spec_{};
   RandomNumberGenerator rng_;
@@ -77,7 +81,8 @@ class CpuTraceBackend : public TraceBackend {
   int height_ = 0;
 
   size_t root_ray_count_ = 0;
-  size_t ms_idx_ = 0;  // advances on each Recombine.
+  size_t last_layer_crystal_count_ = 0;  // task-exit-seam-crystal-count
+  size_t ms_idx_ = 0;                    // advances on each Recombine.
   float total_landed_weight_ = 0.0f;
 
   // Backend-owned storage for the device-resident handle returned by Recombine.

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -181,45 +181,40 @@ void CheckCuda(cudaError_t err, const char* ctx) {
   }
 }
 
-// Exit buffer capacity. Coefficient 2 = reflect+refract conservative upper
-// bound per hit; +4 = safety margin matching the Metal EnsureExitBuffers
-// constant.
-//
-// `n_roots * (max_hits*2 + 4)` is the ANALYTIC HARD upper bound on exit records
-// a layer can emit (every root emits at most that many), so sizing to it means
-// the kernel's `slot < exit_cap` append guard can never trip and no exit is ever
-// silently dropped. A former `std::min` with a 64 MiB cap (~762600 records) was
-// a memory optimization, but it CORRUPTED output for high-continuation configs
-// that exceed it even at the DEFAULT dispatch: scrum-296 Step D dig-out found
-// ms_multi_crystal's layer-1 emitted ~954k > 762k → tail dropped → ds_corr vs
-// legacy fell to 0.913, while total energy (1.02) and cross-seed self-corr
-// (0.9998) both stayed clean and MASKED the bug (only corr-vs-legacy caught it).
-// Correctness over memory: size to the true bound. A dispatch so large the
-// buffer cannot be allocated fails via cudaMalloc → BackendUnavailableError →
-// graceful legacy fallback — never silently-wrong output. (See the seam-design
-// follow-up: the exit-record host round-trip is the real CUDA throughput
-// bottleneck and wants device-side accumulation rather than a bigger buffer.)
-size_t ComputeExitCap(size_t n_roots, size_t max_hits) {
-  return n_roots * (max_hits * 2u + 4u);
-}
-
 // scrum-306.2: CUDA's HasDeviceXyzAccum() is unconditionally true, so every exit
 // is accumulated into d_xyz_buf_ via EmitToDeviceXyz — the trace kernel writes
 // NOTHING to d_exit_ / d_exit_count_ (DrainExits always reads 0 records). The
-// d_exit_/pinned_exit_ pool is therefore dead weight; sizing it to ComputeExitCap
-// (n × (2·max_hits+4)) ballooned to GBs at large LUMICE_DISPATCH_RAY_NUM, causing
-// the big-dispatch throughput collapse + parity OOM. Allocate a token slot so the
-// kernel's (unused) d_exit pointer stays bindable. If HasDeviceXyzAccum ever goes
-// false, restore ComputeExitCap sizing AND the kernel's d_exit write path together.
+// d_exit_/pinned_exit_ pool is therefore dead weight; sizing it to the analytic
+// bound (n_roots × (2·max_hits+4), formerly computed by a since-removed
+// ComputeExitCap helper) ballooned to GBs at large LUMICE_DISPATCH_RAY_NUM,
+// causing the big-dispatch throughput collapse + parity OOM. Allocate a token
+// slot so the kernel's (unused) d_exit pointer stays bindable. If
+// HasDeviceXyzAccum ever goes false, restore that analytic-bound sizing (see
+// ComputeContCap below for the still-live formula) AND the kernel's d_exit
+// write path together.
 constexpr size_t kCudaDeadExitCap = 256u;
 
-// Continuation buffer capacity (296.4). Each root may emit up to
-// (max_hits * 2 + 4) candidate continuations (matches ComputeExitCap upper
-// bound — every outward exit is a continuation candidate). Sized to the same
-// analytic hard upper bound (no silent-drop cap) for the same correctness
-// reason as ComputeExitCap: a dropped continuation loses a downstream ray's
-// entire sub-tree. Cont slots (~20B) are smaller than ExitRayRecord, so this
-// pool's footprint stays below the exit pool's.
+// Continuation buffer capacity (296.4). Coefficient 2 = reflect+refract
+// conservative upper bound per hit; +4 = safety margin matching the Metal
+// EnsureExitBuffers constant. Each root may emit up to (max_hits * 2 + 4)
+// candidate continuations — every outward exit is a continuation candidate.
+//
+// `n_roots * (max_hits*2 + 4)` is the ANALYTIC HARD upper bound on records a
+// layer can emit (every root emits at most that many), so sizing to it means
+// the kernel's `slot < cont_cap` append guard can never trip and no
+// continuation is ever silently dropped. A former `std::min` with a 64 MiB cap
+// (~762600 records, then shared with the now-removed exit-cap sizing) was a
+// memory optimization, but it CORRUPTED output for high-continuation configs
+// that exceed it even at the DEFAULT dispatch: scrum-296 Step D dig-out found
+// ms_multi_crystal's layer-1 emitted ~954k > 762k → tail dropped → ds_corr vs
+// legacy fell to 0.913, while total energy (1.02) and cross-seed self-corr
+// (0.9998) both stayed clean and MASKED the bug (only corr-vs-legacy caught
+// it). Correctness over memory: size to the true bound — a dropped
+// continuation loses a downstream ray's entire sub-tree. A dispatch so large
+// the buffer cannot be allocated fails via cudaMalloc → BackendUnavailableError
+// → graceful legacy fallback — never silently-wrong output. Cont slots (~20B)
+// are smaller than ExitRayRecord, so this pool's footprint stays below the
+// (now-dead) exit pool's.
 size_t ComputeContCap(size_t n_roots, size_t max_hits) {
   return n_roots * (max_hits * 2u + 4u);
 }
@@ -389,19 +384,6 @@ void FillTriToPoly(const Crystal& crystal, std::vector<uint16_t>& out) {
 
 __device__ inline float dot3(const float* a, const float* b) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-}
-
-// Build ExitFaceSeq from a thread-local face-id record. `len` is bounded by
-// the caller (rec_len) via the `if (rec_len < ExitFaceSeq::kCap)` guard on
-// every append, so `len <= kCap` is invariant here. uint32_t loop counter
-// (not uint8_t) keeps the comparison correct should kCap ever grow > 255.
-__device__ inline ExitFaceSeq BuildExitPath(const uint8_t* path_rec, uint32_t len) {
-  ExitFaceSeq seq{};  // zero-init data_[kCap]; trailing bytes stay 0
-  seq.size_ = static_cast<uint8_t>(len);
-  for (uint32_t k = 0u; k < len; ++k) {
-    seq.data_[k] = path_rec[k];
-  }
-  return seq;
 }
 
 // S2 device-fused projection + XYZ accumulation for the ms_mode==0 emit gate.

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -3020,6 +3020,13 @@ uint32_t CudaTraceBackend::WlPoolSize() const {
   return ResolveWlPoolSize(logger);
 }
 
+size_t CudaTraceBackend::GetLastBatchCrystalCount() const {
+  // task-exit-seam-crystal-count: Impl::final_layer_crystals_ is populated
+  // during BeginSession (cuda_trace_backend.cu:2078-2093), so it can be read
+  // safely anytime the session is open.
+  return impl_->final_layer_crystals_.size();
+}
+
 }  // namespace lumice
 
 #endif  // defined(LUMICE_CUDA_ENABLED)

--- a/src/core/backend/cuda_trace_backend.hpp
+++ b/src/core/backend/cuda_trace_backend.hpp
@@ -112,6 +112,11 @@ class CudaTraceBackend : public TraceBackend {
   // driving loop queries it first). Mirrors MetalTraceBackend::WlPoolSize().
   uint32_t WlPoolSize() const override;
 
+  // task-exit-seam-crystal-count: setting count of the final MS layer for the
+  // current session. Backed by Impl::final_layer_crystals_ populated during
+  // BeginSession — safe to read anytime the session is open.
+  size_t GetLastBatchCrystalCount() const override;
+
  private:
   struct Impl;
   std::unique_ptr<Impl> impl_;

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -113,6 +113,12 @@ class MetalTraceBackend : public TraceBackend {
   // thereafter for the backend instance's lifetime.
   uint32_t WlPoolSize() const override;
 
+  // task-exit-seam-crystal-count: setting count of the final MS layer for the
+  // current session. Backed by Impl::last_layer_crystals_ (populated during
+  // the last TraceLayer call). Simulator reads this after the MS loop to
+  // fill SimData.crystal_count_ for stats reporting.
+  size_t GetLastBatchCrystalCount() const override;
+
   // [TEST-ONLY] Return the trace_layer_kernel PSO's
   // maxTotalThreadsPerThreadgroup (or 0 if BeginSession has not yet built the
   // PSO). Used by the scrum-267 task-fused-emit-gate occupancy regression

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -2446,6 +2446,13 @@ uint32_t MetalTraceBackend::WlPoolSize() const {
   return impl_->wl_pool_size_ != 0u ? impl_->wl_pool_size_ : ResolveWlPoolSize(EffectiveLogger(impl_->logger_));
 }
 
+size_t MetalTraceBackend::GetLastBatchCrystalCount() const {
+  // task-exit-seam-crystal-count: Impl::last_layer_crystals_ is resized/filled
+  // only during the final layer's TraceLayer call (see the block at
+  // metal_trace_backend.mm:2127-2168); reading before EndSession is safe.
+  return impl_->last_layer_crystals_.size();
+}
+
 size_t MetalTraceBackend::TraceLayerKernelMaxThreadsForTest() const {
   if (impl_->pso == nil) {
     return 0;

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -467,14 +467,19 @@ class TraceBackend {
   // consumed by Simulator to fill SimData.crystal_count_ for stats reporting.
   //
   // ⚠️ DELIBERATE CROSS-BACKEND SEMANTIC DIFFERENCE (owner-confirmed, 2026-07-01):
-  // the `crystals` stat means DIFFERENT PHYSICAL QUANTITIES per backend today:
-  //   * legacy CPU (SimulateOneWavelength): per-batch Crystal-instance count —
-  //     one Crystal emplaced per kSmallBatchRayNum for random-orientation
-  //     scenes, so it grows ~ray_num/32 (e.g. ~313 for 10k rays).
-  //   * GPU exit-seam (this accessor): final-layer crystal *setting* count —
-  //     a small constant (typically 1-5), because device-gen samples each
-  //     ray's orientation independently and has no "Crystal instance per batch"
-  //     concept.
+  // StatsConsumer ACCUMULATES this per-batch value, but the per-batch increment
+  // means DIFFERENT PHYSICAL QUANTITIES per backend today, so the displayed
+  // `crystals` total diverges by a large factor:
+  //   * legacy CPU (SimulateOneWavelength): per-batch Crystal-INSTANCE count —
+  //     one Crystal emplaced per small batch for random-orientation scenes, so
+  //     the accumulated total grows ~ray_num/128.
+  //   * GPU exit-seam (this accessor): final-layer crystal *SETTING* count —
+  //     a small constant (typically 1-5) per dispatch, because device-gen
+  //     samples each ray's orientation independently and has no "Crystal
+  //     instance per batch" concept; accumulated total grows ~ray_num/dispatch.
+  // Measured (config_example, dev49 2026-07-01): CPU ≈15454 crystals @1.98M
+  // rays vs CUDA ≈2 @524K rays — an ~2000× gap at equal ray count. Both are
+  // non-zero and internally consistent; they are simply not the same metric.
   // This gap is architectural, not a bug, and is acceptable because the ONLY
   // consumer of this stat is the CLI diagnostic line (main.cpp `Stats: ...
   // crystals=N`) — the GUI does not display it and no internal logic depends

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -466,10 +466,23 @@ class TraceBackend {
   // after BeginSession (CUDA) or after the final TraceLayer call (Metal / CPU),
   // consumed by Simulator to fill SimData.crystal_count_ for stats reporting.
   //
-  // Semantics warning: this is the final-layer setting count, NOT a per-batch
-  // Crystal instance count analogous to the legacy CPU path (which emplaces
-  // one Crystal per kSmallBatchRayNum for random-orientation scenes). Do not
-  // use this value in a bit-parity assertion against legacy stats.
+  // ⚠️ DELIBERATE CROSS-BACKEND SEMANTIC DIFFERENCE (owner-confirmed, 2026-07-01):
+  // the `crystals` stat means DIFFERENT PHYSICAL QUANTITIES per backend today:
+  //   * legacy CPU (SimulateOneWavelength): per-batch Crystal-instance count —
+  //     one Crystal emplaced per kSmallBatchRayNum for random-orientation
+  //     scenes, so it grows ~ray_num/32 (e.g. ~313 for 10k rays).
+  //   * GPU exit-seam (this accessor): final-layer crystal *setting* count —
+  //     a small constant (typically 1-5), because device-gen samples each
+  //     ray's orientation independently and has no "Crystal instance per batch"
+  //     concept.
+  // This gap is architectural, not a bug, and is acceptable because the ONLY
+  // consumer of this stat is the CLI diagnostic line (main.cpp `Stats: ...
+  // crystals=N`) — the GUI does not display it and no internal logic depends
+  // on it. Do NOT use this value in a bit-parity assertion against legacy stats.
+  // UNIFY LATER: when crystal geometry randomization lands (crystal itself
+  // becomes a sampled quantity, like rays), the count becomes a genuine
+  // ray-count-like metric and both backends should converge on one meaning.
+  // See backlog "统一 crystal 计数语义（几何随机化落地时）".
   virtual size_t GetLastBatchCrystalCount() const { return 0; }
 
   TraceBackend(const TraceBackend&) = delete;

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -461,6 +461,17 @@ class TraceBackend {
   // and the simulator falls back to per-batch wl in SimData.outgoing_wl_.
   virtual uint32_t WlPoolSize() const { return 0; }
 
+  // task-exit-seam-crystal-count: number of crystal settings in the final
+  // (last) MS layer for the most recent session. Populated by the backend
+  // after BeginSession (CUDA) or after the final TraceLayer call (Metal / CPU),
+  // consumed by Simulator to fill SimData.crystal_count_ for stats reporting.
+  //
+  // Semantics warning: this is the final-layer setting count, NOT a per-batch
+  // Crystal instance count analogous to the legacy CPU path (which emplaces
+  // one Crystal per kSmallBatchRayNum for random-orientation scenes). Do not
+  // use this value in a bit-parity assertion against legacy stats.
+  virtual size_t GetLastBatchCrystalCount() const { return 0; }
+
   TraceBackend(const TraceBackend&) = delete;
   TraceBackend(TraceBackend&&) = delete;
   TraceBackend& operator=(const TraceBackend&) = delete;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -972,6 +972,7 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
   sim_data.outgoing_d_ = std::move(outgoing_d);
   sim_data.outgoing_w_ = std::move(outgoing_w);
   sim_data.root_ray_count_ = original_ray_num;
+  sim_data.crystal_count_ = sim_data.crystals_.size();
   data_queue_->Emplace(std::move(sim_data));
 }
 
@@ -1093,6 +1094,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     sim_data.curr_wl_ = wl_param.wl_;
     sim_data.generation_ = generation;
     sim_data.root_ray_count_ = ray_num;
+    sim_data.crystal_count_ = backend.GetLastBatchCrystalCount();
     size_t pix = static_cast<size_t>(w) * static_cast<size_t>(h);
     sim_data.xyz_pixel_data_.resize(pix * 3u);
     XyzImageData xyz_out;
@@ -1145,6 +1147,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   sim_data.root_ray_count_ = ray_num;  // distinguishes a valid backend batch
                                        // from the shutdown sentinel (see
                                        // server.cpp::ConsumeData).
+  sim_data.crystal_count_ = backend.GetLastBatchCrystalCount();
   sim_data.outgoing_d_ = std::move(exit_d);
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -833,6 +833,7 @@ void ServerImpl::ConsumeData() {
               // same totals as a single whole-Consume call would yield.
               if (emitted == 0) {
                 chunk.root_ray_count_ = sim_data.root_ray_count_;
+                chunk.crystal_count_ = sim_data.crystal_count_;
                 chunk.crystals_ = sim_data.crystals_;
                 chunk.crystal_axis_dists_ = sim_data.crystal_axis_dists_;
               }

--- a/src/server/stats.cpp
+++ b/src/server/stats.cpp
@@ -7,7 +7,7 @@ namespace lumice {
 void StatsConsumer::Consume(const SimData& data) {
   sim_rays_ += data.root_ray_count_;
   total_rays_ += data.rays_.size_;
-  crystals_ += data.crystals_.size();
+  crystals_ += data.crystal_count_;
 }
 
 void StatsConsumer::PrepareSnapshot() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/config/test_sim_data.cpp"
   # server/
   "${PROJ_TEST_DIR}/unit-correctness/server/test_c_api.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/server/test_stats_consumer.cpp"
   # util/
   "${PROJ_TEST_DIR}/unit-correctness/util/test_color_space.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/util/test_queue.cpp"

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -460,5 +460,82 @@ TEST(CpuTraceBackend, CrossHitFanoutDoesNotOverflowWorkspace) {
   backend.EndSession();
 }
 
+// =============================================================================
+// Test — task-exit-seam-crystal-count: GetLastBatchCrystalCount() returns the
+// setting count of the FINAL MS layer (not cross-layer sum). This locks the
+// deliberate semantic decision from plan §2 default assumption 2.
+// =============================================================================
+TEST(CpuTraceBackend, GetLastBatchCrystalCountReturnsFinalLayerSettings) {
+  // Single-MS single-crystal → count == 1.
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 1;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 256;
+    host.crystal = nullptr;
+    backend.TraceLayer(RootRaySource::FromHost(host));
+
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    backend.EndSession();
+  }
+
+  // Multi-MS: layer 0 has 1 crystal, layer 1 (final) has 3 crystals.
+  // Return value MUST be 3 (final-layer settings count), NOT 4 (1+3 sum).
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/2);
+    // Extend final layer to 3 crystals by cloning the existing setting.
+    auto& final_ms = scene.ms_.back();
+    ScatteringSetting extra1 = final_ms.setting_.front();
+    ScatteringSetting extra2 = final_ms.setting_.front();
+    final_ms.setting_.front().crystal_proportion_ = 0.4f;
+    extra1.crystal_.id_ = 100;
+    extra1.crystal_proportion_ = 0.3f;
+    extra2.crystal_.id_ = 101;
+    extra2.crystal_proportion_ = 0.3f;
+    final_ms.setting_.push_back(std::move(extra1));
+    final_ms.setting_.push_back(std::move(extra2));
+    ASSERT_EQ(final_ms.setting_.size(), 3u);
+    ASSERT_EQ(scene.ms_.front().setting_.size(), 1u);
+
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 3;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 512;
+    host.crystal = nullptr;
+    auto h0 = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0, nullptr);
+    // After first (non-final) layer: last_layer count is still 0 (or the
+    // final-layer count once the last layer runs); this test only asserts
+    // the final observed value after all layers, but along the way must not
+    // pick up layer-0's count.
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Non-final layer must not populate last_layer_crystal_count_";
+
+    RecombineSpec rspec;
+    rspec.shuffle = true;
+    auto roots1 = backend.Recombine(std::move(h0), rspec);
+    backend.TraceLayer(roots1);
+
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 3u) << "Final-layer settings count, not cross-layer sum (would be 4)";
+
+    backend.EndSession();
+    // After EndSession the counter is reset by BeginSession on next open.
+  }
+}
+
 }  // namespace
 }  // namespace lumice

--- a/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
@@ -217,6 +217,69 @@ TEST(CudaRichExit, ExitFaceIsValid) {
   }
 }
 
+// =============================================================================
+// task-exit-seam-crystal-count: CUDA backend reports final-layer setting count.
+// Semantics: return value is the LAST MS layer's setting count (mirrors
+// Impl::final_layer_crystals_ populated during BeginSession), not a cross-layer
+// sum. Locks plan §2 default assumption 2.
+// =============================================================================
+TEST(CudaBackendCrystalCount, ReturnsFinalLayerSettings) {
+  if (!CudaDeviceAvailable()) {
+    GTEST_SKIP() << "No CUDA device available on this host.";
+  }
+
+  // Case 1 — single MS, single crystal setting → count == 1.
+  {
+    auto scene = MakePrismScene(/*max_hits=*/4);
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 21;
+
+    CudaTraceBackend backend;
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    backend.EndSession();
+  }
+
+  // Case 2 — multi MS scene with 3 settings on the FINAL layer, 1 on the
+  // first. Return value MUST be 3, not 4 (cross-layer sum).
+  {
+    auto scene = MakePrismScene(/*max_hits=*/4);
+    // Convert single-MS scene to 2-MS: original layer becomes the first
+    // (with prob>0 to route continuations), append a final layer with 3
+    // crystal settings.
+    scene.ms_.front().prob_ = 0.6f;
+
+    MsInfo final_ms;
+    final_ms.prob_ = 0.0f;
+    ScatteringSetting base = scene.ms_.front().setting_.front();
+    for (int i = 0; i < 3; i++) {
+      ScatteringSetting s = base;
+      s.crystal_.id_ = static_cast<IdType>(100 + i);
+      s.crystal_proportion_ = 1.0f / 3.0f;
+      final_ms.setting_.push_back(std::move(s));
+    }
+    scene.ms_.push_back(std::move(final_ms));
+    ASSERT_EQ(scene.ms_.back().setting_.size(), 3u);
+    ASSERT_EQ(scene.ms_.front().setting_.size(), 1u);
+
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 23;
+
+    CudaTraceBackend backend;
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 3u) << "Final-layer settings count, not cross-layer sum (would be 4)";
+    backend.EndSession();
+  }
+}
+
 }  // namespace
 }  // namespace lumice
 

--- a/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
@@ -230,6 +230,80 @@ TEST(MetalTraceBackend, TraceLayerKernelOccupancy) {
          "and progress.md for context.";
 }
 
+// =============================================================================
+// task-exit-seam-crystal-count: Metal backend reports final-layer setting count.
+// Semantics locked here: return value is the LAST MS layer's setting count
+// (mirrors Impl::last_layer_crystals_), not a cross-layer sum.
+// =============================================================================
+TEST(MetalTraceBackend, GetLastBatchCrystalCountReturnsFinalLayerSettings) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  // Single-MS single-crystal → count == 1.
+  {
+    auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/1);
+    auto render = MakeRectangularRender();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 11;
+
+    MetalTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 512;
+    host.crystal = nullptr;
+    host.refractive_index = 0.0f;
+    backend.TraceLayer(RootRaySource::FromHost(host));
+
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    backend.EndSession();
+  }
+
+  // Multi-MS: final layer has 3 crystal settings. Return value MUST be 3.
+  {
+    auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/2);
+    auto& final_ms = scene.ms_.back();
+    ScatteringSetting extra1 = final_ms.setting_.front();
+    ScatteringSetting extra2 = final_ms.setting_.front();
+    final_ms.setting_.front().crystal_proportion_ = 0.4f;
+    extra1.crystal_.id_ = 100;
+    extra1.crystal_proportion_ = 0.3f;
+    extra2.crystal_.id_ = 101;
+    extra2.crystal_proportion_ = 0.3f;
+    final_ms.setting_.push_back(std::move(extra1));
+    final_ms.setting_.push_back(std::move(extra2));
+    ASSERT_EQ(final_ms.setting_.size(), 3u);
+    ASSERT_EQ(scene.ms_.front().setting_.size(), 1u);
+
+    auto render = MakeRectangularRender();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 13;
+
+    MetalTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 1024;
+    host.crystal = nullptr;
+    host.refractive_index = 0.0f;
+
+    auto h0 = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0, nullptr);
+    RecombineSpec rspec;
+    rspec.shuffle = false;
+    auto roots1 = backend.Recombine(std::move(h0), rspec);
+    backend.TraceLayer(roots1);
+
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 3u) << "Final-layer settings count, not cross-layer sum (would be 4)";
+    backend.EndSession();
+  }
+}
+
 }  // namespace
 }  // namespace lumice
 

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -47,8 +47,9 @@ static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 // chore-292 (A2) removes the vestigial outgoing_indices_ (vector<size_t>, 24B)
 // — content never read; count = outgoing_w_.size() — shrinking 240 → 216.
 // S1 device-fused: adds xyz_pixel_data_ (vector<float>, 24B) + xyz_landed_weight_
-// (float, 4B) + 4B padding = 32B, bumping 216 → 248.
-static_assert(sizeof(SimData) == 248,
+// (float, 4B) + 4B padding = 32B, bumping 216 → 248. task-exit-seam-crystal-count
+// adds crystal_count_ (size_t, 8B) for exit-seam stats, bumping 248 → 256.
+static_assert(sizeof(SimData) == 256,
               "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
               "and sim_data.cpp's static_assert.");
 #endif
@@ -104,6 +105,8 @@ SimData MakePopulatedSimData() {
   s.xyz_pixel_data_ = { 0.1f, 0.2f, 0.3f };
   s.xyz_landed_weight_ = 1.5f;
   s.crystals_.emplace_back();
+  // task-exit-seam-crystal-count: propagation coverage for the new field.
+  s.crystal_count_ = 4;
   return s;
 }
 
@@ -808,6 +811,7 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   EXPECT_EQ(copy.exit_records_[1].ms_layer_idx, 1u);
   EXPECT_EQ(copy.xyz_pixel_data_, original.xyz_pixel_data_);  // S1 device-fused
   EXPECT_FLOAT_EQ(copy.xyz_landed_weight_, 1.5f);
+  EXPECT_EQ(copy.crystal_count_, 4u) << "crystal_count_ not copied";  // task-exit-seam-crystal-count
 
   // Deep copy independence — each pointer/container field independently.
   copy.rays_[0].w_ = 999.0f;
@@ -852,6 +856,7 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   EXPECT_EQ(target.exit_records_[0].crystal_id, 7u);
   EXPECT_EQ(target.xyz_pixel_data_, original.xyz_pixel_data_);  // S1 device-fused
   EXPECT_FLOAT_EQ(target.xyz_landed_weight_, 1.5f);
+  EXPECT_EQ(target.crystal_count_, 4u) << "crystal_count_ not assigned";  // task-exit-seam-crystal-count
 
   // Deep copy independence.
   target.rays_[0].w_ = 999.0f;
@@ -905,6 +910,7 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   EXPECT_EQ(moved.crystals_.size(), 1u);
   EXPECT_EQ(moved.xyz_pixel_data_.size(), 3u);  // S1 device-fused
   EXPECT_FLOAT_EQ(moved.xyz_landed_weight_, 1.5f);
+  EXPECT_EQ(moved.crystal_count_, 4u) << "crystal_count_ not moved";  // task-exit-seam-crystal-count
 
   // Moved-from source contract — three categories:
   // (a) rays_ pointer ownership transferred → nullptr + zeroed size/capacity.
@@ -941,6 +947,7 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_FLOAT_EQ(dst.curr_wl_, 550.0f);
   EXPECT_EQ(dst.generation_, 42u);
   EXPECT_EQ(dst.crystals_.size(), 1u);
+  EXPECT_EQ(dst.crystal_count_, 4u) << "crystal_count_ not move-assigned";  // task-exit-seam-crystal-count
 
   // Source moved-from state.
   EXPECT_EQ(src.rays_.rays_, nullptr);

--- a/test/unit-correctness/server/test_stats_consumer.cpp
+++ b/test/unit-correctness/server/test_stats_consumer.cpp
@@ -1,0 +1,90 @@
+// StatsConsumer unit tests (task-exit-seam-crystal-count).
+//
+// Locks the "crystals_ accumulates SimData.crystal_count_ (not
+// crystals_.size())" contract switched in stats.cpp, and covers the
+// server.cpp:834 "only-first-chunk carries stats fields" invariant that
+// chunked SimData dispatch relies on: with the new field, feeding N chunks
+// where only the first has crystal_count_ set must yield exactly that value
+// (not N× that value, not 0).
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+#include "config/sim_data.hpp"
+#include "server/stats.hpp"
+
+namespace lumice {
+namespace {
+
+TEST(StatsConsumer, CrystalCountAccumulatesAcrossBatches) {
+  StatsConsumer stats;
+
+  SimData batch1;
+  batch1.crystal_count_ = 3;
+  batch1.root_ray_count_ = 100;
+  stats.Consume(batch1);
+
+  SimData batch2;
+  batch2.crystal_count_ = 5;
+  batch2.root_ray_count_ = 200;
+  stats.Consume(batch2);
+
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
+  const auto& r = std::get<StatsResult>(result);
+  EXPECT_EQ(r.crystal_num_, 8u);
+  EXPECT_EQ(r.sim_ray_num_, 300u);
+}
+
+TEST(StatsConsumer, ResetClearsCrystalCount) {
+  StatsConsumer stats;
+  SimData batch;
+  batch.crystal_count_ = 7;
+  batch.root_ray_count_ = 42;
+  stats.Consume(batch);
+
+  stats.Reset();
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
+  const auto& r = std::get<StatsResult>(result);
+  EXPECT_EQ(r.crystal_num_, 0u);
+  EXPECT_EQ(r.sim_ray_num_, 0u);
+}
+
+// Server-side chunk dispatch invariant (server.cpp:834): when a large SimData
+// is fanned out to N chunks, ONLY the first chunk carries the stats fields
+// (root_ray_count_, crystal_count_). This test simulates that dispatch and
+// verifies that accumulating N chunks yields exactly the original crystal
+// count once — no N× duplication, no zero.
+TEST(StatsConsumer, ChunkedDispatchAccumulatesFirstChunkOnlyOnce) {
+  constexpr size_t kOriginalCrystals = 4;
+  constexpr size_t kOriginalRootRays = 512;
+  constexpr int kChunkCount = 5;
+
+  StatsConsumer stats;
+  for (int i = 0; i < kChunkCount; i++) {
+    SimData chunk;
+    if (i == 0) {
+      chunk.crystal_count_ = kOriginalCrystals;
+      chunk.root_ray_count_ = kOriginalRootRays;
+    }
+    // Non-first chunks carry only per-chunk outgoing rays (not modelled here).
+    stats.Consume(chunk);
+  }
+
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
+  const auto& r = std::get<StatsResult>(result);
+  EXPECT_EQ(r.crystal_num_, kOriginalCrystals) << "First-chunk-only dispatch: expected the original crystal_count_, "
+                                                  "not "
+                                               << kChunkCount << "x or 0.";
+  EXPECT_EQ(r.sim_ray_num_, kOriginalRootRays)
+      << "First-chunk-only dispatch: root_ray_count_ must also only be counted once.";
+}
+
+}  // namespace
+}  // namespace lumice


### PR DESCRIPTION
清理 + 杂项 batch（scrum-cleanup-cuda-ci-misc #311）。三个独立子任务，全程独立复核。

## 子任务

**311.1 — 删 CUDA 死代码** (`96c9a165`)
- 删 `cuda_trace_backend.cu` 两处 `#177-D declared but never referenced`（`ComputeExitCap` / `BuildExitPath`，scrum-306 exit-cap 落地后残留）。设计推理注释合并进 `ComputeContCap` / `kCudaDeadExitCap`。
- 验证：dev49 CUDA 重编译 `#177-D` 消失、无新告警。

**311.2 — CI actions Node24** (`05bba57d`)
- `Jimver/cuda-toolkit@v0.2.23 → v0.2.35`（上游首个 node24 版）。消除该 action 的 Node20 deprecation 警告。
- `ilammy/msvc-dev-cmd` 上游最新 v1.13.0 仍 node20，无 node24 版可升 → 保持 `@v1`（blocked-on-upstream）。
- 本 PR 用于核对 `windows-cuda-compile` job 仍绿 + cuda-toolkit 侧 Node20 警告消失。

**311.3 — exit-seam crystals 漏报修复** (`59028c4c` `35c76c75` `5fa0eb3d` `b64467f0`)
- Metal/CUDA exit-seam 渲染下 `Stats: crystals=0`：新增 `SimData::crystal_count_` + `TraceBackend::GetLastBatchCrystalCount()`（CPU/Metal/CUDA 三后端实现），StatsConsumer 改累新字段。
- **刻意的跨后端语义差异**（owner 确认）：legacy CPU = per-batch Crystal 实例数；GPU exit-seam = 最终 MS 层 crystal setting 数。唯一消费者是 CLI 诊断行，GUI 不显示、无内部逻辑依赖。语义在 `trace_backend.hpp::GetLastBatchCrystalCount` 大段注释固化，几何随机化落地时再统一（已入 backlog）。

## 验证

- Mac：build + 单测 4/4（含新 `crystal_count_` 单测）+ Metal parity。
- **dev49（4060Ti）**：CUDA build + parity battery **10/10** + CLI `crystals` 非零（实测 CUDA≈2 vs CPU≈15454）。
- **win-builder（1070Ti/sm_61）**：CUDA build + parity battery **10/10**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)