### PR TITLE
gui: MS layer prob footgun guards (four-state slider, +Layer promotion, CLI warning)

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -372,6 +372,17 @@ void RenderLeftPanel(float window_height) {
     g_state.crystals.emplace_back();
     Layer new_layer;
     new_layer.entries.push_back(new_entry);
+    // Footgun #2 guard: the layer that WAS the last layer is about to become
+    // an intermediate layer. If its prob is (near-)zero, no rays will reach the
+    // new layer — the newly added layer would be silently dead. Promote to a
+    // sensible continuation default so the user sees rays in the new layer by
+    // default. This is a user-initiated state transition (not a load), so it
+    // is not covered by the "don't silently rewrite loaded values" rule.
+    // Zero-detection MUST use IsProbZero (same helper as panels.cpp) — a raw
+    // == 0.0f would let a slider-dragged 1e-7 sneak past this promotion.
+    if (!g_state.layers.empty() && IsProbZero(g_state.layers.back().probability)) {
+      g_state.layers.back().probability = kDefaultContinuationProb;
+    }
     g_state.layers.push_back(std::move(new_layer));
     g_thumbnail_cache.OnLayerStructureChanged();
     g_state.MarkDirty();

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -417,6 +417,19 @@ struct Layer {
   std::vector<EntryCard> entries;
 };
 
+// MS layer prob helpers (single source of truth for both panels.cpp last-layer
+// four-state UI and app_panels.cpp "+ Layer" continuation-prob promotion).
+// Keep these in one place: if the two sites diverge, a slider-dragged near-zero
+// (e.g. 1e-7) can pass the strict != 0.0f check in one site while the epsilon
+// check locks/unlocks in the other, silently defeating footgun #2's guard.
+// kProbZeroEps = half the SliderWithInput "%.2f" step (0.01), so any value that
+// the UI displays as "0.00" is treated as zero.
+constexpr float kProbZeroEps = 0.005f;
+constexpr float kDefaultContinuationProb = 0.8f;
+inline bool IsProbZero(float p) {
+  return p < kProbZeroEps;
+}
+
 struct GuiState {
   // ID-pool model (restored from pre-card-redesign): EntryCard holds indices
   // into these pools. Editing a pool slot is observed by every entry sharing

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -424,6 +424,13 @@ struct Layer {
 // check locks/unlocks in the other, silently defeating footgun #2's guard.
 // kProbZeroEps = half the SliderWithInput "%.2f" step (0.01), so any value that
 // the UI displays as "0.00" is treated as zero.
+// Accepted GUI/CLI asymmetry (code-review Minor-2): the CLI last-layer warning
+// uses a strict `prob > 0` (hand-written JSON has no slider drift), so a value
+// in (0, kProbZeroEps) — e.g. a hand-edited last-layer 0.001 — warns on the CLI
+// but reads as "zero" (disabled, no icon) in the GUI. This is intentional and
+// harmless: such a value is below the panel's display precision and discards
+// < 0.5% of output rays; forcing the GUI to flag it would contradict the
+// display-precision rationale of kProbZeroEps.
 constexpr float kProbZeroEps = 0.005f;
 constexpr float kDefaultContinuationProb = 0.8f;
 inline bool IsProbZero(float p) {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -821,20 +821,47 @@ void RenderLayer(GuiState& state, int layer_idx) {
   }
 
   if (header_open) {
-    // Multi-scatter probability slider
+    // Multi-scatter probability slider — four states covering both footguns:
+    //   (a) last layer & prob≈0  → slider disabled (locked at correct 0)
+    //   (b) last layer & prob>0  → slider enabled + warning icon (came from a
+    //       hand-written config; we don't silently rewrite the file value, so
+    //       let the user drag it back to 0)
+    //   (c) non-last layer & prob≈0 → slider enabled + warning icon (the next
+    //       layer will receive no rays — footgun #2)
+    //   (d) otherwise → plain slider
+    // Zero-detection uses IsProbZero (epsilon) rather than == 0.0f — slider
+    // drags can produce sub-step floats that would sneak past a strict check.
     char prob_id[32];
     snprintf(prob_id, sizeof(prob_id), "Prob.##layer_%d", layer_idx);
-    bool single_layer = state.layers.size() <= 1;
-    ImGui::BeginDisabled(single_layer);
+    bool is_last_layer = layer_idx == static_cast<int>(state.layers.size()) - 1;
+    bool prob_is_zero = IsProbZero(layer.probability);
+    bool disable_slider = is_last_layer && prob_is_zero;
+    ImGui::BeginDisabled(disable_slider);
     ImGui::BeginGroup();
     DIRTY_IF(SliderWithInput(prob_id, &layer.probability, 0.0f, 1.0f, "%.2f"));
     ImGui::EndGroup();
     ImGui::EndDisabled();
+    const char* prob_tip = nullptr;
+    if (disable_slider) {
+      prob_tip = "Last layer: all filter-pass rays are effective output; prob does not apply.";
+    } else if (is_last_layer && !prob_is_zero) {
+      prob_tip =
+          "Last layer has prob > 0: that fraction of rays will be discarded (no next layer to receive them). Set to 0.";
+    } else if (!is_last_layer && prob_is_zero) {
+      prob_tip = "prob = 0 means no rays reach the next scattering layer (it will be effectively dead).";
+    } else {
+      prob_tip = "Fraction of rays continuing to the next layer.";
+    }
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      const char* prob_tip = single_layer ?
-                                 "Fraction of rays continuing to the next layer.\nAlways 0 for a single layer." :
-                                 "Fraction of rays continuing to the next layer";
       ImGui::SetTooltip("%s", prob_tip);
+    }
+    bool show_warning_icon = (is_last_layer && !prob_is_zero) || (!is_last_layer && prob_is_zero);
+    if (show_warning_icon) {
+      ImGui::SameLine();
+      ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), ICON_FA_CIRCLE_EXCLAMATION);
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%s", prob_tip);
+      }
     }
 
     // Render entry cards with deferred deletion

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include "lumice.h"
 #include "util/cpu_info.hpp"
+#include "util/logger.hpp"
 
 #ifdef _WIN32
 #define STBIW_WINDOWS_UTF8
@@ -29,6 +30,64 @@ namespace {
 
 constexpr int kDefaultJpegQuality = 95;
 constexpr auto kPollInterval = std::chrono::seconds(1);
+
+// Warn (once, on config load) if the last multi-scattering layer has prob > 0.
+// core semantics: the last layer's prob-fail rays would have "continued to the
+// next layer", but there is no next layer, so they are silently discarded (see
+// simulator.cpp:1134). This is a footgun in hand-written configs; not a bug.
+//
+// Threshold is a strict `prob > 0.0`, intentionally different from the GUI's
+// IsProbZero(epsilon) helper in gui_state.hpp (kProbZeroEps=0.005 half-step).
+// The GUI epsilon absorbs slider-drag/text-input float noise — CLI values come
+// straight from hand-written JSON where a "0" means literal zero. Keeping the
+// CLI check strict avoids false-negatives on tiny hand-written probs (e.g.
+// 1e-4) that would still leak rays. This intentional asymmetry does NOT
+// violate "GUI ≡ CLI" (that rule is about identical rendering per file value,
+// not about UI-noise-absorption epsilon).
+//
+// JSON keys mirror scattering entries as parsed in config_manager.cpp:94
+// (`j_s.at("prob")`) — keep aligned if the schema evolves.
+void WarnIfLastScatteringLayerProbNonzero(const nlohmann::json& j_cfg) {
+  try {
+    const auto& j_scene = j_cfg.at("scene");
+    if (!j_scene.contains("scattering")) {
+      return;
+    }
+    const auto& j_scat = j_scene.at("scattering");
+    if (!j_scat.is_array() || j_scat.empty()) {
+      return;
+    }
+    const auto& j_last = j_scat.back();
+    if (!j_last.contains("prob")) {
+      return;
+    }
+    double prob = j_last.at("prob").get<double>();
+    if (prob > 0.0) {
+      LOG_WARNING(
+          "Last scattering layer has prob={:.4f} > 0: that fraction of filter-pass rays "
+          "will be discarded (no next layer to receive them). Set the last layer's prob to 0 "
+          "unless this is intentional.",
+          prob);
+    }
+  } catch (const nlohmann::json::exception&) {
+    // Malformed / unexpected shape: silently skip. The core parser will
+    // surface any real schema errors when it consumes the config.
+  }
+}
+
+void WarnIfLastScatteringLayerProbNonzero(const std::filesystem::path& config_path) {
+  std::ifstream f(config_path);
+  if (!f.is_open()) {
+    return;  // let CommitConfigFromFile report the real "cannot open" error.
+  }
+  try {
+    nlohmann::json j;
+    f >> j;
+    WarnIfLastScatteringLayerProbNonzero(j);
+  } catch (const nlohmann::json::exception&) {
+    // As above: let the core parser surface real errors.
+  }
+}
 // Fine poll granularity (was 100ms). At 100ms the IDLE-detection quantization
 // alone could add up to a full poll interval to wall time; for a fast backend
 // whose run completes in ~0.2s that deflated rays_per_sec by >30%. 5ms caps the
@@ -480,6 +539,8 @@ int main(int argc, char** argv) {
       return 1;
     }
 
+    WarnIfLastScatteringLayerProbNonzero(config_json);
+
     auto cores = static_cast<int>(std::thread::hardware_concurrency());
 
     // The GPU route is single-engine (worker_count=1, server.cpp) regardless of
@@ -518,6 +579,7 @@ int main(int argc, char** argv) {
   auto* server = LUMICE_CreateServerEx(&server_config);
   LUMICE_SetLogLevel(server, log_level);
 
+  WarnIfLastScatteringLayerProbNonzero(config_filename);
   if (LUMICE_CommitConfigFromFile(server, config_filename.u8string().c_str()) != LUMICE_OK) {
     LUMICE_DestroyServer(server);
     return 1;

--- a/test/e2e-correctness/test_cli.py
+++ b/test/e2e-correctness/test_cli.py
@@ -140,3 +140,41 @@ class TestOutputFormat(LumiceTestCase):
             ["-f", "dummy.json", "--quality"]
         )
         self.assertNotEqual(result.returncode, 0)
+
+
+class TestLastLayerProbWarning(LumiceTestCase):
+    """task-gui-ms-prob-footguns Step 3: CLI warns on last-layer prob>0.
+
+    Uses real hand-written configs (feedback_test_must_use_issue_scenario) — the
+    parity_single_ms_bd_filter fixture has last-layer prob=0.5, the halo_22
+    fixture has last-layer prob=0.0. No fabricated test-only configs.
+    """
+
+    def test_warns_on_last_layer_prob_positive(self):
+        cfg = CONFIGS_DIR / "parity_single_ms_bd_filter.json"
+        if not cfg.exists():
+            self.skipTest(f"{cfg} not found")
+        result = self.run_lumice(["-f", str(cfg), "-o", self.output_dir])
+        self.assertEqual(result.returncode, 0)
+        # Warning is emitted via spdlog (LOG_WARNING → stdout). Match on the
+        # distinctive prefix to avoid coupling to the full message wording.
+        combined = result.stdout + result.stderr
+        self.assertIn(
+            "Last scattering layer has prob=",
+            combined,
+            f"expected last-layer-prob warning, got:\nSTDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}",
+        )
+
+    def test_no_warn_when_last_layer_prob_zero(self):
+        cfg = CONFIGS_DIR / "halo_22.json"
+        if not cfg.exists():
+            self.skipTest(f"{cfg} not found")
+        result = self.run_lumice(["-f", str(cfg), "-o", self.output_dir])
+        self.assertEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertNotIn(
+            "Last scattering layer has prob=",
+            combined,
+            "warning should NOT fire on last-layer prob=0.0 configs",
+        )

--- a/test/e2e/configs/multi_scatter.json
+++ b/test/e2e/configs/multi_scatter.json
@@ -31,7 +31,7 @@
     "max_hits": 7,
     "scattering": [
       {
-        "prob": 0.0,
+        "prob": 0.5,
         "entries": [
           {
             "crystal": 1,
@@ -40,7 +40,7 @@
         ]
       },
       {
-        "prob": 0.5,
+        "prob": 0.0,
         "entries": [
           {
             "crystal": 1,

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -44,6 +44,38 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // task-gui-ms-prob-footguns: layer.probability round-trip must byte-preserve
+  // hand-written values including the "footgun" case (last-layer prob>0). The
+  // GUI's disable/warning logic is display-only; it must not silently rewrite
+  // the loaded value. Locks: file value == deserialized state.probability.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "last_layer_prob_roundtrip");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+
+      // Two layers, both with prob>0 (last layer would trigger the CLI
+      // warning, but load must still preserve the value byte-for-byte).
+      gui::g_state.layers[0].probability = 0.3f;
+      gui::Layer new_layer;
+      gui::EntryCard e;
+      e.crystal_id = 0;
+      new_layer.entries.push_back(e);
+      new_layer.probability = 0.45f;  // last layer, non-zero — the footgun value
+      gui::g_state.layers.push_back(std::move(new_layer));
+
+      std::string json = gui::SerializeCoreConfig(gui::g_state);
+      IM_CHECK(!json.empty());
+
+      gui::GuiState loaded = gui::InitDefaultState();
+      bool ok = gui::DeserializeFromJson(json, loaded);
+      IM_CHECK(ok);
+
+      IM_CHECK_EQ(static_cast<int>(loaded.layers.size()), 2);
+      IM_CHECK_EQ(loaded.layers[0].probability, 0.3f);
+      IM_CHECK_EQ(loaded.layers[1].probability, 0.45f);  // NOT silently zeroed
+    };
+  }
+
   // Test 2: JSON file round-trip — write to file, read back, deserialize, verify
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "json_file_roundtrip");

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -83,8 +83,11 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       // (The .lmc save path SerializeGuiStateJson uses the identical
       // `jl["prob"] = layer.probability` float primitive as SerializeCoreConfig
       // above, so its prob fidelity is covered by equivalence.)
+      // Feed the DESERIALIZED state (not the original g_state) so this is the
+      // full end-to-end chain: file JSON -> deserialize -> loaded -> C struct
+      // -> core (code-review r2 Minor-1).
       LUMICE_Config cfg;
-      gui::FillLumiceConfig(gui::g_state, &cfg);
+      gui::FillLumiceConfig(loaded, &cfg);
       IM_CHECK_EQ(cfg.scatter_count, 2);
       IM_CHECK_EQ(cfg.scattering[0].probability, 0.3f);
       IM_CHECK_EQ(cfg.scattering[1].probability, 0.45f);

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -73,6 +73,21 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(static_cast<int>(loaded.layers.size()), 2);
       IM_CHECK_EQ(loaded.layers[0].probability, 0.3f);
       IM_CHECK_EQ(loaded.layers[1].probability, 0.45f);  // NOT silently zeroed
+
+      // Second serialization path (code-review Major-1): the C struct commit
+      // path (FillLumiceConfig -> LUMICE_CommitConfigStruct) is what actually
+      // feeds the simulator. Assert it preserves the last-layer footgun prob>0
+      // too — the display disable/warning logic must not zero the stored value
+      // on the path that reaches core. This path is commit-only (no reverse
+      // deserialize), so it is a forward-fidelity check, not a round-trip.
+      // (The .lmc save path SerializeGuiStateJson uses the identical
+      // `jl["prob"] = layer.probability` float primitive as SerializeCoreConfig
+      // above, so its prob fidelity is covered by equivalence.)
+      LUMICE_Config cfg;
+      gui::FillLumiceConfig(gui::g_state, &cfg);
+      IM_CHECK_EQ(cfg.scatter_count, 2);
+      IM_CHECK_EQ(cfg.scattering[0].probability, 0.3f);
+      IM_CHECK_EQ(cfg.scattering[1].probability, 0.45f);
     };
   }
 

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -1691,6 +1691,33 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // intermediate_layer_prob_nonzero_normal (code-review Minor-4): the "normal"
+  // fourth state — an intermediate (non-last) layer with prob>0 must have an
+  // ENABLED slider and NO warning (neither the disabled last-layer-zero state
+  // (a) nor a warning state (b)/(c)). Completes the four-state coverage.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "intermediate_layer_prob_nonzero_normal");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      // Two layers; layer 0 (intermediate) with prob>0 → state (d) normal.
+      gui::Layer new_layer;
+      gui::EntryCard e;
+      e.crystal_id = 0;
+      new_layer.entries.push_back(e);
+      gui::g_state.layers.push_back(std::move(new_layer));
+      gui::g_state.layers[0].probability = 0.5f;  // intermediate, non-zero
+      ctx->Yield(2);
+      // Slider enabled (state (d) normal: not the disabled last-layer-zero
+      // state (a)). We assert the disabled dimension only — the warning icon is
+      // a plain ImGui::TextColored with no queryable ID, so its absence cannot
+      // be asserted via ItemInfo (would always report "not found" and give a
+      // false pass). The show_warning_icon predicate is deterministic in
+      // panels.cpp; states (b)/(c) exercise its enable branch elsewhere.
+      auto info = ctx->ItemInfo("**/##Prob.##layer_0_input");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
+
   // p1_card/entry_copy — copy an entry card
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_card", "entry_copy");

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -1548,6 +1548,149 @@ void RegisterP1InteractionTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p1_prob_footguns — task-gui-ms-prob-footguns: cover the four-state prob
+  // slider and the "+ Layer" continuation-prob promotion. Guards two edit-time
+  // footguns without changing core rendering semantics.
+
+  // last_layer_prob_zero_disables_slider: default single-layer (prob=0) → the
+  // Prob slider must be disabled. Same test asserts the degenerate single-layer
+  // case remains covered (was `single_layer` in old code).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "last_layer_prob_zero_disables_slider");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
+      IM_CHECK(gui::IsProbZero(gui::g_state.layers[0].probability));
+      auto info = ctx->ItemInfo("**/##Prob.##layer_0_input");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) != 0);
+    };
+  }
+
+  // last_layer_prob_nonzero_enables_slider: a hand-written config's last layer
+  // with prob>0 → slider must be ENABLED (user can drag it back to 0). Guards
+  // against silently locking the user out of a loaded footgun value.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "last_layer_prob_nonzero_enables_slider");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.layers[0].probability = 0.5f;
+      ctx->Yield(2);
+      auto info = ctx->ItemInfo("**/##Prob.##layer_0_input");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
+
+  // intermediate_layer_prob_zero_enables_slider: after "+ Layer", the old last
+  // layer (now intermediate) with prob=0 must be ENABLED (user needs to fix
+  // the dead-next-layer footgun). This exercises the (c) state.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "intermediate_layer_prob_zero_enables_slider");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      // Manually add a layer without going through "+ Layer" (which would auto-
+      // promote layer[0].probability): construct a two-layer state where the
+      // first layer still has prob=0. This is the state a hand-written config
+      // could produce (footgun #2 from the CLI side).
+      gui::Layer new_layer;
+      gui::EntryCard e;
+      e.crystal_id = 0;
+      new_layer.entries.push_back(e);
+      gui::g_state.layers.push_back(std::move(new_layer));
+      gui::g_state.layers[0].probability = 0.0f;
+      ctx->Yield(2);
+      auto info = ctx->ItemInfo("**/##Prob.##layer_0_input");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
+
+  // add_layer_promotes_prev_last_prob: "+ Layer" must promote the old last
+  // layer's prob from 0 to kDefaultContinuationProb so the new layer receives
+  // rays. Root fix for footgun #2.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "add_layer_promotes_prev_last_prob");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, 0.0f);
+
+      ctx->ItemClick("**/+ Layer");
+      ctx->Yield();
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, gui::kDefaultContinuationProb);
+      IM_CHECK(gui::IsProbZero(gui::g_state.layers[1].probability));  // new last stays 0
+    };
+  }
+
+  // add_layer_promotes_near_zero_prev_last (R2 Major regression): slider drags
+  // can leave layer.probability at a sub-step non-zero (e.g. 1e-7). Promotion
+  // must use the shared IsProbZero epsilon — a strict == 0.0f would sneak this
+  // past the promotion and reproduce footgun #2. This test pins that the
+  // gui_state.hpp IsProbZero helper is actually used by "+ Layer".
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "add_layer_promotes_near_zero_prev_last");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.layers[0].probability = 1e-7f;  // < kProbZeroEps
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/+ Layer");
+      ctx->Yield();
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, gui::kDefaultContinuationProb);
+    };
+  }
+
+  // add_layer_preserves_nonzero_prev_last: "+ Layer" must NOT overwrite a
+  // previously non-zero last-layer prob (already fine — user set it on
+  // purpose). Guards against over-eager promotion.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "add_layer_preserves_nonzero_prev_last");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.layers[0].probability = 0.6f;
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/+ Layer");
+      ctx->Yield();
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, 0.6f);  // preserved
+    };
+  }
+
+  // add_delete_layer_last_falls_back_with_warning (Suggestion-1): "+ Layer"
+  // promotes the old last to kDefaultContinuationProb, then deleting the new
+  // last returns the old last to last-layer status — now with prob>0. Slider
+  // must be ENABLED (state (b)); the reactive four-state logic in panels.cpp
+  // must handle this without any delete-path special-casing.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_prob_footguns", "add_delete_layer_last_falls_back_with_warning");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/+ Layer");
+      ctx->Yield();
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, gui::kDefaultContinuationProb);
+
+      // Delete layer 1 via the per-layer header "x" button. Layer 0 becomes
+      // the last layer again — this time with prob=kDefaultContinuationProb>0.
+      ctx->ItemClick("**/" ICON_FA_XMARK "##layer_1");
+      ctx->Yield();
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
+      IM_CHECK_EQ(gui::g_state.layers[0].probability, gui::kDefaultContinuationProb);
+      // Layer 0 is now last with prob>0 → slider must be ENABLED so the user
+      // can fix it (state (b), not the disabled state (a)).
+      auto info = ctx->ItemInfo("**/##Prob.##layer_0_input");
+      IM_CHECK((info.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+    };
+  }
+
   // p1_card/entry_copy — copy an entry card
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_card", "entry_copy");

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-23T19:02:46",
+  "generated_at": "2026-07-04T00:30:16",
   "n_ref_runs": 10,
   "n_calib_runs": 10,
   "scenes": {
@@ -9,9 +9,9 @@
       "threshold": 18.0
     },
     "multi_scat_on": {
-      "psnr_mean": 19.451,
-      "psnr_std": 0.2234,
-      "threshold": 18.5
+      "psnr_mean": 16.475,
+      "psnr_std": 0.1322,
+      "threshold": 16.0
     },
     "color_on": {
       "psnr_mean": 19.189,
@@ -53,6 +53,5 @@
       "psnr_std": 0.1287,
       "threshold": 20.5
     }
-  },
-  "note": "Recalibrated 2026-06-24 chore-auto-ev-regression-drop-off; on-only; full-suite x10 mean-4sigma floor 0.5dB"
+  }
 }

--- a/test/gui/references/auto_ev_multi_scat_on.jpg
+++ b/test/gui/references/auto_ev_multi_scat_on.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1355b02c42bf1282f8b415f9f9d0dc75f033afc87bb7a99a7674cfc17d5ef34
-size 11695
+oid sha256:06eb6db5405390a151c5ec289d8ae99ce5d3a7bf1b15f20fbbb135acbea47f56
+size 15561

--- a/test/gui/visual/test_gui_auto_ev.cpp
+++ b/test/gui/visual/test_gui_auto_ev.cpp
@@ -37,7 +37,7 @@ struct AutoEvScene {
 // below the observed 10-run minimum with margin. (mean / σ / min per scene shown inline.)
 static const AutoEvScene kScenes[] = {
   {"halo_22",    LUMICE_E2E_CONFIG_DIR "/halo_22.json",                           256, 256, 18.0},  // mean 19.19 σ0.23 min 18.78
-  {"multi_scat", LUMICE_E2E_CONFIG_DIR "/multi_scatter.json",                     256, 256, 18.5},  // mean 19.45 σ0.22 min 18.89
+  {"multi_scat", LUMICE_E2E_CONFIG_DIR "/multi_scatter.json",                     256, 256, 16.0},  // mean 16.48 σ0.13 (regen: real 2-layer scattering, task-gui-ms-prob-footguns)
   {"color",      LUMICE_E2E_CONFIG_DIR "/color.json",                             256, 256, 18.5},  // mean 19.19 σ0.13 min 18.93
   {"pyramid",    LUMICE_E2E_CONFIG_DIR "/pyramid.json",                           256, 256, 19.0},  // mean 20.25 σ0.24 min 19.93
   {"cza",        LUMICE_E2E_CONFIG_DIR "/cza.json",                               256, 256, 34.0},  // mean 35.17 σ0.29 min 34.61


### PR DESCRIPTION
## 目标

治理 multi-scattering 每层 `prob_` 的两个编辑期 footgun，**core 渲染语义零改动**：

1. **末层 prob>0 静默丢有效输出光线** — `prob` = 该层光线"继续到下一层"的概率；最后一层没有下一层接收，continue 的光线被丢弃（`simulator.cpp:468` / `:1134`），末层 prob>0 = 纯损失。
2. **中间层 prob=0.0 使其后续层失效** — 新增层时上一层的 0.0 忘改 → 无光线进新层。

## 改动

- **GUI 四态 prob slider**（`panels.cpp`）：末层&0→禁用锁定 / 末层&>0→启用+warning icon（load 的手写值不静默改写，让用户能改回 0）/ 中间层&0→启用+warning / 正常。
- **"+ Layer" 提升**（`app_panels.cpp`）：新增层时把原末层 prob 从 ~0 提到 `kDefaultContinuationProb=0.8`，根治 footgun #2。
- **共享单源**（`gui_state.hpp`）：`IsProbZero`/`kProbZeroEps`/`kDefaultContinuationProb`，供 panels + app_panels 共用（判据 epsilon 一致，防 slider 拖拽近零值绕过锁定）。
- **CLI 诊断**（`main.cpp`）：加载末层 prob>0 时 `LOG_WARNING`。
- **测试夹具修正**（`multi_scatter.json`）：layer0 0.0→0.5 / 末层 0.5→0.0，改成真·双层散射（原配置第二层是死的），regen `auto_ev_multi_scat_on.jpg` + 阈值 18.5→16.0。

## 边界

不碰 `simulator.cpp` 的 prob 应用 / recombine 逻辑；`layer.probability` 存储与序列化零改动 → 旧配置渲染逐字不变（round-trip 保真测试覆盖 JSON + C-struct 提交两路）。

## 验证

- 新增 8 GUI 功能测试（四态 + +Layer 提升 + 近零 1e-7 回归 + add→delete 回退）+ 2 CLI Python 测试，全绿。
- CLI warning 实跑：`parity_single_ms_bd_filter`（末层 0.5）触发、`halo_22`（末层 0）不触发。
- `multi_scat` 视觉回归新参考图 PSNR 16.76 PASS；unit/parity 4/4。
- 已 rebase 到 main（task-323 后），ray_num 语义交互经实测排除（D75 illuminant identity）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)