### PR TITLE
fix(gpu): decouple per-ray wl draw from orientation stream (Laplacian green-tint)

### DIFF
--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1074,13 +1074,14 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
   const uint32_t gen_mixed_seed =
       lm_pcg::pcg_seed_with_high(gp.gen_seed, gen_hi_epoch);
 
-  // Per-ray wavelength (slot 20, isolated from the orientation/triangle draws
-  // below — mirrors MSL gen_root_kernel:881-895). The wl_idx is the photon's
-  // lifetime tag: it selects spd_weight here and n_idx in the trace kernel.
-  lm_pcg::PcgStream wl_stream;
-  wl_stream.seed       = gen_mixed_seed;
-  wl_stream.global_idx = global_idx;
-  wl_stream.slot       = 20u;
+  // Per-ray wavelength (photon lifetime tag → d_root_wl_idx; selects
+  // spd_weight here and n_idx in the trace kernel). Uses a SEED-DOMAIN-
+  // isolated PCG stream via lm_pcg::BuildWlStream (pcg_shared.h) — mirrors
+  // Metal `gen_root_kernel` form-for-form. See kWlStreamNonce for the design
+  // rationale (the historical "slot 20" isolation was root-cause of the
+  // laplacian near-pole green-tint bug — task-gpu-wl-stream-decouple-green-tint;
+  // seed-domain XOR is immune to slot consumption).
+  lm_pcg::PcgStream wl_stream = lm_pcg::BuildWlStream(gen_mixed_seed, global_idx);
   uint32_t wl_idx = static_cast<uint32_t>(lm_pcg::pcg_uniform(wl_stream) * static_cast<float>(gp.wl_pool_size));
   if (wl_idx >= gp.wl_pool_size) {
     wl_idx = gp.wl_pool_size - 1u;  // guard pcg_uniform → 1.0 rounding

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -823,16 +823,16 @@ kernel void gen_root_kernel(
   stream.global_idx = global_idx;
   stream.slot = 0u;
 
-  // scrum-268.8 (DR-3): per-ray wavelength index. Uses an independent PCG slot
-  // (20) so it cannot collide with the orientation / triangle-pick draws made
-  // below — kWlPcgSlot stays clear of every existing draw count (orientation +
-  // sun + categorical + triangle ≤ ~12 slots). The result is the photon's
-  // lifetime tag, written to root_wl_idx so the trace kernel can look up
-  // n_idx / cmf_* from wl_pool[wl_idx].
-  PcgStream wl_stream;
-  wl_stream.seed       = mixed_seed;
-  wl_stream.global_idx = global_idx;
-  wl_stream.slot       = 20u;
+  // Per-ray wavelength index (photon lifetime tag → root_wl_idx, later
+  // consumed by the trace kernel to look up n_idx / cmf_* from
+  // wl_pool[wl_idx]). Uses a SEED-DOMAIN-isolated PCG stream constructed by
+  // BuildWlStream (pcg_shared.h — see the kWlStreamNonce block for design
+  // rationale). The historical "slot 20" isolation was root-cause of the
+  // laplacian near-pole green-tint bug (task-gpu-wl-stream-decouple-green-tint)
+  // because near-pole GenericReject can consume >20 slots per ray, colliding
+  // the wl draw with an orientation draw. Seed-domain XOR is immune to slot
+  // consumption regardless of how many slots the orientation loop burns.
+  PcgStream wl_stream = BuildWlStream(mixed_seed, global_idx);
   uint wl_idx = (uint)(pcg_uniform(wl_stream) * float(gp.wl_pool_size));
   if (wl_idx >= gp.wl_pool_size) {
     wl_idx = gp.wl_pool_size - 1u;  // guard against pcg_uniform → 1.0f rounding

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -70,6 +70,48 @@ LM_CONSTANT uint32_t kDistGaussianLegacy = 5u;
 LM_CONSTANT uint32_t kMaxTriPerKernel = 64u;
 LM_CONSTANT int kMaxRejectionAttempts = 1000;
 
+// --- Stream-family nonces -------------------------------------------------
+// PCG-stream separation nonce for the per-ray wavelength draw in
+// `gen_root_kernel` (both Metal `lumice_trace.metal` and CUDA
+// `cuda_trace_backend.cu`, form-for-form mirrored). The wl draw MUST live in
+// its own PCG seed domain, independent of the orientation / triangle-pick
+// draws that share `(mixed_seed, global_idx)` — otherwise the wl_idx becomes
+// correlated with the crystal orientation whenever the orientation stream
+// consumes enough slots to reach the wl slot.
+//
+// Background (task-gpu-wl-stream-decouple-green-tint / issue.md):
+// The previous design put wl on `slot = 20` and reused `mixed_seed`, betting
+// that the orientation stream never consumed 20 slots. Under a near-pole
+// axis distribution (e.g. `zenith` = laplacian mean=0), the acceptance rate
+// `cos(phi)/M` → 0 and GenericReject can consume up to
+// `kMaxRejectionAttempts = 1000` iterations (× 2 slots for Laplacian) per
+// ray — ~10% of rays reach slot 20. The colliding draw then reads the same
+// PCG hash as the wl draw, so wl_idx becomes a function of the orientation,
+// systematically suppressing the red end in the halo column (empirically
+// `metal_lap.green_excess = +3.2` vs `cpu_lap = +0.7`). Seed-domain isolation
+// (XOR-mix into the seed) is immune to slot-count consumption, regardless of
+// how many slots the orientation loop burns — this is the only fix that does
+// not depend on the "orientation never consumes N slots" assumption.
+//
+// **Nonce uniqueness clearinghouse** — all other stream nonces currently in
+// use, so that new nonces (added here or elsewhere) can be picked to not
+// collide:
+//   kTransitNonce        = 0xA5A5A5A5u  (metal_trace_backend.mm)
+//   kCudaGateNonce       = 0x5A5A5A5Au  (cuda_trace_backend.cu)
+//   kCudaGenNonce        = 0x3C9A7F11u  (cuda_trace_backend.cu)
+//   kMetalShuffleNonce   = 0xB17CA3D9u  (metal_trace_backend.mm; symmetric to
+//                                        the CUDA shuffle nonce)
+//   kCudaDrainNonce      = 0xD5A1B3C7u  (cuda_trace_backend.cu)
+//   kWlStreamNonce       = 0x9E3779B9u  (this header; the 32-bit golden-ratio
+//                                        constant — same value used in the
+//                                        issue.md causal-verification patch
+//                                        that shrank metal_lap.green_excess
+//                                        from +3.2 → +1.0)
+// All six values are pairwise distinct. `pcg_hash` has good avalanche on any
+// non-zero XOR delta, so no additional statistical validation is required.
+LM_CONSTANT uint32_t kWlStreamNonce = 0x9E3779B9u;
+// (BuildWlStream is defined after PcgStream below.)
+
 // --- GenRootKernelParams --------------------------------------------------
 // Single source for both `gen_root_kernel` (Metal-only, device root sampler)
 // and `transit_root_kernel` / `transit_multi_ms_kernel` (Metal + CUDA, device-
@@ -125,6 +167,18 @@ struct PcgStream {
   uint32_t global_idx;
   uint32_t slot;
 };
+
+// Single-source constructor for the wl PCG stream — see kWlStreamNonce above
+// for the design rationale (seed-domain isolation, not slot isolation).
+// Metal + CUDA gen_root_kernel both call this instead of hand-writing the
+// three-field init, guaranteeing bit-identical wl streams across backends.
+LM_FN PcgStream BuildWlStream(uint32_t mixed_seed, uint32_t global_idx) {
+  PcgStream s;
+  s.seed = mixed_seed ^ kWlStreamNonce;
+  s.global_idx = global_idx;
+  s.slot = 0u;
+  return s;
+}
 
 // --- 64-bit ray-index helpers (task-gpu-rng-ray-index-uint64) -------------
 // Host provides `base_lo` (low 32 bits) + `base_hi` (high 32 bits) of the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/core/test_simulator.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_exit_records.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_pcg_ray_base_split.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/core/test_wl_stream_decouple.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_proj.cpp"
   # config/
   "${PROJ_TEST_DIR}/unit-correctness/config/test_json.cpp"

--- a/test/unit-correctness/core/test_wl_stream_decouple.cpp
+++ b/test/unit-correctness/core/test_wl_stream_decouple.cpp
@@ -1,0 +1,103 @@
+// CPU-only unit test for lm_pcg::BuildWlStream and kWlStreamNonce
+// (task-gpu-wl-stream-decouple-green-tint / issue.md).
+//
+// The device-side bug fixed by this task was: `gen_root_kernel` sampled the
+// per-ray wavelength on `slot = 20u` while reusing the same `mixed_seed` as
+// the orientation stream, betting that orientation never consumed 20 slots.
+// Under a near-pole GenericReject path (laplacian mean=0), orientation CAN
+// consume ≥20 slots on ~10% of rays, colliding wl with an orientation draw
+// → wl correlates with crystal orientation → red end suppressed → green tint.
+//
+// The fix: BuildWlStream XORs `kWlStreamNonce` into the seed, so the wl draw
+// lives in a completely independent PCG seed domain. This test provides a
+// second-per-scale mechanical trip-wire (no Metal/CUDA device needed) that:
+//   (a) the seed is actually mixed (XOR applied);
+//   (b) the nonce is non-zero AND distinct from every other stream nonce in
+//       use anywhere in the codebase (so the "distinct seed domain" invariant
+//       is a whole-project fact, not just a two-nonce check);
+//   (c) the first pcg_uniform draw from BuildWlStream does not equal any of
+//       the first 21 draws from the orientation stream at the same
+//       (mixed_seed, global_idx) — i.e. the seed-domain isolation actually
+//       decouples the wl draw from the historically-colliding slot 20 and
+//       every other slot the orientation stream could consume.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+
+#include "core/shared/pcg_shared.h"
+
+namespace {
+
+// Manually-maintained static SNAPSHOT of the other stream nonces (their real
+// definitions live in metal_trace_backend.mm / cuda_trace_backend.cu, which
+// this host-only test cannot #include). This is a snapshot, NOT a live
+// cross-file guard: it only proves kWlStreamNonce differs from these recorded
+// values. If someone later changes a real nonce in its defining file without
+// updating this copy, the test will keep passing against the stale value — so
+// any nonce change in those files must also update this list (and the
+// clearinghouse comment in pcg_shared.h). The proper drift-proof fix would be
+// to hoist all nonces into pcg_shared.h as shared symbols; deferred as it
+// touches both backend files and is out of this task's scope.
+constexpr uint32_t kTransitNonceValue = 0xA5A5A5A5u;
+constexpr uint32_t kCudaGateNonceValue = 0x5A5A5A5Au;
+constexpr uint32_t kCudaGenNonceValue = 0x3C9A7F11u;
+constexpr uint32_t kMetalShuffleNonceValue = 0xB17CA3D9u;
+constexpr uint32_t kCudaDrainNonceValue = 0xD5A1B3C7u;
+
+TEST(WlStreamDecouple, NonceIsNonZeroAndDistinct) {
+  // (a) non-zero: a zero nonce would silently degrade to the pre-fix behavior
+  // (wl_stream.seed == mixed_seed), reintroducing the green-tint bug.
+  EXPECT_NE(lm_pcg::kWlStreamNonce, 0u);
+  // (b) pairwise distinct vs all other stream nonces in the codebase. Using
+  // std::set to catch any two-way collision in one shot.
+  std::set<uint32_t> all_nonces = {
+    lm_pcg::kWlStreamNonce, kTransitNonceValue,      kCudaGateNonceValue,
+    kCudaGenNonceValue,     kMetalShuffleNonceValue, kCudaDrainNonceValue,
+  };
+  EXPECT_EQ(all_nonces.size(), 6u);
+}
+
+TEST(WlStreamDecouple, SeedIsXorMixed) {
+  // BuildWlStream must actually apply the XOR — a silent off-by-one that
+  // dropped it (e.g. `s.seed = mixed_seed;`) would recreate the bug.
+  uint32_t mixed_seed = 0xC0FFEE00u;
+  uint32_t global_idx = 42u;
+  lm_pcg::PcgStream s = lm_pcg::BuildWlStream(mixed_seed, global_idx);
+  EXPECT_EQ(s.seed, mixed_seed ^ lm_pcg::kWlStreamNonce);
+  EXPECT_NE(s.seed, mixed_seed);
+  EXPECT_EQ(s.global_idx, global_idx);
+  EXPECT_EQ(s.slot, 0u);
+}
+
+TEST(WlStreamDecouple, FirstDrawDiffersFromAllOrientationSlots) {
+  // The direct code-level proof that seed-domain isolation works: the FIRST
+  // wl draw must not equal the first draw at any of the slots the
+  // orientation stream could have consumed at the same (mixed_seed,
+  // global_idx). We sweep slots 0..20 inclusive to cover the historical wl
+  // slot (20) plus every slot the near-pole GenericReject loop could have
+  // reached under the pre-fix design.
+  //
+  // Sweeping several (mixed_seed, global_idx) pairs so a single lucky hash
+  // collision on one pair cannot mask a real regression.
+  uint32_t seeds[] = { 0u, 1u, 0xDEADBEEFu, 0xC0FFEE01u, 0x12345678u };
+  uint32_t gidxs[] = { 0u, 42u, 1000u, 65535u, 0x80000000u };
+  for (uint32_t seed : seeds) {
+    for (uint32_t gidx : gidxs) {
+      lm_pcg::PcgStream wl = lm_pcg::BuildWlStream(seed, gidx);
+      float wl_draw = lm_pcg::pcg_uniform(wl);
+      for (uint32_t slot = 0u; slot <= 20u; ++slot) {
+        lm_pcg::PcgStream orient;
+        orient.seed = seed;
+        orient.global_idx = gidx;
+        orient.slot = slot;
+        float orient_draw = lm_pcg::pcg_uniform(orient);
+        EXPECT_NE(wl_draw, orient_draw) << "wl collides with orientation slot=" << slot << " at seed=" << seed
+                                        << " gidx=" << gidx;
+      }
+    }
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
## 问题

内测用户反馈 `laplacian_green_tint.lmc`(pyramid 晶体,`zenith` = Laplacian mean0/std5 近极摆动,D65 光源)在 **GPU 路线**下太阳正上方光柱区**偏绿**,CPU 正常,且仅 `GPU + Laplacian` 组合触发(Gauss 摆动 / CPU 任意摆动均正常)。

## 根因(已因果验证)

device 首层生成 kernel `gen_root_kernel`(Metal + CUDA form-for-form 镜像)里,每条光线的 per-ray 波长 `wl_idx` 从 PCG **slot 20** 抽取,却与朝向采样流**共用同一 `(mixed_seed, global_idx)`**。"slot 20 安全"的前提是"朝向流只消费 ≤~12 slots",但近极配置下 Jacobian 接受率 `cos(phi)/M → 0`,GenericReject 拒绝循环单条光线可消耗 ≥20 slots(约 10% 光线),某次朝向 draw 落到 slot 20 与波长 draw 读到同一哈希值 → **波长与晶体朝向相关 → 尖锐光柱里红端被系统性压制** → 偏绿。CPU illuminant 走 per-batch 单波长(非 per-ray pool),天然无此耦合。

## 修复

新增单源 `lm_pcg::BuildWlStream` helper(`pcg_shared.h`),把 wl 流 seed 改为 `mixed_seed ^ kWlStreamNonce`(独立 seed 域),对无界 slot 消耗免疫。Metal + CUDA `gen_root_kernel` 都调用同一 helper,两后端不会漂移。

## 验证

| render | green_excess |
|---|---|
| metal_lap(修复前) | **+3.173**(复现 issue +3.2) |
| metal_lap(修复后) | +1.039(收敛到 cpu_lap +1.235 噪声级) |

- host-side 单测(`test_wl_stream_decouple.cpp`,3 用例,CPU-only)
- `LumiceParityTest` Metal↔CPU 无回归;`gui_test` illuminant scenes 无需 regen(50/50 绿)

## ⚠️ 待办(合并前请留意)

**CUDA 侧仅源码镜像,未经硬件验证** —— dev49 在实施环境网络不可达。CUDA 改动是 Metal 的 1 行镜像(nvcc 风险极低),但 **AC「Metal↔CUDA parity 不破」目前只有源码层论证,无一手硬件证据**。合并前建议在 dev49 按 `doc/gpu-remote-cuda-build-testing.md` 跑:CUDA 编译 + `CudaMultiMsParity` + issue 场景 green_excess 收敛。已记 backlog `[FOLLOW-UP] CUDA dev49 硬件构建 + parity 验证`。

## 关联

近极拒绝循环发散(warp divergence)是正交的性能问题,已单列 backlog,不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
