### PR TITLE
feat(gpu): third-clock readback decoupling — fix high-resolution GPU throughput

### DIFF
--- a/doc/env-var-policy.md
+++ b/doc/env-var-policy.md
@@ -40,6 +40,7 @@ env 是标准做法，不在治理范围内。
 | `LUMICE_TRACE_BACKEND` | `env::TraceBackendOverride` ← `simulator.cpp` `CreateBackend` / `server.cpp` `ResolveMetalRoute` | 选后端 `legacy`/`cpu_backend`/`metal`——**曾经的 footgun，已降级** | **CLI `--backend auto\|cpu\|metal`**（`src/main.cpp`）+ C API `LUMICE_SetPreferredBackend` / GUI checkbox。env 仅作 debug/CI 覆盖，生效即 WARN |
 | `LUMICE_DISPATCH_RAY_NUM` | `env::DispatchRayNum` ← `server.cpp` `GenerateScene` | GPU dispatch 粒度（perf 旋钮） | 无（纯实验旋钮，启动 INFO 可观测） |
 | `LUMICE_COMMIT_RAY_NUM` | `env::CommitRayNum` ← `server.cpp` `ConsumeData` | commit 粒度（perf 旋钮） | 无（纯实验旋钮，启动 INFO 可观测） |
+| `LUMICE_XYZ_DRAIN_BATCHES` | `env::XyzDrainBatches` ← `simulator.cpp` `Run` | scrum-312 第三时钟 drain cadence 上限（每 N 个 device-fused batch 强制回读 XYZ；perf/精度旋钮，CUDA 路径） | 无（纯实验旋钮，启动 INFO 可观测；GUI 显示节奏主要由 producer-pause flush 驱动，此为 burst 内上界） |
 | `LUMICE_BATCH_RAY_NUM` | `env::CommitRayNum`（fallback） | 已废弃别名（deprecation WARN） | 由 `COMMIT_RAY_NUM` 取代 |
 | `LUMICE_DISABLE_DEVICE_GEN` | `env::DisableDeviceGen` ← `metal_trace_backend.mm` Impl ctor | 关 device-gen（实验/调试旋钮） | 无（启动 INFO 可观测） |
 | `LUMICE_DISABLE_METAL_SOURCE_COMPILE` | `env::DisableMetalSourceCompile` ← `metal_trace_backend.mm` `LoadMetalLibrary` | 关 metal 源码编译（也被回归 sentinel 当门禁用） | 无（启动 INFO 可观测） |

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -191,6 +191,38 @@ not "× legacy", when judging GPU throughput):
 > numbers are NOT comparable** — always read within one host block; never compare a
 > Mac row against a Linux row. Source: `scripts/bench_throughput.py` (default dispatch,
 > `ray_num`=20M, N≥5 reps, N=9 re-run on CoV>15%).
+>
+> ⚠️ **Third-clock路径读 `multi_wall`（rays/wall_sec），不读 `multi_med`**（后者在稀疏
+> drain 下失真，见「分辨率是一等吞吐维度」）。下方数字均为 `multi_wall`。
+
+#### scrum-312 第三时钟 canonical · `--res-sweep` · `multi_wall` · 2026-07-01
+
+**背景**：readback 从 trace 时钟解耦到显示节奏第三时钟（seam-design §4.8）。真实 GUI 分辨率
+2048×1024 下 readback/per-batch-copy 税被摊薄。`bench_light_single_ms`（轻·单MS，L2/readback 主导），
+per-resolution `multi_wall`：
+
+| host / backend | 256×128 | 512×256 | 1024×512 | 1536×768 | **2048×1024** |
+|---|---|---|---|---|---|
+| dev49 RTX 4060Ti (Ada) CUDA | 116 M/s | 110 M/s | 92 M/s | 65 M/s | **39.2 M/s** |
+| win-builder GTX 1070Ti (Pascal) CUDA | 77 M/s | 69 M/s | 45 M/s | 40 M/s | **33.5 M/s** |
+| Mac M-series Metal | 28.1 M/s | 30.3 M/s | 31.2 M/s | 35.1 M/s | **32.3 M/s** |
+| dev49 legacy CPU (baseline) | 9.0 M/s | 8.8 M/s | 8.4 M/s | 7.7 M/s | 6.9 M/s |
+| Mac legacy CPU (baseline) | 5.1 M/s | 4.8 M/s | 4.7 M/s | 4.8 M/s | 4.7 M/s |
+
+**第三时钟在 2048×1024 的增益**（vs per-batch drain 旧值，interleaved 同 binary 隔离 drain cadence）：
+
+| host / backend | 旧（per-batch） | 第三时钟 | 增益 | 机制 |
+|---|---|---|---|---|
+| 4060Ti (Ada, 32MB L2) CUDA | 28 M/s | 39 M/s | **1.4×** | Ada L2 大→旧值已 L2-resident，税主要是 per-batch D2H readback |
+| 1070Ti (Pascal, 2MB L2) CUDA | 12.5 M/s | 33.5 M/s | **2.7×** | 兼有 L2 溢出 + readback 税；第三时钟消 readback（L2 残留） |
+| M-series Metal（统一内存） | 11 M/s | 32.3 M/s | **~3×** | 无 PCIe readback；per-batch 24MB memset+memcpy(×76 batch≈3.6GB) 被摊薄 |
+
+**要点**：
+- **三种硬件（CUDA-Ada / CUDA-Pascal / Metal）一致确证第三时钟在真实 GUI 分辨率显著提速**；增益随"旧值里 per-batch readback/copy 占比"放大。
+- **Metal 曲线近平**（28→35 M/s 跨 6 档），第三时钟使 Metal 分辨率-鲁棒（旧路径每 batch 全幅 memset+memcpy 在高分辨率是真成本，非仅 CUDA readback）。**推翻早先"Metal 统一内存零收益"判断**。
+- 正确性：CUDA parity 10/10 @4060Ti + 10/10 @1070Ti/sm_61；Metal parity 14/14（含 batch-invariance = drain-cadence 独立性）。
+- win-builder 1070Ti 未列 vs-legacy（CPU 弱，比值虚高，读绝对值）；`multi_med` 列在第三时钟下失真已弃用（用 `multi_wall`）。
+- 重场景 `ms_multi_crystal`（trace 主导，readback 占比小）增益温和：4060Ti 2048 = 14.9 M/s、1070Ti = 7.3 M/s、Metal ≈ 17 M/s@256（Mac 热噪大，N=9 后仍抖）。
 
 #### Mac — Apple M2 Max (12-core: 8P+4E, 32 GB, macOS 14.7) · legacy vs Metal · 2026-06-28
 

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -115,18 +115,40 @@ anchor, re-measure same-session before/after any throughput change.
 
 | config（真实文件） | regime | rays / MS / filter | lens / Metal 可比 | 角色 | Metal vs legacy（实测基线） |
 |---|---|---|---|---|---|
-| `bench_light_single_ms.json` | 轻·单MS | 10M / 1 / 无 | dual_fisheye_EA ✅ | 轻场景吞吐基准（bench 专用，勿因 e2e 改动） | 引擎 ~1.7× / GUI ~1.8× |
-| `ms_multi_crystal.json` | 中·无filter | 2M / 2 / 无 | dual_fisheye_EA ✅ | 无 culling 中等基准 | 引擎 ~2.0× / GUI ~2.2× |
+| `bench_light_single_ms.json` | 轻·单MS · 512×256 | 10M / 1 / 无 | dual_fisheye_EA ✅ | 轻场景吞吐基准（bench 专用，勿因 e2e 改动）；**512×256 落 GPU L2，系统性高估 GPU 优势**；真实分辨率用 `--res-sweep`（见"分辨率是一等吞吐维度"） | 引擎 ~1.7× / GUI ~1.8× |
+| `ms_multi_crystal.json` | 中·无filter | 2M / 2 / 无 | dual_fisheye_EA ✅ | 无 culling 中等基准；`--res-sweep` 第二代表场景（看场景依赖） | 引擎 ~2.0× / GUI ~2.2× |
 | `ms_multi_crystal_complex_filter.json` | 重·标准 | 2M / 2 / complex | dual_fisheye_EA ✅ | **G1 + G4 主基准** | 引擎 ~8.1× / GUI ~9.5× |
 | `ms_multi_crystal_filtered_bd.json` | 重·bd | 2M / 2 / bd | dual_fisheye_EA ✅ | G1 第二基准 | 引擎 ~10.1× |
 | `ms3_mixed_pyramid_heavy.json` | 最重·棱锥 | 5M / 3 / 4×raypath | dual_fisheye_EA ✅ | register-pressure 上界 | 引擎 **~5.5×**（2026-06-24 同会话 M2 Max：legacy multi 46.1K/s、single 7.3K/s；Metal multi 255K/s、single 245K/s）；GUI legacy ~48.7K → Metal ~5.7×（互证）。**注**：legacy single pass ~274s，超出 `bench_throughput.py` 的 `RUN_TIMEOUT_SEC`，故该场景仍从自动跑中排除——基线靠手动大 timeout 单测取得 |
 | `halo_22.json` | 轻·单MS | 10M / 1 / 无 | **fisheye_EA（单）→ CLI Metal 回退** | **e2e 资产，勿改**；legacy-only 轻基准 | N/A（Metal 不兼容此投影；轻·Metal 用 `bench_light_single_ms`） |
 
 Notes:
-- The dispatch sweet spot is 32768 (`LUMICE_DISPATCH_RAY_NUM`); small dispatches
-  starve the GPU (512/2048 = 0.2–0.8× legacy). See the Runtime Tuning Knobs table.
+- **上表 4 个 light/mid/heavy 主基准（bench_light / ms_multi / complex_filter / filtered_bd）都是 512×256**（`ms3_mixed_pyramid_heavy` 例外，为 2048×1024）。512×256 的 XYZ 累加 buffer（W×H×3 float = 1.5MB）落在典型 GPU 的 L2 内，**系统性高估 GPU 吞吐**——真实 GUI 默认渲染 2048×1024（16× 像素，24MB buffer，越 L2）。**跨分辨率数字不可比；报吞吐必须带分辨率**。真实分辨率吞吐用 `bench_throughput.py --res-sweep`（分辨率轴，默认 dispatch，隔离单变量）——详见下方"分辨率是一等吞吐维度"。
+- The dispatch sweet spot is **backend- and resolution-dependent**: Metal 32768 / CUDA 262144 是 **512×256** 下的甜点；**分辨率升高时 CUDA 最优 dispatch 显著上移**（2048×1024 下 ~786K–2M，因 per-batch readback 摊薄——见"分辨率"小节 + Runtime Tuning Knobs）。小 dispatch 饿死 GPU（512/2048 = 0.2–0.8× legacy）。
 - `bench_throughput.py` overrides `ray_num` to a large value per run (temp config,
   committed files untouched) so the steady window is long enough to be stable.
+
+#### 分辨率是一等吞吐维度（device-fused XYZ 累加 → cost 随 buffer vs GPU L2）
+
+> **报任何 GPU 吞吐数字必须带渲染分辨率；跨分辨率不可比。** 这不是二阶细节——它常主导轻场景的 GPU 吞吐（轻场景 trace 便宜，累加/回读占大头）。
+
+机制：device-fused XYZ 累加（scrum-302）把每条出射光线在 **trace kernel 内** `atomicAdd` 进 W×H×3 float 图像 buffer（12 B/px）。cost 随 buffer 相对 GPU L2 变化：
+
+- buffer ≤ L2（512×256 = 1.5MB，落多数 GPU 的 ~2MB L2）→ 累加走 cache，快。
+- buffer ≫ L2（2048×1024 = 24MB）→ 每次 atomicAdd 打 DRAM，DRAM 带宽绑定，慢。膝在 L2 边界（~512→768），越 L2 后随分辨率平滑衰减（非二元断崖）。
+
+**实测分辨率惩罚**（2026-07-01，同机同 binary，仅改分辨率，`bench_light_single_ms` 场景，`--benchmark` 稳态 multi）：
+
+- **1070Ti CUDA**：512×256 = 61 M/s → 2048×1024 = 12.5 M/s（**5×**；含 CUDA per-batch 同步 readback 税，见下）。
+- **M2Max Metal**：512×256 = 29 M/s → 2048×1024 = 8.2 M/s（**3.6×**；Metal 统一内存无 readback 税，纯 in-kernel 累加）。
+
+CUDA 的额外惩罚来自 **per-batch 同步 readback**（`ReadbackXyzAccum` 每 SimBatch 一次 `cudaDeviceSynchronize` + 阻塞 24MB PCIe D2H + memset），可用大 dispatch 摊薄（2048 下 262144→~1M dispatch = 12.5→~30 M/s）。这是对 `seam-design.md` §4.8"回读走第三时钟"的偏离——详见 `scratchpad/backlog.md`「per-batch 同步 readback 税 + XYZ 累加 L2 溢出」条。Metal 无此税（`StorageModeShared` + 延迟等）。
+
+**流程要求**：
+
+1. GPU 吞吐用 `bench_throughput.py --res-sweep` 扫多档分辨率（默认 `256×128 … 2048×1024` 六档，2:1，跨 L2 膝两侧），而非只报单点。脚本每档在 temp config 里 override `render[].resolution`（committed 文件不动，同 ray_num override 机制）。默认扫 `bench_light_single_ms`（轻，累加/回读主导）+ `ms_multi_crystal`（稍重，看场景依赖），`--res-list` / `--res-configs` 可覆盖。至少覆盖 **512×256（引擎天花板 / L2-resident）+ 2048×1024（GUI 真实体验）** 两点。
+2. 与竞品 / 硬件能力对标（下方 25M bar）时**对齐分辨率**——我方历史 512×256 数字是 L2-resident 上界，非用户体验。
+3. 数字入表**必标分辨率**（现有表默认 512×256，除 `ms3_mixed_pyramid_heavy`）。sweep 的**曲线数据不入 committed 文件**（按机器/会话变），入表的是按 N≥5 CoV 协议正式产出的 canonical 点。
 
 #### Acceptance yardstick: hardware capability, NOT just "× legacy CPU"
 
@@ -156,6 +178,10 @@ not "× legacy", when judging GPU throughput):
 - If a target genuinely cannot be reached, the acceptance artifact must be a
   **profiler-grounded mechanism explanation** (where the time goes), not a black-box
   "GPU doesn't naturally win" claim.
+- **⚠️ 分辨率对齐**：25M bar 的竞品渲染分辨率未知；我方 `bench_light_single_ms` 是
+  **512×256（L2-resident，上界）**。真实 GUI 默认 2048×1024 下同卡同场景吞吐掉 3.6–5×
+  （见"分辨率是一等吞吐维度"）。判定是否达标前必须**对齐分辨率**——别拿 512×256 的
+  L2-resident 数字宣称达 bar。用 `bench_throughput.py --res-sweep` 取真实分辨率对标点。
 
 ### Latest measured results (per-run log)
 
@@ -514,8 +540,8 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
-| `LUMICE_DISPATCH_RAY_NUM` | **32768** (Metal) / 128 (CPU) | task-268.4 knob; scrum-268.6 set the Metal backend-aware default to **32768** (empirical sweet spot). Re-measured 2026-06-19 (task-fix-throughput-bench-honesty, setup-excluded `--benchmark`): heavy-scene engine **8–10× legacy** at 32768, GUI steady **~9.5× legacy** on M2 Max. Amortizes Metal kernel launch overhead; small dispatches starve the GPU (512/2048 = 0.2–0.8× legacy, 128 hangs at large ray_num) — the full win requires ≥32768. Set to a power of two for alignment. Applies at server startup; changing mid-run has no effect. Independent of `LUMICE_COMMIT_RAY_NUM` (see next row) — pick "feed GPU big" without sacrificing GUI cadence. |
-| `LUMICE_COMMIT_RAY_NUM` | 128 | task-268.4: SimData-to-consumer commit granularity inside `ConsumeData`. Smaller commits = finer GUI snapshot cadence regardless of dispatch size. Backend exit-seam path only (legacy CPU SimData bypass the chunker). |
+| `LUMICE_DISPATCH_RAY_NUM` | **32768** (Metal) / 128 (CPU) | task-268.4 knob; scrum-268.6 set the Metal backend-aware default to **32768** (empirical sweet spot). Re-measured 2026-06-19 (task-fix-throughput-bench-honesty, setup-excluded `--benchmark`): heavy-scene engine **8–10× legacy** at 32768, GUI steady **~9.5× legacy** on M2 Max. Amortizes Metal kernel launch overhead; small dispatches starve the GPU (512/2048 = 0.2–0.8× legacy, 128 hangs at large ray_num) — the full win requires ≥32768. Set to a power of two for alignment. Applies at server startup; changing mid-run has no effect. Independent of `LUMICE_COMMIT_RAY_NUM` (see next row) — pick "feed GPU big" without sacrificing GUI cadence. **分辨率依赖**：默认 262144(CUDA)/32768(Metal) 甜点测于 **512×256**；分辨率升高时最优 dispatch 上移（2048×1024 下 CUDA ~786K–2M，实测 262144→~1M = 2.25×），因该场景 per-batch readback buffer 16× 大、需更大 dispatch 摊薄。分辨率变时重标（见"分辨率是一等吞吐维度"）。 |
+| `LUMICE_COMMIT_RAY_NUM` | 128 | task-268.4: SimData-to-consumer commit granularity inside `ConsumeData`. Smaller commits = finer GUI snapshot cadence regardless of dispatch size. Backend exit-seam path only (legacy CPU SimData bypass the chunker). **⚠️ GPU device-fused 路线（Metal/CUDA，`HasDeviceXyzAccum()`==true）上是 no-op**：该路径产出 `xyz_pixel_data_` 而非 `outgoing_d_`，commit chunker（`server.cpp:809`）被跳过；device readback 频率实由 `LUMICE_DISPATCH_RAY_NUM`（每 SimBatch 一次 `ReadbackXyzAccum`）决定，**非本旋钮**。（曾误用本旋钮做"readback 无关"判据，无效。） |
 | `LUMICE_BATCH_RAY_NUM` | (deprecated) | Backward-compat fallback for `LUMICE_COMMIT_RAY_NUM` only. Pre-task-268.4 this knob doubled as both dispatch and commit granularity. **scrum-268: the DISPATCH split is the primary driver for Metal throughput; setting `LUMICE_BATCH_RAY_NUM` now only controls commit cadence, not GPU dispatch size.** Prefer the two split env vars above. |
 | `LUMICE_TRACE_BACKEND` | unset (legacy CPU) | Trace backend selection: unset = legacy CPU; `metal` = Metal GPU backend (exit-seam + device root-gen); `cpu_backend` = SoA CPU backend. |
 | `LUMICE_DISABLE_DEVICE_GEN` | unset (device-gen ON) | Escape hatch to force **host** root-ray generation on the Metal backend. Device root-gen (GPU PCG root-ray supply) is the **default** for the Metal backend on eligible layers (single-crystal-per-ci, `tri_count ≤ 64`); it activates on both the deterministic single-worker path and the default multi-worker random path (each worker gets a non-zero derived `effective_seed_`). Set this to `1` only for strict-identity parity tests that mirror the host `std::mt19937` stream (which cannot align with the device PCG stream). Read once per backend instance at construction. |

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -127,6 +127,7 @@ Notes:
 - The dispatch sweet spot is **backend- and resolution-dependent**: Metal 32768 / CUDA 262144 是 **512×256** 下的甜点；**分辨率升高时 CUDA 最优 dispatch 显著上移**（2048×1024 下 ~786K–2M，因 per-batch readback 摊薄——见"分辨率"小节 + Runtime Tuning Knobs）。小 dispatch 饿死 GPU（512/2048 = 0.2–0.8× legacy）。
 - `bench_throughput.py` overrides `ray_num` to a large value per run (temp config,
   committed files untouched) so the steady window is long enough to be stable.
+- **⚠️ 第三时钟 drain 路径（CUDA，scrum-312）用 `multi_wall` 列，不用 `multi_med`**：`multi_med`（binary 的 steady `rays_per_sec`）靠 `sim_ray_num` 进度采样，而第三时钟 drain 稀疏 → 进度粗跳（首个 drain 前 `sim_ray_num` 恒 0）→ steady window 把大部分 tracing 误算进 setup → **系统性假低**（实测 2048 报 22M，真值 39M）。`bench_throughput.py` 已加 `multi_wall = rays/wall_sec`（robust，免疫 drain 粒度），两列背离时**信 `multi_wall`**。per-batch 路径（legacy/Metal/CUDA N=1）两列一致（细进度），不受影响。
 
 #### 分辨率是一等吞吐维度（device-fused XYZ 累加 → cost 随 buffer vs GPU L2）
 

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -198,8 +198,14 @@ def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) ->
     env.pop("LUMICE_COMMIT_RAY_NUM", None)  # keep commit granularity at default
 
     cmd = [str(BIN), "--benchmark", "-f", str(config_path), "-v"]
+    # encoding/errors are explicit (not bare text=True): on a non-UTF-8 locale
+    # (e.g. Windows gbk) text=True decodes the binary's log stream with the locale
+    # codec and a stray non-locale byte (Win-1252 smart quote 0x92, etc.) raises
+    # UnicodeDecodeError in the reader thread → proc.stdout stays None. The
+    # [BENCHMARK] JSON we parse is ASCII, so replace undecodable bytes and move on.
     proc = subprocess.run(
-        cmd, capture_output=True, text=True, env=env, timeout=RUN_TIMEOUT_SEC
+        cmd, capture_output=True, encoding="utf-8", errors="replace",
+        env=env, timeout=RUN_TIMEOUT_SEC,
     )
     out = proc.stdout + proc.stderr
     benches = []

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -209,6 +209,17 @@ def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) ->
         except json.JSONDecodeError:
             pass  # malformed [BENCHMARK] line → INCOMPLETE note below
     by_mode = {b["mode"]: b["rays_per_sec"] for b in benches}
+    # Wall-clock rate = rays / wall_sec. Robust cross-check for the steady
+    # rays_per_sec, which is FOOLED by the scrum-312 third-clock drain: with
+    # coarse drains, sim_ray_num stays 0 until the first drain, so the binary's
+    # steady window counts most tracing as "setup" and under-reports. wall_rate
+    # includes the (small) setup but is immune to drain granularity — trust it
+    # when it diverges from rays_per_sec. See doc/performance-testing.md.
+    by_mode_wall = {}
+    for b in benches:
+        w = b.get("wall_sec")
+        r = b.get("rays")
+        by_mode_wall[b["mode"]] = (r / w) if (w and r) else None
 
     expected_route = GPU_ROUTE_STRINGS.get(backend_env)  # None for legacy/cpu_backend
     routed_gpu = (expected_route in out) if expected_route else True
@@ -229,6 +240,8 @@ def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) ->
     return {
         "single_rps": by_mode.get("single"),
         "multi_rps": by_mode.get("multi"),
+        "single_wall_rps": by_mode_wall.get("single"),
+        "multi_wall_rps": by_mode_wall.get("multi"),
         "routed_ok": routed_ok,
         "note": note,
         "rc": proc.returncode,
@@ -249,28 +262,33 @@ def _cov(values):
 def measure_cell(config_path: Path, backend_env: str | None, dispatch_num: int | None,
                  n_reps: int) -> dict:
     single_vals, multi_vals, all_ok, notes = [], [], True, []
+    multi_wall_vals = []
     for i in range(n_reps):
         try:
             r = run(config_path, backend_env, dispatch_num)
         except subprocess.TimeoutExpired:
             single_vals.append(None)
             multi_vals.append(None)
+            multi_wall_vals.append(None)
             all_ok = False
             notes.append(f"rep{i}:TIMEOUT")
             continue
         single_vals.append(r["single_rps"])
         multi_vals.append(r["multi_rps"])
+        multi_wall_vals.append(r["multi_wall_rps"])
         if not r["routed_ok"]:
             all_ok = False
         if r["note"]:
             notes.append(f"rep{i}:{r['note']}")
     s_clean = [v for v in single_vals if v is not None]
     m_clean = [v for v in multi_vals if v is not None]
+    mw_clean = [v for v in multi_wall_vals if v is not None]
     return {
         "single_vals": single_vals,
         "multi_vals": multi_vals,
         "single_median": statistics.median(s_clean) if s_clean else None,
         "multi_median": statistics.median(m_clean) if m_clean else None,
+        "multi_wall_median": statistics.median(mw_clean) if mw_clean else None,
         "single_cov": _cov(single_vals),
         "multi_cov": _cov(multi_vals),
         "routed_ok": all_ok,
@@ -410,11 +428,14 @@ def run_res_sweep(resolutions: list[tuple[int, int]],
     )
     header = (
         f"{'backend':<12s} {'config':<26s} {'res':>11s} {'buf_MB':>7s} "
-        f"{'single_med':>15s} {'multi_med':>15s} "
+        f"{'single_med':>15s} {'multi_med':>15s} {'multi_wall':>15s} "
         f"{'cov_s':>6s} {'cov_m':>6s} {'vs_legacy':>10s} note"
     )
     print(header, flush=True)
     print("-" * len(header), flush=True)
+    print("# multi_wall = rays/wall_sec (robust); multi_med = steady rays_per_sec "
+          "(UNRELIABLE under third-clock drain — trust multi_wall when they diverge).",
+          flush=True)
 
     rows: list[dict] = []
     cov_log: list[str] = []
@@ -449,6 +470,7 @@ def run_res_sweep(resolutions: list[tuple[int, int]],
                     f"{buf_mb:>7.1f} "
                     f"{_fmt_rps(cell['single_median']):>15s} "
                     f"{_fmt_rps(cell['multi_median']):>15s} "
+                    f"{_fmt_rps(cell['multi_wall_median']):>15s} "
                     f"{_fmt_cov(cell['single_cov']):>6s} "
                     f"{_fmt_cov(cell['multi_cov']):>6s} "
                     f"{ratio_str:>10s} {note_str}",
@@ -459,6 +481,7 @@ def run_res_sweep(resolutions: list[tuple[int, int]],
                     "resolution": [w, h], "buffer_mb": round(buf_mb, 2),
                     "single_median_rps": cell["single_median"],
                     "multi_median_rps": cell["multi_median"],
+                    "multi_wall_median_rps": cell["multi_wall_median"],
                     "single_cov": cell["single_cov"], "multi_cov": cell["multi_cov"],
                     "vs_legacy_multi": (
                         cell["multi_median"] / legacy_multi_median
@@ -548,11 +571,14 @@ def main() -> int:
 
     header = (
         f"{'backend':<12s} {'config':<34s} {'dispatch':>9s} "
-        f"{'single_med':>15s} {'multi_med':>15s} "
+        f"{'single_med':>15s} {'multi_med':>15s} {'multi_wall':>15s} "
         f"{'cov_s':>6s} {'cov_m':>6s} {'vs_legacy':>10s} note"
     )
     print(header, flush=True)
     print("-" * len(header), flush=True)
+    print("# multi_wall = rays/wall_sec (robust); multi_med = steady rays_per_sec "
+          "(UNRELIABLE under third-clock drain — trust multi_wall when they diverge).",
+          flush=True)
 
     for cfg_label, cfg_path in configs.items():
         legacy_multi_median = None
@@ -596,6 +622,7 @@ def main() -> int:
                     f"{_fmt_dispatch(dispatch_num):>9s} "
                     f"{_fmt_rps(cell['single_median']):>15s} "
                     f"{_fmt_rps(cell['multi_median']):>15s} "
+                    f"{_fmt_rps(cell['multi_wall_median']):>15s} "
                     f"{_fmt_cov(cell['single_cov']):>6s} "
                     f"{_fmt_cov(cell['multi_cov']):>6s} "
                     f"{ratio_str:>10s} {note_str}",
@@ -608,6 +635,7 @@ def main() -> int:
                     "dispatch": _fmt_dispatch(dispatch_num),
                     "single_median_rps": cell["single_median"],
                     "multi_median_rps": cell["multi_median"],
+                    "multi_wall_median_rps": cell["multi_wall_median"],
                     "single_cov": cell["single_cov"],
                     "multi_cov": cell["multi_cov"],
                     "vs_legacy_multi": (

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -27,6 +27,7 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import atexit
 import json
 import os
@@ -91,6 +92,26 @@ CONFIGS = {
 # legacy (slower) still finishes well within RUN_TIMEOUT_SEC. The committed
 # config files are NOT mutated; each run writes a temp config with this ray_num.
 RAY_NUM_OVERRIDE = 20_000_000
+
+# --- Resolution sweep (scrum-312.1) ------------------------------------------
+# GPU throughput is NOT resolution-invariant: the device-fused XYZ accumulation
+# (scrum-302) atomicAdds each exit ray into a W*H*3 float image buffer (12 B/px).
+# When that buffer fits GPU L2 (512x256 = 1.5MB) accumulation is cache-fast; once
+# it spills L2 (2048x1024 = 24MB) every atomicAdd hits DRAM and throughput falls
+# 3.6-5x. The knee sits at the L2 boundary and MOVES with the GPU's L2 size, so a
+# handful of fixed points can't locate it — a sweep can. `--res-sweep` overrides
+# render[].resolution per run (temp config, committed files untouched — same
+# mechanism as the ray_num override) at DEFAULT dispatch, isolating resolution as
+# the single variable. (Dispatch x resolution interaction is a separate explore;
+# see doc/performance-testing.md "分辨率是一等吞吐维度".)
+# 2:1 aspect (dual_fisheye full-globe layout); spans the L2 knee both sides.
+RES_SWEEP_DEFAULT = [
+    (256, 128), (512, 256), (768, 384), (1024, 512), (1536, 768), (2048, 1024),
+]
+# Two representative scenes: a light one (accumulation/readback dominates, cleanest
+# L2 signal) and a heavier one (throughput also varies with exit count / scatter
+# locality — see the backlog readback-tax entry).
+RES_SWEEP_CONFIGS_DEFAULT = ["bench_light_single_ms", "ms_multi_crystal"]
 
 # (label, LUMICE_TRACE_BACKEND value).  None => env unset (legacy CPU).
 # IMPORTANT: "legacy" must be first — subsequent backends use legacy_multi_median
@@ -302,8 +323,10 @@ def _preflight() -> list[str]:
     return errs
 
 
-def _override_ray_num(configs: dict, tmp_dir: str) -> dict:
-    """Write temp copies of each config with scene.ray_num = RAY_NUM_OVERRIDE.
+def _override_config(configs: dict, tmp_dir: str,
+                     resolution: tuple[int, int] | None = None) -> dict:
+    """Write temp copies of each config with scene.ray_num = RAY_NUM_OVERRIDE and,
+    when `resolution` is given, every render[].resolution set to [w, h].
 
     Committed config files are never mutated; returns {label: temp_path}.
     """
@@ -313,13 +336,177 @@ def _override_ray_num(configs: dict, tmp_dir: str) -> dict:
         if "scene" not in cfg or "ray_num" not in cfg["scene"]:
             raise KeyError(f"{label}: config missing scene.ray_num (cannot apply override)")
         cfg["scene"]["ray_num"] = RAY_NUM_OVERRIDE
-        dst = Path(tmp_dir) / f"{label}.json"
+        suffix = ""
+        if resolution is not None:
+            renders = cfg.get("render")
+            if not isinstance(renders, list) or not renders:
+                raise KeyError(f"{label}: config missing render[] (cannot set resolution)")
+            for r in renders:
+                r["resolution"] = [resolution[0], resolution[1]]
+            suffix = f"_{resolution[0]}x{resolution[1]}"
+        dst = Path(tmp_dir) / f"{label}{suffix}.json"
         dst.write_text(json.dumps(cfg))
         out[label] = dst
     return out
 
 
+def _measure_with_cov_escalation(cfg_path: Path, backend_env: str | None,
+                                 dispatch_num: int | None, label: str,
+                                 cov_log: list[str]) -> dict:
+    """measure_cell + the >15% CoV -> N=9 re-run -> HIGH_COV_THERMAL decision tree.
+    Shared by the default matrix and the resolution sweep so they can't diverge."""
+    cell = measure_cell(cfg_path, backend_env, dispatch_num, N_REPS)
+    worst_cov = max(
+        (c for c in (cell["single_cov"], cell["multi_cov"]) if c is not None),
+        default=None,
+    )
+    if worst_cov is not None and worst_cov > COV_THRESHOLD:
+        msg = (
+            f"[{label}] CoV={100 * worst_cov:.1f}% > 15% @ N={N_REPS} — "
+            f"re-running at N={N_REPS_HIGH_COV}..."
+        )
+        print(msg, flush=True)
+        cov_log.append(msg)
+        cell = measure_cell(cfg_path, backend_env, dispatch_num, N_REPS_HIGH_COV)
+        worst_cov2 = max(
+            (c for c in (cell["single_cov"], cell["multi_cov"]) if c is not None),
+            default=None,
+        )
+        if worst_cov2 is not None and worst_cov2 > COV_THRESHOLD:
+            cell["notes"].append("HIGH_COV_THERMAL")
+            cov_log.append(
+                f"  ↳ still {100 * worst_cov2:.1f}% after N=9 — HIGH_COV_THERMAL"
+            )
+    return cell
+
+
+def run_res_sweep(resolutions: list[tuple[int, int]],
+                  sweep_config_labels: list[str]) -> int:
+    """Sweep render resolution at DEFAULT dispatch to characterize the GPU L2 knee.
+
+    One curve per (config, backend); legacy CPU is the per-(config, resolution)
+    denominator. Committed configs are never mutated (temp override). See the
+    RES_SWEEP_DEFAULT comment for the mechanism.
+    """
+    # Honor the LUMICE_BENCH_CONFIGS narrowing already applied to CONFIGS.
+    sweep_configs = {k: v for k, v in CONFIGS.items() if k in sweep_config_labels}
+    if not sweep_configs:
+        sys.stderr.write(
+            "[bench_throughput] --res-sweep: no matching configs "
+            f"(requested {sweep_config_labels}, available {list(CONFIGS)})\n"
+        )
+        return 2
+
+    is_darwin = platform.system() == "Darwin"
+    tmp_dir = tempfile.mkdtemp(prefix="bench_res_sweep_")
+    atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
+
+    print(
+        "# bench_throughput --res-sweep — resolution axis, DEFAULT dispatch.\n"
+        "# denominator = legacy CPU multi_rps per (config, resolution).\n"
+        f"# ray_num overridden to {RAY_NUM_OVERRIDE:,}; W*H*3*4 B = XYZ buffer size.\n"
+        "# Watch for the throughput knee where buffer_MB crosses the GPU L2 size.\n",
+        flush=True,
+    )
+    header = (
+        f"{'backend':<12s} {'config':<26s} {'res':>11s} {'buf_MB':>7s} "
+        f"{'single_med':>15s} {'multi_med':>15s} "
+        f"{'cov_s':>6s} {'cov_m':>6s} {'vs_legacy':>10s} note"
+    )
+    print(header, flush=True)
+    print("-" * len(header), flush=True)
+
+    rows: list[dict] = []
+    cov_log: list[str] = []
+    for cfg_label, cfg_src in sweep_configs.items():
+        for (w, h) in resolutions:
+            cfg_path = _override_config({cfg_label: cfg_src}, tmp_dir, (w, h))[cfg_label]
+            buf_mb = w * h * 3 * 4 / (1024 * 1024)
+            legacy_multi_median = None
+            for backend_label, backend_env in BACKENDS:
+                na_reason = _backend_na_reason(backend_label, is_darwin)
+                if na_reason is not None:
+                    continue  # skip N/A rows to keep the curve readable
+                label = f"{backend_label} {cfg_label} {w}x{h}"
+                cell = _measure_with_cov_escalation(cfg_path, backend_env, None,
+                                                    label, cov_log)
+                if backend_label == BASELINE_BACKEND:
+                    legacy_multi_median = cell["multi_median"]
+                    ratio_str = "1.00x" if cell["multi_median"] else "    - "
+                    suffix = BASELINE_LABEL
+                elif backend_label == "cpu_backend":
+                    ratio_str = _fmt_ratio(cell["multi_median"], legacy_multi_median)
+                    suffix = CPU_BACKEND_LABEL
+                else:
+                    ratio_str = _fmt_ratio(cell["multi_median"], legacy_multi_median)
+                    suffix = ""
+                flags = list(cell["notes"])
+                if not cell["routed_ok"]:
+                    flags.insert(0, "ROUTE?")
+                note_str = f"<-- {','.join(flags)} {suffix}".rstrip() if flags else suffix
+                print(
+                    f"{backend_label:<12s} {cfg_label:<26s} {f'{w}x{h}':>11s} "
+                    f"{buf_mb:>7.1f} "
+                    f"{_fmt_rps(cell['single_median']):>15s} "
+                    f"{_fmt_rps(cell['multi_median']):>15s} "
+                    f"{_fmt_cov(cell['single_cov']):>6s} "
+                    f"{_fmt_cov(cell['multi_cov']):>6s} "
+                    f"{ratio_str:>10s} {note_str}",
+                    flush=True,
+                )
+                rows.append({
+                    "backend": backend_label, "config": cfg_label,
+                    "resolution": [w, h], "buffer_mb": round(buf_mb, 2),
+                    "single_median_rps": cell["single_median"],
+                    "multi_median_rps": cell["multi_median"],
+                    "single_cov": cell["single_cov"], "multi_cov": cell["multi_cov"],
+                    "vs_legacy_multi": (
+                        cell["multi_median"] / legacy_multi_median
+                        if cell["multi_median"] and legacy_multi_median else None
+                    ),
+                    "routed_ok": cell["routed_ok"], "notes": cell["notes"],
+                })
+            print("", flush=True)
+
+    if cov_log:
+        print("# CoV escalation log:", flush=True)
+        for line in cov_log:
+            print(f"  {line}", flush=True)
+        print("", flush=True)
+    print("# raw rows (json):", flush=True)
+    print(json.dumps(rows, indent=2, default=str), flush=True)
+    return 0
+
+
+def _parse_res_list(s: str) -> list[tuple[int, int]]:
+    out: list[tuple[int, int]] = []
+    for tok in s.split(","):
+        tok = tok.strip().lower()
+        if not tok:
+            continue
+        w, h = tok.split("x")
+        out.append((int(w), int(h)))
+    return out
+
+
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Committed throughput bench harness (matrix + resolution sweep)."
+    )
+    parser.add_argument(
+        "--res-sweep", action="store_true",
+        help="sweep render resolution at default dispatch (characterize the GPU L2 knee)",
+    )
+    parser.add_argument(
+        "--res-list", default=None, metavar="WxH,...",
+        help="comma-separated resolutions for --res-sweep (default: 256x128..2048x1024)",
+    )
+    parser.add_argument(
+        "--res-configs", default=None, metavar="label,...",
+        help="config labels to sweep (default: bench_light_single_ms,ms_multi_crystal)",
+    )
+    args = parser.parse_args()
+
     errs = _preflight()
     if errs:
         sys.stderr.write("[bench_throughput] preflight failed:\n")
@@ -327,9 +514,17 @@ def main() -> int:
             sys.stderr.write(f"  - {e}\n")
         return 2
 
+    if args.res_sweep:
+        resolutions = _parse_res_list(args.res_list) if args.res_list else RES_SWEEP_DEFAULT
+        sweep_labels = (
+            [s.strip() for s in args.res_configs.split(",") if s.strip()]
+            if args.res_configs else RES_SWEEP_CONFIGS_DEFAULT
+        )
+        return run_res_sweep(resolutions, sweep_labels)
+
     tmp_dir = tempfile.mkdtemp(prefix="bench_throughput_")
     atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
-    configs = _override_ray_num(CONFIGS, tmp_dir)
+    configs = _override_config(CONFIGS, tmp_dir)
 
     is_darwin = platform.system() == "Darwin"
     if not is_darwin:
@@ -374,31 +569,11 @@ def main() -> int:
                 continue
 
             for dispatch_num in DISPATCH_PLAN[backend_label]:
-                cell = measure_cell(cfg_path, backend_env, dispatch_num, N_REPS)
-
                 # CoV decision tree: >15% @ N=5 -> rerun at N=9; still >15% -> flag thermal.
-                worst_cov = max(
-                    (c for c in (cell["single_cov"], cell["multi_cov"]) if c is not None),
-                    default=None,
+                label = f"{backend_label} {cfg_label} disp={_fmt_dispatch(dispatch_num)}"
+                cell = _measure_with_cov_escalation(
+                    cfg_path, backend_env, dispatch_num, label, cov_log
                 )
-                if worst_cov is not None and worst_cov > COV_THRESHOLD:
-                    msg = (
-                        f"[{backend_label} {cfg_label} disp={_fmt_dispatch(dispatch_num)}] "
-                        f"CoV={100 * worst_cov:.1f}% > 15% @ N={N_REPS} — "
-                        f"re-running at N={N_REPS_HIGH_COV}..."
-                    )
-                    print(msg, flush=True)
-                    cov_log.append(msg)
-                    cell = measure_cell(cfg_path, backend_env, dispatch_num, N_REPS_HIGH_COV)
-                    worst_cov2 = max(
-                        (c for c in (cell["single_cov"], cell["multi_cov"]) if c is not None),
-                        default=None,
-                    )
-                    if worst_cov2 is not None and worst_cov2 > COV_THRESHOLD:
-                        cell["notes"].append("HIGH_COV_THERMAL")
-                        cov_log.append(
-                            f"  ↳ still {100 * worst_cov2:.1f}% after N=9 — HIGH_COV_THERMAL"
-                        )
 
                 if backend_label == BASELINE_BACKEND:
                     legacy_multi_median = cell["multi_median"]

--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -26,8 +26,9 @@ namespace lumice {
 // S1 device-fused: adds xyz_pixel_data_ (vector<float>, 24B) + xyz_landed_weight_
 // (float, 4B) + 4B padding = 32B total, bumping 216 → 248. task-exit-seam-
 // crystal-count adds crystal_count_ (size_t, 8B) for exit-seam stats, bumping
-// 248 → 256.
-static_assert(sizeof(SimData) == 256, "SimData size changed — update copy/move ctors and operators");
+// 248 → 256. scrum-312 adds sim_scene_credit_ (size_t, 8B) for third-clock drain
+// counter balance, bumping 256 → 264.
+static_assert(sizeof(SimData) == 264, "SimData size changed — update copy/move ctors and operators");
 
 namespace {
 
@@ -316,7 +317,7 @@ SimData::SimData(const SimData& other)
       crystal_axis_dists_(other.crystal_axis_dists_), outgoing_d_(other.outgoing_d_), outgoing_w_(other.outgoing_w_),
       outgoing_wl_(other.outgoing_wl_), exit_records_(other.exit_records_), xyz_pixel_data_(other.xyz_pixel_data_),
       xyz_landed_weight_(other.xyz_landed_weight_), root_ray_count_(other.root_ray_count_),
-      crystal_count_(other.crystal_count_) {}
+      crystal_count_(other.crystal_count_), sim_scene_credit_(other.sim_scene_credit_) {}
 
 SimData::SimData(SimData&& other) noexcept
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(std::move(other.rays_)),
@@ -324,7 +325,8 @@ SimData::SimData(SimData&& other) noexcept
       outgoing_d_(std::move(other.outgoing_d_)), outgoing_w_(std::move(other.outgoing_w_)),
       outgoing_wl_(std::move(other.outgoing_wl_)), exit_records_(std::move(other.exit_records_)),
       xyz_pixel_data_(std::move(other.xyz_pixel_data_)), xyz_landed_weight_(other.xyz_landed_weight_),
-      root_ray_count_(other.root_ray_count_), crystal_count_(other.crystal_count_) {}
+      root_ray_count_(other.root_ray_count_), crystal_count_(other.crystal_count_),
+      sim_scene_credit_(other.sim_scene_credit_) {}
 
 SimData& SimData::operator=(const SimData& other) {
   if (&other == this) {
@@ -344,6 +346,7 @@ SimData& SimData::operator=(const SimData& other) {
   xyz_landed_weight_ = other.xyz_landed_weight_;
   root_ray_count_ = other.root_ray_count_;
   crystal_count_ = other.crystal_count_;
+  sim_scene_credit_ = other.sim_scene_credit_;
   return *this;
 }
 
@@ -371,6 +374,7 @@ SimData& SimData::operator=(SimData&& other) noexcept {
   xyz_landed_weight_ = other.xyz_landed_weight_;
   root_ray_count_ = other.root_ray_count_;
   crystal_count_ = other.crystal_count_;
+  sim_scene_credit_ = other.sim_scene_credit_;
   return *this;
 }
 

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -162,6 +162,10 @@ struct SimData {
   std::vector<float> xyz_pixel_data_;
   float xyz_landed_weight_ = 0.0f;
 
+  // --- Consumer-side bookkeeping (NOT physical render payload) ---
+  // The fields below are counters the server/consumer use for stats + queue
+  // accounting; they do not affect the rendered image. Keep them distinct from
+  // the physical-result fields above (rays_/xyz_pixel_data_/exit_records_).
   size_t root_ray_count_ = 0;  // Count of root rays (prev_ray_idx_ == kInfSize)
 
   // Crystal count for stats reporting. Populated by legacy path from

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -169,6 +169,16 @@ struct SimData {
   // TraceBackend::GetLastBatchCrystalCount() (== final-layer setting count).
   // See scrum-cleanup-cuda-ci-misc/task-exit-seam-crystal-count.
   size_t crystal_count_ = 0;
+
+  // scrum-312 (third-clock drain): how many sim_scene_cnt_ units this SimData
+  // accounts for on the consumer side. Normally 1 (one SimData per
+  // SimulateOneWavelength* call, paired 1:1 with GenerateScene's per-wavelength
+  // increment). The CUDA third-clock path drains ONE SimData for a WINDOW of N
+  // accumulated (batch × wavelength) calls, so it sets this to N — ConsumeData
+  // decrements sim_scene_cnt_ by this credit to keep the increment/decrement
+  // invariant balanced (else the counter never reaches 0 and the server hangs /
+  // never idles). See simulator.cpp DrainDeviceXyz + server.cpp ConsumeData.
+  size_t sim_scene_credit_ = 1;
 };
 
 using SimDataPtrS = std::shared_ptr<SimData>;

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -2330,18 +2330,25 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     }
     const size_t xyz_floats = static_cast<size_t>(impl_->img_w_) *
                               static_cast<size_t>(impl_->img_h_) * 3u;
+    // scrum-312 (third-clock drain): d_xyz_buf_ / d_landed_weight_ are PERSISTENT
+    // accumulators across batches. Zero ONLY on fresh allocation — the former
+    // per-call memset moved to ReadbackXyzAccum's post-drain reset, so device
+    // accumulation survives across BeginSession/EndSession within a drain window
+    // (the simulator drains on display cadence, not per batch). The buffer is
+    // always zero at a window start: first window via this alloc-zero, later
+    // windows via the previous drain's memset.
     if (impl_->d_xyz_buf_ == nullptr) {
       CheckCuda(cudaMalloc(&impl_->d_xyz_buf_, xyz_floats * sizeof(float)),
                 "BeginSession cudaMalloc d_xyz_buf");
+      CheckCuda(cudaMemset(impl_->d_xyz_buf_, 0, xyz_floats * sizeof(float)),
+                "BeginSession cudaMemset d_xyz_buf");
     }
-    CheckCuda(cudaMemset(impl_->d_xyz_buf_, 0, xyz_floats * sizeof(float)),
-              "BeginSession cudaMemset d_xyz_buf");
     if (impl_->d_landed_weight_ == nullptr) {
       CheckCuda(cudaMalloc(&impl_->d_landed_weight_, sizeof(float)),
                 "BeginSession cudaMalloc d_landed_weight");
+      CheckCuda(cudaMemset(impl_->d_landed_weight_, 0, sizeof(float)),
+                "BeginSession cudaMemset d_landed_weight");
     }
-    CheckCuda(cudaMemset(impl_->d_landed_weight_, 0, sizeof(float)),
-              "BeginSession cudaMemset d_landed_weight");
 
     // Per-ray rotation matrix device buffer (cont_cap_ × 9) is allocated
     // lazily in EnsureSessionBuffers, not here — n_roots is unknown until the
@@ -2959,22 +2966,31 @@ bool CudaTraceBackend::HasDeviceXyzAccum() const { return true; }
 // same batch returns zeros on the second call (by design — the buffers are
 // cleared after the first read).
 void CudaTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) {
-  if (!impl_->in_session_) {
-    throw BackendUnavailableError("CudaTraceBackend::ReadbackXyzAccum called outside session");
+  // scrum-312 (third-clock drain): the XYZ accumulator is persistent and drained
+  // on display cadence, which the simulator triggers BETWEEN per-batch sessions
+  // (generation-change / producer-pause / run-exit flush). Gate on the buffer
+  // being allocated, not on in_session_ — the persisted buffer is valid to read
+  // after EndSession(keep_persistent_buffers=true).
+  if (impl_->d_xyz_buf_ == nullptr) {
+    throw BackendUnavailableError("CudaTraceBackend::ReadbackXyzAccum called before any session allocated the buffer");
   }
   // Defensive guards (Risk 4 / 务实评审 Minor 3): nullptr device buffer or
   // mismatched host destination would silently corrupt memory on D2H copy.
   assert(impl_->d_xyz_buf_ != nullptr && "d_xyz_buf_ unallocated — BeginSession failed?");
   assert(impl_->d_landed_weight_ != nullptr);
   assert(xyz.data != nullptr && "ReadbackXyzAccum: caller must pre-allocate xyz.data");
-  assert(static_cast<uint32_t>(xyz.width) == impl_->img_w_ &&
-         static_cast<uint32_t>(xyz.height) == impl_->img_h_ &&
-         "ReadbackXyzAccum: xyz dimensions mismatch session render config");
+  // scrum-312: pixel count comes from the CALLER (xyz.width/height), NOT from
+  // impl_->img_w_/img_h_ — those are cleared to 0 by EndSession/Reset (see the
+  // "always reset" block), and the third-clock drain runs BETWEEN sessions, so
+  // reading impl_ dims here would copy 0 bytes and yield a black image. The
+  // simulator sets xyz.width/height from the accumulation window (= the render
+  // dims the persistent d_xyz_buf_ was allocated for, constant within a run).
+  assert(xyz.width > 0 && xyz.height > 0 && "ReadbackXyzAccum: caller must set xyz.width/height");
 
   // waitUntilCompleted-equivalent — all preceding TraceLayer kernel work must
   // finalize before the D2H copy. Mirrors Metal's cmd-buffer wait.
   cudaDeviceSynchronize();
-  const size_t pix = static_cast<size_t>(impl_->img_w_) * static_cast<size_t>(impl_->img_h_);
+  const size_t pix = static_cast<size_t>(xyz.width) * static_cast<size_t>(xyz.height);
   CheckCuda(cudaMemcpy(xyz.data, impl_->d_xyz_buf_, pix * 3u * sizeof(float),
                        cudaMemcpyDeviceToHost),
             "ReadbackXyzAccum D2H d_xyz_buf");

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -3019,8 +3019,9 @@ void CudaTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight)
   CheckCuda(cudaMemcpy(&lw, impl_->d_landed_weight_, sizeof(float), cudaMemcpyDeviceToHost),
             "ReadbackXyzAccum D2H d_landed_weight");
   landed_weight += lw;
-  // Clear for the next batch — second call in the same batch returns zeros
-  // (per-batch one-shot contract; see header comment).
+  // Reset the accumulator so the NEXT drain window starts from zero (scrum-312:
+  // this is now the per-window reset — BeginSession no longer zeroes; a second
+  // drain with no intervening accumulation returns zeros).
   CheckCuda(cudaMemset(impl_->d_xyz_buf_, 0, pix * 3u * sizeof(float)),
             "ReadbackXyzAccum cudaMemset d_xyz_buf");
   CheckCuda(cudaMemset(impl_->d_landed_weight_, 0, sizeof(float)),

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -2341,27 +2341,40 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     const size_t xyz_floats = static_cast<size_t>(impl_->img_w_) *
                               static_cast<size_t>(impl_->img_h_) * 3u;
     // scrum-312 (third-clock drain): d_xyz_buf_ / d_landed_weight_ are PERSISTENT
-    // accumulators across batches. Zero ONLY on fresh allocation — the former
+    // accumulators across batches. Zero ONLY on (re)allocation — the former
     // per-call memset moved to ReadbackXyzAccum's post-drain reset, so device
     // accumulation survives across BeginSession/EndSession within a drain window
     // (the simulator drains on display cadence, not per batch). The buffer is
     // always zero at a window start: first window via this alloc-zero, later
     // windows via the previous drain's memset.
-    if (impl_->d_xyz_buf_ == nullptr) {
-      CheckCuda(cudaMalloc(&impl_->d_xyz_buf_, xyz_floats * sizeof(float)),
-                "BeginSession cudaMalloc d_xyz_buf");
+    //
+    // Re-allocate when the render RESOLUTION changes (not just when null): a
+    // resolution increase on a persistent smaller buffer would let the kernel
+    // atomicAdd new-dims pixel indices out of bounds (memory corruption). A
+    // resolution change always rides a generation change, whose flush already
+    // drained the prior window, so re-zeroing is correct. Mirrors the Metal
+    // EnsureImage shape-change reset (312.4 review-Major). d_landed_weight_ is the
+    // twin accumulator — reset it in lock-step so the two never mix resolutions.
+    const bool xyz_dims_changed = (impl_->d_xyz_buf_ == nullptr) ||
+                                  (impl_->alloc_xyz_w_ != impl_->img_w_) ||
+                                  (impl_->alloc_xyz_h_ != impl_->img_h_);
+    if (xyz_dims_changed) {
+      const size_t old_pix = static_cast<size_t>(impl_->alloc_xyz_w_) * static_cast<size_t>(impl_->alloc_xyz_h_);
+      if (impl_->d_xyz_buf_ == nullptr || old_pix != static_cast<size_t>(impl_->img_w_) * impl_->img_h_) {
+        cudaFree(impl_->d_xyz_buf_);  // no-op on nullptr
+        CheckCuda(cudaMalloc(&impl_->d_xyz_buf_, xyz_floats * sizeof(float)),
+                  "BeginSession cudaMalloc d_xyz_buf");
+      }
+      if (impl_->d_landed_weight_ == nullptr) {
+        CheckCuda(cudaMalloc(&impl_->d_landed_weight_, sizeof(float)),
+                  "BeginSession cudaMalloc d_landed_weight");
+      }
       CheckCuda(cudaMemset(impl_->d_xyz_buf_, 0, xyz_floats * sizeof(float)),
                 "BeginSession cudaMemset d_xyz_buf");
-      // scrum-312: remember the dims this persistent buffer was sized for so the
-      // between-session drain can verify caller dims against real capacity.
-      impl_->alloc_xyz_w_ = impl_->img_w_;
-      impl_->alloc_xyz_h_ = impl_->img_h_;
-    }
-    if (impl_->d_landed_weight_ == nullptr) {
-      CheckCuda(cudaMalloc(&impl_->d_landed_weight_, sizeof(float)),
-                "BeginSession cudaMalloc d_landed_weight");
       CheckCuda(cudaMemset(impl_->d_landed_weight_, 0, sizeof(float)),
                 "BeginSession cudaMemset d_landed_weight");
+      impl_->alloc_xyz_w_ = impl_->img_w_;
+      impl_->alloc_xyz_h_ = impl_->img_h_;
     }
 
     // Per-ray rotation matrix device buffer (cont_cap_ × 9) is allocated

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1403,12 +1403,20 @@ struct CudaTraceBackend::Impl {
   // --- S2 device-fused XYZ accumulation -----------------------------------
   // ms_mode==0 emit gate accumulates per-ray (cmf_x/y/z * weight) directly into
   // a device-resident W*H*3 float buffer via atomicAdd, replacing the per-exit
-  // PCIe round-trip (`DrainExits` + host projection). Allocated per BeginSession,
-  // sized to render.resolution_; cleared at allocation. `ReadbackXyzAccum` D2H
-  // copies it to the host and zeros it for the next batch (one-shot per batch
-  // contract — second call in the same batch returns zeros).
-  float*   d_xyz_buf_       = nullptr;  // img_w_ * img_h_ * 3 floats, atomicAdd target
+  // PCIe round-trip (`DrainExits` + host projection). scrum-312 third clock: the
+  // buffer PERSISTS across per-batch sessions (allocated once, zeroed on alloc);
+  // BeginSession no longer zeroes it. `ReadbackXyzAccum` D2H copies it to the host
+  // and zeros it, but the simulator now drains on display cadence (a whole window
+  // of batches), not per batch.
+  float*   d_xyz_buf_       = nullptr;  // alloc_xyz_w_ * alloc_xyz_h_ * 3 floats, atomicAdd target
   float*   d_landed_weight_ = nullptr;  // 1 float, atomicAdd target (running total)
+  // scrum-312: dims the persistent d_xyz_buf_ was actually allocated for. Unlike
+  // img_w_/img_h_ (per-session, cleared by Reset), these survive across sessions
+  // so ReadbackXyzAccum — which drains BETWEEN sessions — can release-safe-verify
+  // the caller's dims against the real buffer capacity (guards the Bug-1 class:
+  // dims decoupled from the buffer). Zeroed only on full teardown (buffer freed).
+  uint32_t alloc_xyz_w_     = 0u;
+  uint32_t alloc_xyz_h_     = 0u;
   uint32_t proj_type_       = 0u;       // 0=rectangular, 1=dual_fisheye_equal_area
   float    az0_             = 0.0f;     // rectangular: view azimuth offset (radians)
   float    r_scale_         = 1.0f;     // dual_fisheye: equal-area r scale
@@ -1553,6 +1561,8 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     // S2 device-fused XYZ accumulation buffers.
     cudaFree(d_xyz_buf_);      d_xyz_buf_ = nullptr;
     cudaFree(d_landed_weight_); d_landed_weight_ = nullptr;
+    alloc_xyz_w_ = 0u;  // scrum-312: buffer freed → clear its remembered dims
+    alloc_xyz_h_ = 0u;
 
     cudaFreeHost(pinned_dirs_);        pinned_dirs_ = nullptr;
     cudaFreeHost(pinned_pos_);         pinned_pos_ = nullptr;
@@ -2342,6 +2352,10 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
                 "BeginSession cudaMalloc d_xyz_buf");
       CheckCuda(cudaMemset(impl_->d_xyz_buf_, 0, xyz_floats * sizeof(float)),
                 "BeginSession cudaMemset d_xyz_buf");
+      // scrum-312: remember the dims this persistent buffer was sized for so the
+      // between-session drain can verify caller dims against real capacity.
+      impl_->alloc_xyz_w_ = impl_->img_w_;
+      impl_->alloc_xyz_h_ = impl_->img_h_;
     }
     if (impl_->d_landed_weight_ == nullptr) {
       CheckCuda(cudaMalloc(&impl_->d_landed_weight_, sizeof(float)),
@@ -2960,11 +2974,12 @@ void CudaTraceBackend::EndSession() {
 // throughput to 0.10–0.12× legacy CPU.
 bool CudaTraceBackend::HasDeviceXyzAccum() const { return true; }
 
-// One-shot per batch: copies d_xyz_buf_ + d_landed_weight_ to host, accumulates
-// landed_weight into the running scalar, and zeros the device buffers so the
-// NEXT batch's BeginSession-allocated state starts clean. Calling twice in the
-// same batch returns zeros on the second call (by design — the buffers are
-// cleared after the first read).
+// scrum-312 third-clock drain: copies the PERSISTENT cross-batch d_xyz_buf_ +
+// d_landed_weight_ accumulator to host, accumulates landed_weight into the running
+// scalar, and zeros the device buffers to start the next drain window clean. The
+// simulator calls this on display cadence (a whole window of batches), not per
+// batch, and possibly BETWEEN sessions. Draining twice with no accumulation in
+// between returns zeros on the second call (buffers cleared after the first read).
 void CudaTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) {
   // scrum-312 (third-clock drain): the XYZ accumulator is persistent and drained
   // on display cadence, which the simulator triggers BETWEEN per-batch sessions
@@ -2974,23 +2989,29 @@ void CudaTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight)
   if (impl_->d_xyz_buf_ == nullptr) {
     throw BackendUnavailableError("CudaTraceBackend::ReadbackXyzAccum called before any session allocated the buffer");
   }
-  // Defensive guards (Risk 4 / 务实评审 Minor 3): nullptr device buffer or
-  // mismatched host destination would silently corrupt memory on D2H copy.
-  assert(impl_->d_xyz_buf_ != nullptr && "d_xyz_buf_ unallocated — BeginSession failed?");
   assert(impl_->d_landed_weight_ != nullptr);
   assert(xyz.data != nullptr && "ReadbackXyzAccum: caller must pre-allocate xyz.data");
-  // scrum-312: pixel count comes from the CALLER (xyz.width/height), NOT from
-  // impl_->img_w_/img_h_ — those are cleared to 0 by EndSession/Reset (see the
-  // "always reset" block), and the third-clock drain runs BETWEEN sessions, so
-  // reading impl_ dims here would copy 0 bytes and yield a black image. The
-  // simulator sets xyz.width/height from the accumulation window (= the render
-  // dims the persistent d_xyz_buf_ was allocated for, constant within a run).
-  assert(xyz.width > 0 && xyz.height > 0 && "ReadbackXyzAccum: caller must set xyz.width/height");
+  // scrum-312 (release-safe, code-review Major): pixel count comes from the dims
+  // the persistent buffer was ACTUALLY allocated for (alloc_xyz_w_/h_), NOT from
+  // impl_->img_w_/img_h_ (cleared to 0 by EndSession/Reset — reading them here was
+  // Bug 1: 0-byte copy → black image). Cross-check the caller's declared dims
+  // against the real buffer capacity with a RELEASE-safe throw (not an assert —
+  // asserts are no-ops under NDEBUG, which is exactly how Bug 1 stayed silent):
+  // a mismatch means the buffer size and the caller's expectation have decoupled
+  // (e.g. a resolution change on the persistent buffer), which would corrupt the
+  // D2H copy.
+  if (static_cast<uint32_t>(xyz.width) != impl_->alloc_xyz_w_ ||
+      static_cast<uint32_t>(xyz.height) != impl_->alloc_xyz_h_) {
+    throw BackendUnavailableError(
+        "CudaTraceBackend::ReadbackXyzAccum: caller dims (" + std::to_string(xyz.width) + "x" +
+        std::to_string(xyz.height) + ") != allocated buffer dims (" + std::to_string(impl_->alloc_xyz_w_) +
+        "x" + std::to_string(impl_->alloc_xyz_h_) + ")");
+  }
 
   // waitUntilCompleted-equivalent — all preceding TraceLayer kernel work must
   // finalize before the D2H copy. Mirrors Metal's cmd-buffer wait.
   cudaDeviceSynchronize();
-  const size_t pix = static_cast<size_t>(xyz.width) * static_cast<size_t>(xyz.height);
+  const size_t pix = static_cast<size_t>(impl_->alloc_xyz_w_) * static_cast<size_t>(impl_->alloc_xyz_h_);
   CheckCuda(cudaMemcpy(xyz.data, impl_->d_xyz_buf_, pix * 3u * sizeof(float),
                        cudaMemcpyDeviceToHost),
             "ReadbackXyzAccum D2H d_xyz_buf");

--- a/src/core/backend/cuda_trace_backend.hpp
+++ b/src/core/backend/cuda_trace_backend.hpp
@@ -104,6 +104,9 @@ class CudaTraceBackend : public TraceBackend {
   // to legacy CPU via simulator backend dispatch.
   bool HasDeviceXyzAccum() const override;
   void ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) override;
+  // scrum-312: CUDA opts into third-clock drain (persistent device accumulator +
+  // display-cadence readback) to shed the per-batch synchronous D2H readback tax.
+  bool SupportsThirdClockDrain() const override { return true; }
   bool IsCompatible(const RenderConfig& render) const override;
   void EndSession() override;
   // Per-ray wavelength pool size M (296.6 DR-3). Non-zero routes the driving

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -106,6 +106,10 @@ class MetalTraceBackend : public TraceBackend {
   // of materialising per-exit records.
   bool HasDeviceXyzAccum() const override { return true; }
   void ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) override;
+  // scrum-312.4: Metal joins the third clock (persistent cross-batch XYZ
+  // accumulator + display-cadence drain). Unlike CUDA the payoff is architectural
+  // uniformity, not throughput — unified-memory readback was already ~free.
+  bool SupportsThirdClockDrain() const override { return true; }
   void EndSession() override;
   bool IsCompatible(const RenderConfig& render) const override;
   // scrum-268.8 (DR-3): per-ray wavelength pool size. Resolved from

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -868,18 +868,28 @@ void MetalTraceBackend::Impl::EnsurePso() {
 
 void MetalTraceBackend::Impl::EnsureImage(int w, int h) {
   size_t pix = static_cast<size_t>(w) * static_cast<size_t>(h);
+  // Grow/shrink the byte allocation only when the pixel COUNT changes.
   if (pix != xyz_pix_capacity) {
     xyz_image = [device newBufferWithLength:pix * 3 * sizeof(float)
                                     options:MTLResourceStorageModeShared];
     assert(xyz_image != nil);
     xyz_pix_capacity = pix;
-    // scrum-312 third clock: zero ONLY on (re)alloc — the buffer now PERSISTS as
-    // a cross-batch accumulator (BeginSession no longer clears it per call; the
-    // drain's post-read memset resets each window). Remember the dims it was
-    // sized for so the between-session drain can release-safe-verify caller dims
-    // (width/height get cleared by Reset — reading them mid-drain would be a
-    // 0-byte copy, the CUDA Bug-1 class).
+  }
+  // scrum-312 third clock: reset on any SHAPE change (w or h), not just pixel
+  // count — a same-area shape swap (e.g. 512x1024 -> 1024x512) reuses the buffer
+  // but is a fresh accumulation region. Gate on (w,h) so alloc_xyz_w_/h_ track the
+  // current shape (else the between-session drain's dim check would false-throw,
+  // review-Major-1) and BOTH twin accumulators reset together (else landed_weight
+  // would mix old/new-shape rays while xyz_image reset, review-Major-2). A shape
+  // change always rides a generation change, whose flush already drained the prior
+  // window, so re-zeroing here is correct. Steady state: BeginSession does NOT
+  // clear these — they persist across batches; the drain's post-read reset is the
+  // per-window reset.
+  if (w != alloc_xyz_w_ || h != alloc_xyz_h_) {
     std::memset([xyz_image contents], 0, pix * 3 * sizeof(float));
+    if (landed_weight_buf_ != nil) {
+      *static_cast<float*>([landed_weight_buf_ contents]) = 0.0f;
+    }
     alloc_xyz_w_ = w;
     alloc_xyz_h_ = h;
   }
@@ -2006,18 +2016,18 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   try {
     impl_->EnsureDevice();
     impl_->EnsurePso();
-    impl_->EnsureImage(impl_->width, impl_->height);
     // S1 device-fused: landed_weight scalar (1 × float, MTLResourceStorageModeShared).
-    // scrum-312 third clock: allocate + zero ONCE (nil-check); it persists as a
-    // cross-batch accumulator like xyz_image (the drain resets it after reading),
-    // so BeginSession no longer clears it per call.
+    // scrum-312 third clock: allocate ONCE (nil-check); it persists as a cross-batch
+    // accumulator like xyz_image. Allocate it BEFORE EnsureImage so EnsureImage
+    // resets BOTH twin accumulators atomically on a fresh accumulation region /
+    // shape change (review-Major-2). No per-call zero here.
     if (impl_->landed_weight_buf_ == nil) {
       impl_->landed_weight_buf_ =
           [impl_->device newBufferWithLength:sizeof(float)
                                      options:MTLResourceStorageModeShared];
       assert(impl_->landed_weight_buf_ != nil);
-      *static_cast<float*>([impl_->landed_weight_buf_ contents]) = 0.0f;
     }
+    impl_->EnsureImage(impl_->width, impl_->height);
     // scrum-268.8 (DR-3): allocate the wavelength pool buffer once per backend
     // (size invariant across sessions) and populate it once per BeginSession.
     // Pool content depends only on (illuminant mode, per_batch_wl_) — both
@@ -2411,11 +2421,16 @@ size_t MetalTraceBackend::ReadbackExitRays(std::vector<ExitRayRecord>& out) {
 // this must not depend on in_session/width/height (Reset clears those), and must
 // itself guarantee GPU completion rather than rely on the caller having waited.
 void MetalTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) {
-  // Release-safe gates (mirror the CUDA backend; asserts are no-ops under NDEBUG).
-  if (impl_->xyz_image == nil || impl_->landed_weight_buf_ == nil) {
-    throw BackendUnavailableError("MetalTraceBackend::ReadbackXyzAccum called before any session allocated the buffers");
+  // Release-safe gates (mirror the CUDA backend; asserts are no-ops under NDEBUG,
+  // review-Minor: all three preconditions throw, not assert).
+  if (impl_->xyz_image == nil || impl_->landed_weight_buf_ == nil || xyz.data == nullptr) {
+    throw BackendUnavailableError("MetalTraceBackend::ReadbackXyzAccum: unallocated buffer or null xyz.data");
   }
-  assert(xyz.data != nullptr && "ReadbackXyzAccum: caller must pre-allocate xyz.data");
+  // Invariant (review-Minor): alloc_xyz_w_/h_ and xyz_pix_capacity encode the same
+  // underlying allocation and are set together in EnsureImage — assert they agree.
+  assert(static_cast<size_t>(impl_->alloc_xyz_w_) * static_cast<size_t>(impl_->alloc_xyz_h_) ==
+             impl_->xyz_pix_capacity &&
+         "alloc dims out of sync with xyz_pix_capacity");
   // Pixel count from the dims the buffer was ACTUALLY allocated for (persist
   // across Reset), cross-checked release-safe against the caller's declared dims.
   if (xyz.width != impl_->alloc_xyz_w_ || xyz.height != impl_->alloc_xyz_h_) {
@@ -2426,6 +2441,12 @@ void MetalTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight
   // Defensive GPU-completion barrier: the per-batch WaitAndReadbackLayer (ci-loop
   // tail) + EndSession already drain pending_cb_, so this is normally nil, but a
   // between-session drain must not assume that — mirror CUDA's cudaDeviceSynchronize.
+  // Thread-safety (review-Minor): pending_cb_ is only ever touched on the simulator
+  // Run() thread — the trace (DispatchLayer sets it), the per-batch waits, and this
+  // drain (via DrainDeviceXyz at Run()'s flush points / batch-cap) all run on that
+  // single thread sequentially. No cross-thread access, so the bare-pointer r/w is
+  // race-free (the display-cadence "clock" is the Run loop's own control flow, not a
+  // separate GUI thread).
   if (impl_->pending_cb_ != nil) {
     [impl_->pending_cb_ waitUntilCompleted];
     impl_->pending_cb_ = nil;

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -527,6 +527,11 @@ struct MetalTraceBackend::Impl {
   // XYZ accumulator (W*H*3 floats).
   id<MTLBuffer> xyz_image = nil;
   size_t        xyz_pix_capacity = 0;
+  // scrum-312: dims xyz_image was actually allocated for (persist across sessions,
+  // unlike width/height which Reset clears). Used by the between-session
+  // third-clock drain to release-safe-verify the caller's dims.
+  int           alloc_xyz_w_ = 0;
+  int           alloc_xyz_h_ = 0;
 
   // Polygon geometry (uploaded per-layer; capacity-resized lazily).
   id<MTLBuffer> poly_n_buf  = nil;
@@ -868,8 +873,16 @@ void MetalTraceBackend::Impl::EnsureImage(int w, int h) {
                                     options:MTLResourceStorageModeShared];
     assert(xyz_image != nil);
     xyz_pix_capacity = pix;
+    // scrum-312 third clock: zero ONLY on (re)alloc — the buffer now PERSISTS as
+    // a cross-batch accumulator (BeginSession no longer clears it per call; the
+    // drain's post-read memset resets each window). Remember the dims it was
+    // sized for so the between-session drain can release-safe-verify caller dims
+    // (width/height get cleared by Reset — reading them mid-drain would be a
+    // 0-byte copy, the CUDA Bug-1 class).
+    std::memset([xyz_image contents], 0, pix * 3 * sizeof(float));
+    alloc_xyz_w_ = w;
+    alloc_xyz_h_ = h;
   }
-  std::memset([xyz_image contents], 0, pix * 3 * sizeof(float));
 }
 
 void MetalTraceBackend::Impl::EnsurePolyBuffers(size_t poly_cnt) {
@@ -1995,15 +2008,16 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
     impl_->EnsurePso();
     impl_->EnsureImage(impl_->width, impl_->height);
     // S1 device-fused: landed_weight scalar (1 × float, MTLResourceStorageModeShared).
-    // Allocated once (nil-check), cleared every BeginSession so cross-batch
-    // accumulation starts from zero.
+    // scrum-312 third clock: allocate + zero ONCE (nil-check); it persists as a
+    // cross-batch accumulator like xyz_image (the drain resets it after reading),
+    // so BeginSession no longer clears it per call.
     if (impl_->landed_weight_buf_ == nil) {
       impl_->landed_weight_buf_ =
           [impl_->device newBufferWithLength:sizeof(float)
                                      options:MTLResourceStorageModeShared];
       assert(impl_->landed_weight_buf_ != nil);
+      *static_cast<float*>([impl_->landed_weight_buf_ contents]) = 0.0f;
     }
-    *static_cast<float*>([impl_->landed_weight_buf_ contents]) = 0.0f;
     // scrum-268.8 (DR-3): allocate the wavelength pool buffer once per backend
     // (size invariant across sessions) and populate it once per BeginSession.
     // Pool content depends only on (illuminant mode, per_batch_wl_) — both
@@ -2391,19 +2405,38 @@ size_t MetalTraceBackend::ReadbackExitRays(std::vector<ExitRayRecord>& out) {
   return 0;
 }
 
-// S1 device-fused: copy the device-accumulated W*H*3 XYZ image and the total
-// landed weight. Called once per wavelength batch AFTER the layer loop.
-// The xyz_image buffer is in MTLResourceStorageModeShared (unified memory on
-// Apple Silicon); waitUntilCompleted in WaitAndReadbackLayer guarantees all
-// pending command buffers have finished before we reach here.
+// scrum-312 third-clock drain: copy the PERSISTENT cross-batch xyz_image + landed
+// weight to host and reset them for the next window. The simulator drains on
+// display cadence (a whole window of batches), possibly BETWEEN sessions — so
+// this must not depend on in_session/width/height (Reset clears those), and must
+// itself guarantee GPU completion rather than rely on the caller having waited.
 void MetalTraceBackend::ReadbackXyzAccum(XyzImageData& xyz, float& landed_weight) {
-  assert(impl_->in_session);
-  assert(impl_->landed_weight_buf_ != nil);
-  size_t pix = static_cast<size_t>(impl_->width) * static_cast<size_t>(impl_->height);
-  assert(xyz.data != nullptr);
-  assert(xyz.width == impl_->width && xyz.height == impl_->height);
+  // Release-safe gates (mirror the CUDA backend; asserts are no-ops under NDEBUG).
+  if (impl_->xyz_image == nil || impl_->landed_weight_buf_ == nil) {
+    throw BackendUnavailableError("MetalTraceBackend::ReadbackXyzAccum called before any session allocated the buffers");
+  }
+  assert(xyz.data != nullptr && "ReadbackXyzAccum: caller must pre-allocate xyz.data");
+  // Pixel count from the dims the buffer was ACTUALLY allocated for (persist
+  // across Reset), cross-checked release-safe against the caller's declared dims.
+  if (xyz.width != impl_->alloc_xyz_w_ || xyz.height != impl_->alloc_xyz_h_) {
+    throw BackendUnavailableError("MetalTraceBackend::ReadbackXyzAccum: caller dims (" + std::to_string(xyz.width) +
+                                  "x" + std::to_string(xyz.height) + ") != allocated buffer dims (" +
+                                  std::to_string(impl_->alloc_xyz_w_) + "x" + std::to_string(impl_->alloc_xyz_h_) + ")");
+  }
+  // Defensive GPU-completion barrier: the per-batch WaitAndReadbackLayer (ci-loop
+  // tail) + EndSession already drain pending_cb_, so this is normally nil, but a
+  // between-session drain must not assume that — mirror CUDA's cudaDeviceSynchronize.
+  if (impl_->pending_cb_ != nil) {
+    [impl_->pending_cb_ waitUntilCompleted];
+    impl_->pending_cb_ = nil;
+  }
+  size_t pix = static_cast<size_t>(impl_->alloc_xyz_w_) * static_cast<size_t>(impl_->alloc_xyz_h_);
   std::memcpy(xyz.data, [impl_->xyz_image contents], pix * 3 * sizeof(float));
   landed_weight += *static_cast<const float*>([impl_->landed_weight_buf_ contents]);
+  // Reset the accumulators so the next drain window starts from zero (BeginSession
+  // no longer clears them). Unified memory → a plain host memset/store suffices.
+  std::memset([impl_->xyz_image contents], 0, pix * 3 * sizeof(float));
+  *static_cast<float*>([impl_->landed_weight_buf_ contents]) = 0.0f;
 }
 
 // task-268.4 per-layer destructive drain. Identical to ReadbackExitRays

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -886,10 +886,14 @@ void MetalTraceBackend::Impl::EnsureImage(int w, int h) {
   // clear these — they persist across batches; the drain's post-read reset is the
   // per-window reset.
   if (w != alloc_xyz_w_ || h != alloc_xyz_h_) {
+    // Reset BOTH twin accumulators together. landed_weight_buf_ MUST already be
+    // allocated (BeginSession allocates it before calling EnsureImage) — assert
+    // the invariant loudly rather than silently best-effort, so a future caller
+    // that forgets the ordering can't silently reintroduce the round-1 Major-2
+    // (xyz reset while landed keeps stale rays).
+    assert(landed_weight_buf_ != nil && "EnsureImage: landed_weight_buf_ must be allocated before reset");
     std::memset([xyz_image contents], 0, pix * 3 * sizeof(float));
-    if (landed_weight_buf_ != nil) {
-      *static_cast<float*>([landed_weight_buf_ contents]) = 0.0f;
-    }
+    *static_cast<float*>([landed_weight_buf_ contents]) = 0.0f;
     alloc_xyz_w_ = w;
     alloc_xyz_h_ = h;
   }

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -443,6 +443,16 @@ class TraceBackend {
     landed_weight = 0.0f;
   }
 
+  // scrum-312 (third-clock drain): true = the device XYZ accumulator PERSISTS
+  // across per-batch BeginSession/EndSession cycles (BeginSession does not zero
+  // it), so the simulator may decouple readback from the trace clock and drain
+  // on display cadence (generation-change / producer-pause / run-exit) instead
+  // of every batch — eliminating the per-batch synchronous D2H readback tax on
+  // discrete-memory backends (CUDA). False = the legacy per-batch drain path
+  // (BeginSession zeroes, readback+enqueue every batch); correct + cheap on
+  // unified-memory backends (Metal), which stay here until 312.4.
+  virtual bool SupportsThirdClockDrain() const { return false; }
+
   // Close the session. Releases per-session backend state. Calling any
   // method other than BeginSession after EndSession is undefined.
   virtual void EndSession() = 0;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -692,6 +692,9 @@ void Simulator::Run() {
   // a backend pool, that gate's semantics must be revisited (cross-Run() PCG
   // determinism + counter rollover both depend on the per-Run() lifecycle here).
   auto backend = CreateBackend(preferred_backend_.load(std::memory_order_acquire), logger_);
+  // scrum-312 third-clock drain cadence cap + fresh window per Run().
+  xyz_drain_batches_ = env::XyzDrainBatches(logger_, kDefaultXyzDrainBatches);
+  xyz_win_ = XyzDrainWindow{};
   bool warned_no_renders = false;
   bool warned_multi_renderer = false;
   bool warned_compat = false;
@@ -702,6 +705,13 @@ void Simulator::Run() {
   uint64_t prev_generation = 0;
 
   while (true) {
+    // scrum-312 third-clock: producer-pause flush. When no batch is queued we are
+    // about to block; drain any pending device XYZ window first so the consumer/
+    // GUI sees the latest image at the natural display cadence (the producer
+    // feeds a burst, pauses, we drain) instead of waiting for the next burst.
+    if (xyz_win_.pending && config_queue_->Empty()) {
+      DrainDeviceXyz(backend.get());
+    }
     auto batch = config_queue_->Get();  // Will block until get one
     if (batch.ray_num_ == 0 || stop_) {
       ILOG_DEBUG(logger_, "Simulator::Run: exit (ray_num={}, stop={})", batch.ray_num_, stop_.load());
@@ -719,6 +729,11 @@ void Simulator::Run() {
     // Reset carry when config changes (new generation = new proportions).
     if (generation != prev_generation) {
       ray_alloc_carry.clear();
+      // scrum-312 third-clock: flush the old generation's device XYZ window
+      // BEFORE any new-generation batch traces into the (shared, persistent)
+      // device buffer — otherwise the new generation's atomicAdds would mix into
+      // the old generation's un-drained accumulation.
+      DrainDeviceXyz(backend.get());
       prev_generation = generation;
     }
 
@@ -803,6 +818,9 @@ void Simulator::Run() {
 
     idle_ = true;
   }
+  // scrum-312 third-clock: final flush on loop exit (ray_num==0 sentinel / stop /
+  // null scene) so the last accumulation window is not lost on shutdown.
+  DrainDeviceXyz(backend.get());
 }
 
 
@@ -998,6 +1016,33 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
 //
 // `stop_` is checked between TraceLayer/Recombine calls. On stop the session
 // is closed via EndSession (RAII-equivalent) but no SimData is emplaced.
+void Simulator::DrainDeviceXyz(TraceBackend* backend) {
+  // scrum-312 third-clock drain: read the persistent device XYZ accumulator into
+  // a SimData carrying the WINDOW-aggregated root/crystal counts, enqueue it, and
+  // reset the window. ReadbackXyzAccum zeroes the device buffer after the copy so
+  // the next window starts clean. No-op when no backend or nothing accumulated.
+  if (backend == nullptr || !xyz_win_.pending) {
+    return;
+  }
+  SimData sim_data;
+  sim_data.curr_wl_ = xyz_win_.wl;
+  sim_data.generation_ = xyz_win_.generation;
+  sim_data.root_ray_count_ = xyz_win_.root_rays;
+  sim_data.crystal_count_ = xyz_win_.crystals;
+  // This one SimData stands in for xyz_win_.calls per-wavelength calls; ConsumeData
+  // decrements sim_scene_cnt_ by this so the counter invariant stays balanced.
+  sim_data.sim_scene_credit_ = xyz_win_.calls;
+  size_t pix = static_cast<size_t>(xyz_win_.w) * static_cast<size_t>(xyz_win_.h);
+  sim_data.xyz_pixel_data_.resize(pix * 3u);
+  XyzImageData xyz_out;
+  xyz_out.data = sim_data.xyz_pixel_data_.data();
+  xyz_out.width = xyz_win_.w;
+  xyz_out.height = xyz_win_.h;
+  backend->ReadbackXyzAccum(xyz_out, sim_data.xyz_landed_weight_);
+  data_queue_->Emplace(std::move(sim_data));
+  xyz_win_ = XyzDrainWindow{};
+}
+
 void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const SceneConfig& scene,
                                                  const RenderConfig& render, const WlParam& wl_param, size_t ray_num,
                                                  uint64_t generation) {
@@ -1090,6 +1135,29 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   // path in RenderConsumer::Consume picks up xyz_pixel_data_ instead of the
   // ScatterOutgoingToXyz path.
   if (backend.HasDeviceXyzAccum()) {
+    if (backend.SupportsThirdClockDrain()) {
+      // scrum-312 third-clock: the device XYZ accumulator persists across
+      // batches (BeginSession no longer zeroes it). Accumulate this batch's
+      // normalization/stats into the drain window and return WITHOUT reading
+      // back — the drain (readback+reset+enqueue) fires on display cadence in
+      // Run() (producer-pause / generation-change / run-exit) or when the window
+      // hits the batch cap here. This sheds the per-batch synchronous D2H tax.
+      xyz_win_.pending = true;
+      xyz_win_.root_rays += ray_num;
+      xyz_win_.crystals += backend.GetLastBatchCrystalCount();
+      xyz_win_.generation = generation;
+      xyz_win_.w = w;
+      xyz_win_.h = h;
+      xyz_win_.wl = wl_param.wl_;
+      xyz_win_.calls += 1;
+      if (xyz_win_.calls >= xyz_drain_batches_) {
+        DrainDeviceXyz(&backend);
+      }
+      return;
+    }
+    // Legacy per-batch drain (unified-memory backends, e.g. Metal): readback +
+    // enqueue every batch. Cheap here because the readback is a shared-memory
+    // memcpy, not a synchronous PCIe D2H. Metal moves to the third clock in 312.4.
     SimData sim_data;
     sim_data.curr_wl_ = wl_param.wl_;
     sim_data.generation_ = generation;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1017,6 +1017,12 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
 // `stop_` is checked between TraceLayer/Recombine calls. On stop the session
 // is closed via EndSession (RAII-equivalent) but no SimData is emplaced.
 void Simulator::DrainDeviceXyz(TraceBackend* backend) {
+  // Drain-OR-settle the pending third-clock window: with a live backend this
+  // reads the device XYZ accumulator back into a SimData and enqueues it; with a
+  // null backend (task-282 fallback killed it mid-window) it enqueues a degenerate
+  // credit-only SimData instead — so the sim_scene_cnt_ books stay balanced even
+  // though the device image is unrecoverable. Callers should NOT assume a real
+  // image always lands.
   // Takes a pointer (not a reference like SimulateOneWavelengthWithBackend)
   // because the Run() flush sites pass `backend.get()`, and `backend` CAN be null
   // there: the task-282 fallback resets it to null mid-Run() on

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1017,6 +1017,13 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const WlParam& 
 // `stop_` is checked between TraceLayer/Recombine calls. On stop the session
 // is closed via EndSession (RAII-equivalent) but no SimData is emplaced.
 void Simulator::DrainDeviceXyz(TraceBackend* backend) {
+  // Takes a pointer (not a reference like SimulateOneWavelengthWithBackend)
+  // because the Run() flush sites pass `backend.get()`, and `backend` CAN be null
+  // there: the task-282 fallback resets it to null mid-Run() on
+  // BackendUnavailableError. In that degraded case any device accumulation is
+  // unrecoverable (backend gone), so a null-backend drain is a no-op — the
+  // self-guard below keeps the call sites flat. (SimulateOneWavelengthWithBackend
+  // stays a reference: run_with_backend gates on non-null before calling it.)
   // scrum-312 third-clock drain: read the persistent device XYZ accumulator into
   // a SimData carrying the WINDOW-aggregated root/crystal counts, enqueue it, and
   // reset the window. ReadbackXyzAccum zeroes the device buffer after the copy so

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1020,15 +1020,15 @@ void Simulator::DrainDeviceXyz(TraceBackend* backend) {
   // Takes a pointer (not a reference like SimulateOneWavelengthWithBackend)
   // because the Run() flush sites pass `backend.get()`, and `backend` CAN be null
   // there: the task-282 fallback resets it to null mid-Run() on
-  // BackendUnavailableError. In that degraded case any device accumulation is
-  // unrecoverable (backend gone), so a null-backend drain is a no-op — the
-  // self-guard below keeps the call sites flat. (SimulateOneWavelengthWithBackend
-  // stays a reference: run_with_backend gates on non-null before calling it.)
+  // BackendUnavailableError. See the backend==nullptr branch below for how the
+  // pending window's counter debt is still settled in that degraded case.
+  // (SimulateOneWavelengthWithBackend stays a reference: run_with_backend gates on
+  // non-null before calling it.)
   // scrum-312 third-clock drain: read the persistent device XYZ accumulator into
   // a SimData carrying the WINDOW-aggregated root/crystal counts, enqueue it, and
   // reset the window. ReadbackXyzAccum zeroes the device buffer after the copy so
-  // the next window starts clean. No-op when no backend or nothing accumulated.
-  if (backend == nullptr || !xyz_win_.pending) {
+  // the next window starts clean. No-op when nothing has accumulated.
+  if (!xyz_win_.pending) {
     return;
   }
   SimData sim_data;
@@ -1039,13 +1039,30 @@ void Simulator::DrainDeviceXyz(TraceBackend* backend) {
   // This one SimData stands in for xyz_win_.calls per-wavelength calls; ConsumeData
   // decrements sim_scene_cnt_ by this so the counter invariant stays balanced.
   sim_data.sim_scene_credit_ = xyz_win_.calls;
-  size_t pix = static_cast<size_t>(xyz_win_.w) * static_cast<size_t>(xyz_win_.h);
-  sim_data.xyz_pixel_data_.resize(pix * 3u);
-  XyzImageData xyz_out;
-  xyz_out.data = sim_data.xyz_pixel_data_.data();
-  xyz_out.width = xyz_win_.w;
-  xyz_out.height = xyz_win_.h;
-  backend->ReadbackXyzAccum(xyz_out, sim_data.xyz_landed_weight_);
+  if (backend != nullptr) {
+    // Normal drain: pull the accumulated image off the device.
+    size_t pix = static_cast<size_t>(xyz_win_.w) * static_cast<size_t>(xyz_win_.h);
+    sim_data.xyz_pixel_data_.resize(pix * 3u);
+    XyzImageData xyz_out;
+    xyz_out.data = sim_data.xyz_pixel_data_.data();
+    xyz_out.width = xyz_win_.w;
+    xyz_out.height = xyz_win_.h;
+    backend->ReadbackXyzAccum(xyz_out, sim_data.xyz_landed_weight_);
+  } else {
+    // Degraded path (code-review round-2 Major): backend went null mid-window via
+    // the task-282 fallback. The device image is unrecoverable, but we MUST still
+    // emplace so ConsumeData decrements sim_scene_cnt_ by this window's credit —
+    // else the increments GenerateScene already counted for these batches are
+    // never balanced and the server never idles (the "producer++ / consumer--
+    // must stay bound" invariant; dropping the window entirely reintroduces the
+    // historical IDLE-hang class). Empty xyz_pixel_data_ → the consumer's 0-exit
+    // path decrements without accumulating. root_ray_count_ stays > 0 so this is
+    // not mistaken for the shutdown sentinel (rays_ empty && root_ray_count_ == 0).
+    ILOG_WARN(logger_,
+              "DrainDeviceXyz: backend null mid-window; settling {} credit with empty image "
+              "(device data lost to fallback)",
+              xyz_win_.calls);
+  }
   data_queue_->Emplace(std::move(sim_data));
   xyz_win_ = XyzDrainWindow{};
 }

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -92,6 +92,31 @@ class Simulator {
   void SimulateOneWavelengthWithBackend(TraceBackend& backend, const SceneConfig& scene, const RenderConfig& render,
                                         const WlParam& wl_param, size_t ray_num, uint64_t generation);
 
+  // scrum-312 (third-clock drain): for SupportsThirdClockDrain() backends the
+  // device XYZ accumulator persists across per-batch sessions; this window holds
+  // the host-side aggregation (Σ root rays / crystals) since the last drain so
+  // the drained SimData carries correct normalization + stats. Drained on
+  // display cadence (producer-pause / generation-change / run-exit / batch cap),
+  // not per batch — see Run() and DrainDeviceXyz.
+  struct XyzDrainWindow {
+    bool pending = false;     // undrained device accumulation present
+    size_t root_rays = 0;     // Σ ray_num over the window (normalization denom)
+    size_t crystals = 0;      // Σ crystal_count over the window (stats)
+    uint64_t generation = 0;  // generation the window belongs to
+    int w = 0;                // render resolution of the window
+    int h = 0;
+    float wl = 0.0f;     // last wl (device-fused: not consumed downstream)
+    uint32_t calls = 0;  // batches accumulated since last drain (cadence cap)
+  };
+  XyzDrainWindow xyz_win_;
+  static constexpr uint32_t kDefaultXyzDrainBatches = 64;
+  uint32_t xyz_drain_batches_ = kDefaultXyzDrainBatches;  // resolved from env at Run() entry
+  // Readback the persistent device XYZ accumulator into a SimData (window-
+  // aggregated root/crystal counts), enqueue it, and reset the window. No-op if
+  // `backend` is null or nothing is pending (self-guarding so call sites stay
+  // flat). Called only for SupportsThirdClockDrain() backends.
+  void DrainDeviceXyz(TraceBackend* backend);
+
   static constexpr size_t kSmallBatchRayNum = 32;
 
   QueuePtrS<SimBatch> config_queue_;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -905,7 +905,11 @@ void ServerImpl::ConsumeData() {
     } else {
       ILOG_DEBUG(logger_, "ConsumeData: skip consume (sim_scene_cnt_={})", sim_scene_cnt_.load());
     }
-    sim_scene_cnt_--;
+    // scrum-312 third-clock: a windowed device-fused SimData stands in for N
+    // per-wavelength calls (sim_scene_credit_ == N); all other paths credit 1.
+    // Decrement by the credit to keep the GenerateScene ++ / ConsumeData --
+    // invariant balanced regardless of drain windowing.
+    sim_scene_cnt_ -= static_cast<int>(sim_data.sim_scene_credit_);
     if (sim_scene_cnt_ < kMaxSceneCnt / 2) {
       scene_cv_.notify_one();
     }

--- a/src/util/env_knobs.cpp
+++ b/src/util/env_knobs.cpp
@@ -55,6 +55,20 @@ std::size_t DispatchRayNum(Logger& logger, std::size_t default_val) {
   return default_val;
 }
 
+std::uint32_t XyzDrainBatches(Logger& logger, std::uint32_t default_val) {
+  if (const char* env = std::getenv("LUMICE_XYZ_DRAIN_BATCHES")) {
+    long b = std::atol(env);
+    if (b > 0) {
+      static std::once_flag logged;
+      std::call_once(logged, [&logger, b, default_val]() {
+        ILOG_INFO(logger, "env override: LUMICE_XYZ_DRAIN_BATCHES={} (default {})", b, default_val);
+      });
+      return static_cast<std::uint32_t>(b);
+    }
+  }
+  return default_val;
+}
+
 std::size_t CommitRayNum(Logger& logger, std::size_t default_val) {
   std::size_t result = default_val;
   bool overridden = false;

--- a/src/util/env_knobs.hpp
+++ b/src/util/env_knobs.hpp
@@ -43,6 +43,14 @@ std::size_t DispatchRayNum(Logger& logger, std::size_t default_val);
 // deprecation WARN once if the legacy LUMICE_BATCH_RAY_NUM name is set at all.
 std::size_t CommitRayNum(Logger& logger, std::size_t default_val);
 
+// LUMICE_XYZ_DRAIN_BATCHES — scrum-312 third-clock drain cadence cap. Max number
+// of device-fused XYZ batches accumulated on-device before a forced drain
+// (readback+reset), bounding within-window float32 accumulation + latency during
+// continuous bursts (CLI). GUI display cadence is driven mainly by producer-pause
+// flush; this is the burst-internal upper bound. Returns the override when set to
+// a positive integer, else default_val. INFO once if applied.
+std::uint32_t XyzDrainBatches(Logger& logger, std::uint32_t default_val);
+
 // LUMICE_WL_POOL_SIZE — Metal per-ray wavelength pool size. Clamped to
 // [1, max_val]; returns default_val when unset/invalid. INFO once if applied.
 std::uint32_t WlPoolSize(Logger& logger, std::uint32_t default_val, std::uint32_t max_val);

--- a/src/util/queue.hpp
+++ b/src/util/queue.hpp
@@ -30,6 +30,15 @@ class Queue {
     return e;
   }
 
+  // Non-blocking emptiness check. Used by the device-fused XYZ drain cadence
+  // (scrum-312: third-clock decoupling) to flush the accumulation window when
+  // the producer pauses. TOCTOU is benign here — a batch arriving right after
+  // the check just drains one window later.
+  bool Empty() {
+    std::unique_lock lock(q_mutex_);
+    return q_.empty();
+  }
+
   template <class... Args>
   void Emplace(Args&&... args) {
     std::unique_lock lock(q_mutex_);

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -49,7 +49,9 @@ static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 // S1 device-fused: adds xyz_pixel_data_ (vector<float>, 24B) + xyz_landed_weight_
 // (float, 4B) + 4B padding = 32B, bumping 216 → 248. task-exit-seam-crystal-count
 // adds crystal_count_ (size_t, 8B) for exit-seam stats, bumping 248 → 256.
-static_assert(sizeof(SimData) == 256,
+// scrum-312 adds sim_scene_credit_ (size_t, 8B) for third-clock drain counter
+// balance, bumping 256 → 264.
+static_assert(sizeof(SimData) == 264,
               "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
               "and sim_data.cpp's static_assert.");
 #endif
@@ -107,6 +109,8 @@ SimData MakePopulatedSimData() {
   s.crystals_.emplace_back();
   // task-exit-seam-crystal-count: propagation coverage for the new field.
   s.crystal_count_ = 4;
+  // scrum-312: third-clock drain counter-balance credit propagation coverage.
+  s.sim_scene_credit_ = 11;
   return s;
 }
 
@@ -811,7 +815,8 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   EXPECT_EQ(copy.exit_records_[1].ms_layer_idx, 1u);
   EXPECT_EQ(copy.xyz_pixel_data_, original.xyz_pixel_data_);  // S1 device-fused
   EXPECT_FLOAT_EQ(copy.xyz_landed_weight_, 1.5f);
-  EXPECT_EQ(copy.crystal_count_, 4u) << "crystal_count_ not copied";  // task-exit-seam-crystal-count
+  EXPECT_EQ(copy.crystal_count_, 4u) << "crystal_count_ not copied";         // task-exit-seam-crystal-count
+  EXPECT_EQ(copy.sim_scene_credit_, 11u) << "sim_scene_credit_ not copied";  // scrum-312
 
   // Deep copy independence — each pointer/container field independently.
   copy.rays_[0].w_ = 999.0f;
@@ -856,7 +861,8 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   EXPECT_EQ(target.exit_records_[0].crystal_id, 7u);
   EXPECT_EQ(target.xyz_pixel_data_, original.xyz_pixel_data_);  // S1 device-fused
   EXPECT_FLOAT_EQ(target.xyz_landed_weight_, 1.5f);
-  EXPECT_EQ(target.crystal_count_, 4u) << "crystal_count_ not assigned";  // task-exit-seam-crystal-count
+  EXPECT_EQ(target.crystal_count_, 4u) << "crystal_count_ not assigned";         // task-exit-seam-crystal-count
+  EXPECT_EQ(target.sim_scene_credit_, 11u) << "sim_scene_credit_ not assigned";  // scrum-312
 
   // Deep copy independence.
   target.rays_[0].w_ = 999.0f;
@@ -910,7 +916,8 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   EXPECT_EQ(moved.crystals_.size(), 1u);
   EXPECT_EQ(moved.xyz_pixel_data_.size(), 3u);  // S1 device-fused
   EXPECT_FLOAT_EQ(moved.xyz_landed_weight_, 1.5f);
-  EXPECT_EQ(moved.crystal_count_, 4u) << "crystal_count_ not moved";  // task-exit-seam-crystal-count
+  EXPECT_EQ(moved.crystal_count_, 4u) << "crystal_count_ not moved";         // task-exit-seam-crystal-count
+  EXPECT_EQ(moved.sim_scene_credit_, 11u) << "sim_scene_credit_ not moved";  // scrum-312
 
   // Moved-from source contract — three categories:
   // (a) rays_ pointer ownership transferred → nullptr + zeroed size/capacity.
@@ -947,7 +954,8 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_FLOAT_EQ(dst.curr_wl_, 550.0f);
   EXPECT_EQ(dst.generation_, 42u);
   EXPECT_EQ(dst.crystals_.size(), 1u);
-  EXPECT_EQ(dst.crystal_count_, 4u) << "crystal_count_ not move-assigned";  // task-exit-seam-crystal-count
+  EXPECT_EQ(dst.crystal_count_, 4u) << "crystal_count_ not move-assigned";         // task-exit-seam-crystal-count
+  EXPECT_EQ(dst.sim_scene_credit_, 11u) << "sim_scene_credit_ not move-assigned";  // scrum-312
 
   // Source moved-from state.
   EXPECT_EQ(src.rays_.rays_, nullptr);

--- a/test/unit-correctness/util/test_queue.cpp
+++ b/test/unit-correctness/util/test_queue.cpp
@@ -57,6 +57,22 @@ TEST(QueueTest, EmplaceForwardsArgs) {
   EXPECT_EQ(b.second, "world");
 }
 
+TEST(QueueTest, EmptyReflectsQueueContents) {
+  // scrum-312: Empty() is the non-blocking emptiness check the third-clock drain
+  // uses for producer-pause flush. True on a fresh queue, false after Emplace,
+  // true again once drained.
+  Queue<int> q;
+  EXPECT_TRUE(q.Empty());
+  q.Emplace(1);
+  EXPECT_FALSE(q.Empty());
+  q.Emplace(2);
+  EXPECT_FALSE(q.Empty());
+  (void)q.Get();
+  EXPECT_FALSE(q.Empty()) << "one item still queued";
+  (void)q.Get();
+  EXPECT_TRUE(q.Empty()) << "drained back to empty";
+}
+
 TEST(QueueTest, GetBlocksUntilEmplace) {
   // Consumer thread calls Get() first; main thread Emplaces; consumer wakes.
   // Synchronization point is t.join(): if consumer never unblocks, join hangs the test.


### PR DESCRIPTION
## What & why

Internal testers reported "GPU slow at the default resolution." Root cause (diagnosed 2026-07-01): the device-fused XYZ readback was welded to the trace clock — the simulator read the whole W×H×3 accumulator back **every SimBatch**. At the GUI-real 2048×1024 this per-batch readback dominates the light-scene cost. That's exactly the coupling seam-design §4.8 ("third clock") calls out.

This PR implements **route B**: decouple readback onto a display-cadence third clock. The device XYZ buffer persists across per-batch sessions; the simulator drains it on cadence (batch-cap / generation-change / producer-pause / run-exit), not every batch.

## Results (2048×1024 `multi_wall`, third clock vs old per-batch)

| Hardware | old | third clock | gain |
|---|---|---|---|
| RTX 4060Ti (Ada) CUDA | 28M | 39M | 1.4× |
| GTX 1070Ti (Pascal) CUDA | 12.5M | 33.5M | 2.7× |
| Apple M-series Metal | 11M | 32.3M | ~3× |

Metal's curve is now nearly flat across resolutions (28–35M) — resolution-robust. Correctness: CUDA parity 10/10 on both arches (4060Ti + 1070Ti/sm_61), Metal parity 14/14 including batch-invariance (drain-cadence independence).

## Key decisions (measured, not assumed)

- **Precision = periodic-drain** (float32 device + host Neumaier + coarse drain), **not f64** — a 48MB f64 buffer spills L2 and runs 0.6×.
- **Metal benefits too** (corrected an earlier "unified memory = zero benefit" guess): the per-batch 24MB memset+memcpy (~3.6GB traffic at 2048) was a real cost the third clock amortizes.
- **Throughput measured via wall-clock** (`bench_throughput.py --res-sweep`, `multi_wall`): the steady `rays_per_sec` is fooled by the now-coarse `sim_ray_num` progress under sparse drains.

## Scope

- `TraceBackend::SupportsThirdClockDrain()` capability-gates the new path; simulator/server/SimData are backend-agnostic.
- `SimData.sim_scene_credit_` keeps the `sim_scene_cnt_` produce/consume invariant balanced under windowing (incl. settling the debt when a backend dies mid-window).
- New `LUMICE_XYZ_DRAIN_BATCHES` dev knob (default 64), registered in `doc/env-var-policy.md`.
- Fixed a latent cross-backend OOB: a resolution increase mid-run wrote past the persistent buffer (pre-existing since the scrum-304.2 persist-buffer design).
- **Not** in scope: mechanism-C (in-kernel atomicAdd L2 overflow, both backends) — a separate product/quality decision (fp16 / preview-resolution decoupling), tracked in backlog.

Both backends independently code-reviewed (CUDA 3 rounds, Metal 2 rounds) → APPROVE; the reviews caught 4 real bugs. Full write-up: `scratchpad/scrum-gpu-readback-third-clock/SUMMARY.md`; canonical numbers in `doc/performance-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)