### PR TITLE
docs+bench: GPU doc consolidation + collapse GPU --benchmark to one steady pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant
   - `trace-backend-frame-lifecycle.md` — Metal frame lifecycle (as-built, multi-MS transit via device `transit_root_kernel`, parity harness methodology, §8 DR-3 per-ray wavelength).
   - `gpu-single-engine-implementation.md` — **§0 as-built 接手须知**（scrum-267+268 完成：CLI 9.5×/GUI 2.07×/dispatch 32768/concern #2 解/DR-3 波长/R1 occupancy 640 benign）+ §5 设计推理 + §8 DR-3 决策链 + §9 关键发现；接手 GPU 路线先读 §0。
 - **Perf / testing**: `performance-testing.md`, `windows-remote-testing.md`, `xyz-stats-tool.md`
+  - `gpu-remote-cuda-build-testing.md` — **dev49 + win-builder 现成 recipe**（CUDA build + parity/正确性
+    验证的两机操作手册：源码同步、docker/BuildTools 工具链、`LUMICE_HAS_CUDA` un-skip 闸、parity battery
+    三文件、PS-over-ssh 坑）。**任何触及 `cuda_trace_backend.*` / 三后端共享头 / SimData / simulator 的
+    改动，先读这份**，别对两台机器从头摸索。与 `windows-remote-testing.md`（GUI VSync 物理桌面）场景正交。
   - `testing-architecture.md` — **authoritative test-organization spec**: verification-purpose primary axis × subsystem tag, seven layers (unit-correctness / golden-analytic / parity-cross-backend / e2e-correctness / performance / gui / regression-sentinel), the "how to add a test" decision tree, cross-cutting rules (perf denominator = legacy CPU; parity metric-masks-bugs battery; reference ownership), and the layer×subsystem physical-layout blueprint. Read before adding or reorganizing any test.
 - **Engineering policy**: `env-var-policy.md` — **环境变量使用策略**: user-facing behavior switches must NOT live only in env vars (they cause silent per-machine drift / undebuggable bugs); use CLI/config/API instead. A-class runtime knobs (`LUMICE_TRACE_BACKEND` + 6 perf knobs, with file:line) vs B-class test/build infra (leave alone); three disposition rules; and the **decision gate to answer before adding any new `getenv`**. Read before introducing a new env knob.
 - Example config: `examples/config_example.json`

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -1,0 +1,116 @@
+# 远程 CUDA 编译 / 测试流程（dev49 + win-builder）
+
+> Mac 本机编不了 CUDA，subprocess 自报不可信 → CUDA 改动必须在 dev49（Linux/NVIDIA）
+> 和/或 win-builder（Windows/NVIDIA）亲跑。本文档是这两台机器的现成 recipe，免每次重新折腾。
+> 首次落地：scrum-311（2026-07-01）；scrum-313 从 scratchpad 提升为 tracked 文档并加索引（避免每
+> 次新 session 对两台机器从头摸索）。关联记忆 `reference_win_builder_cuda_build_recipe`、
+> `reference_dev49_linux_bench`、`reference_win_test_machine`（三者均以本文档为单一真源）。
+>
+> **与 [`windows-remote-testing.md`](windows-remote-testing.md) 的分工**：那份讲的是 **GUI VSync
+> 物理桌面性能测试**（`win_remote_test.sh` + `win_test_watcher.ps1`，需真实显示器 session）；**本文档**
+> 讲的是 **CUDA build + parity/正确性验证**（dev49 docker + win-builder BuildTools，headless 即可）。
+> 二者场景正交，别混用。吞吐 bench 口径见 [`performance-testing.md`](performance-testing.md)。
+
+## 0. 何时需要
+
+- 任何触及 `src/core/backend/cuda_trace_backend.*` 或三后端共享头（`trace_backend.hpp`、
+  `pcg_shared.h`、`*_shared.h`）、`SimData`、simulator/server/stats 的改动。
+- 验收口径：**CUDA parity battery 10/10**（exit-seam 2 + filter 4 + multi-MS 4）+（按需）CLI 冒烟。
+- perf bench 才需要 dev49 idle-gate 锁频窗口；**纯正确性验证不需要等窗口**，随时可跑。
+
+## 1. 通用约定（两台机器都适用）
+
+- **un-skip 闸**：CUDA parity pytest 用 `pytest.mark.skipif(platform in (Linux,Windows) and
+  os.environ["LUMICE_HAS_CUDA"]=="1")`。**必须设 `LUMICE_HAS_CUDA=1`** 才会跑（不是
+  `LUMICE_CUDA_ENABLED`——那个是 runtime 路由用的，两个都要设）。
+- **CApiRunner 找 lib**：`LUMICE_LIB` 指向 shared lib（`.so`/`.dll`），cudart 需与之同目录或在 PATH。
+- **parity battery 三文件**：`test/parity-cross-backend/backend/test_cuda_{exit_seam,filter,multi_ms}_parity.py`。
+- **别信 subprocess 自报**：读 build EXIT、grep 告警、亲看 pytest 计数（`N passed`）。
+
+## 2. dev49（Linux / RTX 4060Ti / `ssh 49-GPU`，主机 wztest49）
+
+- **源码树**：`/home/work/zjj/ice-halo-sim`（rsync 同步改动：
+  `rsync -az --delete src/ 49-GPU:/home/work/zjj/ice-halo-sim/src/` + 同理 test/，
+  排除 `__pycache__`/`references/`）。非 git 仓，rsync 覆盖即可。
+- **CUDA docker 镜像**：
+  `registry.cn-zhangjiakou.aliyuncs.com/weizhendev/wzffm-centos7-cuda11.6:20250811T094454Z-e7555768`
+  （CUDA 11.6）。
+- **build dir**：`build/cmake_build_cuda`（已配好，Ninja，`LUMICE_CUDA_ENABLED=ON`，86-virtual PTX）。
+- **build**：
+  ```bash
+  ssh 49-GPU 'cd /home/work/zjj/ice-halo-sim && IMG=<镜像> && \
+    docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work \
+      -w /work/build/cmake_build_cuda $IMG bash -lc "ninja"'
+  ```
+  单 TU 强制重编：`rm -f CMakeFiles/lumice_obj.dir/src/core/backend/cuda_trace_backend.cu.o &&
+  ninja <该 .o target>`；grep `177-D`/`declared but never referenced` 查死代码告警
+  （既有噪声：spdlog/fmt 的 `#128-D loop is not reachable`、`trace_backend.hpp` multi-line comment，
+  与改动无关）。
+- **parity**：docker 默认 `/usr/local/bin/python3` **无 pytest/numpy**，需一次性装：
+  ```bash
+  docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work -w /work $IMG bash -lc '
+    python3 -m pip install -q pytest numpy Pillow
+    export LUMICE_HAS_CUDA=1 LUMICE_CUDA_ENABLED=1
+    export LUMICE_LIB=/work/build/Release/lib/liblumice.so
+    export LD_LIBRARY_PATH=/work/build/Release/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+    python3 -m pytest -v test/parity-cross-backend/backend/test_cuda_{exit_seam,filter,multi_ms}_parity.py'
+  ```
+  （ctest 的 `CudaMultiMsParity` 因 cmake `PYTEST_EXECUTABLE` cache 指向不存在路径会 Not Run，
+  直接 `python3 -m pytest` 绕过。）耗时 ~7min。
+- **CLI 冒烟**：`Lumice -f examples/config_example.json --backend cuda -o /tmp`
+  （`-o` 是**目录**不是文件），grep `Stats: ... crystals=N`。
+- **坑**：shared 机 CPU 争用使 host-bound 吞吐剧烈抖动（只信 interleaved，perf 才在意）；
+  rsync 对 root 生成的历史文件报 Permission denied 是环境噪声，忽略。
+
+## 3. win-builder（Windows / GTX 1070Ti sm_61 / `ssh win-builder`，主机 DESKTOP-4G9MT1O）
+
+- **源码树**：`C:\lumice-src`。**同步坑**：`scp` 到 `C:/lumice-src/深层/路径` 会因盘符冒号
+  解析失败 → **tarball 法**：
+  ```bash
+  git diff --name-only <base>..HEAD -- src/ test/ > files.txt
+  tar czf changed.tgz -T files.txt
+  scp changed.tgz win-builder:C:/lumice-test/changed.tgz   # 浅路径 scp OK
+  ssh win-builder "powershell -NoProfile -Command \"cd C:/lumice-src; tar xzf C:/lumice-test/changed.tgz\""
+  ```
+  （Windows 10+ 自带 `tar`=bsdtar。）验证：`Select-String -Path <file> -Pattern <新符号>`。
+- **工具链**：VS BuildTools `C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools`，
+  MSVC 工具集 **14.39.33519**（scrum-309 定；14.51 太新 CUDA 11.7 收不了）。CUDA `v11.7`。
+  cmake/ninja 不在 PATH，走 BuildTools 内置（build.ninja 已 baked 绝对路径，纯 ninja 增量即可）。
+- **配好的 CUDA build dirs**（CMakeCache+build.ninja 齐全，`LUMICE_CUDA_ENABLED=ON`）：
+  - `C:\lumice-src\build\win-cuda`（静态 CLI）
+  - `C:\lumice-src\build\win-cuda-shared`（**shared→liblumice.dll，parity 用这个**）
+  - `C:\lumice-src\build\win-gui-cuda`（GUI）
+- **build**（写 .bat scp 过去，`cmd /c` 跑——**别用 PowerShell `&` 后台化，会 AmpersandNotAllowed**；
+  同步跑，我方 bash `run_in_background` 拿 notification）：
+  ```bat
+  @echo off
+  call "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.39 >nul 2>&1
+  set NINJA="C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe"
+  cd /d C:\lumice-src\build\win-cuda-shared
+  %NINJA%
+  echo NINJA_EXIT=%ERRORLEVEL%
+  ```
+  产物 `C:\lumice-src\build\Release\bin\lumice.dll` + `Lumice.exe`（cudart64_110.dll 同目录）。
+  既有噪声告警：fmt/spdlog `#27-D character out of range`、`math.hpp` C4305 truncation（无关）。
+- **parity**：embeddable python `C:\lumice-test\py311\python.exe`（**已装 pytest+numpy**）：
+  ```bat
+  set LUMICE_HAS_CUDA=1
+  set LUMICE_CUDA_ENABLED=1
+  set LUMICE_LIB=C:\lumice-src\build\Release\bin\lumice.dll
+  set PATH=C:\lumice-src\build\Release\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin;%PATH%
+  cd /d C:\lumice-src
+  C:\lumice-test\py311\python.exe -m pytest -v test\parity-cross-backend\backend\test_cuda_exit_seam_parity.py test\parity-cross-backend\backend\test_cuda_filter_parity.py test\parity-cross-backend\backend\test_cuda_multi_ms_parity.py
+  ```
+  耗时 ~7min，1070Ti/sm_61 走 compute_61 PTX JIT。
+- **PS over ssh 通用坑**：默认 shell 是 PowerShell，内联引号 + 中文 locale 易乱码/解析错 →
+  **一律写 .ps1/.bat 文件 scp 过去，再 `powershell -NoProfile -ExecutionPolicy Bypass -File`
+  或 `cmd /c`**。用完清理 `C:\lumice-test` 下的临时脚本（共享机卫生）。
+
+## 4. 一次完整改动的推荐顺序
+
+1. 本机改代码 + Mac build/单测/Metal parity（`./scripts/build.sh -tj release`）。
+2. rsync/tarball 同步到 dev49 + win-builder。
+3. 两台各自 build（查 EXIT + 告警）。
+4. 两台各自跑 CUDA parity battery（各 10/10）。
+5.（按需）CLI 冒烟核 `Stats`/出图。
+6. commit + push + PR，CI 的 `windows-cuda-compile` job 再兜一层 Windows 编译。

--- a/doc/gpu-route-history.md
+++ b/doc/gpu-route-history.md
@@ -1,4 +1,6 @@
-# GPU 路线系统回顾（#250 → #265，截至 2026-06-13）
+# GPU 路线系统回顾（#250 → #312，截至 2026-07-01）
+
+> §一~§四 = Metal 单引擎弧（#250→268，原始回顾，截至 2026-06-13）；§五 Phase 10 = CUDA 第二步 + device-fused（#294→302）；§六 Phase 11 = CUDA 吞吐收口 + Windows 交付 + 第三时钟（#303→312）。
 
 > 目的：把 GPU 迁移一路的决策演进、已积累数据、遗留项盘点清楚，作为重新深想的全局参照系。
 > 触发：owner 反思"行动前想得不够深→地基不稳、结论来回摇摆、积累不成形"。
@@ -138,3 +140,21 @@
 - **S2（CUDA/dev49）**：CUDA 接共享核 + device 累加。inline 亲跑 dev49 修 2 bug（mid-exit 漏 device 累加 → energy=1/层数 / 测试 config 用不支持的 fisheye 投影）→ **parity 10/10 绿**。runner 三犯（被 kill / Mac 编不了 CUDA / 收窄 scope 误报 DONE）→ 巩固纪律「CUDA AC 真闭只能 scrum owner 在 dev49 亲跑」。
 
 **⚠️ 未解的核心张力（scrum-302 S2 暴露，owner 定性）**：device-fused 去掉 roundtrip 后，CUDA 吞吐 **0.16-0.40× legacy**（16 线程 Zen5），随 max_hits 收窄不反超。owner 定性:**对一块 4060 Ti 根本不合理 = 设计/实现缺陷**（非"GPU 非天然胜"的可接受现实）。诊断：compute-bound（max_hits 反比）+ 低 max_hits 仍只 1.82M/s 疑 per-CI 串行 dispatch/launch 开销（单引擎大 dispatch 理想在 CUDA 多 CI 未兑现，§3.6 原始之罪复发）+ recorder local-mem。**#250「250×」spike 与 production 间有未追的退化**——这是下一个 explore 的核心(profiler-first，见 backlog)。
+
+---
+
+## 六、Phase 11 — CUDA 吞吐收口 + Windows 交付 + 第三时钟(#303 → #312，2026-06-29 → 07-01)
+
+> 接 Phase 10。这一段把上面「未解的核心张力」（CUDA 0.16-0.40× "根本不合理"）**彻底收口**——真因大半是**测量假象**，剩下是几个真 lever；随后把 CUDA 从"能算对"推到"Windows 可交付"，最后补上蓝图 §4.8 第三时钟。**Phase 10 的悲观基线全部作废，别再引用。**
+
+**explore-303 → scrum-304（吞吐收口第一刀）**：explore-303 一度归因"零 cudaStream + 每层 sync readback → GPU 1-2% 利用"，但 scrum-304 profiling 修正：真因 = **per-batch buffer 拆建 churn**（CUDA Reset 每 batch cudaFree+cudaFreeHost，占 mh15 wall 83%）。**buffer-persist**（`Reset(keep_persistent_buffers)`，镜像 Metal Reset）一刀 → 可比轻·单MS CUDA **35–56M/s（>25M 竞品线，>Mac Metal 28-30M）**，parity 10/10。**"0.16-0.40×" 定性为测量假象**（ad-hoc 非 idle-gate + 拿重场景 `ms_multi_crystal` 当可比口径）。
+
+**scrum-306（dispatch + exit-cap，逼近 intrinsic）**：**async 前提被 profiling 推翻**（nsys 证 cudaEventSynchronize 仅 0.3% host time，stream deferral 值 <1%，增量 2 放弃）。真杠杆 = **默认 dispatch 32768→262144 + exit-cap**（CUDA `HasDeviceXyzAccum` 恒 true → trace kernel 从不写 `d_exit_`，这块死缓冲按 n×(2·max_hits+4) 膨到 GB→崩，capping 解锁大 dispatch）→ out-of-box **~114M/s（= 134M intrinsic 的 85%）**。几何池/persist = parity-clean 结构改进但**吞吐中性**（不得当加速源）。旁证：306.6 Metal 无便宜 kernel 杠杆（同 CUDA→算法级 backlog）；306.7 legacy 能量随 dispatch 波动证伪为 MC 方差非 bug。血泪：shared dev49 CPU 争用使 host-bound 吞吐 33M↔114M 同 binary 剧烈抖动，只信 per-run interleaved。
+
+**explore-307 → task-308（77h 漏光，MSVC 专属正确性 bug）**：`RandomSample` 在 `curr_p==0.0`（MSVC `std::uniform_real_distribution` 可返精确 0）时 no-match→out 未写→保留调用方默认 tri_id=0→选背光面当入射→全反射异色高权重漏光。两平台插桩铁证（MSVC 2e9 抽样 115 次命中 / Mac 1e8 抽样 0 次）。与 GPU 吞吐正交，但同期落地。
+
+**scrum-309 + scrum-310（CUDA Windows 交付）**：1070Ti/sm_61 parity 10/10 + 吞吐数据点 + GUI 跨平台"Use GPU"勾选（owner 眼验）；CI 门禁（windows-2022 pin，windows-2025=VS2026 拒 CUDA）+ 多 arch fatbin（PTX 61 floor + 75/86/89 real）+ 运行时 capability<sm_61 探测+优雅降级 + release 打包 cudart dll + CLI `--backend cuda`。**CUDA 在 Windows 真正可交付。** scrum-311 清理（CUDA 死代码 + CI Node24 + exit-seam crystal 计数）。
+
+**scrum-312（第三时钟 readback 解耦，蓝图 §4.8 兑现）**：内测反馈"默认场景 GPU 慢"→真因 = 真实 GUI 分辨率 2048×1024 下 readback 焊死在 trace 时钟（每 SimBatch 一次 device XYZ 回读）。route B 把 readback 解耦到显示节奏第三时钟 → 2048×1024 增益：4060Ti(Ada) 28→39M(1.4×) / 1070Ti(Pascal) 12.5→33.5M(2.7×) / Metal 11→32.3M(~3×)，三机一致。**推翻"Metal 统一内存零收益"**（per-batch 全幅 24MB memset+memcpy 是真成本）。精度用 periodic-drain（float32+host Neumaier+稀 drain），**f64 淘汰**（48MB 溢 L2，0.6×）。parity CUDA 10/10×2arch + Metal 14/14。
+
+**Phase 11 元模式**：Phase 10 的"根本不合理"张力，收口后大半是**测量方法学问题**（非 idle-gate / 错口径 / setup 计进分母 / drain 粒度失真），真机制 lever 只有三个（buffer-persist / dispatch / exit-cap / 第三时钟）。**教训固化**：GPU 吞吐 correctness 不可单一复现路径自证；shared 机只信 interleaved；profile 先于改代码（async 增量差点白建）。当前 canonical 吞吐见 `doc/performance-testing.md`；per-run 详录见 `scratchpad/perf-results-log.md`。**残余**：机制 C（in-kernel atomicAdd L2 溢出，高分辨率残税）+ kernel 算法级重构（SOL 逼近）归 backlog 远期。

--- a/doc/gpu-single-engine-implementation.md
+++ b/doc/gpu-single-engine-implementation.md
@@ -62,6 +62,19 @@
   - 唯一有意义优化 = **device 侧 XYZ 累加**（不每 dispatch 把裸 records 过 PCIe+主机处理），非 dispatch/batch 调参。详见 `scratchpad/backlog.md` seam 条目（待单起 explore）。
   - 仪表瑕疵待修：多 CI 重写把 cudaEvent `ev_end_kernel_` 记录点挪到 per-CI 循环外，TraceLayer kernel 计时失真（≈0ms 假象）；profiling 前先修 event placement。
 
+> ⚠️ **SUPERSEDED（2026-07-01，scrum-313 doc 审计）**——上面这份 "CUDA ≈ 0.10–0.12× legacy，flat，
+> 唯一优化 = device 侧 XYZ 累加（待 explore）" 的 2026-06-27 基线**已被后续整条 arc 兑现+推翻**，仅作历史留存：
+> - **device 侧 XYZ 累加已落地**（scrum-302 device-fused accumulation）——正是当时点名的"唯一有意义优化"，
+>   消掉了裸 records 过 PCIe 的瓶颈。
+> - **buffer-persist**（scrum-304.2，镜像 Metal Reset）消掉 per-batch alloc churn → 可比轻·单MS CUDA
+>   **35–56M/s（6× legacy，≥25M 竞品线）**。
+> - **dispatch 默认 262144 + exit-cap**（scrum-306.2）→ out-of-box **~114M/s**（= 134M intrinsic 的 85%）。
+> - **第三时钟 readback 解耦**（scrum-312，seam-design §4.8）→ 真实 GUI 分辨率 2048×1024 下 CUDA 28→39M、
+>   Metal 11→32M、1070Ti 12.5→33.5M。
+>
+> 当前 canonical 吞吐数字见 **`doc/performance-testing.md`「当前 canonical 吞吐结果」**（历史 per-run 详录
+> 在 `scratchpad/perf-results-log.md`）。GPU 路线 #294→312 的完整演进见 `doc/gpu-route-history.md` Phase 10–11。
+
 ## 1. 状态与目标（设计期原文）
 
 > **接手注意**：本节描述 scrum-267/268 之前的出发状态（设计期），已是历史。

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -83,22 +83,20 @@ total thread count = workers + 2.
 good scaling; lower values suggest lock contention, memory bandwidth saturation, or
 scheduling overhead. **Meaningful for the legacy CPU route only** — see the GPU caveat next.
 
-> **⚠️ GPU backends are single-engine — "single" vs "multi" is NOT parallelism.** The GPU route
-> (Metal / CUDA) runs `worker_count=1` unconditionally (`server.cpp:284`); only the legacy CPU
-> route is genuinely multi-worker (`worker_count = PhysicalCoreCount()`). In `--benchmark`'s
-> dual-pass **both** GPU passes run on the same single engine — the "single" pass is just the
-> 2M-ray, JIT-warmup-dominated short run and the "multi" pass is the full-ray-count, warm, long
-> run. So for GPU:
-> - The two numbers are **not** equal (e.g. dev49 CUDA 35→56 M/s, 1070Ti 32→60 M/s) — but the
->   gap is **warmup + ray-count + window-length**, not parallelism.
-> - **The "multi" number is the representative steady figure** (warm + long window); read it, not
->   because it is "parallel" but because it is the settled rate.
-> - **`efficiency` is meaningless for GPU** (`workers` in a GPU `[BENCHMARK]` line is the
->   configured core count, not GPU engines; `explore-306.1` E1 `worker_count=1` is the proof).
->
-> This is documented, not a bug. **Planned simplification** (backlog, needs hardware validation):
-> the GPU dual-pass may be collapsed to a single steady number so the self-reported data stops
-> implying parallelism — until then, apply this caveat when reading GPU `single`/`multi`.
+> **⚠️ GPU backends are single-engine — there is no "single" vs "multi" parallelism.** The GPU
+> route (Metal / CUDA) runs `worker_count=1` unconditionally (`server.cpp:284`); only the legacy
+> CPU route is genuinely multi-worker (`worker_count = PhysicalCoreCount()`). Because a GPU
+> "single" and "multi" pass would both run on the same one engine (differing only by warmup +
+> ray-count, not parallelism), **`--benchmark` collapses the GPU route to ONE steady pass**
+> (labelled `mode="multi"`) and skips the warmup pass; the legacy CPU route keeps the genuine
+> dual-pass. Route detection is env-aware (`LUMICE_WillUseGpuRoute` honors `LUMICE_TRACE_BACKEND`,
+> so an env-selected GPU run collapses too). Consequences when reading GPU results:
+> - A GPU `[BENCHMARK]`/`bench_throughput.py` row has **`multi` only** (`single`/`single_rps` are
+>   absent — this is expected, not INCOMPLETE). The `multi` number is the representative steady rate.
+> - **`efficiency` does not apply to GPU** (there is no single/parallel pair; `explore-306.1` E1
+>   `worker_count=1` is the proof). The CI summary's efficiency column is legacy-CPU-only.
+> - Cross-checking old data: pre-2026-07 GPU tables that show a `single` column were the old
+>   dual-pass (single = 2M-ray warmup run); those `single` GPU numbers were never a per-core figure.
 
 Behavior differences in benchmark mode:
 - **Dual-pass**: Two independent server instances are created sequentially, each with a

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -5,6 +5,13 @@ benchmarking to real-world GUI interaction testing.
 
 All commands assume the working directory is the project root.
 
+> **Scope**: this guide holds the stable how-to + the **current canonical** throughput
+> reference. Historical per-run measurement dumps (dated tables, raw reps, per-effort
+> methodology notes) live in the git-ignored `scratchpad/perf-results-log.md` — append new
+> per-run numbers there, and promote a number here only when it becomes the new canonical
+> anchor. CUDA build + parity/correctness on the remote boxes is a separate concern — see
+> [`gpu-remote-cuda-build-testing.md`](gpu-remote-cuda-build-testing.md).
+
 ## Log Level
 
 Both CLI benchmark and GUI perf test support log level options.
@@ -97,9 +104,9 @@ Behavior differences in benchmark mode:
 Measurement basis: **engine** = `Lumice --benchmark` multi pass, setup-excluded
 steady rate; **GUI** = `gui_test perf_test` steady_state, infinite budget,
 reconstruct path. Baseline denominator is always **legacy CPU** (the GUI's real
-path) — never `cpu_backend`. All ratios below measured on **M2 Max, 2026-06-19**
-(`scratchpad/task-fix-throughput-bench-honesty/data/`); treat as the regression
-anchor, re-measure same-session before/after any throughput change.
+path) — never `cpu_backend`. The `Metal vs legacy` ratios below are the M2 Max,
+2026-06-19 regression anchor (`scratchpad/task-fix-throughput-bench-honesty/data/`);
+re-measure same-session before/after any throughput change.
 
 > **Why two measurement paths (engine vs GUI) coexist — do not collapse them.**
 > `Lumice --benchmark` (engine ceiling) and `gui_test perf_test` (GUI-fidelity)
@@ -111,45 +118,77 @@ anchor, re-measure same-session before/after any throughput change.
 > (`scripts/bench_throughput.py`) both invoke it — and is **not** redundant with
 > the GUI path, so it is not a retire candidate. (Evaluated & settled 2026-06-24;
 > the now-removed `LumiceGUI --perf-bench` flag *was* a genuine orphan, retired in
-> #292.) Revisit only if a GUI-regime gate ever becomes the sole throughput门.
+> #292.)
 
-| config（真实文件） | regime | rays / MS / filter | lens / Metal 可比 | 角色 | Metal vs legacy（实测基线） |
+| config (real file) | regime | rays / MS / filter | lens / Metal-comparable | role | Metal vs legacy (anchor) |
 |---|---|---|---|---|---|
-| `bench_light_single_ms.json` | 轻·单MS · 512×256 | 10M / 1 / 无 | dual_fisheye_EA ✅ | 轻场景吞吐基准（bench 专用，勿因 e2e 改动）；**512×256 落 GPU L2，系统性高估 GPU 优势**；真实分辨率用 `--res-sweep`（见"分辨率是一等吞吐维度"） | 引擎 ~1.7× / GUI ~1.8× |
-| `ms_multi_crystal.json` | 中·无filter | 2M / 2 / 无 | dual_fisheye_EA ✅ | 无 culling 中等基准；`--res-sweep` 第二代表场景（看场景依赖） | 引擎 ~2.0× / GUI ~2.2× |
-| `ms_multi_crystal_complex_filter.json` | 重·标准 | 2M / 2 / complex | dual_fisheye_EA ✅ | **G1 + G4 主基准** | 引擎 ~8.1× / GUI ~9.5× |
-| `ms_multi_crystal_filtered_bd.json` | 重·bd | 2M / 2 / bd | dual_fisheye_EA ✅ | G1 第二基准 | 引擎 ~10.1× |
-| `ms3_mixed_pyramid_heavy.json` | 最重·棱锥 | 5M / 3 / 4×raypath | dual_fisheye_EA ✅ | register-pressure 上界 | 引擎 **~5.5×**（2026-06-24 同会话 M2 Max：legacy multi 46.1K/s、single 7.3K/s；Metal multi 255K/s、single 245K/s）；GUI legacy ~48.7K → Metal ~5.7×（互证）。**注**：legacy single pass ~274s，超出 `bench_throughput.py` 的 `RUN_TIMEOUT_SEC`，故该场景仍从自动跑中排除——基线靠手动大 timeout 单测取得 |
-| `halo_22.json` | 轻·单MS | 10M / 1 / 无 | **fisheye_EA（单）→ CLI Metal 回退** | **e2e 资产，勿改**；legacy-only 轻基准 | N/A（Metal 不兼容此投影；轻·Metal 用 `bench_light_single_ms`） |
+| `bench_light_single_ms.json` | light·single-MS · 512×256 | 10M / 1 / none | dual_fisheye_EA ✅ | light-scene throughput baseline (bench-only, do NOT change for e2e); **512×256 fits GPU L2, systematically overstates the GPU advantage**; use `--res-sweep` for real resolution (see "resolution is a first-class throughput dimension") | engine ~1.7× / GUI ~1.8× |
+| `ms_multi_crystal.json` | mid·no-filter | 2M / 2 / none | dual_fisheye_EA ✅ | no-culling mid baseline; second `--res-sweep` scene (scene-dependence check) | engine ~2.0× / GUI ~2.2× |
+| `ms_multi_crystal_complex_filter.json` | heavy·standard | 2M / 2 / complex | dual_fisheye_EA ✅ | **G1 + G4 primary baseline** | engine ~8.1× / GUI ~9.5× |
+| `ms_multi_crystal_filtered_bd.json` | heavy·bd | 2M / 2 / bd | dual_fisheye_EA ✅ | G1 second baseline | engine ~10.1× |
+| `ms3_mixed_pyramid_heavy.json` | heaviest·pyramid | 5M / 3 / 4×raypath | dual_fisheye_EA ✅ | register-pressure upper bound | engine **~5.5×** (M2 Max, 2026-06-24; GUI corroborated ~5.7×). Note: legacy single pass ~274s exceeds `bench_throughput.py`'s `RUN_TIMEOUT_SEC`, so this scene stays excluded from the auto run — its baseline is taken via a manual large-timeout unit test |
+| `halo_22.json` | light·single-MS | 10M / 1 / none | **fisheye_EA (single) → CLI Metal falls back** | **e2e asset, do NOT change**; legacy-only light baseline | N/A (Metal incompatible with this projection; use `bench_light_single_ms` for light·Metal) |
 
 Notes:
-- **上表 4 个 light/mid/heavy 主基准（bench_light / ms_multi / complex_filter / filtered_bd）都是 512×256**（`ms3_mixed_pyramid_heavy` 例外，为 2048×1024）。512×256 的 XYZ 累加 buffer（W×H×3 float = 1.5MB）落在典型 GPU 的 L2 内，**系统性高估 GPU 吞吐**——真实 GUI 默认渲染 2048×1024（16× 像素，24MB buffer，越 L2）。**跨分辨率数字不可比；报吞吐必须带分辨率**。真实分辨率吞吐用 `bench_throughput.py --res-sweep`（分辨率轴，默认 dispatch，隔离单变量）——详见下方"分辨率是一等吞吐维度"。
-- The dispatch sweet spot is **backend- and resolution-dependent**: Metal 32768 / CUDA 262144 是 **512×256** 下的甜点；**分辨率升高时 CUDA 最优 dispatch 显著上移**（2048×1024 下 ~786K–2M，因 per-batch readback 摊薄——见"分辨率"小节 + Runtime Tuning Knobs）。小 dispatch 饿死 GPU（512/2048 = 0.2–0.8× legacy）。
+- **The 4 primary light/mid/heavy baselines (bench_light / ms_multi / complex_filter /
+  filtered_bd) are all 512×256** (`ms3_mixed_pyramid_heavy` is the exception, at 2048×1024).
+  A 512×256 XYZ accumulation buffer (W×H×3 float = 1.5 MB) fits in a typical GPU's L2 and
+  **systematically overstates GPU throughput** — the real GUI default renders 2048×1024 (16×
+  pixels, 24 MB buffer, exceeds L2). **Cross-resolution numbers are not comparable; always
+  report throughput with its resolution.** For real-resolution throughput use
+  `bench_throughput.py --res-sweep` (resolution axis, default dispatch, single variable
+  isolated) — see "resolution is a first-class throughput dimension" below.
+- The dispatch sweet spot is **backend- and resolution-dependent**: Metal 32768 / CUDA 262144
+  are the **512×256** sweet spots; **as resolution rises the CUDA optimum shifts up markedly**
+  (~786K–2M at 2048×1024, because it amortizes the per-batch readback — see the resolution
+  subsection + Runtime Tuning Knobs). Small dispatches starve the GPU (512/2048 = 0.2–0.8×
+  legacy).
 - `bench_throughput.py` overrides `ray_num` to a large value per run (temp config,
   committed files untouched) so the steady window is long enough to be stable.
-- **⚠️ 第三时钟 drain 路径（CUDA，scrum-312）用 `multi_wall` 列，不用 `multi_med`**：`multi_med`（binary 的 steady `rays_per_sec`）靠 `sim_ray_num` 进度采样，而第三时钟 drain 稀疏 → 进度粗跳（首个 drain 前 `sim_ray_num` 恒 0）→ steady window 把大部分 tracing 误算进 setup → **系统性假低**（实测 2048 报 22M，真值 39M）。`bench_throughput.py` 已加 `multi_wall = rays/wall_sec`（robust，免疫 drain 粒度），两列背离时**信 `multi_wall`**。per-batch 路径（legacy/Metal/CUDA N=1）两列一致（细进度），不受影响。
+- **⚠️ The third-clock drain path (CUDA, scrum-312) uses the `multi_wall` column, not
+  `multi_med`**: `multi_med` (the binary's steady `rays_per_sec`) samples `sim_ray_num`
+  progress, but the sparse third-clock drain makes that progress jump coarsely (`sim_ray_num`
+  stays 0 until the first drain) → the steady window mis-counts most tracing as setup →
+  **systematic under-report** (2048 read 22M, true 39M). `bench_throughput.py` adds
+  `multi_wall = rays/wall_sec` (robust, immune to drain granularity); when the two columns
+  diverge, **trust `multi_wall`**. Per-batch paths (legacy / Metal / CUDA N=1) agree on both
+  columns (fine-grained progress) and are unaffected.
 
-#### 分辨率是一等吞吐维度（device-fused XYZ 累加 → cost 随 buffer vs GPU L2）
+#### Resolution is a first-class throughput dimension (device-fused XYZ accumulation → cost scales with buffer vs GPU L2)
 
-> **报任何 GPU 吞吐数字必须带渲染分辨率；跨分辨率不可比。** 这不是二阶细节——它常主导轻场景的 GPU 吞吐（轻场景 trace 便宜，累加/回读占大头）。
+> **Every GPU throughput number MUST carry its render resolution; cross-resolution numbers are
+> not comparable.** This is not a second-order detail — it often dominates GPU throughput on
+> light scenes (light scenes trace cheaply, so accumulation/readback dominate).
 
-机制：device-fused XYZ 累加（scrum-302）把每条出射光线在 **trace kernel 内** `atomicAdd` 进 W×H×3 float 图像 buffer（12 B/px）。cost 随 buffer 相对 GPU L2 变化：
+Mechanism: device-fused XYZ accumulation (scrum-302) has every exit ray `atomicAdd` into a
+W×H×3 float image buffer (12 B/px) **inside the trace kernel**. Cost scales with the buffer
+relative to GPU L2:
 
-- buffer ≤ L2（512×256 = 1.5MB，落多数 GPU 的 ~2MB L2）→ 累加走 cache，快。
-- buffer ≫ L2（2048×1024 = 24MB）→ 每次 atomicAdd 打 DRAM，DRAM 带宽绑定，慢。膝在 L2 边界（~512→768），越 L2 后随分辨率平滑衰减（非二元断崖）。
+- buffer ≤ L2 (512×256 = 1.5 MB, fits most GPUs' ~2 MB L2) → accumulation is cached, fast.
+- buffer ≫ L2 (2048×1024 = 24 MB) → each atomicAdd hits DRAM, DRAM-bandwidth-bound, slow. The
+  knee is at the L2 boundary (~512→768), decaying smoothly with resolution past it (not a
+  binary cliff).
 
-**实测分辨率惩罚**（2026-07-01，同机同 binary，仅改分辨率，`bench_light_single_ms` 场景，`--benchmark` 稳态 multi）：
+The CUDA route also carries a **per-batch synchronous readback** tax (`ReadbackXyzAccum`: one
+`cudaDeviceSynchronize` + blocking 24 MB PCIe D2H + memset per SimBatch), which was decoupled to
+the display cadence (the "third clock", `seam-design.md` §4.8) in scrum-312 — see the canonical
+results below. Metal has no such tax (`StorageModeShared` unified memory + deferred wait).
 
-- **1070Ti CUDA**：512×256 = 61 M/s → 2048×1024 = 12.5 M/s（**5×**；含 CUDA per-batch 同步 readback 税，见下）。
-- **M2Max Metal**：512×256 = 29 M/s → 2048×1024 = 8.2 M/s（**3.6×**；Metal 统一内存无 readback 税，纯 in-kernel 累加）。
+**Process requirements**:
 
-CUDA 的额外惩罚来自 **per-batch 同步 readback**（`ReadbackXyzAccum` 每 SimBatch 一次 `cudaDeviceSynchronize` + 阻塞 24MB PCIe D2H + memset），可用大 dispatch 摊薄（2048 下 262144→~1M dispatch = 12.5→~30 M/s）。这是对 `seam-design.md` §4.8"回读走第三时钟"的偏离——详见 `scratchpad/backlog.md`「per-batch 同步 readback 税 + XYZ 累加 L2 溢出」条。Metal 无此税（`StorageModeShared` + 延迟等）。
-
-**流程要求**：
-
-1. GPU 吞吐用 `bench_throughput.py --res-sweep` 扫多档分辨率（默认 `256×128 … 2048×1024` 六档，2:1，跨 L2 膝两侧），而非只报单点。脚本每档在 temp config 里 override `render[].resolution`（committed 文件不动，同 ray_num override 机制）。默认扫 `bench_light_single_ms`（轻，累加/回读主导）+ `ms_multi_crystal`（稍重，看场景依赖），`--res-list` / `--res-configs` 可覆盖。至少覆盖 **512×256（引擎天花板 / L2-resident）+ 2048×1024（GUI 真实体验）** 两点。
-2. 与竞品 / 硬件能力对标（下方 25M bar）时**对齐分辨率**——我方历史 512×256 数字是 L2-resident 上界，非用户体验。
-3. 数字入表**必标分辨率**（现有表默认 512×256，除 `ms3_mixed_pyramid_heavy`）。sweep 的**曲线数据不入 committed 文件**（按机器/会话变），入表的是按 N≥5 CoV 协议正式产出的 canonical 点。
+1. Measure GPU throughput with `bench_throughput.py --res-sweep` across resolutions (default six
+   steps `256×128 … 2048×1024`, 2:1, straddling the L2 knee), not a single point. The script
+   overrides `render[].resolution` in a temp config (committed files untouched, same mechanism as
+   the `ray_num` override). Default sweeps `bench_light_single_ms` (light, accumulation/readback
+   dominated) + `ms_multi_crystal` (heavier, scene-dependence check); `--res-list` / `--res-configs`
+   override. Cover at least **512×256 (engine ceiling / L2-resident) + 2048×1024 (real GUI
+   experience)**.
+2. When comparing against a competitor / hardware capability (the 25M bar below), **align
+   resolution** — our historical 512×256 numbers are an L2-resident upper bound, not the user
+   experience.
+3. Numbers entering a table **must state their resolution** (existing tables default to 512×256,
+   except `ms3_mixed_pyramid_heavy`). Sweep curve data does NOT enter committed files (varies by
+   machine/session); what enters a table is a canonical point produced under the N≥5 CoV protocol.
 
 #### Acceptance yardstick: hardware capability, NOT just "× legacy CPU"
 
@@ -166,7 +205,7 @@ not "× legacy", when judging GPU throughput):
 
 | scene | comparable workload | hardware-capability target | source |
 |---|---|---|---|
-| `bench_light_single_ms` (轻·单MS) | single crystal, single MS, no continuation | **≥ 25M rays/s on RTX 4060 Ti** | competitor product (measured) — the light single-MS scene is the apples-to-apples comparison |
+| `bench_light_single_ms` (light·single-MS) | single crystal, single MS, no continuation | **≥ 25M rays/s on RTX 4060 Ti** | competitor product (measured) — the light single-MS scene is the apples-to-apples comparison |
 
 - Always benchmark the **comparable** scene against an external target — do NOT
   cite a heavy multi-crystal / multi-MS number (e.g. `ms_multi_crystal`) when
@@ -179,27 +218,24 @@ not "× legacy", when judging GPU throughput):
 - If a target genuinely cannot be reached, the acceptance artifact must be a
   **profiler-grounded mechanism explanation** (where the time goes), not a black-box
   "GPU doesn't naturally win" claim.
-- **⚠️ 分辨率对齐**：25M bar 的竞品渲染分辨率未知；我方 `bench_light_single_ms` 是
-  **512×256（L2-resident，上界）**。真实 GUI 默认 2048×1024 下同卡同场景吞吐掉 3.6–5×
-  （见"分辨率是一等吞吐维度"）。判定是否达标前必须**对齐分辨率**——别拿 512×256 的
-  L2-resident 数字宣称达 bar。用 `bench_throughput.py --res-sweep` 取真实分辨率对标点。
+- **⚠️ Align resolution**: the 25M bar's competitor render resolution is unknown; our
+  `bench_light_single_ms` is **512×256 (L2-resident, upper bound)**. On the same card / scene the
+  real GUI default 2048×1024 drops throughput 3.6–5× (see "resolution is a first-class throughput
+  dimension"). Align resolution before judging the bar — don't claim the bar is met from a 512×256
+  L2-resident number. Use `bench_throughput.py --res-sweep` for the real-resolution comparison point.
 
-### Latest measured results (per-run log)
+### Canonical throughput results (current)
 
-> Append the newest numbers here each time the bench is re-run. Record **absolute
-> rays/sec** (not just × legacy), per config, with a hardware summary. **Cross-hardware
-> numbers are NOT comparable** — always read within one host block; never compare a
-> Mac row against a Linux row. Source: `scripts/bench_throughput.py` (default dispatch,
-> `ray_num`=20M, N≥5 reps, N=9 re-run on CoV>15%).
->
-> ⚠️ **Third-clock路径读 `multi_wall`（rays/wall_sec），不读 `multi_med`**（后者在稀疏
-> drain 下失真，见「分辨率是一等吞吐维度」）。下方数字均为 `multi_wall`。
+> The current authoritative reference numbers. **Cross-hardware numbers are NOT comparable** —
+> read within one host block. Historical per-run dumps (dated tables, raw reps, per-effort
+> methodology) live in `scratchpad/perf-results-log.md`. Third-clock path reads `multi_wall`.
 
-#### scrum-312 第三时钟 canonical · `--res-sweep` · `multi_wall` · 2026-07-01
+#### scrum-312 third-clock canonical · `--res-sweep` · `multi_wall` · 2026-07-01
 
-**背景**：readback 从 trace 时钟解耦到显示节奏第三时钟（seam-design §4.8）。真实 GUI 分辨率
-2048×1024 下 readback/per-batch-copy 税被摊薄。`bench_light_single_ms`（轻·单MS，L2/readback 主导），
-per-resolution `multi_wall`：
+**Context**: readback decoupled from the trace clock to the display-cadence third clock
+(seam-design §4.8). At the real GUI resolution 2048×1024 the readback / per-batch-copy tax is
+amortized. `bench_light_single_ms` (light·single-MS, L2/readback dominated), per-resolution
+`multi_wall`:
 
 | host / backend | 256×128 | 512×256 | 1024×512 | 1536×768 | **2048×1024** |
 |---|---|---|---|---|---|
@@ -209,228 +245,30 @@ per-resolution `multi_wall`：
 | dev49 legacy CPU (baseline) | 9.0 M/s | 8.8 M/s | 8.4 M/s | 7.7 M/s | 6.9 M/s |
 | Mac legacy CPU (baseline) | 5.1 M/s | 4.8 M/s | 4.7 M/s | 4.8 M/s | 4.7 M/s |
 
-**第三时钟在 2048×1024 的增益**（vs per-batch drain 旧值，interleaved 同 binary 隔离 drain cadence）：
+**Third-clock gain at 2048×1024** (vs the old per-batch drain, interleaved same-binary to isolate
+the drain cadence):
 
-| host / backend | 旧（per-batch） | 第三时钟 | 增益 | 机制 |
+| host / backend | old (per-batch) | third clock | gain | mechanism |
 |---|---|---|---|---|
-| 4060Ti (Ada, 32MB L2) CUDA | 28 M/s | 39 M/s | **1.4×** | Ada L2 大→旧值已 L2-resident，税主要是 per-batch D2H readback |
-| 1070Ti (Pascal, 2MB L2) CUDA | 12.5 M/s | 33.5 M/s | **2.7×** | 兼有 L2 溢出 + readback 税；第三时钟消 readback（L2 残留） |
-| M-series Metal（统一内存） | 11 M/s | 32.3 M/s | **~3×** | 无 PCIe readback；per-batch 24MB memset+memcpy(×76 batch≈3.6GB) 被摊薄 |
+| 4060Ti (Ada, 32MB L2) CUDA | 28 M/s | 39 M/s | **1.4×** | large Ada L2 → old value already L2-resident; the tax is mainly per-batch D2H readback |
+| 1070Ti (Pascal, 2MB L2) CUDA | 12.5 M/s | 33.5 M/s | **2.7×** | both L2 overflow + readback tax; third clock removes the readback (L2 residual) |
+| M-series Metal (unified memory) | 11 M/s | 32.3 M/s | **~3×** | no PCIe readback; per-batch 24MB memset+memcpy (×76 batch ≈ 3.6GB) amortized |
 
-**要点**：
-- **三种硬件（CUDA-Ada / CUDA-Pascal / Metal）一致确证第三时钟在真实 GUI 分辨率显著提速**；增益随"旧值里 per-batch readback/copy 占比"放大。
-- **Metal 曲线近平**（28→35 M/s 跨 6 档），第三时钟使 Metal 分辨率-鲁棒（旧路径每 batch 全幅 memset+memcpy 在高分辨率是真成本，非仅 CUDA readback）。**推翻早先"Metal 统一内存零收益"判断**。
-- 正确性：CUDA parity 10/10 @4060Ti + 10/10 @1070Ti/sm_61；Metal parity 14/14（含 batch-invariance = drain-cadence 独立性）。
-- win-builder 1070Ti 未列 vs-legacy（CPU 弱，比值虚高，读绝对值）；`multi_med` 列在第三时钟下失真已弃用（用 `multi_wall`）。
-- 重场景 `ms_multi_crystal`（trace 主导，readback 占比小）增益温和：4060Ti 2048 = 14.9 M/s、1070Ti = 7.3 M/s、Metal ≈ 17 M/s@256（Mac 热噪大，N=9 后仍抖）。
-
-#### Mac — Apple M2 Max (12-core: 8P+4E, 32 GB, macOS 14.7) · legacy vs Metal · 2026-06-28
-
-| config | legacy single | legacy multi | Metal single | Metal multi | Metal/legacy (multi) |
-|---|---|---|---|---|---|
-| `bench_light_single_ms` (轻·单MS) | 573 K/s | 4.62 M/s | **27.8 M/s** | **30.6 M/s** | 6.62× |
-| `ms_multi_crystal` (中·无filter) | 94 K/s | 759 K/s | 7.08 M/s | 7.66 M/s | 10.08× |
-| `ms_multi_crystal_complex_filter` (重·标准) | 333 K/s | 1.54 M/s | 12.4 M/s | 12.8 M/s | 8.33× |
-| `ms_multi_crystal_filtered_bd` (重·bd) | 368 K/s | 1.62 M/s | 13.7 M/s | 14.0 M/s | 8.59× |
-
-- **Metal on the comparable light single-MS scene already hits ~28–30 M/s — at/above
-  the 25 M/s hardware-capability target.** This proves the bar is reachable on this
-  codebase and gives CUDA a same-engine target (the RTX 4060 Ti is comparable raw
-  compute to the M2 Max GPU); the remaining CUDA gap is execution-model, not a
-  fundamental kernel limit.
-
-#### Linux — dev49 RTX 4060 Ti (AMD Zen5 9950X 16C/32T host) · legacy vs CUDA · 2026-06-29
-
-After scrum-304.2 buffer-persist, GPU-idle-gated (`nvidia-smi` 0% verified before run),
-`scripts/bench_throughput.py` default dispatch (=32768), ray_num=20M, N≥5 (N=9 on CoV>15%).
-
-| config | legacy single | legacy multi | CUDA single | CUDA multi | CUDA/legacy (multi) |
-|---|---|---|---|---|---|
-| `bench_light_single_ms` (轻·单MS) | 744 K/s | 8.98 M/s | **35.2 M/s** | **55.9 M/s** | 6.23× |
-| `ms_multi_crystal` (中·无filter) | 126 K/s | 1.44 M/s | 9.67 M/s | 13.7 M/s | 9.55× |
-| `ms_multi_crystal_complex_filter` (重·标准) | 471 K/s | 6.26 M/s | 38.0 M/s | 60.3 M/s | 9.63× |
-| `ms_multi_crystal_filtered_bd` (重·bd) | 510 K/s | 6.73 M/s | 39.1 M/s | 61.9 M/s | 9.19× |
-
-##### Rebench at the new CUDA default (262144) — scrum-306.3 (2026-06-29, dev49 idle-gated, 20M rays, 3 reps median)
-
-| config | legacy multi | CUDA multi (default=262144) | CUDA/legacy | vs old 32768 default |
-|---|---|---|---|---|
-| `bench_light_single_ms` (轻·单MS) | 6.2 M/s | **~87 M/s** | ~14× | 56→87 (1.6×) |
-| `ms_multi_crystal` (中·无filter) | 0.93 M/s | ~19.7 M/s | ~21× | 13.7→19.7 (1.4×) |
-| `ms_multi_crystal_complex_filter` (重·标准) | 3.2 M/s | ~178 M/s | ~56× | 60→178 (3.0×) |
-| `ms_multi_crystal_filtered_bd` (重·bd) | 2.7 M/s | ~232 M/s | ~85× | 62→232 (3.7×) |
-
-- **Out-of-box CUDA improved 1.4–3.7× by the new default dispatch + exit-cap** (scrum-306.2). The
-  filtered configs run *faster* than the light scene (178/232 vs 87 M/s) because the filter
-  terminates most rays early (rays/s counts root rays) — NOT a higher kernel throughput; the light
-  single-MS scene (~87 M/s here, ~114 M/s in the dedicated quiet-machine interleaved sweep) is the
-  honest comparable-load figure.
-- **⚠️ Absolute-number caveat (shared dev49 CPU contention):** CUDA is host-bound and legacy is
-  CPU-bound, so even with the GPU idle-gated (0%), co-tenant **CPU** load depresses both columns and
-  shifts run-to-run (the same bench_light CUDA cell read 87 M here vs 114 M in a quieter window).
-  Trust the **ratios** and the **new-vs-old-default** deltas (intra-run, robust); treat the absolute
-  M/s as indicative. Only per-run **interleaved** comparison (A,B,C,A,B,C…) is drift-proof — see the
-  scrum-306.2 methodology note below. The legacy column is also lower than the pre-306.2 table above
-  for the same reason (CPU contention at measurement time), which inflates the ratios — do not read
-  the ratio jump as pure CUDA gain.
-
-- **Competitive bar MET**: the comparable light single-MS scene is **35–56 M/s**, at/above
-  the 25 M/s competitor target AND above the Mac Metal reference (28–30 M/s). buffer-persist
-  alone (scrum-304.2) got CUDA here; the earlier "0.16–0.40× / 1.5M" pessimism was a
-  measurement artifact — ad-hoc non-idle-gated runs on the heavier `ms_multi_crystal`, the
-  wrong yardstick. Always idle-gate + use the canonical harness + the comparable scene.
-- **GPU not yet saturated** (at the 32768 default this table used): nsys = benchmark steady-window
-  active ≈ 43%; trace_single_ms_kernel is 95% of GPU time; intrinsic kernel ceiling ≈ 134 M/s, so
-  the 56 M here was ~43% of ceiling. **⚠️ SUPERSEDED by scrum-306.2** (see the resolution subsection
-  below): the headroom was NOT locked behind async (per-dispatch sync was 0.3% of host time) but
-  behind per-batch host overhead + a dead `d_exit_` buffer. With those fixed and the CUDA default
-  dispatch raised to 262144, **out-of-box CUDA now reaches ~114 M/s** (= 85% of the 134 M intrinsic
-  rate) on the comparable light scene — these 35–56 M numbers are the pre-306.2 figures at the old
-  32768 default and are retained only as the baseline the 306.2 work improved on.
-- **The GPU route has no true multi-worker parallelism** (worker_count=1, server.cpp:275). The
-  benchmark's "single" and "multi" passes BOTH run on the single GPU engine; their difference is a
-  JIT-warmup + ray-count artifact, not parallelism (explore-306.1 E1: worker_count=1 is the铁证).
-  The "workers":N field in a GPU [BENCHMARK] line is the configured core count, NOT GPU engines.
-  Only the legacy CPU route is genuinely multi-worker (N = PhysicalCoreCount).
-- Caveat: the competitor's exact config (spectrum / max_hits) is unknown; our scene is a
-  reasonable single-crystal single-MS proxy (prism, D65, max_hits 7). Align if a precise
-  apples-to-apples is needed.
-
-##### scrum-306.2 resolution: the 2.3× headroom was unlocked by dispatch size + exit-cap, NOT async (2026-06-29)
-
-The "~2.3× headroom locked behind per-dispatch host serialization → pursue async" framing
-above was **half wrong**, corrected by profiling:
-
-- **async (stream deferral) was the wrong lever.** nsys CUDA-API summary after the geometry
-  pool: `cudaEventSynchronize` / `cudaDeviceSynchronize` were **0.3% / 0.4%** of host-API
-  time — deferring them buys <1%. The originally-planned increment-2 (mirror Metal
-  `pending_cb_`/`WaitAndReadbackLayer`) was dropped.
-- **The GPU was host-bound, not sync-bound.** nsys GPU-side: `trace_single_ms_kernel` =
-  44.8 ms / 185 dispatches for 6M rays → **~134 M/s intrinsic kernel rate**; the GPU sat ~70%
-  idle waiting on **per-batch host overhead** (BeginSession + XYZ readback + orchestration),
-  which is **common to every variant** and amortizes with **fewer, bigger batches**.
-- **The lever = `LUMICE_DISPATCH_RAY_NUM`** (the default was raised for the CUDA route:
-  `kDefaultCudaDispatchRayNum = 262144`). Idle-gated **interleaved** sweep (cfg_50m, 50M
-  multi): 37M @32768 → **~114M @262144** (= 85% of the 134M ceiling) → ~115M @1M, then
-  declining (2M→106M, 4M→97M) as the continuation/root buffers grow.
-- **exit-cap was the enabler.** CUDA's `HasDeviceXyzAccum()` is unconditionally true, so the
-  trace kernel writes nothing to `d_exit_` (all exits go to `d_xyz_buf_` via `EmitToDeviceXyz`;
-  `DrainExits` reads 0 records). `d_exit_` sized `ComputeExitCap = n·(2·max_hits+4)` was dead
-  weight that ballooned to GBs at large dispatch — causing both the big-dispatch throughput
-  collapse and a parity OOM. Capping it (`kCudaDeadExitCap`) unlocked the dispatch sweep.
-- **The geometry pool (upload-once) + filter/wl persist were throughput-NEUTRAL** (interleaved
-  round-robin: pre ≈ pool ≈ pool+persist). They are correct, parity-clean structural changes
-  (remove per-batch H2D churn, align with seam-design §5) but the churn they removed overlaps
-  GPU compute / sits in setup — NOT on the steady-state critical path. Do not cite them as the
-  speedup source.
-- **Result**: out-of-box (no env knob) CUDA reaches **~114 M/s**, idle-gated, with the full
-  parity suite 10/10 at the new default AND at 524288/1048576. CUDA energy stays
-  dispatch-invariant; `kCommitCap=128` keeps the GUI snapshot cadence decoupled.
-
-**Methodology lessons (shared dev49 is CPU-contended → host-bound CUDA throughput is noisy):**
-- Same binary + same dispatch swung **33M ↔ 114M** with machine load. `nvidia-smi` GPU 0%
-  gate is necessary but NOT sufficient — it doesn't show CPU contention from co-tenant
-  containers. **Only trust per-run interleaved comparison** (A,B,C,A,B,C…), never cross-session,
-  and never even "back-to-back phases" (minute-scale drift between phases faked a 1.9× win once).
-- Use nsys **GPU-side** (`gpukernsum`: kernel time vs wall) to classify GPU-bound vs host-bound.
-  The CUDA-API summary (cudaMemcpy/cudaFree) is host time that may overlap compute — not the
-  bottleneck by itself.
-- **Profile before coding a fix.** A fully-designed stream-deferral increment was abandoned once
-  nsys showed it was worth <1%.
-
-##### scrum-306.6 (Metal kernel lever) + 306.7 (legacy energy) — both converged, no code change (2026-06-29)
-
-- **306.6 Metal kernel lever probe → NO cheap lever.** The path_rec spike (remove the per-bounce
-  `path[]` store + the `rec_csum`/`rec_sink` checksum, rebuild, idle-gated interleaved Metal multi
-  bench) gave **0 throughput change** (BASE ≈ SPIKE ≈ 30 M/s) — exactly like the CUDA path_rec
-  spike. Metal `trace_layer_kernel` dominates (~143–214µs/dispatch, ~80% of GPU time, from the
-  `xctrace export` of the Metal System Trace) and is ALU-bound (occ ~29% / ALU 63–73%, prior E7) —
-  the *hard* case: no cheap occupancy/memory knob, only algorithmic ALU reduction. Same bucket as
-  CUDA (latency-bound, 3 spikes all 0) → folded into the far-future algorithmic-kernel backlog, not
-  a standalone task. (The precise which-ALU breakdown / occupancy-limiter reason needs a
-  counter-enabled Xcode GPU frame capture — interactive, not headless-driveable; the existing
-  `metal-profile.trace` lacks hardware counters.)
-- **306.7 legacy energy "dispatch dependence" → NOT a bug (MC variance).** Legacy ΣY drifts with
-  `LUMICE_DISPATCH_RAY_NUM` because the legacy/illuminant path samples **one wavelength per
-  SimBatch** (`simulator.cpp`): wl-samples = ray_num/dispatch (128 → 78125 samples, converged;
-  131072 → ~77, high variance). `sim_ray_num`/`ray_seg_num` are invariant (10M/150M) — it is NOT a
-  ray-count or normalization bug. The per-batch-wl estimator has the **same expectation** as
-  per-ray wl (unbiased); only variance differs (cross-seed CV 0.3% @128 vs 8.6% @131072 = √(1024×
-  fewer samples)). Legacy at its default (128) is well-converged and correct; 306.4 already strips
-  the GPU-only knob from legacy. A root-cause change (per-ray or per-fixed-chunk wl) would touch the
-  legacy **reference oracle** (re-baseline risk) for zero real-world benefit → not pursued.
-
-> #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` is a GPU-only knob — never apply it to legacy in a comparison (scrum-306.1/306.4)
->
-> `LUMICE_DISPATCH_RAY_NUM` sizes the GPU engine's per-dispatch grid. **CUDA total
-> energy is dispatch-invariant** (verified: ΣY = 261.29 M ±0.001% across dispatch
-> ∈ {128, 8192, 32768, 131072} on `dual_fisheye_ref`) — i.e. the GPU result is
-> correct at any dispatch. **Legacy (CPU) total energy is NOT dispatch-invariant**:
-> the same knob (which overrides legacy's `kDefaultRayNum`=128) swings legacy ΣY
-> **−5 %..+13 %** (259.65 M @128 / 245.5 M @8192 / 275.5 M @32768 / 292.9 M @131072).
-> This is a real legacy correctness bug tracked in **scrum-306.7** (energy must be
-> batch-size invariant; mechanism TBD — normalization / ray-count / RNG-per-batch).
->
-> **Consequence / historical misdiagnosis to NOT repeat**: setting
-> `LUMICE_DISPATCH_RAY_NUM=131072` globally to probe CUDA made
-> `test_cuda_single_ms_no_filter_parity` report `energy_ratio=0.8922` — this was
-> **mis-attributed to a "CUDA exit-cap/cont-cap silent energy loss"** (the original
-> scrum-304.3 backlog entry). It is NOT a CUDA bug: the knob leaked into the legacy
-> reference run and inflated the **denominator** (legacy_Y), `261.29/292.87 = 0.892`.
-> The parity harness now strips `LUMICE_DISPATCH_RAY_NUM` for the `legacy` backend
-> (`test/e2e/capi_runner.py`, scrum-306.4) so the oracle stays at its canonical
-> default and `energy_ratio` reflects the GPU backend's correctness alone
-> (re-verified: @131072 0.8922 FAIL → 1.0063 PASS). `bench_throughput.py` already
-> excludes legacy from the dispatch sweep (`DISPATCH_PLAN["legacy"]=[None]`).
->
-> **Process lesson (why this is documented here, tracked)**: the 304.3 correctness
-> claim lived only as a backlog one-liner with no preserved script → a wrong
-> diagnosis (CUDA) propagated and could not be re-aligned. Correctness assertions
-> must land in a tracked doc with a reproducible recipe. Reproduce recipe: container
-> `pip install pytest numpy`, `LUMICE_HAS_CUDA=1`, then
-> `LUMICE_DISPATCH_RAY_NUM=131072 pytest -m slow test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py::test_cuda_single_ms_no_filter_parity`;
-> per-dispatch ΣY split via `bench_work/harness2.cpp` (dev49).
-
-#### Windows — win-builder GTX 1070 Ti (Pascal sm_61, 8 GB, driver 560.94, CUDA 11.7, MSVC 14.39) · legacy vs CUDA · 2026-06-30
-
-Cross-arch **data point** (scrum-309.3), NOT a gate. GTX 1070 Ti is an old (2017) mid-range
-Pascal card; the shipped PTX floor (compute_61) is JIT'd at runtime. GPU idle-gated
-(`nvidia-smi` 4% desktop, 0% Lumice before/after). **Interleaved** A,B,A,B per rep (legacy then
-CUDA each round, drift-proof), `ray_num`=20M, N=5, default dispatch (CUDA default=262144). Host =
-8C/16T x86-64 (legacy `multi` runs 8 workers; CUDA route is single-engine, `worker_count=1`). Route
-confirmed every CUDA run (`routing via CudaTraceBackend`, no fallback); legacy never routed GPU
-(`gpu_route=false`). Driver: custom interleaved harness (`Lumice.exe --benchmark` per backend;
-`bench_throughput.py` semantics, ray_num=20M override) — the committed harness is not Windows-path-
-hardened, so a thin interleaved wrapper was used instead.
-
-| config | legacy single | legacy multi | CUDA single | CUDA multi | CUDA/legacy (multi) |
-|---|---|---|---|---|---|
-| `bench_light_single_ms` (轻·单MS) | 0.47 M/s | 3.25 M/s | 31.8 M/s | **60.3 M/s** | 18.6× |
-| `ms_multi_crystal` (中·无filter) | 0.07 M/s | 0.22 M/s | 7.42 M/s | **11.5 M/s** | 52.6× |
-
-Raw per-run (median of N=5; CoV: light CUDA multi ~3.3%, ms_multi CUDA multi <1%, legacy <1% both):
-- light CUDA multi reps: 56.4 / 60.2 / 61.1 / 58.8 / 61.2 M/s; light legacy multi: 3.25 / 3.22 / 3.26 / 3.27 / 3.24 M/s.
-- ms_multi CUDA multi reps: 11.49 / 11.49 / 11.55 / 11.45 / 11.36 M/s; ms_multi legacy multi: 0.219 / 0.220 / 0.218 / 0.219 / 0.215 M/s.
-- Independently reproduced (separate interleaved run, N=3, CUDA `ray_num`=50M for a larger ~0.8 s / ~4.1 s
-  GPU window vs the 20M run's shorter window): CUDA multi 61.0 M/s (light) / 12.0 M/s (ms_multi),
-  legacy multi 3.16 / 0.22 M/s — within ~1–4% of the above, confirming the figures are not a
-  short-measurement-window artifact.
-
-- **Read the absolute M/s, NOT the ratio.** The 18.6×/52.6× ratios are **inflated by an unusually
-  weak legacy CPU baseline** on this host (light legacy multi = 3.25 M/s here vs 8.98 M/s on dev49 —
-  the win-builder CPU is ~2.8× slower per-core/thread), so the ratio is a property of a slow CPU, not
-  a fast GPU. **Cross-host numbers are not comparable** (read within this block only).
-- **Absolute CUDA throughput on the 1070 Ti is below the dev49 RTX 4060 Ti, as expected for the older
-  arch**: comparable light single-MS scene **60 M/s** (1070 Ti) vs ~87–114 M/s (4060 Ti @262144);
-  ms_multi 11.5 M/s vs ~19.7 M/s. Pascal lands ~0.5–0.7× the 4060 Ti — a sane cross-arch ordering.
-- The `single` column (2M-ray pass, JIT-warmup-dominated) reads lower than `multi` (20M-ray pass);
-  per the dev49 notes above, the GPU route has no true multi-worker parallelism, so the single/multi
-  gap is a warmup + ray-count artifact, and `multi` is the representative steady figure.
-- **Honesty caveats**: CPU model name unavailable (admin-gated `Win32_Processor`), so the CPU is
-  characterized only by core count (8C/16T from the `[BENCHMARK]` `cores`/`workers` fields). MSVC
-  version per the 309.1 build env, not re-verified at bench time (binary is the prebuilt CUDA-enabled
-  static `Lumice.exe` from 309.1). Variance is low (this is a dedicated, quiet machine), but only the
-  interleaved per-run numbers are reported — no cross-session averaging.
+**Key points**:
+- **All three hardware classes (CUDA-Ada / CUDA-Pascal / Metal) confirm the third clock is a
+  significant speedup at the real GUI resolution**; the gain scales with how much per-batch
+  readback/copy the old value contained.
+- **The Metal curve is nearly flat** (28→35 M/s across 6 steps) — the third clock makes Metal
+  resolution-robust (the old path's full-frame per-batch memset+memcpy is a real cost at high
+  resolution, not just CUDA readback). **Refutes the earlier "Metal unified memory = zero benefit"
+  judgment.**
+- Correctness: CUDA parity 10/10 @4060Ti + 10/10 @1070Ti/sm_61; Metal parity 14/14 (incl.
+  batch-invariance = drain-cadence independence).
+- win-builder 1070Ti omits vs-legacy (weak CPU inflates the ratio, read absolute values); the
+  `multi_med` column is distorted under the third clock and is deprecated (use `multi_wall`).
+- Heavy scene `ms_multi_crystal` (trace-dominated, small readback share) has a modest gain: 4060Ti
+  2048 = 14.9 M/s, 1070Ti = 7.3 M/s, Metal ≈ 17 M/s@256 (Mac thermal noise large, still jittery at
+  N=9 — needs a stable box to re-measure the canonical).
 
 ### macOS
 
@@ -477,7 +315,9 @@ Measure-Command { .\Lumice.exe -f bench_config.json -o . 2>&1 | Out-Null } | Sel
 ### Linux / CUDA (dev49)
 
 CUDA throughput is measured on the dev49 bench box (NVIDIA RTX 4060 Ti, Linux,
-CUDA docker — see `reference_dev49_linux_bench` / `explore-cuda-step2-derisk/TOOLCHAIN.md`).
+CUDA docker). For the full two-machine build + parity/correctness recipe (source sync,
+docker/BuildTools toolchain, `LUMICE_HAS_CUDA` un-skip gate, parity battery), see
+[`gpu-remote-cuda-build-testing.md`](gpu-remote-cuda-build-testing.md).
 **Do NOT improvise per-task bench scripts.** Use the committed harness
 `scripts/bench_throughput.py` — it already supports CUDA via env overrides, runs
 the canonical scene set (including the comparable `bench_light_single_ms`),
@@ -505,11 +345,11 @@ A throughput number alone cannot tell you whether the GPU is fed or starved.
 On CUDA/dev49, pair the bench with an `nsys` capture to read GPU utilization —
 this is the diagnostic that distinguishes a real win from a "beat the CPU while
 the GPU idles" false win. Profiler is already de-risked on dev49 (nsys 2023.4.4 +
-ncu 2024.1.1; install + usage recipe in `explore-cuda-step2-derisk/TOOLCHAIN.md`
-§"Profiler 可用性"). active% is **not a hard universal gate** — Metal on macOS has
-no comparable CLI active% path, so the cross-platform acceptance criterion stays
-the absolute hardware-capability target above; active% is a CUDA-side corroborating
-diagnostic for *why* a number is high or low.
+ncu 2024.1.1; install + usage recipe in `explore-cuda-step2-derisk/TOOLCHAIN.md`).
+active% is **not a hard universal gate** — Metal on macOS has no comparable CLI
+active% path, so the cross-platform acceptance criterion stays the absolute
+hardware-capability target above; active% is a CUDA-side corroborating diagnostic
+for *why* a number is high or low.
 
 ```bash
 # GPU active% = (sum of cuda_gpu_kern_sum) / wall, from an nsys timeline of one
@@ -573,44 +413,48 @@ The dashboard tracks 12 time-series (4 platforms × 3 metrics):
 
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
-| `LUMICE_DISPATCH_RAY_NUM` | **32768** (Metal) / 128 (CPU) | task-268.4 knob; scrum-268.6 set the Metal backend-aware default to **32768** (empirical sweet spot). Re-measured 2026-06-19 (task-fix-throughput-bench-honesty, setup-excluded `--benchmark`): heavy-scene engine **8–10× legacy** at 32768, GUI steady **~9.5× legacy** on M2 Max. Amortizes Metal kernel launch overhead; small dispatches starve the GPU (512/2048 = 0.2–0.8× legacy, 128 hangs at large ray_num) — the full win requires ≥32768. Set to a power of two for alignment. Applies at server startup; changing mid-run has no effect. Independent of `LUMICE_COMMIT_RAY_NUM` (see next row) — pick "feed GPU big" without sacrificing GUI cadence. **分辨率依赖**：默认 262144(CUDA)/32768(Metal) 甜点测于 **512×256**；分辨率升高时最优 dispatch 上移（2048×1024 下 CUDA ~786K–2M，实测 262144→~1M = 2.25×），因该场景 per-batch readback buffer 16× 大、需更大 dispatch 摊薄。分辨率变时重标（见"分辨率是一等吞吐维度"）。 |
-| `LUMICE_COMMIT_RAY_NUM` | 128 | task-268.4: SimData-to-consumer commit granularity inside `ConsumeData`. Smaller commits = finer GUI snapshot cadence regardless of dispatch size. Backend exit-seam path only (legacy CPU SimData bypass the chunker). **⚠️ GPU device-fused 路线（Metal/CUDA，`HasDeviceXyzAccum()`==true）上是 no-op**：该路径产出 `xyz_pixel_data_` 而非 `outgoing_d_`，commit chunker（`server.cpp:809`）被跳过；device readback 频率实由 `LUMICE_DISPATCH_RAY_NUM`（每 SimBatch 一次 `ReadbackXyzAccum`）决定，**非本旋钮**。（曾误用本旋钮做"readback 无关"判据，无效。） |
-| `LUMICE_BATCH_RAY_NUM` | (deprecated) | Backward-compat fallback for `LUMICE_COMMIT_RAY_NUM` only. Pre-task-268.4 this knob doubled as both dispatch and commit granularity. **scrum-268: the DISPATCH split is the primary driver for Metal throughput; setting `LUMICE_BATCH_RAY_NUM` now only controls commit cadence, not GPU dispatch size.** Prefer the two split env vars above. |
-| `LUMICE_TRACE_BACKEND` | unset (legacy CPU) | Trace backend selection: unset = legacy CPU; `metal` = Metal GPU backend (exit-seam + device root-gen); `cpu_backend` = SoA CPU backend. |
-| `LUMICE_DISABLE_DEVICE_GEN` | unset (device-gen ON) | Escape hatch to force **host** root-ray generation on the Metal backend. Device root-gen (GPU PCG root-ray supply) is the **default** for the Metal backend on eligible layers (single-crystal-per-ci, `tri_count ≤ 64`); it activates on both the deterministic single-worker path and the default multi-worker random path (each worker gets a non-zero derived `effective_seed_`). Set this to `1` only for strict-identity parity tests that mirror the host `std::mt19937` stream (which cannot align with the device PCG stream). Read once per backend instance at construction. |
+| `LUMICE_DISPATCH_RAY_NUM` | **262144** (CUDA) / **32768** (Metal) / 128 (CPU) | task-268.4 knob; the GPU per-dispatch grid size. scrum-268.6 set the Metal default to 32768; scrum-306.2 set the CUDA default to 262144 (both empirical sweet spots). Amortizes GPU kernel launch + per-batch host overhead; small dispatches starve the GPU (512/2048 = 0.2–0.8× legacy, 128 hangs at large ray_num). Set to a power of two for alignment. Applies at server startup; changing mid-run has no effect. Independent of `LUMICE_COMMIT_RAY_NUM` — feed the GPU big without sacrificing GUI cadence. **Resolution-dependent**: the 262144/32768 sweet spots were measured at **512×256**; the optimum shifts up as resolution rises (2048×1024: CUDA ~786K–2M, measured 262144→~1M = 2.25×), because the per-batch readback buffer is 16× larger and needs a bigger dispatch to amortize. Re-calibrate when resolution changes (see "resolution is a first-class throughput dimension"). |
+| `LUMICE_COMMIT_RAY_NUM` | 128 | task-268.4: SimData-to-consumer commit granularity inside `ConsumeData`. Smaller commits = finer GUI snapshot cadence regardless of dispatch size. Backend exit-seam path only (legacy CPU SimData bypass the chunker). **⚠️ No-op on the GPU device-fused route (Metal/CUDA, `HasDeviceXyzAccum()`==true)**: that path produces `xyz_pixel_data_`, not `outgoing_d_`, so the commit chunker (`server.cpp:809`) is skipped; device readback frequency is set by `LUMICE_DISPATCH_RAY_NUM` (one `ReadbackXyzAccum` per SimBatch), **not this knob**. (Was once mis-used as a "readback-independent" probe — ineffective.) |
+| `LUMICE_BATCH_RAY_NUM` | (deprecated) | Backward-compat fallback for `LUMICE_COMMIT_RAY_NUM` only. Pre-task-268.4 this knob doubled as both dispatch and commit granularity. scrum-268: the DISPATCH split is the primary driver for GPU throughput; setting `LUMICE_BATCH_RAY_NUM` now only controls commit cadence, not GPU dispatch size. Prefer the two split env vars above. |
+| `LUMICE_TRACE_BACKEND` | unset (legacy CPU) | Trace backend selection: unset = legacy CPU; `metal` = Metal GPU backend; `cuda` = CUDA GPU backend; `cpu_backend` = SoA CPU backend. |
+| `LUMICE_DISABLE_DEVICE_GEN` | unset (device-gen ON) | Escape hatch to force **host** root-ray generation on the GPU backends. Device root-gen (GPU PCG root-ray supply) is the **default** on eligible layers (single-crystal-per-ci, `tri_count ≤ 64`). Set this to `1` only for strict-identity parity tests that mirror the host `std::mt19937` stream (which cannot align with the device PCG stream). Read once per backend instance at construction. |
 
-**GPU device root-gen (scrum-260)**: on the Metal backend, root rays (orientation / direction / entry point) are generated on-device via a counter-based PCG stream keyed by `(gen_seed, gen_ray_base + tid)`, replacing host pre-generation + upload. This is the default path (single- and multi-crystal per-ci); statistical equivalence vs legacy is validated by the slow-e2e parity harness (`ds_corr ≥ 0.99`). Throughput uplift is hardware-dependent — quantify on a frequency-locked bench machine.
+> #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` is a GPU-only knob — never apply it to legacy in a comparison (scrum-306.1/306.4)
+>
+> `LUMICE_DISPATCH_RAY_NUM` sizes the GPU engine's per-dispatch grid. **CUDA total
+> energy is dispatch-invariant** (verified: ΣY = 261.29 M ±0.001% across dispatch
+> ∈ {128, 8192, 32768, 131072} on `dual_fisheye_ref`) — i.e. the GPU result is
+> correct at any dispatch. **Legacy (CPU) total energy is NOT dispatch-invariant**:
+> the same knob (which overrides legacy's `kDefaultRayNum`=128) swings legacy ΣY
+> **−5%..+13%** — this is Monte-Carlo variance from per-batch wavelength sampling,
+> not a bug (converged at the default 128; see scrum-306.7 in the per-run log).
+>
+> **Consequence / historical misdiagnosis to NOT repeat**: setting
+> `LUMICE_DISPATCH_RAY_NUM=131072` globally to probe CUDA made
+> `test_cuda_single_ms_no_filter_parity` report `energy_ratio=0.8922` — this was
+> **mis-attributed to a "CUDA exit-cap/cont-cap silent energy loss"** (the original
+> scrum-304.3 backlog entry). It is NOT a CUDA bug: the knob leaked into the legacy
+> reference run and inflated the **denominator** (legacy_Y), `261.29/292.87 = 0.892`.
+> The parity harness now strips `LUMICE_DISPATCH_RAY_NUM` for the `legacy` backend
+> (`test/e2e/capi_runner.py`, scrum-306.4) so the oracle stays at its canonical
+> default and `energy_ratio` reflects the GPU backend's correctness alone
+> (re-verified: @131072 0.8922 FAIL → 1.0063 PASS). `bench_throughput.py` already
+> excludes legacy from the dispatch sweep (`DISPATCH_PLAN["legacy"]=[None]`).
+>
+> **Process lesson**: the 304.3 correctness claim lived only as a backlog one-liner
+> with no preserved script → a wrong diagnosis (CUDA) propagated and could not be
+> re-aligned. Correctness assertions must land in a tracked doc with a reproducible
+> recipe. Reproduce: container `pip install pytest numpy`, `LUMICE_HAS_CUDA=1`, then
+> `LUMICE_DISPATCH_RAY_NUM=131072 pytest -m slow test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py::test_cuda_single_ms_no_filter_parity`;
+> per-dispatch ΣY split via `bench_work/harness2.cpp` (dev49).
 
-**Phase-1 confirmed throughput (task-metal-rootgen-throughput-confirm, Mac M2 Max, 2026-06-11)**: device-gen ON vs OFF measured with `scratchpad/bench/device_gen_throughput_bench.py` (`LUMICE_TRACE_BACKEND=metal`; ON = `LUMICE_DISABLE_DEVICE_GEN` unset, OFF = `=1`). 5 reps per cell, median; CoV reported. Activation that ON==GPU PCG vs OFF==host mt19937 is independently asserted by the slow-e2e test `test_device_gen_activation_proof_fixed_seed` (`dual_fisheye_ref` sim_seed=42, rel_err=4.4e-5 ≫ 1e-5 floor — host-gen fallback would give rel_err=0). (Note: the bench script lives under the git-ignored `scratchpad/` tree by design — consistent with `seam_exit_bench.py` — and is not committed; re-running requires the author's local copy. The numbers below are the durable record.)
-
-| Config | Batch | Single rps ON | Single rps OFF | ON/OFF (single) | Multi rps ON | Multi rps OFF | ON/OFF (multi) |
-|--------|-------|---------------|----------------|-----------------|--------------|---------------|----------------|
-| `dual_fisheye_ref` (single-MS, 1 crystal) | 128  |   343 k |   476 k | **0.72×** |  2.45 M |  4.03 M | **0.61×** |
-| `dual_fisheye_ref`                        | 512  | 1.22 M | 1.18 M | 1.04× |  9.19 M |  9.34 M | 0.98× |
-| `dual_fisheye_ref`                        | 2048 | 3.06 M | 1.23 M | 2.47× | 23.37 M | 13.27 M | 1.76× |
-| `ms_multi_crystal` (multi-MS, 2 crystals) | 128  |   107 k |   111 k | 0.97× |   979 k |   793 k | **1.23×** |
-| `ms_multi_crystal`                        | 512  |   311 k |   242 k | 1.28× |  2.63 M |  1.17 M | 2.24× |
-| `ms_multi_crystal`                        | 2048 |   447 k |   318 k | 1.41× |  4.77 M |  1.61 M | **2.95×** |
-
-All cells `routed_ok=True` (no fallback); CoV ≤ 5% for 21 of 24 measurements, max CoV 15.0% (`single_ms` b2048 multi ON — kernel saturation, not thermal). The 15.0% cell sits exactly at the CoV>15% retry threshold and was not re-run because the threshold is strict-greater (per the pre-specified CoV>15% → N=9 retry rule; ≤15% is in-spec, not a license to skip warranted reruns).
-
-**Verdicts**:
-
-- **`dual_fisheye_ref` (single-MS, 1 crystal) at default batch=128 is a NET LOSS for device-gen** (single 0.72×, multi 0.61×). This **contradicts the scrum-260 probe** which reported ~1.87× at the same config — the probe was a single throwaway invocation and did not reflect steady-state behavior. Net gain only kicks in at `batch ≥ ~512` and reaches 2.47× / 1.76× at `batch=2048`. At default batch GPU device-gen pays per-dispatch overhead that the small per-batch ray count cannot amortize.
-- **`ms_multi_crystal` (multi-MS, 2 crystals) at default batch=128 is roughly neutral for single-worker (0.97×) and a net gain (1.23×) for multi-worker.** This is the opposite of the plan's pre-bench hypothesis (which feared multi-crystal per-ci dispatch overhead would dominate); in fact multi-MS workloads amortize device-gen better than single-MS because the multi-MS layer count multiplies the per-batch work GPU-side. At larger batches the multi-MS multi-worker gain grows to 2.24× (b512) and 2.95× (b2048).
-- **Activation cross-check for multi-crystal**: `ms_multi_crystal` multi-worker ON/OFF goes 1.23× → 2.24× → 2.95× as batch grows. The monotone ON-favored ratio with batch (the b2048 crossover predicted by plan §3 Step 3 Minor 1 for "device-gen active but small-dispatch overhead-dominated") confirms device-gen IS activating on multi-crystal per-ci paths; if it had silently fallen back, ON ≡ OFF and the ratio would sit at 1.0 across all batches. The activation-proof test only covers single-crystal; the batch-scaling pattern here is the indirect activation evidence for multi-crystal.
-
-**Implication for default config**: users running the Metal backend at the default `LUMICE_BATCH_RAY_NUM=128` see device-gen **hurt** single-crystal throughput and **help** multi-crystal multi-worker throughput modestly. The strong wins (>2×) require `LUMICE_BATCH_RAY_NUM=2048`. A future task may revisit (a) raising the default batch when device-gen is active, (b) adaptive per-ci batch coalescing for the small-dispatch regime, or (c) selectively disabling device-gen for single-crystal/single-MS scenes at small batches. Until then the escape hatch `LUMICE_DISABLE_DEVICE_GEN=1` is the workaround for users hitting the small-batch single-crystal loss.
-
-Example: measure throughput at a higher batch size to characterize the Metal dispatch amortization curve:
-
-```bash
-# Default batch (128 rays/batch)
-./build/cmake_install/Lumice --benchmark -f examples/bench_config.json -o /tmp
-
-# Larger batch (512 rays/batch) — Metal backend crosses over here
-LUMICE_BATCH_RAY_NUM=512 ./build/cmake_install/Lumice --benchmark -f examples/bench_config.json -o /tmp
-```
+**GPU device root-gen (scrum-260)**: on the GPU backends, root rays (orientation / direction /
+entry point) are generated on-device via a counter-based PCG stream keyed by
+`(gen_seed, gen_ray_base + tid)`, replacing host pre-generation + upload. This is the default
+path; statistical equivalence vs legacy is validated by the slow-e2e parity harness
+(`ds_corr ≥ 0.99`). The device-gen ON/OFF throughput characterization (Metal, phase-1) — device-gen
+is a net loss for single-crystal single-MS at the default batch and a net gain for multi-crystal
+multi-worker, with strong wins only at large batch — is recorded in `scratchpad/perf-results-log.md`.
 
 ## 2. GUI Perf Test (Hidden Window, No VSync)
 

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -81,7 +81,24 @@ total thread count = workers + 2.
 
 **Parallel efficiency** = `multi_rps / (single_rps × workers)`. A value near 1.0 indicates
 good scaling; lower values suggest lock contention, memory bandwidth saturation, or
-scheduling overhead.
+scheduling overhead. **Meaningful for the legacy CPU route only** — see the GPU caveat next.
+
+> **⚠️ GPU backends are single-engine — "single" vs "multi" is NOT parallelism.** The GPU route
+> (Metal / CUDA) runs `worker_count=1` unconditionally (`server.cpp:284`); only the legacy CPU
+> route is genuinely multi-worker (`worker_count = PhysicalCoreCount()`). In `--benchmark`'s
+> dual-pass **both** GPU passes run on the same single engine — the "single" pass is just the
+> 2M-ray, JIT-warmup-dominated short run and the "multi" pass is the full-ray-count, warm, long
+> run. So for GPU:
+> - The two numbers are **not** equal (e.g. dev49 CUDA 35→56 M/s, 1070Ti 32→60 M/s) — but the
+>   gap is **warmup + ray-count + window-length**, not parallelism.
+> - **The "multi" number is the representative steady figure** (warm + long window); read it, not
+>   because it is "parallel" but because it is the settled rate.
+> - **`efficiency` is meaningless for GPU** (`workers` in a GPU `[BENCHMARK]` line is the
+>   configured core count, not GPU engines; `explore-306.1` E1 `worker_count=1` is the proof).
+>
+> This is documented, not a bug. **Planned simplification** (backlog, needs hardware validation):
+> the GPU dual-pass may be collapsed to a single steady number so the self-reported data stops
+> implying parallelism — until then, apply this caveat when reading GPU `single`/`multi`.
 
 Behavior differences in benchmark mode:
 - **Dual-pass**: Two independent server instances are created sequentially, each with a

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -74,18 +74,18 @@ setup 会把它们的 rays_per_sec 压低 >30%。
 **并行扩展效率** = `multi_rps / (single_rps × workers)`。接近 1.0 表示良好扩展；
 偏低说明存在锁竞争、内存带宽饱和或调度开销。**仅对 legacy CPU 路线有意义**——见下方 GPU caveat。
 
-> **⚠️ GPU 后端是单引擎——"single" vs "multi" 不是并行。** GPU 路线（Metal / CUDA）无条件
+> **⚠️ GPU 后端是单引擎——不存在 "single" vs "multi" 并行。** GPU 路线（Metal / CUDA）无条件
 > `worker_count=1`（`server.cpp:284`）；只有 legacy CPU 路线是真多 worker（`worker_count =
-> PhysicalCoreCount()`）。`--benchmark` 双趟里 GPU **两趟都跑在同一个单引擎**上——"single" 趟只是
-> 2M 光线、JIT-warmup 主导的短 run，"multi" 趟是全光线数、暖机后、长窗口的 run。所以对 GPU：
-> - 两个数**并不相等**（如 dev49 CUDA 35→56 M/s，1070Ti 32→60 M/s）——但差异来自 **暖机 + 光线数 +
->   窗口长度**，不是并行。
-> - **"multi" 数是稳态代表值**（暖机 + 长窗口）；读它，不是因为它"并行"，而是因为它是稳定率。
-> - **`efficiency` 对 GPU 无意义**（GPU `[BENCHMARK]` 行里的 `workers` 是配置的核数、非 GPU 引擎数；
->   `explore-306.1` E1 `worker_count=1` 是铁证）。
->
-> 这是已记录的现实，非 bug。**计划中的简化**（backlog，需硬件验证）：GPU 双趟可能塌成单个稳态数，
-> 使自报数据不再暗示并行——在此之前，读 GPU `single`/`multi` 时套用本 caveat。
+> PhysicalCoreCount()`）。既然 GPU 的 "single" 与 "multi" 趟都跑在同一个单引擎（只差暖机+光线数、
+> 非并行），**`--benchmark` 对 GPU 路线塌成 ONE 稳态趟**（label `mode="multi"`）、跳过暖机趟；
+> legacy CPU 路线保留真双趟。路线检测是 env-aware 的（`LUMICE_WillUseGpuRoute` 认 `LUMICE_TRACE_BACKEND`，
+> 故 env 选的 GPU run 也塌）。读 GPU 结果时：
+> - GPU 的 `[BENCHMARK]` / `bench_throughput.py` 行**只有 `multi`**（`single`/`single_rps` 缺失
+>   =预期、非 INCOMPLETE）。`multi` 数是稳态代表值。
+> - **`efficiency` 对 GPU 不适用**（无 single/parallel 对；`explore-306.1` E1 `worker_count=1` 铁证）。
+>   CI summary 的 efficiency 列仅对 legacy CPU 有意义。
+> - 对旧数据：2026-07 前带 `single` 列的 GPU 表是旧双趟（single = 2M 光线暖机 run），那些 GPU `single`
+>   数从来不是"单核"指标。
 
 benchmark 模式的行为差异：
 - **双趟运行**：依次创建两个独立 server 实例，指定不同 worker 数

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -4,6 +4,11 @@
 
 所有命令假设工作目录为项目根目录。
 
+> **范围**：本指南保留稳定的操作手册 + **当前 canonical** 吞吐参考。历史 per-run 实测详录
+> （带日期的表、原始 reps、各 effort 的方法论）放在 git-ignored 的 `scratchpad/perf-results-log.md`
+> ——新 per-run 数字追加那里，只有成为新 canonical 锚时才提升进本文档。远程机器上的 CUDA build +
+> parity/正确性验证是另一件事——见 [`gpu-remote-cuda-build-testing.md`](gpu-remote-cuda-build-testing.md)。
+
 ## 日志级别
 
 CLI 基准测试和 GUI 性能测试均支持日志级别选项。
@@ -53,9 +58,15 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 并行吞吐量。输出两行 JSON：
 
 ```
-[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.5, "rays_per_sec": 235294.1}
-[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 2.4, "rays_per_sec": 4166666.7}
+[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.51, "setup_sec": 0.01, "active_sec": 8.5, "rays_per_sec": 235294.1, "rate_basis": "steady"}
+[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 0.6, "setup_sec": 0.02, "active_sec": 0.58, "rays_per_sec": 17241379.3, "rate_basis": "steady"}
 ```
+
+`rays_per_sec` 是 `active_sec`（从首条光线追踪到 IDLE 的窗口）上的**稳态追踪率**，
+**不是** `rays / wall_sec`。`setup_sec`（server alloc + 场景生成 + 首 dispatch 延迟）从分母
+剔除；`rate_basis` 记录产出该率的路径（`steady` / `active_short` / `wall_fallback`）。这个
+setup-剔除修复（task-fix-throughput-bench-honesty）对整个 run 只 ~0.2s 的快后端很重要——折进
+setup 会把它们的 rays_per_sec 压低 >30%。
 
 **术语**："workers"指 simulator 线程（执行光线追踪的线程）。每个 server 实例还有 2 个
 内部线程（场景生成 + 数据消费），总线程数 = workers + 2。
@@ -68,37 +79,137 @@ benchmark 模式的行为差异：
   （单 worker pass 为 1，多 worker pass 为 `hardware_concurrency()`）
 - **单 worker pass 光线数减少**：2M（而非配置原始值），以限制 CI 耗时
 - **不写图片**：跳过 `SaveRenderResults`，`wall_sec` 纯反映模拟耗时
-- **100ms 轮询间隔**（默认 1s）：将计时量化误差降至 ~0.1s
+- **5ms 轮询间隔**（默认 1s）：把 IDLE 检测量化误差压到几毫秒（曾是 100ms，那单独就能给快 run 的
+  wall time 加上一整个轮询间隔）
 
-### 最新实测结果（每次更新追加）
+### Benchmark 场景注册表（canonical 吞吐场景）
 
-> 每次重跑 bench 把最新数字追加这里。记**绝对 rays/sec**(不止倍数)、各 config 都有、附硬件摘要。**跨硬件数字不可比**——只在同一 host 块内读,别拿 Mac 行比 Linux 行。来源:`scripts/bench_throughput.py`(默认 dispatch,`ray_num`=20M,N≥5,CoV>15% 重跑 N=9)。
+> **吞吐比较的单一真源。** 永远引用本表里的真实 config——绝不臆造场景名。（本表存在是因为文档
+> 曾引用不存在的 `ms3_multi_crystal_complex_filter` 并对标无法复现的数字；见
+> task-fix-throughput-bench-honesty。）`scripts/bench_throughput.py` 跑 Metal-可比子集；两者保持同步。
 
-#### Mac — Apple M2 Max(12 核 8P+4E,32GB,macOS 14.7)· legacy vs Metal · 2026-06-28
+测量口径：**引擎** = `Lumice --benchmark` multi pass，setup-剔除稳态率；**GUI** =
+`gui_test perf_test` steady_state，无限 budget，reconstruct 路径。基线分母永远是 **legacy CPU**
+（GUI 真实路径）——绝不用 `cpu_backend`。下方 `Metal vs legacy` 比值是 M2 Max、2026-06-19 回归锚
+（`scratchpad/task-fix-throughput-bench-honesty/data/`）；任何吞吐改动前后须同会话重测。
 
-| config | legacy single | legacy multi | Metal single | Metal multi | Metal/legacy(multi) |
+| config（真实文件） | regime | rays / MS / filter | lens / Metal 可比 | 角色 | Metal vs legacy（锚） |
 |---|---|---|---|---|---|
-| `bench_light_single_ms`（轻·单MS） | 573 K/s | 4.62 M/s | **27.8 M/s** | **30.6 M/s** | 6.62× |
-| `ms_multi_crystal`（中·无filter） | 94 K/s | 759 K/s | 7.08 M/s | 7.66 M/s | 10.08× |
-| `ms_multi_crystal_complex_filter`（重·标准） | 333 K/s | 1.54 M/s | 12.4 M/s | 12.8 M/s | 8.33× |
-| `ms_multi_crystal_filtered_bd`（重·bd） | 368 K/s | 1.62 M/s | 13.7 M/s | 14.0 M/s | 8.59× |
+| `bench_light_single_ms.json` | 轻·单MS · 512×256 | 10M / 1 / 无 | dual_fisheye_EA ✅ | 轻场景吞吐基准（bench 专用，勿因 e2e 改动）；**512×256 落 GPU L2，系统性高估 GPU 优势**；真实分辨率用 `--res-sweep`（见"分辨率是一等吞吐维度"） | 引擎 ~1.7× / GUI ~1.8× |
+| `ms_multi_crystal.json` | 中·无filter | 2M / 2 / 无 | dual_fisheye_EA ✅ | 无 culling 中等基准；`--res-sweep` 第二代表场景（看场景依赖） | 引擎 ~2.0× / GUI ~2.2× |
+| `ms_multi_crystal_complex_filter.json` | 重·标准 | 2M / 2 / complex | dual_fisheye_EA ✅ | **G1 + G4 主基准** | 引擎 ~8.1× / GUI ~9.5× |
+| `ms_multi_crystal_filtered_bd.json` | 重·bd | 2M / 2 / bd | dual_fisheye_EA ✅ | G1 第二基准 | 引擎 ~10.1× |
+| `ms3_mixed_pyramid_heavy.json` | 最重·棱锥 | 5M / 3 / 4×raypath | dual_fisheye_EA ✅ | register-pressure 上界 | 引擎 **~5.5×**（M2 Max，2026-06-24；GUI 互证 ~5.7×）。注：legacy single pass ~274s 超出 `bench_throughput.py` 的 `RUN_TIMEOUT_SEC`，故该场景仍从自动跑中排除——基线靠手动大 timeout 单测取得 |
+| `halo_22.json` | 轻·单MS | 10M / 1 / 无 | **fisheye_EA（单）→ CLI Metal 回退** | **e2e 资产，勿改**；legacy-only 轻基准 | N/A（Metal 不兼容此投影；轻·Metal 用 `bench_light_single_ms`） |
 
-- **Metal 在可比的轻·单MS 场景已 ~28–30 M/s,达到/超过 25 M/s 硬件能力目标。** 证明这个标尺在本 codebase 够得着,给 CUDA 一个同引擎目标(4060 Ti 与 M2 Max GPU 算力同级);CUDA 剩余差距是执行模型,不是 kernel 根本极限。
+注意：
+- **上表 4 个 light/mid/heavy 主基准（bench_light / ms_multi / complex_filter / filtered_bd）都是
+  512×256**（`ms3_mixed_pyramid_heavy` 例外，为 2048×1024）。512×256 的 XYZ 累加 buffer（W×H×3
+  float = 1.5MB）落在典型 GPU 的 L2 内，**系统性高估 GPU 吞吐**——真实 GUI 默认渲染 2048×1024
+  （16× 像素，24MB buffer，越 L2）。**跨分辨率数字不可比；报吞吐必须带分辨率**。真实分辨率吞吐用
+  `bench_throughput.py --res-sweep`（分辨率轴，默认 dispatch，隔离单变量）——详见下方"分辨率是一等
+  吞吐维度"。
+- dispatch 甜点是**后端 + 分辨率依赖**：Metal 32768 / CUDA 262144 是 **512×256** 下的甜点；**分辨率
+  升高时 CUDA 最优 dispatch 显著上移**（2048×1024 下 ~786K–2M，因 per-batch readback 摊薄）。小
+  dispatch 饿死 GPU（512/2048 = 0.2–0.8× legacy）。
+- `bench_throughput.py` 每 run 把 `ray_num` override 到大值（temp config，不动 committed 文件），
+  使稳态窗口足够长而稳定。
+- **⚠️ 第三时钟 drain 路径（CUDA，scrum-312）用 `multi_wall` 列，不用 `multi_med`**：`multi_med`
+  （binary 的 steady `rays_per_sec`）靠 `sim_ray_num` 进度采样，而第三时钟 drain 稀疏 → 进度粗跳
+  （首个 drain 前 `sim_ray_num` 恒 0）→ steady window 把大部分 tracing 误算进 setup → **系统性假低**
+  （实测 2048 报 22M，真值 39M）。`bench_throughput.py` 已加 `multi_wall = rays/wall_sec`（robust，
+  免疫 drain 粒度），两列背离时**信 `multi_wall`**。per-batch 路径（legacy/Metal/CUDA N=1）两列一致，
+  不受影响。
 
-#### Linux — dev49 RTX 4060 Ti(AMD Zen5 9950X 16C/32T host）· legacy vs CUDA · 2026-06-29
+#### 分辨率是一等吞吐维度（device-fused XYZ 累加 → cost 随 buffer vs GPU L2）
 
-scrum-304.2 buffer-persist 后,GPU idle-gate(跑前 `nvidia-smi` 实测 0%),`scripts/bench_throughput.py` 默认 dispatch(=32768),ray_num=20M,N≥5(CoV>15% 重跑 N=9)。
+> **报任何 GPU 吞吐数字必须带渲染分辨率；跨分辨率不可比。** 这不是二阶细节——它常主导轻场景的 GPU
+> 吞吐（轻场景 trace 便宜，累加/回读占大头）。
 
-| config | legacy single | legacy multi | CUDA single | CUDA multi | CUDA/legacy(multi) |
+机制：device-fused XYZ 累加（scrum-302）把每条出射光线在 **trace kernel 内** `atomicAdd` 进
+W×H×3 float 图像 buffer（12 B/px）。cost 随 buffer 相对 GPU L2 变化：
+
+- buffer ≤ L2（512×256 = 1.5MB，落多数 GPU 的 ~2MB L2）→ 累加走 cache，快。
+- buffer ≫ L2（2048×1024 = 24MB）→ 每次 atomicAdd 打 DRAM，DRAM 带宽绑定，慢。膝在 L2 边界
+  （~512→768），越 L2 后随分辨率平滑衰减（非二元断崖）。
+
+CUDA 路线还有 **per-batch 同步 readback** 税（`ReadbackXyzAccum` 每 SimBatch 一次
+`cudaDeviceSynchronize` + 阻塞 24MB PCIe D2H + memset），scrum-312 已把它解耦到显示节奏（"第三时钟"，
+`seam-design.md` §4.8）——见下方 canonical 结果。Metal 无此税（`StorageModeShared` 统一内存 + 延迟等）。
+
+**流程要求**：
+
+1. GPU 吞吐用 `bench_throughput.py --res-sweep` 扫多档分辨率（默认 `256×128 … 2048×1024` 六档，2:1，
+   跨 L2 膝两侧），而非只报单点。脚本每档在 temp config 里 override `render[].resolution`（committed
+   文件不动，同 ray_num override 机制）。默认扫 `bench_light_single_ms`（轻，累加/回读主导）+
+   `ms_multi_crystal`（稍重，看场景依赖），`--res-list` / `--res-configs` 可覆盖。至少覆盖 **512×256
+   （引擎天花板 / L2-resident）+ 2048×1024（GUI 真实体验）** 两点。
+2. 与竞品 / 硬件能力对标（下方 25M bar）时**对齐分辨率**——我方历史 512×256 数字是 L2-resident 上界，
+   非用户体验。
+3. 数字入表**必标分辨率**（现有表默认 512×256，除 `ms3_mixed_pyramid_heavy`）。sweep 的**曲线数据不入
+   committed 文件**（按机器/会话变），入表的是按 N≥5 CoV 协议正式产出的 canonical 点。
+
+#### 验收标尺：硬件能力，不是"× legacy CPU"
+
+> **`× legacy CPU` 比值是地板，不是成功标尺。** 打过 legacy 只是必要门槛，绝非目标——GPU 后端可以
+> "× legacy 赢"却只用 1–2% 利用率（scrum-304 就踩过这坑：一个报成"~1.7× legacy 16 核"的 CUDA 数其实
+> 是重于可比口径的场景上饿着的 GPU）。GPU 后端真正的标尺是**这块卡的硬件能力**，锚到可比工作负载 +
+> 外部参照。
+
+**已注册硬件能力目标**（绝对、场景锚——判 GPU 吞吐时引用这个，而非"× legacy"）：
+
+| 场景 | 可比负载 | 硬件能力目标 | 来源 |
+|---|---|---|---|
+| `bench_light_single_ms`（轻·单MS） | 单晶 + 单 MS + 无续传 | **4060 Ti ≥ 25M rays/s** | 竞品实测——轻·单MS 是 apples-to-apples 对比 |
+
+- 永远拿**可比**场景对标外部目标——别拿重场景（多晶/多 MS，如 `ms_multi_crystal`）的数去对标单晶单散射。
+  逐光线工作量差一个数量级。
+- GPU 数远低于硬件能力目标时，**无论对 legacy 比值多少都不算成功**；查利用率（CUDA 可用 nsys active%，
+  见下）+ 机制，别收尾。
+- 到不了目标，交付物必须是 **profiler 落地的机制解释**（时间花哪了），不是"GPU 非天然胜"的黑盒话术。
+- **⚠️ 分辨率对齐**：25M bar 的竞品渲染分辨率未知；我方 `bench_light_single_ms` 是 **512×256
+  （L2-resident，上界）**。真实 GUI 默认 2048×1024 下同卡同场景吞吐掉 3.6–5×（见"分辨率是一等吞吐
+  维度"）。判定是否达标前必须**对齐分辨率**——别拿 512×256 的 L2-resident 数字宣称达 bar。用
+  `bench_throughput.py --res-sweep` 取真实分辨率对标点。
+
+### 当前 canonical 吞吐结果
+
+> 当前权威参考数字。**跨硬件数字不可比**——只在同一 host 块内读。历史 per-run 详录（带日期的表、原始
+> reps、各 effort 方法论）在 `scratchpad/perf-results-log.md`。第三时钟路径读 `multi_wall`。
+
+#### scrum-312 第三时钟 canonical · `--res-sweep` · `multi_wall` · 2026-07-01
+
+**背景**：readback 从 trace 时钟解耦到显示节奏第三时钟（seam-design §4.8）。真实 GUI 分辨率
+2048×1024 下 readback/per-batch-copy 税被摊薄。`bench_light_single_ms`（轻·单MS，L2/readback 主导），
+per-resolution `multi_wall`：
+
+| host / backend | 256×128 | 512×256 | 1024×512 | 1536×768 | **2048×1024** |
 |---|---|---|---|---|---|
-| `bench_light_single_ms`（轻·单MS） | 744 K/s | 8.98 M/s | **35.2 M/s** | **55.9 M/s** | 6.23× |
-| `ms_multi_crystal`（中·无filter） | 126 K/s | 1.44 M/s | 9.67 M/s | 13.7 M/s | 9.55× |
-| `ms_multi_crystal_complex_filter`（重·标准） | 471 K/s | 6.26 M/s | 38.0 M/s | 60.3 M/s | 9.63× |
-| `ms_multi_crystal_filtered_bd`（重·bd） | 510 K/s | 6.73 M/s | 39.1 M/s | 61.9 M/s | 9.19× |
+| dev49 RTX 4060Ti (Ada) CUDA | 116 M/s | 110 M/s | 92 M/s | 65 M/s | **39.2 M/s** |
+| win-builder GTX 1070Ti (Pascal) CUDA | 77 M/s | 69 M/s | 45 M/s | 40 M/s | **33.5 M/s** |
+| Mac M-series Metal | 28.1 M/s | 30.3 M/s | 31.2 M/s | 35.1 M/s | **32.3 M/s** |
+| dev49 legacy CPU (baseline) | 9.0 M/s | 8.8 M/s | 8.4 M/s | 7.7 M/s | 6.9 M/s |
+| Mac legacy CPU (baseline) | 5.1 M/s | 4.8 M/s | 4.7 M/s | 4.8 M/s | 4.7 M/s |
 
-- **竞品线 25M 已达到/超过**:可比轻·单MS 场景 **35–56 M/s**,≥ 25M 竞品目标,也 > Mac Metal 参照(28–30M)。仅 buffer-persist(304.2)就到这了;之前"0.16–0.40× / 1.5M"的悲观是**测量假象**——ad-hoc 非 idle-gate 在重场景 `ms_multi_crystal` 上测、用错标尺。务必 idle-gate + 用 canonical harness + 可比场景。
-- **GPU 尚未满载**:nsys 轻场景(50M plain run)GPU active 17.6%(含 JIT/setup);benchmark steady 窗口 active ≈ 43%。trace kernel 占 GPU 95%。满载天花板 ≈ 129M rays/s(50M / 386ms kernel),现在 56M ≈ 43% → **还剩 ~2.3× headroom**,锁在每-dispatch host 串行(默认流 + per-layer 同步;explore-303 找到,304.2 未动)。要拿这部分=async-engine 工作,**现由 active% 数据支撑,非猜测**。
-- 注:竞品确切配置(光谱/max_hits)未知,我们场景是合理的单晶单MS 代理(prism,D65,max_hits 7)。需精确 apples-to-apples 时对齐。
+**第三时钟在 2048×1024 的增益**（vs per-batch drain 旧值，interleaved 同 binary 隔离 drain cadence）：
+
+| host / backend | 旧（per-batch） | 第三时钟 | 增益 | 机制 |
+|---|---|---|---|---|
+| 4060Ti (Ada, 32MB L2) CUDA | 28 M/s | 39 M/s | **1.4×** | Ada L2 大→旧值已 L2-resident，税主要是 per-batch D2H readback |
+| 1070Ti (Pascal, 2MB L2) CUDA | 12.5 M/s | 33.5 M/s | **2.7×** | 兼有 L2 溢出 + readback 税；第三时钟消 readback（L2 残留） |
+| M-series Metal（统一内存） | 11 M/s | 32.3 M/s | **~3×** | 无 PCIe readback；per-batch 24MB memset+memcpy(×76 batch≈3.6GB) 被摊薄 |
+
+**要点**：
+- **三种硬件（CUDA-Ada / CUDA-Pascal / Metal）一致确证第三时钟在真实 GUI 分辨率显著提速**；增益随
+  "旧值里 per-batch readback/copy 占比"放大。
+- **Metal 曲线近平**（28→35 M/s 跨 6 档），第三时钟使 Metal 分辨率-鲁棒（旧路径每 batch 全幅
+  memset+memcpy 在高分辨率是真成本，非仅 CUDA readback）。**推翻早先"Metal 统一内存零收益"判断**。
+- 正确性：CUDA parity 10/10 @4060Ti + 10/10 @1070Ti/sm_61；Metal parity 14/14（含 batch-invariance
+  = drain-cadence 独立性）。
+- win-builder 1070Ti 未列 vs-legacy（CPU 弱，比值虚高，读绝对值）；`multi_med` 列在第三时钟下失真已弃用
+  （用 `multi_wall`）。
+- 重场景 `ms_multi_crystal`（trace 主导，readback 占比小）增益温和：4060Ti 2048 = 14.9 M/s、1070Ti =
+  7.3 M/s、Metal ≈ 17 M/s@256（Mac 热噪大，N=9 后仍抖，需稳定机复测 canonical）。
 
 ### macOS
 
@@ -143,7 +254,11 @@ Measure-Command { .\Lumice.exe -f bench_config.json -o . 2>&1 | Out-Null } | Sel
 
 ### Linux / CUDA（dev49）
 
-CUDA 吞吐在 dev49（RTX 4060 Ti，Linux，CUDA docker）测。**禁止每个 task 自己写 bench 脚本**——用 committed harness `scripts/bench_throughput.py`（已支持 CUDA env 覆盖、跑 canonical 场景集含可比的 `bench_light_single_ms`、确认 GPU 路由、median+CoV）。详见英文版 `performance-testing.md` 同名节 + `explore-cuda-step2-derisk/TOOLCHAIN.md`。
+CUDA 吞吐在 dev49（RTX 4060 Ti，Linux，CUDA docker）测。两机完整 build + parity/正确性 recipe
+（源码同步、docker/BuildTools 工具链、`LUMICE_HAS_CUDA` un-skip 闸、parity battery）见
+[`gpu-remote-cuda-build-testing.md`](gpu-remote-cuda-build-testing.md)。**禁止每个 task 自己写 bench
+脚本**——用 committed harness `scripts/bench_throughput.py`（已支持 CUDA env 覆盖、跑 canonical 场景集
+含可比的 `bench_light_single_ms`、确认 GPU 路由、median+CoV）。
 
 ```bash
 # dev49 CUDA docker 内（先 build -DLUMICE_CUDA_ENABLED=ON -DBUILD_SHARED_LIBS=ON）
@@ -155,15 +270,19 @@ LUMICE_BENCH_BACKENDS=legacy,cuda \
 # dev49 共享机：严格吞吐须 idle 窗口；用完立刻清自己进程，别占机。
 ```
 
-**⭐ 验收标尺 = 硬件能力,不是"× legacy CPU"。** 打过 legacy 只是必要门槛（floor），不是成功——GPU 可以"× legacy 赢"却只用 1–2% 利用率（scrum-304 踩过这坑）。GPU 后端真正的标尺是**这块卡的硬件能力**，锚到**可比工作负载 + 外部参照**：
+#### GPU active% 诊断（仅 CUDA——Metal/Mac 无同口径 CLI 路径）
 
-| 场景 | 可比负载 | 硬件能力目标 | 来源 |
-|---|---|---|---|
-| `bench_light_single_ms`（轻·单MS） | 单晶 + 单 MS + 无续传 | **4060 Ti ≥ 25M rays/s** | 竞品实测 |
+单看吞吐数字无法判断 GPU 是被喂饱还是饿着。CUDA/dev49 上把 bench 配一个 `nsys` capture 读 GPU 利用率
+——这是区分"真赢"与"GPU 空转还打过 CPU 的假赢"的诊断。profiler 已在 dev49 de-risk（nsys 2023.4.4 +
+ncu 2024.1.1；安装 + 用法见 `explore-cuda-step2-derisk/TOOLCHAIN.md`）。active% **非硬性普适门**——
+macOS 上 Metal 无同口径 CLI active% 路径，故跨平台验收判据仍是上方绝对硬件能力目标；active% 是 CUDA 侧
+佐证"为何这个数字高或低"的诊断。
 
-- 别拿重场景（多晶/多 MS）的数对标单晶单散射——逐光线工作量差一个数量级。
-- GPU 数远低于硬件能力目标时,**无论对 legacy 比值多少都不算成功**;查利用率（CUDA 可用 nsys active%；Mac/Metal 无同口径 CLI 路径,故 active% 非硬性普适门,跨平台判据仍是绝对能力目标）+ 机制,别收尾。
-- 到不了目标,交付物必须是 **profiler 落地的机制解释**（时间花哪了），不是"GPU 非天然胜"的黑盒话术。
+```bash
+# GPU active% = (sum of cuda_gpu_kern_sum) / wall，取自一次代表性 run 的 nsys timeline。
+# 低 active%（如 1–2%）=> GPU 饿着 => 吞吐数字是 host-bound，非硬件能力结果。
+nsys profile --trace=cuda --stats=true -o /tmp/rep <Lumice ...>   # 见 TOOLCHAIN.md
+```
 
 ### CI 自动化基准测试
 
@@ -179,7 +298,7 @@ summary 表包含硬件上下文和双模式结果：
 | Cores | 逻辑核心数（`hardware_concurrency()`） |
 | Workers | 多 worker pass 使用的 simulator 线程数 |
 | Single rps | 单 worker rays/sec（单核效率） |
-| Multi rps | 多 worker rays/sec（并行吞吐���） |
+| Multi rps | 多 worker rays/sec（并行吞吐量） |
 | Efficiency | `multi_rps / (single_rps × workers)`——并行扩展效率 |
 
 **注意**：`Single rps` 是跨平台比较最有意义的指标，因为它自然包含了 IPC、
@@ -210,6 +329,44 @@ push 到 `main` 的 benchmark 结果会通过
 - 仅存储 `main` 分支 push 的历史；功能分支 benchmark 仅在 per-run summary 表中显示
 - CI runner 硬件可能不经通知就更换，导致绝对 rps 指标出现阶跃变化
 - 告警阈值是全局的（所有指标共享 200%）；Efficiency 回归低于阈值时需人工巡检图表
+
+### 运行时调优旋钮
+
+| 环境变量 | 默认 | 说明 |
+|----------|------|------|
+| `LUMICE_DISPATCH_RAY_NUM` | **262144**（CUDA）/ **32768**（Metal）/ 128（CPU） | task-268.4 旋钮；GPU 每-dispatch 网格大小。scrum-268.6 定 Metal 默认 32768；scrum-306.2 定 CUDA 默认 262144（都是实测甜点）。摊薄 GPU kernel 启动 + per-batch host 开销；小 dispatch 饿死 GPU（512/2048 = 0.2–0.8× legacy，128 在大 ray_num 下 hang）。设为 2 的幂对齐。server 启动时读取，运行中改无效。与 `LUMICE_COMMIT_RAY_NUM` 独立——喂大 GPU 而不牺牲 GUI 节奏。**分辨率依赖**：262144/32768 甜点测于 **512×256**；分辨率升高最优上移（2048×1024 下 CUDA ~786K–2M，实测 262144→~1M = 2.25×），因 per-batch readback buffer 16× 大、需更大 dispatch 摊薄。分辨率变时重标（见"分辨率是一等吞吐维度"）。 |
+| `LUMICE_COMMIT_RAY_NUM` | 128 | task-268.4：`ConsumeData` 内 SimData-to-consumer 提交粒度。更小提交 = 更细 GUI 快照节奏（与 dispatch 大小无关）。仅 backend exit-seam 路径（legacy CPU SimData 绕过 chunker）。**⚠️ GPU device-fused 路线（Metal/CUDA，`HasDeviceXyzAccum()`==true）上是 no-op**：该路径产出 `xyz_pixel_data_` 而非 `outgoing_d_`，commit chunker（`server.cpp:809`）被跳过；device readback 频率实由 `LUMICE_DISPATCH_RAY_NUM`（每 SimBatch 一次 `ReadbackXyzAccum`）决定，**非本旋钮**。（曾误用本旋钮做"readback 无关"判据，无效。） |
+| `LUMICE_BATCH_RAY_NUM` | （已废弃） | 仅作 `LUMICE_COMMIT_RAY_NUM` 的向后兼容回退。task-268.4 前它同时兼作 dispatch 和 commit 粒度。scrum-268：DISPATCH 拆分是 GPU 吞吐的主驱动；现在设 `LUMICE_BATCH_RAY_NUM` 只控 commit 节奏、不控 GPU dispatch 大小。优先用上面两个拆分 env。 |
+| `LUMICE_TRACE_BACKEND` | 未设（legacy CPU） | trace 后端选择：未设 = legacy CPU；`metal` = Metal GPU 后端；`cuda` = CUDA GPU 后端；`cpu_backend` = SoA CPU 后端。 |
+| `LUMICE_DISABLE_DEVICE_GEN` | 未设（device-gen 开） | 逃生舱：强制 GPU 后端走 **host** root-ray 生成。device root-gen（GPU PCG root-ray 供给）在合格层（single-crystal-per-ci，`tri_count ≤ 64`）是**默认**。仅在镜像 host `std::mt19937` 流的严格-一致 parity 测试里设 `1`（device PCG 流无法与之对齐）。每个后端实例构造时读一次。 |
+
+> #### ⚠️ `LUMICE_DISPATCH_RAY_NUM` 是 GPU 专属旋钮——比较中绝不施给 legacy（scrum-306.1/306.4）
+>
+> `LUMICE_DISPATCH_RAY_NUM` 定 GPU 引擎的 per-dispatch 网格。**CUDA 总能量 dispatch-不变**
+> （实测：ΣY = 261.29 M ±0.001% 跨 dispatch ∈ {128, 8192, 32768, 131072}，`dual_fisheye_ref`）——
+> 即 GPU 结果在任何 dispatch 下都正确。**legacy（CPU）总能量 dispatch-不不变**：同旋钮（override
+> legacy 的 `kDefaultRayNum`=128）使 legacy ΣY 波动 **−5%..+13%**——这是 per-batch 波长采样的
+> Monte-Carlo 方差，**非 bug**（默认 128 收敛正确；见 per-run log 里 scrum-306.7）。
+>
+> **须避免的历史误诊**：为探 CUDA 而全局设 `LUMICE_DISPATCH_RAY_NUM=131072`，使
+> `test_cuda_single_ms_no_filter_parity` 报 `energy_ratio=0.8922`——曾被**误归为"CUDA
+> exit-cap/cont-cap 静默丢能量"**（原 scrum-304.3 backlog 条）。这不是 CUDA bug：旋钮漏进 legacy
+> 参考 run、膨胀了**分母**（legacy_Y），`261.29/292.87 = 0.892`。parity harness 现对 `legacy` 后端
+> 剥掉 `LUMICE_DISPATCH_RAY_NUM`（`test/e2e/capi_runner.py`，scrum-306.4），使 oracle 停在 canonical
+> 默认，`energy_ratio` 只反映 GPU 后端正确性（复验：@131072 0.8922 FAIL → 1.0063 PASS）。
+> `bench_throughput.py` 已把 legacy 排除出 dispatch sweep（`DISPATCH_PLAN["legacy"]=[None]`）。
+>
+> **过程教训**：304.3 的正确性断言只以 backlog 一行存在、无保留脚本 → 一个错诊断（CUDA）传播且无法
+> 对齐。正确性断言必须落进 tracked 文档 + 可复现 recipe。复现：容器 `pip install pytest numpy`，
+> `LUMICE_HAS_CUDA=1`，然后
+> `LUMICE_DISPATCH_RAY_NUM=131072 pytest -m slow test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py::test_cuda_single_ms_no_filter_parity`；
+> 逐 dispatch ΣY 拆分用 `bench_work/harness2.cpp`（dev49）。
+
+**GPU device root-gen（scrum-260）**：GPU 后端上，root 光线（取向 / 方向 / 入射点）经 counter-based
+PCG 流 `(gen_seed, gen_ray_base + tid)` 在 device 上生成，替代 host 预生成 + 上传。这是默认路径；对
+legacy 的统计等价性由 slow-e2e parity harness 验证（`ds_corr ≥ 0.99`）。device-gen ON/OFF 吞吐刻画
+（Metal，phase-1）——默认 batch 下 device-gen 对单晶单散射是净亏、对多晶多 worker 是净赚，大 batch 才
+有强赢——记录在 `scratchpad/perf-results-log.md`。
 
 ## 2. GUI 性能测试（隐藏窗口，无 VSync）
 

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -72,7 +72,20 @@ setup 会把它们的 rays_per_sec 压低 >30%。
 内部线程（场景生成 + 数据消费），总线程数 = workers + 2。
 
 **并行扩展效率** = `multi_rps / (single_rps × workers)`。接近 1.0 表示良好扩展；
-偏低说明存在锁竞争、内存带宽饱和或调度开销。
+偏低说明存在锁竞争、内存带宽饱和或调度开销。**仅对 legacy CPU 路线有意义**——见下方 GPU caveat。
+
+> **⚠️ GPU 后端是单引擎——"single" vs "multi" 不是并行。** GPU 路线（Metal / CUDA）无条件
+> `worker_count=1`（`server.cpp:284`）；只有 legacy CPU 路线是真多 worker（`worker_count =
+> PhysicalCoreCount()`）。`--benchmark` 双趟里 GPU **两趟都跑在同一个单引擎**上——"single" 趟只是
+> 2M 光线、JIT-warmup 主导的短 run，"multi" 趟是全光线数、暖机后、长窗口的 run。所以对 GPU：
+> - 两个数**并不相等**（如 dev49 CUDA 35→56 M/s，1070Ti 32→60 M/s）——但差异来自 **暖机 + 光线数 +
+>   窗口长度**，不是并行。
+> - **"multi" 数是稳态代表值**（暖机 + 长窗口）；读它，不是因为它"并行"，而是因为它是稳定率。
+> - **`efficiency` 对 GPU 无意义**（GPU `[BENCHMARK]` 行里的 `workers` 是配置的核数、非 GPU 引擎数；
+>   `explore-306.1` E1 `worker_count=1` 是铁证）。
+>
+> 这是已记录的现实，非 bug。**计划中的简化**（backlog，需硬件验证）：GPU 双趟可能塌成单个稳态数，
+> 使自报数据不再暗示并行——在此之前，读 GPU `single`/`multi` 时套用本 caveat。
 
 benchmark 模式的行为差异：
 - **双趟运行**：依次创建两个独立 server 实例，指定不同 worker 数

--- a/doc/seam-design.md
+++ b/doc/seam-design.md
@@ -204,6 +204,12 @@ device 巨型 dispatch (batch = 纯性能旋钮):
 
 三时钟独立：几何=逐线程(池索引)、trace=dispatch 尺寸纯性能、回读=下游策略各自节奏。
 
+> ✅ **第三时钟已落地（scrum-312，2026-07-01）**：readback 从 trace 时钟解耦到显示节奏（device 持久累加 +
+> GUI 按显示节奏回读 / CLI 收尾一次，精度用 periodic-drain=float32+host Neumaier）。真实 GUI 分辨率
+> 2048×1024 增益三机一致：4060Ti 28→39M / 1070Ti 12.5→33.5M / Metal 11→32.3M。**蓝图赌对了**——本节
+> 预言的"回读走各自节奏"正是 312 兑现的形态。数字/机制见 `doc/performance-testing.md`「当前 canonical」+
+> `doc/gpu-route-history.md` Phase 11。
+
 ---
 
 ## 6. 待定项（收敛前需各下判断）

--- a/doc/windows-remote-testing.md
+++ b/doc/windows-remote-testing.md
@@ -90,3 +90,6 @@ Parameters:
 ## See Also
 
 - [Performance Testing Guide](performance-testing.md) — comprehensive perf testing overview
+- [Remote CUDA Build / Test Recipe](gpu-remote-cuda-build-testing.md) — **different concern**: CUDA
+  compile + parity/correctness on dev49 (Linux) and win-builder (Windows), headless. This guide (Windows
+  remote testing) is for GUI VSync perf on a *physical desktop session*; that one is for CUDA build+parity.

--- a/scripts/bench_throughput.py
+++ b/scripts/bench_throughput.py
@@ -12,9 +12,12 @@ Baseline policy: the denominator is always legacy CPU (env unset = the GUI's
 real path). `CpuTraceBackend` is a GPU-validation reference, NOT a perf
 baseline — see feedback_perf_baseline_is_legacy_cpu / doc/testing-architecture.md §4.1.
 
-Metal pass note: the server is single-engine, so the benchmark's "single" pass
-and "multi" pass both run on 1 Metal engine. The legacy CPU "multi" pass runs
-on N=PhysicalCoreCount workers. The G1 gate compares Metal(1-engine, large
+GPU pass note: the GPU route (Metal/CUDA) is single-engine (worker_count=1), so
+--benchmark emits ONE steady "multi" pass for GPU and skips the "single" warmup
+pass (single/multi would not be parallel — the gap is warmup+ray-count). The
+legacy CPU route still emits the genuine dual pass: "single" = 1 worker, "multi"
+= N=PhysicalCoreCount workers. So a GPU row has multi_rps but single_rps=None;
+that is expected, not INCOMPLETE. The G1 gate compares GPU(1-engine, large
 dispatch) vs legacy(N-workers, small dispatch); that asymmetry is intentional.
 
 Lineage: framework (run / measure_cell / _cov / _fmt_*) was lifted from
@@ -236,10 +239,12 @@ def run(config_path: Path, backend_env: str | None, dispatch_num: int | None) ->
             note = "FELL_BACK"
         elif not routed_gpu:
             note = f"NO_{backend_env.upper()}_ROUTE(rc={proc.returncode})"
-        elif len(benches) < 2:
+        elif "multi" not in by_mode:
+            # GPU route is single-engine → --benchmark emits ONE steady ("multi")
+            # pass and skips the "single" warmup pass (it would not be parallel).
             note = f"INCOMPLETE(n={len(benches)},rc={proc.returncode})"
     else:
-        if len(benches) < 2:
+        if len(benches) < 2:  # legacy CPU: genuine single + multi dual-pass
             note = f"INCOMPLETE(n={len(benches)},rc={proc.returncode})"
 
     routed_ok = (expected_route is None) or (routed_gpu and not fell_back)
@@ -565,7 +570,7 @@ def main() -> int:
 
     print(
         "# bench_throughput — denominator = legacy CPU multi_rps (per config).\n"
-        "# Metal: single-engine; single/multi passes both run 1 engine.\n"
+        "# GPU (Metal/CUDA): single-engine; one steady 'multi' pass, no 'single' (shown as '-').\n"
         "# CpuTraceBackend rows are verify-only (NOT a baseline).\n"
         f"# rays_per_sec = steady trace rate (setup excluded, --benchmark fix);\n"
         f"# ray_num overridden to {RAY_NUM_OVERRIDE:,} for a stable steady window.\n",

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -440,6 +440,17 @@ void LUMICE_SetPreferredBackend(LUMICE_Server* server, int backend);
 // matching branch here; CPU / Metal semantics are unchanged.
 int LUMICE_IsBackendAvailable(int backend);
 
+// Query whether a server built with `preferred_backend` would take the GPU
+// single-engine route (worker_count=1) on this machine. Unlike
+// LUMICE_IsBackendAvailable (which only reports device presence), this also honors
+// the `LUMICE_TRACE_BACKEND` env override, which wins over `preferred_backend` — so
+// e.g. `LUMICE_TRACE_BACKEND=cuda` with preferred_backend=CPU returns 1 (iff an
+// eligible CUDA device exists). Same resolution the server uses to size worker_count.
+// Intended for the CLI `--benchmark` dual-pass: the GPU route is single-engine, so
+// its "single" (warmup) vs "multi" (steady) passes are NOT parallel — callers use
+// this to collapse the GPU benchmark to one steady pass. Returns 1 (GPU route) or 0.
+int LUMICE_WillUseGpuRoute(int preferred_backend);
+
 #if !defined(_MSC_VER)
 #pragma GCC visibility pop
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,8 +51,10 @@ void PrintUsage(const char* prog_name) {
             << "                     'auto' and 'cpu' both select the CPU route today; 'metal'\n"
             << "                     falls back to CPU if unavailable. The LUMICE_TRACE_BACKEND\n"
             << "                     env var, if set, still overrides this (debug/CI only).\n"
-            << "  --benchmark        Run dual-mode benchmark (single-worker + multi-worker) and output\n"
-            << "                     two [BENCHMARK] JSON lines with per-core and parallel efficiency data\n"
+            << "  --benchmark        Run a throughput benchmark and output [BENCHMARK] JSON. The legacy\n"
+            << "                     CPU route runs a dual pass (single-worker + multi-worker → per-core\n"
+            << "                     and parallel-efficiency data); a GPU route is single-engine, so it\n"
+            << "                     runs one steady pass only (single/multi would not be parallel)\n"
             << "  -v                 Verbose output (trace level logging)\n"
             << "  -d                 Debug output (debug level logging)\n"
             << "  -h                 Show this help message and exit\n"
@@ -357,18 +359,28 @@ int main(int argc, char** argv) {
     }
 
     auto cores = static_cast<int>(std::thread::hardware_concurrency());
-    // task-268.7: server is always single-engine; num_workers is ignored. The
-    // "multi" pass remains as a higher ray-count comparison vs. the reduced
-    // "single" pass — both run with one Simulator. The `multi_workers` label
-    // is kept only for benchmark-output continuity.
-    int multi_workers = lumice::PhysicalCoreCount();
 
-    // Pass 1: reduced rays (label="single")
-    auto single_config = config_json;
-    single_config["scene"]["ray_num"] = kBenchmarkSingleRays;
-    RunBenchmarkPass(single_config.dump(), 1, "single", cores, log_level, preferred_backend);
+    // The GPU route is single-engine (worker_count=1, server.cpp) regardless of
+    // num_workers. Its "single" (2M-ray, JIT-warmup-dominated) and "multi"
+    // (full-ray, warm) passes are therefore NOT single-vs-parallel — the gap is
+    // warmup + ray-count, not workers. So for the GPU route we run ONE steady pass
+    // (kept labelled "multi" for output continuity) and skip the meaningless warmup
+    // pass. Only the legacy CPU route keeps the genuine dual-pass: "single" = 1
+    // worker (per-core efficiency), "multi" = PhysicalCoreCount() workers (real
+    // parallelism). LUMICE_WillUseGpuRoute is env-aware (LUMICE_TRACE_BACKEND wins
+    // over --backend), so this matches how bench_throughput.py selects a GPU run.
+    bool gpu_route = LUMICE_WillUseGpuRoute(preferred_backend) != 0;
 
-    // Pass 2: original ray count (label="multi"; worker count is still 1)
+    if (!gpu_route) {
+      // Pass 1: reduced rays, single worker (label="single") — CPU per-core efficiency.
+      auto single_config = config_json;
+      single_config["scene"]["ray_num"] = kBenchmarkSingleRays;
+      RunBenchmarkPass(single_config.dump(), 1, "single", cores, log_level, preferred_backend);
+    }
+
+    // Steady pass (label="multi"): original ray count. CPU = PhysicalCoreCount()
+    // workers (parallel); GPU = the single engine (the representative steady figure).
+    int multi_workers = gpu_route ? 1 : lumice::PhysicalCoreCount();
     RunBenchmarkPass(config_json.dump(), multi_workers, "multi", cores, log_level, preferred_backend);
 
     return 0;

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -892,6 +892,18 @@ int LUMICE_IsBackendAvailable(int backend) {
   }
 }
 
+int LUMICE_WillUseGpuRoute(int preferred_backend) {
+  try {
+    // Single source of truth: delegate to the same env-aware ResolveGpuRoute the
+    // server uses to size worker_count (server.cpp). Casting an unknown int to
+    // BackendKind is safe here — ResolveGpuRoute treats non-Metal/non-CUDA (or an
+    // unavailable device) as the legacy CPU route (returns false).
+    return ns::ResolveGpuRoute(static_cast<ns::BackendKind>(preferred_backend), ns::GetGlobalLogger()) ? 1 : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
 
 // =============== Crystal Mesh ===============
 

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -897,9 +897,15 @@ int LUMICE_WillUseGpuRoute(int preferred_backend) {
     // Single source of truth: delegate to the same env-aware ResolveGpuRoute the
     // server uses to size worker_count (server.cpp). Casting an unknown int to
     // BackendKind is safe here — ResolveGpuRoute treats non-Metal/non-CUDA (or an
-    // unavailable device) as the legacy CPU route (returns false).
+    // unavailable device) as the legacy CPU route (returns false), the runtime analog
+    // of LUMICE_IsBackendAvailable's compile-time -Wswitch guard above.
     return ns::ResolveGpuRoute(static_cast<ns::BackendKind>(preferred_backend), ns::GetGlobalLogger()) ? 1 : 0;
   } catch (...) {
+    // Fail safe to the legacy CPU route, but not silently: a swallowed device-probe
+    // error here would run the benchmark's CPU dual-pass while preferred_backend is a
+    // GPU, with no trace (project discipline: silent fallbacks cause undebuggable
+    // per-machine drift).
+    ILOG_WARN(ns::GetGlobalLogger(), "LUMICE_WillUseGpuRoute: route resolution threw; assuming legacy CPU route");
     return 0;
   }
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -216,7 +216,6 @@ void ServerImpl::RunPersistentLoop(F work_fn) {
 }
 
 
-namespace {
 // task-268.7 (owner 2026-06-15): the CPU and GPU routes do NOT mirror each other
 // — each picks its own optimal orchestration, so the server runs two parallel
 // shapes. The GPU/Metal route is a SINGLE engine (N engines would contend one
@@ -273,7 +272,6 @@ bool ResolveGpuRoute(BackendKind preferred_backend, Logger& logger) {
 #endif
   return false;  // kCpu, or the requested GPU backend is unavailable in this build
 }
-}  // namespace
 
 ServerImpl::ServerImpl(int num_workers, uint32_t sim_seed, BackendKind preferred_backend)
     : config_manager_{}, scene_queue_(std::make_shared<Queue<SimBatch>>()),

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -153,6 +153,18 @@ struct StatsResult {
 using Result = std::variant<NoneResult, RenderResult, StatsResult>;
 
 
+// =============== GPU route query ===============
+/**
+ * @brief Would a server built with @p preferred_backend take the GPU single-engine route?
+ * @details Single source of truth for the routing decision (env `LUMICE_TRACE_BACKEND`
+ *          override wins over @p preferred_backend, CUDA gated on device availability),
+ *          mirroring CreateBackend. `ServerImpl`'s constructor uses the same function to
+ *          decide `worker_count` (GPU route => 1). Callers outside the server (e.g. the CLI
+ *          `--benchmark` dual-pass, which must skip the meaningless "single" warmup pass for
+ *          the single-engine GPU route) should query this rather than re-deriving the logic.
+ */
+bool ResolveGpuRoute(BackendKind preferred_backend, Logger& logger);
+
 // =============== Server Status ===============
 /**
  * @brief Server status enumeration


### PR DESCRIPTION
Two related efforts on the same branch (docs describe the behavior the code implements → one coherent PR).

## chore-313 — GPU/perf doc consolidation
- **Promote remote CUDA recipe**: `scratchpad/gpu-remote-cuda-build-testing.md` → tracked `doc/gpu-remote-cuda-build-testing.md`, indexed in AGENTS.md, cross-linked with `windows-remote-testing.md` (clarified as orthogonal concerns).
- **Restructure `performance-testing{,_zh}.md`**: de-mix languages (EN now pure English), move the ~250-line per-run measurement log to git-ignored `scratchpad/perf-results-log.md`, keep only the current scrum-312 canonical + how-to, relocate the durable `LUMICE_DISPATCH_RAY_NUM` misdiagnosis warning, sync EN/ZH.
- **Refresh GPU architecture docs post scrum-302→312**: `gpu-route-history.md` Phase 11 (#303→312); mark `gpu-single-engine-implementation.md` §0.1's stale CUDA baseline SUPERSEDED; record the third clock as landed in `seam-design.md` §4.8.

## chore-314 — collapse GPU `--benchmark` to one steady pass
The GPU route is single-engine (`worker_count=1`), so `--benchmark`'s "single"/"multi" passes were never parallel. Add env-aware `LUMICE_WillUseGpuRoute` (C API delegating to the same server-side `ResolveGpuRoute`, now exposed via `server.hpp` — single source, honors `LUMICE_TRACE_BACKEND`); `main.cpp` skips the GPU warmup pass and emits one steady pass; legacy CPU keeps the genuine dual-pass. `bench_throughput.py` no longer flags a GPU (single-absent) run as INCOMPLETE. Docs updated to as-built.

**Validation**: Mac Metal + dev49 CUDA(Ada) + win-builder CUDA(Pascal) route detection (env + `--backend`); dev49 CUDA parity battery 10/10; Mac G1 Metal throughput gate 2 passed. CI is unaffected (it always runs legacy CPU).

> Note: a follow-up (task-316 `gpu-bench-drain-aligned-rate`) addresses a separate, pre-existing bench under-measurement at short ray_num — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)