### PR TITLE
ci: parallelize slow-e2e with pytest-xdist, isolate throughput gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        run: pip install Pillow pytest numpy
+        run: pip install Pillow pytest numpy pytest-xdist
 
       - name: Run slow E2E tests
         # 'not heavy' drops redundant parity variants (prob05*, single-MS no-filter)
@@ -467,7 +467,21 @@ jobs:
             export DYLD_LIBRARY_PATH="$libdir:${DYLD_LIBRARY_PATH:-}"
             export LD_LIBRARY_PATH="$libdir:${LD_LIBRARY_PATH:-}"
           fi
-          pytest ${{ matrix.pytest_args }} -v -m "slow and not heavy"
+          # Phase 1 — parallel (pytest-xdist, -n 3). xdist runs each test in a
+          # separate WORKER PROCESS, so capi_runner's process-global os.environ +
+          # log callback stay per-process isolated (validated: the full slow suite
+          # passes under -n 3, ~4min vs ~14min serial). The projection-parity
+          # tests (the bulk of the macOS "rest" leg) dominate wall-time; this is
+          # what keeps the leg under the step timeout. Throughput gates are
+          # EXCLUDED here — they must not measure under concurrent GPU load.
+          pytest ${{ matrix.pytest_args }} --ignore=test/performance -n 3 -v -m "slow and not heavy"
+          # Phase 2 — serial + GPU-isolated: the throughput gates run alone so the
+          # measured rate is not deflated by concurrent tests. Only legs whose args
+          # include test/performance run this (the metal-exit-seam parity leg has
+          # no perf tests → skipped). Cheap (~2 gates); no -n on purpose.
+          case "${{ matrix.pytest_args }}" in
+            *test/performance*) pytest test/performance -v -m "slow and not heavy" ;;
+          esac
         timeout-minutes: 15
 
   benchmark-summary:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,15 @@ testpaths = [
     "test/regression-sentinel",
 ]
 pythonpath = ["."]
-addopts = "-p no:xdist"
+# pytest-xdist parallelism is safe for this suite: xdist runs each test in a
+# separate worker PROCESS, so capi_runner's process-global os.environ + log
+# callback stay isolated per-process. (It was previously disabled via
+# `-p no:xdist` to guard that shared state, but that risk only applies to
+# intra-process concurrency, which xdist does not do — validated: the full slow
+# suite passes under `-n 3`.) CI's e2e-slow job runs the correctness/parity phase
+# with `-n 3` and the throughput gates serially so their measurement is not
+# deflated by concurrent GPU load. Without `-n`, xdist is inert (serial), so
+# default `pytest` behaviour is unchanged.
 markers = [
     "slow: requires shared-lib build; excluded from CI fast path",
     "heavy: slow + redundant parity variant; run locally/nightly, deselected per-PR via 'not heavy'",


### PR DESCRIPTION
## Problem
The macOS `E2E Slow (rest)` leg flakily times out at the 15-min step limit. Root cause: PR #162 added 11 Metal projection-parity tests (~60s each, ~11min total), pushing the sequential suite to a ~14.5min razor margin — runner variance now tips it over (observed failing on PR #161's runs and re-runs).

## Fix
Run the correctness/parity phase under `pytest-xdist -n 3`, keep throughput gates serial.

- **Why xdist is safe here**: xdist runs each test in a separate worker *process*, so `capi_runner`'s process-global `os.environ` + log callback stay per-process isolated. The prior `-p no:xdist` guard only mattered for *intra-process* concurrency, which xdist does not do.
- **Throughput gates isolated**: `test/performance` (Metal-vs-legacy rate gate) runs in a serial second phase — a rate measured under concurrent GPU load would deflate and falsely fail the gate.

## Validation
Full slow suite locally under `-n 3`: **23 passed / 0 failed / 22 skipped in ~4min** (vs ~14min serial). Projection-parity leg: 12/12 passed. This CI run itself exercises the new parallel config end-to-end.

## Notes
- Benefits every PR (the timeout is a shared main-level regression from PR #162), so landed as its own change rather than inside a feature PR.
- `-p no:xdist` removed from `pyproject.toml`; without `-n`, xdist is inert (serial), so default `pytest` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)