### PR TITLE
C API filter typed-struct commit convergence (327) + backend-swap preview fix

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -715,6 +715,13 @@ bool MaybeReconstructServerForBackend() {
 
   // Re-apply per-server settings that died with the old instance (cf. main.cpp startup).
   LUMICE_SetLogLevel(g_server, static_cast<LUMICE_LogLevel>(g_state.core_log_level));
+
+  // The fresh server restarts its epoch authority at 0. Reset the GUI's display generation so the
+  // new backend's low-epoch frames are not fenced out by the old server's carried-over
+  // display_epoch_floor (else the preview freezes on the previous backend's texture). See
+  // GuiState::ResetDisplayGenerationForBackendSwap. The epoch is re-read from the new server by
+  // DoRun's post-commit LUMICE_GetSimLifecycle.
+  g_state.ResetDisplayGenerationForBackendSwap();
   return true;
 }
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -603,7 +603,13 @@ void CalibrateQualityThreshold() {
 
   // Use current default state to build a calibration config
   LUMICE_Config config{};
-  FillLumiceConfig(g_state, &config);
+  if (!FillLumiceConfig(g_state, &config)) {
+    // Unlike DoRun (which pops SetGuiWarning), calibration degrades silently to the default
+    // threshold: it does not touch the user's edited/committed config, so a log line is
+    // sufficient and a modal would be noise. Intentional asymmetry, not an oversight.
+    GUI_LOG_WARNING("[Calibration] filter exceeds ABI limits, using default threshold");
+    return;
+  }
   config.infinite = 0;
   config.ray_num = kCalibrationRays;
 
@@ -658,31 +664,6 @@ void CalibrateQualityThreshold() {
   LUMICE_StopServer(g_server);
 }
 
-
-// Whether all filters in the GuiState can be expressed via the C-struct
-// `LUMICE_FilterParam` ABI (single-segment raypath only). When any filter is
-// a non-raypath type or carries multi-segment ';' OR text, DoRun must take
-// the JSON-commit path so SerializeCoreConfig can expand it into core JSON
-// (incl. multi-raypath → ComplexFilterParam composition). See plan §2 默认假设
-// for the locked physical placement of this helper.
-static bool IsTrivialFilterSet(const GuiState& state) {
-  for (const auto& layer : state.layers) {
-    for (const auto& entry : layer.entries) {
-      if (!entry.filter_id.has_value()) {
-        continue;
-      }
-      const auto& f = state.filters[*entry.filter_id];
-      if (!f.IsRaypath()) {
-        return false;
-      }
-      // Multi-segment OR (';'-separated) — must take JSON path.
-      if (f.RaypathText().find(';') != std::string::npos) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
 
 // Resolve which GPU backend to request on this host: Metal on Apple, CUDA on
 // NVIDIA. Both are single-engine GPU routes (vs the CPU N-worker topology). Probes
@@ -761,12 +742,29 @@ void DoRun() {
   // and cannot produce new false-positive reuse paths.
   bool expect_rebuild = backend_reconstructed || !g_state.last_committed_state.has_value() ||
                         g_state.renderer != g_state.last_committed_state->renderer;
-  // JSON path always rebuilds (LUMICE_CommitConfig has no out_reused signal,
-  // and any new filter type triggers a server-side topology change).
-  bool use_json_path = !IsTrivialFilterSet(g_state);
-  if (use_json_path) {
-    expect_rebuild = true;
+
+  // Single typed-struct commit path (327.4): all filter types — including multi-segment
+  // raypath / multi-value EE (expanded to N simple + 1 complex) — go through the C struct, so
+  // the out_reused signal is always available (no more JSON path that forced full rebuild and
+  // tore live-preview buffers on every EE/multi-segment slider drag).
+  //
+  // Build the struct BEFORE stopping the poller: if a filter exceeds the ABI bounds
+  // (composition pool / clause / filter capacity), keep the previously committed state
+  // (graceful degradation) — poller untouched, buffer not torn — rather than commit a
+  // truncated config.
+  LUMICE_Config config{};
+  if (!FillLumiceConfig(g_state, &config)) {
+    GUI_LOG_WARNING(
+        "[GUI] DoRun: filter exceeds ABI limits (too many OR segments/values); keeping the "
+        "previous configuration. Simplify the filter to apply the change.");
+    // User-visible prompt (the Log panel is collapsed by default): the edit did NOT apply and
+    // the previous configuration was kept, so the user knows why nothing changed.
+    SetGuiWarning("This filter has too many OR segments / values to apply (limit " +
+                  std::to_string(LUMICE_MAX_CONFIG_CLAUSES) +
+                  ").\nThe previous configuration was kept. Simplify the filter and try again.");
+    return;
   }
+
   if (expect_rebuild) {
     g_server_poller.Stop();  // Must pause before consumer destruction
   }
@@ -775,19 +773,10 @@ void DoRun() {
   // (see MaybeReconstructServerForBackend) — no per-DoRun SetPreferredBackend push.
 
   int reused = 0;
-  LUMICE_ErrorCode err = LUMICE_OK;
-  if (use_json_path) {
-    auto json_str = SerializeCoreConfig(g_state);
-    err = LUMICE_CommitConfig(g_server, json_str.c_str());
-    // JSON path: assume rebuild (no out_reused signal). Set reused=0 so the
-    // downstream branch picks the rebuild path.
-    reused = 0;
-  } else {
-    LUMICE_Config config{};
-    FillLumiceConfig(g_state, &config);
-    err = LUMICE_CommitConfigStruct(g_server, &config, &reused);
-  }
+  LUMICE_ErrorCode err = LUMICE_CommitConfigStruct(g_server, &config, &reused);
   if (err == LUMICE_OK) {
+    // A good commit clears any prior over-bounds warning so a later re-occurrence warns again.
+    ClearGuiWarning();
     g_state.last_committed_state = GuiState::ConfigSnapshot::From(g_state);
     // Intent + epoch readback (I1): the synchronous commit above has already minted (or reused)
     // the lifecycle epoch; read it back so ReconcileSimState keys the display on THIS generation.

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -138,6 +138,14 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
 void RenderStatusBar(float window_width, float window_height);
 void RenderUnsavedPopup(GLFWwindow* window);
 void RenderImportWarningPopup();
+// Generic GUI warning modal (see app_panels.cpp). SetGuiWarning queues a message (idempotent
+// while the same message is in-flight, so a persistent condition re-detected every debounced
+// commit does not re-spam the modal). ClearGuiWarning re-arms it (called on a successful
+// commit). RenderGuiWarningPopup shows it. Used e.g. when a filter edit exceeds the ABI bounds.
+void SetGuiWarning(const std::string& msg);
+void ClearGuiWarning();
+std::string PeekGuiWarning();  // test accessor: current in-flight message ("" if none)
+void RenderGuiWarningPopup();
 void RenderLogPanel(float window_width, float window_height);
 
 }  // namespace lumice::gui

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1096,6 +1096,59 @@ void RenderImportWarningPopup() {
   }
 }
 
+// Generic GUI warning modal (not import-specific). Fires ONCE per distinct warning episode:
+// SetGuiWarning is idempotent while the same message is in-flight, so a persistent condition
+// re-detected on every debounced commit (e.g. an over-bounds filter re-checked on each 70ms
+// DoRun while the user drags an unrelated slider) does NOT re-open the modal and freeze
+// interaction. ClearGuiWarning (called on a successful commit) re-arms it so a later
+// re-occurrence of the same condition warns again.
+//
+// Identity contract (the message text IS the episode key): callers MUST guarantee that one
+// logical warning event always produces byte-identical text, and that distinct events use
+// distinct text. Today the only caller (DoRun over-bounds) uses a constant string, so this
+// holds. Before a second caller reuses this modal, promote the key from message content to an
+// explicit warning-id/source enum (text becomes display-only) to avoid text collisions
+// (two events, same wording -> new warning swallowed) or wording drift (one event, changed
+// wording -> spurious re-open).
+std::string g_gui_warning_current;   // "" = none; else the message currently in-flight
+bool g_gui_warning_trigger = false;  // request OpenPopup on the next render
+
+void SetGuiWarning(const std::string& msg) {
+  if (msg == g_gui_warning_current) {
+    return;  // this exact warning is already showing / dismissed — do not re-open (anti-spam)
+  }
+  g_gui_warning_current = msg;
+  g_gui_warning_trigger = true;
+}
+
+void ClearGuiWarning() {
+  g_gui_warning_current.clear();
+  g_gui_warning_trigger = false;
+}
+
+// Test accessor: the message currently in-flight ("" if none).
+std::string PeekGuiWarning() {
+  return g_gui_warning_current;
+}
+
+void RenderGuiWarningPopup() {
+  if (g_gui_warning_trigger) {
+    g_gui_warning_trigger = false;
+    ImGui::OpenPopup("Warning");
+  }
+  if (ImGui::BeginPopupModal("Warning", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::TextUnformatted(g_gui_warning_current.c_str());
+    ImGui::Separator();
+    if (ImGui::Button("OK", ImVec2(80, 0))) {
+      // Keep g_gui_warning_current set so the same persistent condition, re-detected on the
+      // next debounced commit, is deduped (does not re-open). ClearGuiWarning (on a successful
+      // commit) re-arms it.
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndPopup();
+  }
+}
+
 void RenderUnsavedPopup(GLFWwindow* window) {
   if (g_show_unsaved_popup) {
     ImGui::OpenPopup("Unsaved Changes");

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -254,8 +254,7 @@ static json SerializeFilterForGui(const FilterConfig& f, int id) {
 // filter entries. `main_id` is the id the scattering entry should reference
 // (== last id emitted for multi-raypath OR; == base id for trivial cases).
 //
-// TU-local (file_io.cpp internal) — see plan §3 default assumption #IsTrivialFilterSet
-// pattern: helpers consumed only by SerializeCoreConfig stay private.
+// TU-local (file_io.cpp internal): helpers consumed only by SerializeCoreConfig stay private.
 struct FilterCoreResult {
   int main_id;
   std::vector<json> filters;
@@ -406,6 +405,11 @@ static int ClampIdValue(int v, const char* field_name) {
 // entry_exit/direction: 1 simple filter of the matching type.
 // next_filter_id_base: caller's id counter; result.main_id = next_filter_id_base + filters.size() - 1
 //                      (matters only for multi-raypath where main_id is the complex filter's id).
+//
+// SYNC: this is the JSON-emit twin of ExpandFilterToStruct (the C-struct emit, below). Any
+// change to the raypath/EE expansion (segment/pair -> N simple + 1 complex-of-singletons)
+// must update both; the struct-vs-JSON cross-check test (filter_expand_struct_vs_json) will
+// catch a drift, but keep the two in step here too.
 static FilterCoreResult SerializeFilterForCore(const FilterConfig& f, int next_filter_id_base) {
   FilterCoreResult result;
   result.main_id = next_filter_id_base;
@@ -898,37 +902,137 @@ static void FillCrystalParam(const CrystalConfig& c, int id, LUMICE_CrystalParam
   FillAxisDist(c.roll, &dst->roll);
 }
 
-// Helper: fill a LUMICE_FilterParam from GUI FilterConfig with a given ID.
-// PRECONDITION: caller must ensure the filter is a single-segment raypath
-// (IsTrivialFilterSet() is true for the whole GuiState). For non-raypath types
-// or multi-segment raypath, the caller must take the JSON commit path
-// (LUMICE_CommitConfig + SerializeCoreConfig) instead. The C struct path lacks
-// the ABI to express those types; routing them here would silently lose data.
-static void FillFilterParam(const FilterConfig& f, int id, LUMICE_FilterParam* dst) {
-  assert(f.IsRaypath() && "FillFilterParam called on non-raypath filter (route via SerializeCoreConfig instead)");
-  dst->id = id;
-  dst->type = LUMICE_FILTER_TYPE_RAYPATH;
-  dst->action = f.action;
-  dst->symmetry = (f.sym_p ? 1 : 0) | (f.sym_b ? 2 : 0) | (f.sym_d ? 4 : 0);
-  auto rp = ParseRaypathText(f.RaypathText());
-  dst->raypath_count = static_cast<int>(std::min(rp.size(), static_cast<size_t>(LUMICE_MAX_CONFIG_RAYPATH_LEN)));
-  for (int k = 0; k < dst->raypath_count; k++) {
-    dst->raypath[k] = rp[k];
-  }
+// Struct analog of SerializeFilterForCore: expand a GUI FilterConfig into one or more
+// LUMICE_FilterParam entries — a single simple filter, or (for multi-segment raypath /
+// multi-value EE) N simple filters + 1 complex referencing them via an out->compositions[]
+// slot. Appends to out->filters[] starting at *filter_idx, assigning ids from next_filter_id
+// (a running counter, matching SerializeCoreConfig). Sets *out_main_id to the id a scattering
+// entry should reference (the complex id when expanded, else the sole simple id). All ABI-
+// bounds checks are performed up front, so on overflow the function returns false WITHOUT any
+// partial writes to the counts (*filter_idx / composition_count untouched).
+//
+// SYNC: this mirrors SerializeFilterForCore (the JSON-emit twin) — any change to the
+// raypath/EE expansion (segment/pair -> N simple + 1 complex-of-singletons) must update both;
+// guarded by the struct-vs-JSON cross-check test.
+static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMICE_Config* out, int* filter_idx,
+                                 int* out_main_id) {
+  const int action = f.action;
+  const int symmetry = (f.sym_p ? 1 : 0) | (f.sym_b ? 2 : 0) | (f.sym_d ? 4 : 0);
+  auto set_common = [&](LUMICE_FilterParam* dst, int id, int type) {
+    dst->id = id;
+    dst->type = type;
+    dst->action = action;
+    dst->symmetry = symmetry;
+  };
+
+  return std::visit(
+      [&](const auto& p) -> bool {
+        using T = std::decay_t<decltype(p)>;
+        if constexpr (std::is_same_v<T, RaypathParams>) {
+          auto segs = ParseRaypathTextMultiSegment(p.raypath_text);
+          auto fill_rp = [&](LUMICE_FilterParam* dst, int id, const std::vector<int>& seg) {
+            set_common(dst, id, LUMICE_FILTER_TYPE_RAYPATH);
+            dst->raypath_count =
+                static_cast<int>(std::min(seg.size(), static_cast<size_t>(LUMICE_MAX_CONFIG_RAYPATH_LEN)));
+            for (int k = 0; k < dst->raypath_count; k++) {
+              dst->raypath[k] = seg[k];
+            }
+          };
+          if (segs.size() <= 1) {
+            if (*filter_idx >= LUMICE_MAX_CONFIG_FILTERS) {
+              return false;
+            }
+            fill_rp(&out->filters[(*filter_idx)++], next_filter_id, segs.empty() ? std::vector<int>{} : segs[0]);
+            *out_main_id = next_filter_id;
+            return true;
+          }
+          // Multi-segment OR: N simple raypaths + 1 complex (OR of singleton clauses).
+          const int n = static_cast<int>(segs.size());
+          if (n > LUMICE_MAX_CONFIG_CLAUSES || out->composition_count >= LUMICE_MAX_CONFIG_COMPLEX ||
+              *filter_idx + n + 1 > LUMICE_MAX_CONFIG_FILTERS) {
+            return false;
+          }
+          int comp_idx = out->composition_count++;
+          LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
+          comp->clause_count = n;
+          for (int i = 0; i < n; i++) {
+            int cid = next_filter_id + i;
+            fill_rp(&out->filters[(*filter_idx)++], cid, segs[i]);
+            comp->term_counts[i] = 1;
+            comp->clauses[i][0] = cid;
+          }
+          int complex_id = next_filter_id + n;
+          LUMICE_FilterParam* cdst = &out->filters[(*filter_idx)++];
+          set_common(cdst, complex_id, LUMICE_FILTER_TYPE_COMPLEX);
+          cdst->composition_index = comp_idx;
+          *out_main_id = complex_id;
+          return true;
+        } else if constexpr (std::is_same_v<T, EntryExitParams>) {
+          auto entries = ParseFaceNumberList(p.entry_text);
+          auto exits = ParseFaceNumberList(p.exit_text);
+          const auto bounds = DecodeLengthMode(p.length_mode, p.min_len, p.max_len);
+          const int pair_count = static_cast<int>(entries.size() * exits.size());
+          auto fill_ee = [&](LUMICE_FilterParam* dst, int id, int e, int x) {
+            set_common(dst, id, LUMICE_FILTER_TYPE_ENTRY_EXIT);
+            dst->ee_entry = (e == kEEWildcardSentinel) ? -1 : ClampIdValue(e, "entry");
+            dst->ee_exit = (x == kEEWildcardSentinel) ? -1 : ClampIdValue(x, "exit");
+            dst->ee_min_len = bounds.min_len;
+            dst->ee_max_len = bounds.max_len;
+          };
+          if (pair_count <= 1) {
+            if (*filter_idx >= LUMICE_MAX_CONFIG_FILTERS) {
+              return false;
+            }
+            fill_ee(&out->filters[(*filter_idx)++], next_filter_id, entries[0], exits[0]);
+            *out_main_id = next_filter_id;
+            return true;
+          }
+          if (pair_count > LUMICE_MAX_CONFIG_CLAUSES || out->composition_count >= LUMICE_MAX_CONFIG_COMPLEX ||
+              *filter_idx + pair_count + 1 > LUMICE_MAX_CONFIG_FILTERS) {
+            return false;
+          }
+          int comp_idx = out->composition_count++;
+          LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
+          comp->clause_count = pair_count;
+          int i = 0;
+          for (int e : entries) {
+            for (int x : exits) {
+              int cid = next_filter_id + i;
+              fill_ee(&out->filters[(*filter_idx)++], cid, e, x);
+              comp->term_counts[i] = 1;
+              comp->clauses[i][0] = cid;
+              i++;
+            }
+          }
+          int complex_id = next_filter_id + pair_count;
+          LUMICE_FilterParam* cdst = &out->filters[(*filter_idx)++];
+          set_common(cdst, complex_id, LUMICE_FILTER_TYPE_COMPLEX);
+          cdst->composition_index = comp_idx;
+          *out_main_id = complex_id;
+          return true;
+        } else {
+          return false;  // unreachable: FilterParamVariant only has Raypath/EntryExit
+        }
+      },
+      f.param);
 }
 
-void FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
+// Returns false if a filter expansion exceeded the ABI bounds (composition pool / clause /
+// filter capacity); the caller must then keep the previously committed state (graceful
+// degradation), not commit `out`. Crystals still use the P+1 pool-id scheme; filters use a
+// running id counter (matching SerializeCoreConfig) because one GUI filter may expand into
+// N simple + 1 complex.
+bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
   std::memset(out, 0, sizeof(LUMICE_Config));
 
-  // ID-pool model: walk entries, dedupe by pool id, emit one C crystal/filter
-  // per reachable pool slot. Pool slot at index P becomes C API id P+1
-  // (1-based). Core's ConfigManager looks up by ID-field (not array position),
-  // so non-contiguous id sequences are safe when an orphan pool slot is
-  // skipped.
+  // ID-pool model: walk entries, dedupe by pool id, emit one C crystal per reachable pool
+  // slot (P -> C API id P+1). Filters map pool_id -> main_id (the id a scattering entry
+  // references; the complex id for an expanded multi-segment/multi-value filter).
   std::map<int, int> crystal_pool_to_core;  // pool_id -> C api id (1-based)
-  std::map<int, int> filter_pool_to_core;
+  std::map<int, int> filter_pool_to_core;   // pool_id -> main_id
   int crystal_idx = 0;
   int filter_idx = 0;
+  int next_filter_id = 1;  // running C-API filter id counter (mirrors SerializeCoreConfig)
 
   out->scatter_count =
       static_cast<int>(std::min(state.layers.size(), static_cast<size_t>(LUMICE_MAX_CONFIG_SCATTER_LAYERS)));
@@ -960,17 +1064,23 @@ void FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
 
       if (entry.filter_id.has_value()) {
         int fpool = *entry.filter_id;
-        int fid;
+        int fid = -1;
         auto it_f = filter_pool_to_core.find(fpool);
         if (it_f != filter_pool_to_core.end()) {
           fid = it_f->second;
-        } else if (filter_idx < LUMICE_MAX_CONFIG_FILTERS) {
-          fid = fpool + 1;  // 0-based pool → 1-based C API
-          filter_pool_to_core.emplace(fpool, fid);
-          FillFilterParam(state.filters[fpool], fid, &out->filters[filter_idx++]);
         } else {
-          // Filter buffer full — drop this entry's filter (entry survives).
-          fid = -1;
+          int before_idx = filter_idx;
+          int main_id = -1;
+          if (ExpandFilterToStruct(state.filters[fpool], next_filter_id, out, &filter_idx, &main_id)) {
+            next_filter_id += (filter_idx - before_idx);  // ids consumed == filters appended
+            filter_pool_to_core.emplace(fpool, main_id);
+            fid = main_id;
+          } else {
+            // Exceeded ABI bounds (composition pool / clause / filter capacity). Bail out
+            // immediately with false so the caller keeps the old committed state rather than
+            // commit a truncated config (no point finishing the rest of `out`, it is discarded).
+            return false;
+          }
         }
         dst_layer.entries[k].filter_id = fid;
       } else {
@@ -1027,6 +1137,8 @@ void FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
   out->infinite = state.sim.infinite ? 1 : 0;
   out->ray_num = static_cast<LUMICE_RayCount>(state.sim.ray_num_millions * 1e6);
   out->max_hits = state.sim.max_hits;
+
+  return true;
 }
 
 

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -907,6 +907,7 @@ static void FillCrystalParam(const CrystalConfig& c, int id, LUMICE_CrystalParam
 static void FillFilterParam(const FilterConfig& f, int id, LUMICE_FilterParam* dst) {
   assert(f.IsRaypath() && "FillFilterParam called on non-raypath filter (route via SerializeCoreConfig instead)");
   dst->id = id;
+  dst->type = LUMICE_FILTER_TYPE_RAYPATH;
   dst->action = f.action;
   dst->symmetry = (f.sym_p ? 1 : 0) | (f.sym_b ? 2 : 0) | (f.sym_d ? 4 : 0);
   auto rp = ParseRaypathText(f.RaypathText());

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -14,7 +14,10 @@ struct PreviewViewport;
 class PreviewRenderer;
 
 // Fill LUMICE_Config C struct from GuiState (for LUMICE_CommitConfigStruct, bypasses JSON serialization)
-void FillLumiceConfig(const GuiState& state, LUMICE_Config* out);
+// Fill a LUMICE_Config from GuiState for the typed-struct commit path. Returns false if a
+// filter expansion exceeded the ABI bounds (composition pool / clause / filter capacity),
+// in which case the caller must NOT commit `out` and should keep the prior committed state.
+bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out);
 
 // Serialize GuiState to Core JSON string (for .lmc save and CLI compatibility)
 std::string SerializeCoreConfig(const GuiState& state);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -551,8 +551,9 @@ struct GuiState {
   // kModified via that reconcile (base kDone + dirty), not via a direct write.
   void MarkDirty() { dirty = true; }
 
-  // Mark a filter-related change. Filter edits ALWAYS trigger a server rebuild on the next
-  // commit (IsTrivialFilterSet ⇒ JSON path ⇒ epoch++), so this does two orthogonal things:
+  // Mark a filter-related change. A filter edit changes the server's filter topology, so the
+  // next struct commit rebuilds (epoch++) rather than reusing consumers; this does two
+  // orthogonal things:
   //   (a) immediate display clear — snapshot_intensity/p99 reset so the shader renders black
   //       right away (a legitimate display action, not a lock);
   //   (b) raise display_epoch_floor to the current committed_epoch so any payload still being

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -570,6 +570,25 @@ struct GuiState {
     display_epoch_floor = committed_epoch;
   }
 
+  // Backend swap (CPU<->GPU) destroys the live server and constructs a fresh one whose epoch
+  // authority (server-side committed_epoch_) resets to 0 — the next commit mints epoch 1. The
+  // display epoch fence (display_epoch_floor) and the epoch bookkeeping below belong to the OLD
+  // server's epoch space; carried across the swap they would fence out the new backend's low-epoch
+  // payloads (the upload gate payload_epoch > display_epoch_floor fails whenever the old floor was
+  // raised to >=1 by any prior filter edit), freezing the previous backend's texture on screen. A
+  // reconstructed server also has no old-generation payloads in flight (the old server is destroyed),
+  // so the fence has nothing legitimate left to guard. Reset the display generation to epoch 0 and
+  // clear the carried-forward texture so the new backend's first frame reaches the screen. Called by
+  // MaybeReconstructServerForBackend (the sole owner of server reconstruction). The epoch fields are
+  // re-established from the fresh server via DoRun's post-commit LUMICE_GetSimLifecycle readback.
+  void ResetDisplayGenerationForBackendSwap() {
+    committed_epoch = 0;
+    display_epoch_floor = 0;
+    last_uploaded_texture_serial = 0;
+    snapshot_intensity = 0;  // immediate clear; the new backend's first payload fills it back in
+    p99_raw_y = 0.0f;
+  }
+
   // Panel state (view preference — does not call MarkDirty)
   // not persisted to .lmc (unlike right_panel_collapsed)
   bool left_panel_collapsed = false;

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -347,6 +347,7 @@ int main(int argc, char** argv) {
     gui::RenderSpectrumModal(gui::g_state);
     gui::RenderUnsavedPopup(window);
     gui::RenderImportWarningPopup();
+    gui::RenderGuiWarningPopup();
 
     // Reset aspect ratio to Free when panel collapse state changes (window size doesn't adjust automatically).
     if (gui::g_state.left_panel_collapsed != prev_left_collapsed ||

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -167,6 +167,11 @@ LUMICE_ErrorCode LUMICE_CommitConfigFromFile(LUMICE_Server* server, const char* 
 #define LUMICE_MAX_CONFIG_RAYPATH_LEN 32
 // Discrete-spectrum entry cap. Mirrors core wl_pool.hpp::kWlPoolSizeMax (255).
 #define LUMICE_MAX_CONFIG_SPECTRUM_ENTRIES 255
+// Complex (sum-of-products) filter composition bounds. See LUMICE_ComplexComposition.
+// These are ABI ceilings baked into the struct layout; widen (breaking bump) if needed.
+#define LUMICE_MAX_CONFIG_COMPLEX 32  // max complex-filter composition records per config
+#define LUMICE_MAX_CONFIG_CLAUSES 16  // max OR clauses per complex filter
+#define LUMICE_MAX_CONFIG_TERMS 8     // max AND terms per clause
 
 // Axis distribution type constants for LUMICE_AxisDist.type
 #define LUMICE_AXIS_DIST_GAUSS 0
@@ -259,7 +264,25 @@ typedef struct LUMICE_FilterParam_ {
 
   // Crystal arm (type == LUMICE_FILTER_TYPE_CRYSTAL)
   int crystal_id;
+
+  // Complex arm (type == LUMICE_FILTER_TYPE_COMPLEX): index into
+  // LUMICE_Config.compositions[] holding this filter's sum-of-products.
+  int composition_index;
 } LUMICE_FilterParam;
+
+// Sum-of-products composition for a complex filter, referenced by
+// LUMICE_FilterParam.composition_index. The outer level is an OR over clauses; each clause
+// is an AND over its terms; each term (clauses[c][t]) is the ID of a SIMPLE filter in the
+// same config's filters[] pool (referenced by id — reorder-robust — not by array index;
+// a term may never reference another complex filter, matching core config semantics).
+// INVARIANT: compositions[] is rebuilt wholesale together with its host LUMICE_Config;
+// records are not individually reordered (composition_index is a pool index valid only
+// within one config snapshot). Consumers (e.g. GUI) must respect this whole-rebuild model.
+typedef struct LUMICE_ComplexComposition_ {
+  int clauses[LUMICE_MAX_CONFIG_CLAUSES][LUMICE_MAX_CONFIG_TERMS];  // simple-filter IDs
+  int term_counts[LUMICE_MAX_CONFIG_CLAUSES];                       // number of terms in each clause
+  int clause_count;
+} LUMICE_ComplexComposition;
 
 typedef struct LUMICE_ScatterEntry_ {
   int crystal_id;
@@ -298,6 +321,9 @@ typedef struct LUMICE_RenderParam_ {
 // BREAKING (v4.4): added spectrum_entries[]/spectrum_count for custom discrete spectrum.
 // Layout changed; callers must recompile against this header. spectrum_count > 0 selects the
 // discrete-list path and overrides the spectrum string field (mirrors filters/filter_count).
+// BREAKING (v4.6): added compositions[]/composition_count for complex (sum-of-products)
+// filters. Layout changed; callers must recompile. A filters[] entry with type ==
+// LUMICE_FILTER_TYPE_COMPLEX indexes into compositions[] via its composition_index.
 typedef struct LUMICE_Config_ {
   // Crystals
   LUMICE_CrystalParam crystals[LUMICE_MAX_CONFIG_CRYSTALS];
@@ -306,6 +332,10 @@ typedef struct LUMICE_Config_ {
   // Filters
   LUMICE_FilterParam filters[LUMICE_MAX_CONFIG_FILTERS];
   int filter_count;
+
+  // Complex-filter compositions (referenced by filters[].composition_index for COMPLEX type).
+  LUMICE_ComplexComposition compositions[LUMICE_MAX_CONFIG_COMPLEX];
+  int composition_count;
 
   // Renderers
   LUMICE_RenderParam renderers[LUMICE_MAX_CONFIG_RENDERERS];
@@ -341,11 +371,13 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
 // (i.e., the subset of the full config format that LUMICE_Config can represent).
 // Specifically:
 //   - crystal: height/face_distance as scalars/arrays, axis as {type, mean, std} objects
-//   - filter: parse (JSON -> struct) supports the 5 simple types (none / raypath /
-//     entry_exit / direction / crystal), mirroring the LUMICE_ConfigToJson emit. type=
-//     "complex" and any unknown type return LUMICE_ERR_INVALID_VALUE (complex struct
-//     encoding lands in a follow-up). Parse does lossless field mapping only; value
-//     validation (e.g. entry_exit min_len >= 1) fires at commit time in core.
+//   - filter: parse (JSON -> struct) supports all 6 types (none / raypath / entry_exit /
+//     direction / crystal / complex), mirroring the LUMICE_ConfigToJson emit; unknown type
+//     strings return LUMICE_ERR_INVALID_VALUE. Complex filters populate compositions[] and
+//     set composition_index (resolved in a second pass; each composition term must reference
+//     an existing simple filter, else LUMICE_ERR_INVALID_CONFIG). Parse does lossless field
+//     mapping only; per-value semantic validation (e.g. entry_exit min_len >= 1) fires at
+//     commit time in core.
 //   - render: lens/view/visible/background fields are ignored; only id/resolution/opacity/
 //     intensity_factor/overlap are parsed
 //   - spectrum: string enumerations ("D65","D55","D50","D75","A","E") populate the spectrum

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -341,10 +341,11 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
 // (i.e., the subset of the full config format that LUMICE_Config can represent).
 // Specifically:
 //   - crystal: height/face_distance as scalars/arrays, axis as {type, mean, std} objects
-//   - filter: parse (JSON -> struct) supports only type="raypath"; other types return
-//     LUMICE_ERR_INVALID_VALUE. NOTE: the emit direction (struct -> JSON via ConfigToJson,
-//     used by LUMICE_CommitConfigStruct) already covers all 5 simple types as of v4.5;
-//     full parse-side support lands in a follow-up. So emit/parse are not yet symmetric.
+//   - filter: parse (JSON -> struct) supports the 5 simple types (none / raypath /
+//     entry_exit / direction / crystal), mirroring the LUMICE_ConfigToJson emit. type=
+//     "complex" and any unknown type return LUMICE_ERR_INVALID_VALUE (complex struct
+//     encoding lands in a follow-up). Parse does lossless field mapping only; value
+//     validation (e.g. entry_exit min_len >= 1) fires at commit time in core.
 //   - render: lens/view/visible/background fields are ignored; only id/resolution/opacity/
 //     intensity_factor/overlap are parsed
 //   - spectrum: string enumerations ("D65","D55","D50","D75","A","E") populate the spectrum
@@ -364,6 +365,18 @@ LUMICE_ErrorCode LUMICE_ParseConfigString(const char* json_str, LUMICE_Config* o
 // Parse a JSON file into LUMICE_Config. filename must be UTF-8 encoded.
 // Returns LUMICE_ERR_FILE_NOT_FOUND if the file cannot be opened.
 LUMICE_ErrorCode LUMICE_ParseConfigFile(const char* filename, LUMICE_Config* out);
+
+// Serialize a LUMICE_Config into its JSON string form — the inverse of
+// LUMICE_ParseConfigString and the explicit serialization half of the typed-struct API
+// (for save / round-trip / debugging; distinct from the commit path).
+//
+// Buffer contract (snprintf-style, no cross-ABI allocation): writes at most buf_size bytes
+// into out_buf, always NUL-terminated when buf_size > 0. out_buf may be NULL (or buf_size 0)
+// to query the length without writing. If out_len is non-NULL it receives the full JSON
+// length EXCLUDING the NUL terminator; the output was truncated iff out_len >= buf_size.
+// Returns LUMICE_ERR_NULL_ARG if config is NULL, LUMICE_ERR_INVALID_CONFIG if the config
+// cannot be serialized (e.g. a filter with an unset/invalid type).
+LUMICE_ErrorCode LUMICE_ConfigToJson(const LUMICE_Config* config, char* out_buf, size_t buf_size, size_t* out_len);
 
 // =============== Results ===============
 // See doc/capi-lifecycle-architecture.md §5 for sentinel contract.

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -206,12 +206,59 @@ typedef struct LUMICE_CrystalParam_ {
   LUMICE_AxisDist roll;
 } LUMICE_CrystalParam;
 
+// Filter type discriminant for LUMICE_FilterParam.type.
+// 0 = UNSET is a deliberate zero-init guard: a struct built via memset/aggregate
+// initialization without an explicit type lands on UNSET and is rejected at commit
+// (LUMICE_ERR_INVALID_CONFIG) rather than being silently treated as "none". Callers
+// that want the no-op "none" filter must set LUMICE_FILTER_TYPE_NONE explicitly.
+#define LUMICE_FILTER_TYPE_UNSET 0
+#define LUMICE_FILTER_TYPE_NONE 1
+#define LUMICE_FILTER_TYPE_RAYPATH 2
+#define LUMICE_FILTER_TYPE_ENTRY_EXIT 3
+#define LUMICE_FILTER_TYPE_DIRECTION 4
+#define LUMICE_FILTER_TYPE_CRYSTAL 5
+// Reserved: complex (sum-of-products) filter reference encoding lands in a follow-up.
+// Until then a filter with this type has no ConfigToJson case and is rejected at commit.
+#define LUMICE_FILTER_TYPE_COMPLEX 6
+
+// BREAKING (v4.5): LUMICE_FilterParam extended from raypath-only to a 5-arm tagged
+// union (None/Raypath/EntryExit/Direction/Crystal). Layout changed; callers must
+// recompile against this header. `type` selects the active arm; arm-specific fields are
+// prefixed by arm (raypath_*, ee_*, dir_*, crystal_*). Field naming/units mirror core
+// config/filter_config.hpp. -1 sentinels encode optional fields.
 typedef struct LUMICE_FilterParam_ {
   int id;
-  int action;    // 0=filter_in, 1=filter_out
+  int action;  // 0=filter_in, 1=filter_out
+  // Symmetry is a common field for ALL filter types (mirrors core FilterConfig.symmetry_,
+  // emitted by filter_config.cpp::to_json before the per-type fields), not raypath-only.
   int symmetry;  // bitmask: 1=P, 2=B, 4=D
+  int type;      // LUMICE_FILTER_TYPE_* (UNSET=0 is rejected at commit)
+
+  // Raypath arm (type == LUMICE_FILTER_TYPE_RAYPATH)
   int raypath[LUMICE_MAX_CONFIG_RAYPATH_LEN];
   int raypath_count;
+
+  // EntryExit arm (type == LUMICE_FILTER_TYPE_ENTRY_EXIT). -1 sentinels below.
+  // NOTE: ee_min_len/ee_max_len mirror core's to_json emit conditions (min_len emitted
+  // only when > 1; max_len only when >= 0). An out-of-contract value like ee_min_len == 0
+  // is therefore emitted as "absent" and normalized to the core default (1) at commit
+  // rather than rejected here. Callers must supply ee_min_len >= 1.
+  // -1 is the ONLY sentinel: any other negative value is undefined (treated as wildcard/
+  // absent, not rejected). These fields are int (matching the raypath[] convention); core
+  // stores IdType(uint16_t) for entry/exit and size_t for the lengths, so keep entry/exit
+  // in [0, 65535] and lengths reasonably small.
+  int ee_entry;    // entry face id; -1 = wildcard (any entry face)
+  int ee_exit;     // exit face id;  -1 = wildcard (any exit face)
+  int ee_min_len;  // path length lower bound (>= 1)
+  int ee_max_len;  // path length upper bound; -1 = no upper bound
+
+  // Direction arm (type == LUMICE_FILTER_TYPE_DIRECTION). Degrees.
+  float dir_az;     // azimuth (lon)
+  float dir_el;     // elevation (lat)
+  float dir_radii;  // angular radius (scalar, not an array)
+
+  // Crystal arm (type == LUMICE_FILTER_TYPE_CRYSTAL)
+  int crystal_id;
 } LUMICE_FilterParam;
 
 typedef struct LUMICE_ScatterEntry_ {
@@ -294,7 +341,10 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
 // (i.e., the subset of the full config format that LUMICE_Config can represent).
 // Specifically:
 //   - crystal: height/face_distance as scalars/arrays, axis as {type, mean, std} objects
-//   - filter: only type="raypath" supported; other types return LUMICE_ERR_INVALID_VALUE
+//   - filter: parse (JSON -> struct) supports only type="raypath"; other types return
+//     LUMICE_ERR_INVALID_VALUE. NOTE: the emit direction (struct -> JSON via ConfigToJson,
+//     used by LUMICE_CommitConfigStruct) already covers all 5 simple types as of v4.5;
+//     full parse-side support lands in a follow-up. So emit/parse are not yet symmetric.
 //   - render: lens/view/visible/background fields are ignored; only id/resolution/opacity/
 //     intensity_factor/overlap are parsed
 //   - spectrum: string enumerations ("D65","D55","D50","D75","A","E") populate the spectrum

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -290,6 +290,29 @@ nlohmann::json ConfigToJson(const LUMICE_Config& c) {
         j["type"] = "crystal";
         j["crystal_id"] = f.crystal_id;
         break;
+      case LUMICE_FILTER_TYPE_COMPLEX: {
+        j["type"] = "complex";
+        if (f.composition_index < 0 || f.composition_index >= c.composition_count) {
+          throw std::invalid_argument("LUMICE_FilterParam.composition_index out of range: " +
+                                      std::to_string(f.composition_index));
+        }
+        const auto& comp = c.compositions[f.composition_index];
+        json composition = json::array();
+        for (int cl = 0; cl < comp.clause_count; cl++) {
+          // Mirror core to_json: a 1-term clause emits a bare id; a multi-term clause an array.
+          if (comp.term_counts[cl] == 1) {
+            composition.push_back(comp.clauses[cl][0]);
+          } else {
+            json terms = json::array();
+            for (int t = 0; t < comp.term_counts[cl]; t++) {
+              terms.push_back(comp.clauses[cl][t]);
+            }
+            composition.push_back(terms);
+          }
+        }
+        j["composition"] = composition;
+        break;
+      }
       default:
         // UNSET (zero-init guard) or an out-of-range discriminant: fail fast rather
         // than silently emitting a wrong/empty filter. Caller LUMICE_CommitConfigStruct
@@ -611,9 +634,14 @@ static LUMICE_ErrorCode JsonToFilter(const nlohmann::json& fj, LUMICE_FilterPara
   } else if (type_str == "crystal") {
     f->type = LUMICE_FILTER_TYPE_CRYSTAL;
     f->crystal_id = fj.at("crystal_id").get<int>();
+  } else if (type_str == "complex") {
+    // Placeholder: type is set here, but composition + composition_index are resolved by
+    // the second pass in JsonToConfig (needs all simple filters parsed first so composition
+    // cell ids can be validated). -1 marks "not yet resolved".
+    f->type = LUMICE_FILTER_TYPE_COMPLEX;
+    f->composition_index = -1;
   } else {
-    // "complex" (task 327.3) and any unknown type are not yet representable in the struct.
-    return LUMICE_ERR_INVALID_VALUE;
+    return LUMICE_ERR_INVALID_VALUE;  // unknown type string
   }
 
   // Symmetry: common field for all types. "PBD" -> bitmask.
@@ -766,6 +794,60 @@ static LUMICE_ErrorCode JsonToRenderers(const nlohmann::json& render_arr, LUMICE
   return LUMICE_OK;
 }
 
+// Resolve a complex filter's "composition" JSON into a LUMICE_Config compositions[] slot and
+// set f->composition_index. Validates reference integrity: each term id must reference an
+// existing SIMPLE (non-complex) filter, and clause/term/composition counts respect the ABI
+// bounds. Must run after all simple filters are parsed (two-pass, mirrors config_manager.cpp).
+static LUMICE_ErrorCode JsonToComplexComposition(const nlohmann::json& fj, LUMICE_Config* out, LUMICE_FilterParam* f) {
+  if (!fj.contains("composition") || !fj.at("composition").is_array()) {
+    return LUMICE_ERR_MISSING_FIELD;
+  }
+  const auto& cmp = fj.at("composition");
+  // Bounds are checked before writing into the pool slot so a rejected input never leaves a
+  // clause_count inconsistent with the ABI ceiling. An empty composition ([]) is accepted as
+  // a degenerate "OR of nothing" (clause_count == 0), mirroring core (no non-empty requirement).
+  if (out->composition_count >= LUMICE_MAX_CONFIG_COMPLEX || static_cast<int>(cmp.size()) > LUMICE_MAX_CONFIG_CLAUSES) {
+    return LUMICE_ERR_INVALID_CONFIG;
+  }
+  int comp_idx = out->composition_count++;
+  LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
+  comp->clause_count = static_cast<int>(cmp.size());
+  for (int cl = 0; cl < comp->clause_count; cl++) {
+    const auto& clause = cmp[cl];
+    // A clause is either a bare id (1-term) or an array of ids (matches core to_json).
+    if (clause.is_array()) {
+      comp->term_counts[cl] = static_cast<int>(clause.size());
+      if (comp->term_counts[cl] > LUMICE_MAX_CONFIG_TERMS) {
+        return LUMICE_ERR_INVALID_CONFIG;
+      }
+      for (int t = 0; t < comp->term_counts[cl]; t++) {
+        comp->clauses[cl][t] = clause[t].get<int>();
+      }
+    } else {
+      comp->term_counts[cl] = 1;
+      comp->clauses[cl][0] = clause.get<int>();
+    }
+    // Reference integrity: each term must name an existing SIMPLE filter (dangling ids and
+    // references to a complex filter are rejected — the latter matches core semantics, which
+    // only allow SimpleFilterParam in a composition, so cycles are impossible by construction).
+    for (int t = 0; t < comp->term_counts[cl]; t++) {
+      int ref_id = comp->clauses[cl][t];
+      bool found_simple = false;
+      for (int k = 0; k < out->filter_count; k++) {
+        if (out->filters[k].id == ref_id && out->filters[k].type != LUMICE_FILTER_TYPE_COMPLEX) {
+          found_simple = true;
+          break;
+        }
+      }
+      if (!found_simple) {
+        return LUMICE_ERR_INVALID_CONFIG;
+      }
+    }
+  }
+  f->composition_index = comp_idx;
+  return LUMICE_OK;
+}
+
 static LUMICE_ErrorCode JsonToConfig(const nlohmann::json& root, LUMICE_Config* out) {
   std::memset(out, 0, sizeof(LUMICE_Config));
   out->spectrum = "D65";  // Safe default (memset leaves nullptr)
@@ -793,8 +875,20 @@ static LUMICE_ErrorCode JsonToConfig(const nlohmann::json& root, LUMICE_Config* 
       return LUMICE_ERR_INVALID_CONFIG;
     }
     out->filter_count = static_cast<int>(filters.size());
+    // Two-pass (mirrors core config_manager.cpp): pass 1 parses simple filters and marks
+    // complex ones as placeholders; pass 2 resolves complex compositions once every simple
+    // filter's id/type is known (needed to validate composition references).
     for (int i = 0; i < out->filter_count; i++) {
       auto err = JsonToFilter(filters[i], &out->filters[i]);
+      if (err != LUMICE_OK) {
+        return err;
+      }
+    }
+    for (int i = 0; i < out->filter_count; i++) {
+      if (out->filters[i].type != LUMICE_FILTER_TYPE_COMPLEX) {
+        continue;
+      }
+      auto err = JsonToComplexComposition(filters[i], out, &out->filters[i]);
       if (err != LUMICE_OK) {
         return err;
       }

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -250,6 +250,8 @@ nlohmann::json ConfigToJson(const LUMICE_Config& c) {
 
     // Type-specific fields. Mirrors core config/filter_config.cpp::to_json so that
     // server->CommitConfig(json) -> from_json consumes the output losslessly.
+    // SYNC: the per-type field list here mirrors the parse side in JsonToFilter (below);
+    // adding/removing a filter type or field requires updating both.
     switch (f.type) {
       case LUMICE_FILTER_TYPE_NONE:
         j["type"] = "none";
@@ -419,6 +421,34 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
 }
 
 
+// =============== Configuration Serialization (LUMICE_Config -> JSON) ===============
+// Public serialization API: struct -> JSON string, the symmetric pair of the parsing
+// section below. snprintf-style caller buffer (see the contract in lumice.h). Wraps the
+// internal ConfigToJson, mapping its throw (unset/invalid filter type) to
+// LUMICE_ERR_INVALID_CONFIG so nothing escapes the C ABI boundary.
+LUMICE_ErrorCode LUMICE_ConfigToJson(const LUMICE_Config* config, char* out_buf, size_t buf_size, size_t* out_len) {
+  if (!config) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  std::string json_str;
+  try {
+    json_str = ConfigToJson(*config).dump();
+  } catch (const std::exception& e) {
+    LOG_ERROR("LUMICE_ConfigToJson: failed to serialize config: {}", e.what());
+    return LUMICE_ERR_INVALID_CONFIG;
+  }
+  if (out_len) {
+    *out_len = json_str.size();
+  }
+  if (out_buf && buf_size > 0) {
+    size_t n = std::min(json_str.size(), buf_size - 1);
+    std::memcpy(out_buf, json_str.data(), n);
+    out_buf[n] = '\0';
+  }
+  return LUMICE_OK;
+}
+
+
 // =============== Configuration Parsing (JSON -> LUMICE_Config) ===============
 // Symmetric inverse of ConfigToJson. Decomposed into per-section helpers.
 
@@ -536,13 +566,6 @@ static LUMICE_ErrorCode JsonToFilter(const nlohmann::json& fj, LUMICE_FilterPara
   }
   f->id = fj.at("id").get<int>();
 
-  if (fj.at("type").get<std::string>() != "raypath") {
-    return LUMICE_ERR_INVALID_VALUE;
-  }
-  // Parse currently supports raypath only (full 5-type parse is task 327.1).
-  // Set the discriminant so the struct is self-consistent after ParseConfigString.
-  f->type = LUMICE_FILTER_TYPE_RAYPATH;
-
   auto action_str = fj.at("action").get<std::string>();
   if (action_str == "filter_in") {
     f->action = 0;
@@ -552,18 +575,48 @@ static LUMICE_ErrorCode JsonToFilter(const nlohmann::json& fj, LUMICE_FilterPara
     return LUMICE_ERR_INVALID_VALUE;
   }
 
-  if (fj.contains("raypath") && fj.at("raypath").is_array()) {
-    const auto& rp = fj.at("raypath");
-    f->raypath_count = static_cast<int>(rp.size());
-    if (f->raypath_count > LUMICE_MAX_CONFIG_RAYPATH_LEN) {
-      return LUMICE_ERR_INVALID_CONFIG;
+  // Type-specific fields (JSON -> struct arm). Field names/defaults mirror core
+  // config/filter_config.cpp::from_json. Parse does lossless mapping ONLY: value
+  // validation (e.g. entry_exit min_len >= 1, max_len <= kMaxHits) stays single-source
+  // in core and fires at commit time (caught by LUMICE_CommitConfigStruct). -1 encodes
+  // an absent optional (wildcard / no bound).
+  // SYNC: the per-type field list here mirrors the emit side in ConfigToJson (above);
+  // adding/removing a filter type or field requires updating both.
+  auto type_str = fj.at("type").get<std::string>();
+  if (type_str == "none") {
+    f->type = LUMICE_FILTER_TYPE_NONE;
+  } else if (type_str == "raypath") {
+    f->type = LUMICE_FILTER_TYPE_RAYPATH;
+    if (fj.contains("raypath") && fj.at("raypath").is_array()) {
+      const auto& rp = fj.at("raypath");
+      f->raypath_count = static_cast<int>(rp.size());
+      if (f->raypath_count > LUMICE_MAX_CONFIG_RAYPATH_LEN) {
+        return LUMICE_ERR_INVALID_CONFIG;
+      }
+      for (int k = 0; k < f->raypath_count; k++) {
+        f->raypath[k] = rp[k].get<int>();
+      }
     }
-    for (int k = 0; k < f->raypath_count; k++) {
-      f->raypath[k] = rp[k].get<int>();
-    }
+  } else if (type_str == "entry_exit") {
+    f->type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+    f->ee_entry = (fj.contains("entry") && !fj.at("entry").is_null()) ? fj.at("entry").get<int>() : -1;
+    f->ee_exit = (fj.contains("exit") && !fj.at("exit").is_null()) ? fj.at("exit").get<int>() : -1;
+    f->ee_min_len = (fj.contains("min_len") && !fj.at("min_len").is_null()) ? fj.at("min_len").get<int>() : 1;
+    f->ee_max_len = (fj.contains("max_len") && !fj.at("max_len").is_null()) ? fj.at("max_len").get<int>() : -1;
+  } else if (type_str == "direction") {
+    f->type = LUMICE_FILTER_TYPE_DIRECTION;
+    f->dir_az = fj.at("az").get<float>();
+    f->dir_el = fj.at("el").get<float>();
+    f->dir_radii = fj.at("radii").get<float>();
+  } else if (type_str == "crystal") {
+    f->type = LUMICE_FILTER_TYPE_CRYSTAL;
+    f->crystal_id = fj.at("crystal_id").get<int>();
+  } else {
+    // "complex" (task 327.3) and any unknown type are not yet representable in the struct.
+    return LUMICE_ERR_INVALID_VALUE;
   }
 
-  // Symmetry: string "PBD" -> bitmask
+  // Symmetry: common field for all types. "PBD" -> bitmask.
   f->symmetry = 0;
   if (fj.contains("symmetry")) {
     for (char ch : fj.at("symmetry").get<std::string>()) {

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -20,6 +22,7 @@
 #include "core/backend/cuda_trace_backend.hpp"  // CudaDeviceAvailable() for LUMICE_IsBackendAvailable
 #endif
 #include "include/lumice.h"
+#include "server/c_api_internal.hpp"
 #include "server/server.hpp"
 #include "util/callback_sink.hpp"
 #include "util/color_space.hpp"
@@ -196,7 +199,9 @@ static nlohmann::json AxisDistToJson(const LUMICE_AxisDist& d) {
   return j;
 }
 
-static nlohmann::json ConfigToJson(const LUMICE_Config& c) {
+// Non-static (declared in server/c_api_internal.hpp) so unit tests can assert the
+// emitted filter JSON shape field by field. See that header for rationale.
+nlohmann::json ConfigToJson(const LUMICE_Config& c) {
   using json = nlohmann::json;
   json root;
 
@@ -241,13 +246,60 @@ static nlohmann::json ConfigToJson(const LUMICE_Config& c) {
     const auto& f = c.filters[i];
     json j;
     j["id"] = f.id;
-    j["type"] = "raypath";
     j["action"] = f.action == 0 ? "filter_in" : "filter_out";
-    json rp = json::array();
-    for (int k = 0; k < f.raypath_count; k++) {
-      rp.push_back(f.raypath[k]);
+
+    // Type-specific fields. Mirrors core config/filter_config.cpp::to_json so that
+    // server->CommitConfig(json) -> from_json consumes the output losslessly.
+    switch (f.type) {
+      case LUMICE_FILTER_TYPE_NONE:
+        j["type"] = "none";
+        break;
+      case LUMICE_FILTER_TYPE_RAYPATH: {
+        j["type"] = "raypath";
+        json rp = json::array();
+        for (int k = 0; k < f.raypath_count; k++) {
+          rp.push_back(f.raypath[k]);
+        }
+        j["raypath"] = rp;
+        break;
+      }
+      case LUMICE_FILTER_TYPE_ENTRY_EXIT:
+        j["type"] = "entry_exit";
+        if (f.ee_entry >= 0) {
+          j["entry"] = f.ee_entry;
+        }
+        if (f.ee_exit >= 0) {
+          j["exit"] = f.ee_exit;
+        }
+        if (f.ee_min_len > 1) {
+          j["min_len"] = f.ee_min_len;
+        }
+        if (f.ee_max_len >= 0) {
+          j["max_len"] = f.ee_max_len;
+        }
+        break;
+      case LUMICE_FILTER_TYPE_DIRECTION:
+        j["type"] = "direction";
+        j["az"] = f.dir_az;
+        j["el"] = f.dir_el;
+        j["radii"] = f.dir_radii;
+        break;
+      case LUMICE_FILTER_TYPE_CRYSTAL:
+        j["type"] = "crystal";
+        j["crystal_id"] = f.crystal_id;
+        break;
+      default:
+        // UNSET (zero-init guard) or an out-of-range discriminant: fail fast rather
+        // than silently emitting a wrong/empty filter. Caller LUMICE_CommitConfigStruct
+        // wraps this in try/catch and maps it to LUMICE_ERR_INVALID_CONFIG.
+        throw std::invalid_argument("LUMICE_FilterParam.type is unset or invalid: " + std::to_string(f.type));
     }
-    j["raypath"] = rp;
+
+    // symmetry is a common FilterConfig field (see core filter_config.cpp::to_json, which
+    // emits it for every type before the per-type fields), so it stays outside the switch
+    // and applies to all arms — do not fold it into the raypath case. Emitted
+    // UNCONDITIONALLY (empty string when no bits set) to stay byte-isomorphic with core,
+    // whose to_json always writes j["symmetry"] = sym.
     std::string sym;
     if (f.symmetry & 1)
       sym += "P";
@@ -255,9 +307,7 @@ static nlohmann::json ConfigToJson(const LUMICE_Config& c) {
       sym += "B";
     if (f.symmetry & 4)
       sym += "D";
-    if (!sym.empty()) {
-      j["symmetry"] = sym;
-    }
+    j["symmetry"] = sym;
     root["filter"].push_back(j);
   }
 
@@ -345,12 +395,22 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
     return LUMICE_ERR_INVALID_CONFIG;
   }
 
-  auto config_json = ConfigToJson(*config);
+  // ConfigToJson is a new throw source (std::invalid_argument on an unset/invalid filter
+  // type — the zero-init guard); the raypath-only version never threw. server_->CommitConfig
+  // already converts core from_json exceptions to an Error return internally (server.cpp),
+  // so those don't reach here — this try/catch primarily guards ConfigToJson's throw from
+  // escaping the C ABI boundary. Map any escaped exception to LUMICE_ERR_INVALID_CONFIG.
   bool reused = false;
-  auto err = server->server_->CommitConfig(config_json, &reused);
-  if (err) {
-    LOG_ERROR("Failed to commit configuration (struct): {}", err.message);
-    return MapErrorCode(err.code);
+  try {
+    auto config_json = ConfigToJson(*config);
+    auto err = server->server_->CommitConfig(config_json, &reused);
+    if (err) {
+      LOG_ERROR("Failed to commit configuration (struct): {}", err.message);
+      return MapErrorCode(err.code);
+    }
+  } catch (const std::exception& e) {
+    LOG_ERROR("Failed to commit configuration (struct): invalid config: {}", e.what());
+    return LUMICE_ERR_INVALID_CONFIG;
   }
   if (out_reused) {
     *out_reused = reused ? 1 : 0;
@@ -479,6 +539,9 @@ static LUMICE_ErrorCode JsonToFilter(const nlohmann::json& fj, LUMICE_FilterPara
   if (fj.at("type").get<std::string>() != "raypath") {
     return LUMICE_ERR_INVALID_VALUE;
   }
+  // Parse currently supports raypath only (full 5-type parse is task 327.1).
+  // Set the discriminant so the struct is self-consistent after ParseConfigString.
+  f->type = LUMICE_FILTER_TYPE_RAYPATH;
 
   auto action_str = fj.at("action").get<std::string>();
   if (action_str == "filter_in") {

--- a/src/server/c_api_internal.hpp
+++ b/src/server/c_api_internal.hpp
@@ -1,0 +1,21 @@
+#ifndef SERVER_C_API_INTERNAL_H_
+#define SERVER_C_API_INTERNAL_H_
+
+// Internal (non-public) declarations for c_api.cpp implementation details that unit
+// tests need to exercise directly. This is NOT part of the public C API surface
+// (include/lumice.h): do not include it from src/gui/ or ship it to consumers.
+
+#include <nlohmann/json.hpp>
+
+#include "include/lumice.h"
+
+// Serialize a LUMICE_Config struct into the core config JSON schema (the same shape
+// core config/filter_config.cpp::to_json produces). Exposed here — rather than kept
+// file-static in c_api.cpp — so tests can assert the emitted filter shape field by
+// field, instead of only observing the LUMICE_CommitConfigStruct return code (whose
+// lenient core from_json would mask emit-side field-name/condition errors).
+//
+// Throws std::invalid_argument if any filter has an unset/invalid LUMICE_FilterParam.type.
+nlohmann::json ConfigToJson(const LUMICE_Config& c);
+
+#endif  // SERVER_C_API_INTERNAL_H_

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -1322,4 +1322,147 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       gui::ClearImportComplexFilterWarning();
     };
   }
+
+  // 327.4 cross-check: the GUI filter expansion has two twins — SerializeFilterForCore
+  // (GUI -> JSON) and ExpandFilterToStruct (GUI -> C struct, via FillLumiceConfig). For the
+  // same GuiState the struct built directly must field-match the struct obtained by JSON
+  // round-trip. Guards the twins against drift (plan §3-2 / review Major 1).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "filter_expand_struct_vs_json");
+    t->TestFunc = [](ImGuiTestContext*) {
+      auto cross_check = [](gui::FilterParamVariant param) {
+        ResetTestState();
+        gui::g_state.crystals.clear();
+        gui::g_state.filters.clear();
+        gui::g_state.layers.clear();
+        gui::CrystalConfig c;
+        c.type = gui::CrystalType::kPrism;
+        c.height = 1.0f;
+        for (int i = 0; i < 6; ++i) {
+          c.face_distance[i] = 1.0f;
+        }
+        gui::g_state.crystals.push_back(c);
+        gui::FilterConfig f;
+        f.param = std::move(param);
+        gui::g_state.filters.push_back(f);
+        gui::Layer layer;
+        layer.probability = 1.0f;
+        gui::EntryCard e;
+        e.crystal_id = 0;
+        e.filter_id = 0;
+        e.proportion = 100.0f;
+        layer.entries.push_back(e);
+        gui::g_state.layers.push_back(layer);
+
+        LUMICE_Config from_struct{};
+        IM_CHECK(gui::FillLumiceConfig(gui::g_state, &from_struct));  // struct path (ExpandFilterToStruct)
+        std::string json = gui::SerializeCoreConfig(gui::g_state);    // JSON path (SerializeFilterForCore)
+        LUMICE_Config from_json{};
+        IM_CHECK_EQ(LUMICE_ParseConfigString(json.c_str(), &from_json), LUMICE_OK);
+
+        IM_CHECK_EQ(from_struct.filter_count, from_json.filter_count);
+        IM_CHECK_EQ(from_struct.composition_count, from_json.composition_count);
+        for (int i = 0; i < from_struct.filter_count; i++) {
+          const LUMICE_FilterParam& a = from_struct.filters[i];
+          const LUMICE_FilterParam& b = from_json.filters[i];
+          IM_CHECK_EQ(a.id, b.id);
+          IM_CHECK_EQ(a.type, b.type);
+          IM_CHECK_EQ(a.action, b.action);
+          IM_CHECK_EQ(a.symmetry, b.symmetry);
+          if (a.type == LUMICE_FILTER_TYPE_RAYPATH) {
+            IM_CHECK_EQ(a.raypath_count, b.raypath_count);
+            for (int k = 0; k < a.raypath_count; k++) {
+              IM_CHECK_EQ(a.raypath[k], b.raypath[k]);
+            }
+          } else if (a.type == LUMICE_FILTER_TYPE_ENTRY_EXIT) {
+            IM_CHECK_EQ(a.ee_entry, b.ee_entry);
+            IM_CHECK_EQ(a.ee_exit, b.ee_exit);
+            IM_CHECK_EQ(a.ee_min_len, b.ee_min_len);
+            IM_CHECK_EQ(a.ee_max_len, b.ee_max_len);
+          } else if (a.type == LUMICE_FILTER_TYPE_COMPLEX) {
+            const LUMICE_ComplexComposition& ca = from_struct.compositions[a.composition_index];
+            const LUMICE_ComplexComposition& cb = from_json.compositions[b.composition_index];
+            IM_CHECK_EQ(ca.clause_count, cb.clause_count);
+            for (int cl = 0; cl < ca.clause_count; cl++) {
+              IM_CHECK_EQ(ca.term_counts[cl], cb.term_counts[cl]);
+              for (int tt = 0; tt < ca.term_counts[cl]; tt++) {
+                IM_CHECK_EQ(ca.clauses[cl][tt], cb.clauses[cl][tt]);
+              }
+            }
+          }
+        }
+      };
+      cross_check(gui::RaypathParams{ "3-1-5" });          // single-segment -> 1 simple raypath
+      cross_check(gui::RaypathParams{ "3-5; 1-4; 2-6" });  // multi-segment -> 3 simple + 1 complex
+      cross_check(gui::EntryExitParams{ "3", "5" });       // single pair -> 1 simple EE
+      gui::EntryExitParams ee_multi{ "3,5", "1" };         // 2x1 -> 2 simple + 1 complex
+      ee_multi.length_mode = 3;
+      ee_multi.min_len = 2;
+      ee_multi.max_len = 6;
+      cross_check(ee_multi);
+
+      // Overflow: a raypath with more than LUMICE_MAX_CONFIG_CLAUSES OR segments exceeds the
+      // composition ABI bounds -> FillLumiceConfig must return false (graceful degradation),
+      // so app.cpp keeps the prior committed state instead of committing a truncated config.
+      {
+        ResetTestState();
+        gui::g_state.crystals.clear();
+        gui::g_state.filters.clear();
+        gui::g_state.layers.clear();
+        gui::CrystalConfig c;
+        c.type = gui::CrystalType::kPrism;
+        c.height = 1.0f;
+        for (int i = 0; i < 6; ++i) {
+          c.face_distance[i] = 1.0f;
+        }
+        gui::g_state.crystals.push_back(c);
+        std::string too_many_segments;  // LUMICE_MAX_CONFIG_CLAUSES + 1 OR segments
+        for (int i = 0; i < LUMICE_MAX_CONFIG_CLAUSES + 1; ++i) {
+          if (i) {
+            too_many_segments += ";";
+          }
+          too_many_segments += "3-5";
+        }
+        gui::FilterConfig f;
+        f.param = gui::RaypathParams{ too_many_segments };
+        gui::g_state.filters.push_back(f);
+        gui::Layer layer;
+        layer.probability = 1.0f;
+        gui::EntryCard e;
+        e.crystal_id = 0;
+        e.filter_id = 0;
+        e.proportion = 100.0f;
+        layer.entries.push_back(e);
+        gui::g_state.layers.push_back(layer);
+        LUMICE_Config over{};
+        IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over));  // over ABI bounds -> false
+        // "no partial writes on overflow" contract (ExpandFilterToStruct doc): the overflowing
+        // filter bails before any filter/composition is written for it.
+        IM_CHECK_EQ(over.filter_count, 0);
+        IM_CHECK_EQ(over.composition_count, 0);
+      }
+    };
+  }
+
+  // 327.4 anti-spam: SetGuiWarning is idempotent while the same message is in-flight, so an
+  // over-bounds filter re-detected on every debounced commit does NOT re-open the modal and
+  // freeze interaction. ClearGuiWarning (a successful commit) re-arms it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "gui_warning_dedup");
+    t->TestFunc = [](ImGuiTestContext*) {
+      gui::ClearGuiWarning();
+      IM_CHECK(gui::PeekGuiWarning().empty());
+      gui::SetGuiWarning("over-bounds A");
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), "over-bounds A");
+      gui::SetGuiWarning("over-bounds A");  // same message -> idempotent, no re-open
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), "over-bounds A");
+      gui::SetGuiWarning("over-bounds B");  // different -> updates (would re-open)
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), "over-bounds B");
+      gui::ClearGuiWarning();  // successful commit re-arms
+      IM_CHECK(gui::PeekGuiWarning().empty());
+      gui::SetGuiWarning("over-bounds A");  // same message after a clear -> warns again
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), "over-bounds A");
+      gui::ClearGuiWarning();
+    };
+  }
 }

--- a/test/gui/functional/test_gui_lifecycle.cpp
+++ b/test/gui/functional/test_gui_lifecycle.cpp
@@ -423,6 +423,51 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     }
   };
 
+  // ---- Test 4b: backend swap (CPU<->GPU) resets the display epoch fence ----
+  // Pins the fix for "run on CPU, switch to GPU, click Run, preview does not update". A reconstructed
+  // server restarts its epoch authority at 0, so its first frame carries a LOW epoch (1). If the old
+  // server's display_epoch_floor (raised to >=1 by any prior filter edit) is carried across the swap,
+  // ShouldUploadPayload fences the new backend's frame forever and the stale texture sticks on screen.
+  // ResetDisplayGenerationForBackendSwap must clear the fence + carried texture so the new backend's
+  // frame uploads. Bites the real production predicate + the real reset method (fully headless — no
+  // GPU needed, since the bug is a pure epoch-bookkeeping defect independent of the backend kind).
+  ImGuiTest* t4b = IM_REGISTER_TEST(engine, "gui_lifecycle", "backend_swap_resets_epoch_fence");
+  t4b->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+    // The new backend's first commit mints epoch 1 (server committed_epoch_ resets to 0, +1 on rebuild).
+    auto fresh_payload = std::make_shared<gui::TexturePayload>();
+    fresh_payload->payload_epoch = 1;
+    fresh_payload->texture_ray_count = 100;  // valid, non-empty frame
+    fresh_payload->snapshot_intensity = 1.0f;
+    gui::PreviewSnapshot fresh_snap;
+    fresh_snap.valid = true;
+    fresh_snap.epoch = 1;
+    fresh_snap.payload = fresh_payload;
+    fresh_snap.texture_serial = 42;  // poller serial is global-monotonic across the swap
+
+    // Accumulated CPU session: the floor was raised to a prior generation by an earlier filter edit,
+    // and a texture from that session was already uploaded.
+    gui::GuiState st;
+    st.committed_epoch = 3;
+    st.display_epoch_floor = 3;
+    st.last_uploaded_texture_serial = 41;
+    st.snapshot_intensity = 1.0f;
+
+    // BUG condition (pre-reset): the new backend's epoch-1 frame is fenced out (1 > 3 is false), so
+    // the preview would freeze on the previous backend's texture.
+    IM_CHECK(!gui::ShouldUploadPayload(fresh_snap, st.last_uploaded_texture_serial, st.display_epoch_floor));
+
+    // FIX: the backend swap resets the display generation to epoch 0 and clears the carried texture.
+    st.ResetDisplayGenerationForBackendSwap();
+    IM_CHECK_EQ(st.committed_epoch, 0u);
+    IM_CHECK_EQ(st.display_epoch_floor, 0u);
+    IM_CHECK_EQ(st.last_uploaded_texture_serial, 0ull);
+    IM_CHECK_EQ(st.snapshot_intensity, 0.0f);  // immediate clear of the stale texture
+
+    // After the reset the new backend's epoch-1 frame clears the fence and uploads.
+    IM_CHECK(gui::ShouldUploadPayload(fresh_snap, st.last_uploaded_texture_serial, st.display_epoch_floor));
+  };
+
   // ---- Test 5: optimistic async Stop (1.6, blueprint §5/§8) ----
   // INTEGRATION through the real DoRun→DoStop→JoinPendingStop→SyncFromPoller flow on a live server.
   // Determinism: no sleep/poll guesses — run_intent is set synchronously by DoStop, the optimistic

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1692,3 +1692,258 @@ TEST(StructFilterCommit, OutOfRangeTypeReturnsInvalidConfigNotCrash) {
   f.type = 99;  // out of range
   EXPECT_EQ(CommitFilter(f), LUMICE_ERR_INVALID_CONFIG);
 }
+
+// =====================================================================================
+// task-serialize-completion (327.1): parse direction (JSON -> struct) for all 5 simple
+// types + public LUMICE_ConfigToJson. Round-trip goes through the public serialize + parse
+// APIs; cross-check against core from_json (source of truth) rather than hand-transcribed
+// expectations (see learnings: contract-and-property-tests / emit-schema cross-check).
+// =====================================================================================
+
+namespace {
+// struct -> JSON (public LUMICE_ConfigToJson) -> struct (LUMICE_ParseConfigString). Returns
+// the round-tripped filters[0]. Exercises both new 327.1 pieces end to end.
+LUMICE_FilterParam RoundTripFilter(const LUMICE_FilterParam& in) {
+  LUMICE_Config cfg = MakeOneFilterConfig(in);
+  // Zero-init so that if LUMICE_ConfigToJson unexpectedly fails, the subsequent
+  // LUMICE_ParseConfigString sees a valid empty C-string (loud parse error) rather than
+  // reading uninitialized stack memory (ASSERT_EQ can't be used in this value-returning
+  // helper). Truncation is covered separately by ConfigToJsonBufferTruncationContract.
+  char buf[8192] = {};
+  size_t len = 0;
+  EXPECT_EQ(LUMICE_ConfigToJson(&cfg, buf, sizeof(buf), &len), LUMICE_OK);
+  EXPECT_LT(len, sizeof(buf));  // these small configs never truncate
+  LUMICE_Config out{};
+  EXPECT_EQ(LUMICE_ParseConfigString(buf, &out), LUMICE_OK);
+  EXPECT_EQ(out.filter_count, 1);
+  return out.filters[0];
+}
+
+// Replace MakeFullConfigJson's filter[0] with `jf` (id kept 1 so scattering ref stays valid)
+// and return the full config JSON string, for parse-side tests.
+std::string FullConfigWithFilterJson(const nlohmann::json& jf) {
+  auto root = nlohmann::json::parse(MakeFullConfigJson());
+  root["filter"][0] = jf;
+  return root.dump();
+}
+}  // namespace
+
+TEST(StructFilterParse, NoneRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 7;
+  in.action = 0;
+  in.type = LUMICE_FILTER_TYPE_NONE;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_NONE);
+  EXPECT_EQ(out.action, 0);
+}
+
+TEST(StructFilterParse, RaypathRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 1;
+  in.action = 1;
+  in.symmetry = 1 | 2;
+  in.type = LUMICE_FILTER_TYPE_RAYPATH;
+  in.raypath_count = 3;
+  in.raypath[0] = 3;
+  in.raypath[1] = 1;
+  in.raypath[2] = 5;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_RAYPATH);
+  EXPECT_EQ(out.action, 1);
+  EXPECT_EQ(out.symmetry, 1 | 2);
+  EXPECT_EQ(out.raypath_count, 3);
+  EXPECT_EQ(out.raypath[0], 3);
+  EXPECT_EQ(out.raypath[2], 5);
+}
+
+TEST(StructFilterParse, EntryExitRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 2;
+  in.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  in.ee_entry = 3;
+  in.ee_exit = 5;
+  in.ee_min_len = 2;
+  in.ee_max_len = 8;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_ENTRY_EXIT);
+  EXPECT_EQ(out.ee_entry, 3);
+  EXPECT_EQ(out.ee_exit, 5);
+  EXPECT_EQ(out.ee_min_len, 2);
+  EXPECT_EQ(out.ee_max_len, 8);
+}
+
+TEST(StructFilterParse, EntryExitWildcardRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 2;
+  in.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  in.ee_entry = -1;
+  in.ee_exit = -1;
+  in.ee_min_len = 1;
+  in.ee_max_len = -1;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_ENTRY_EXIT);
+  EXPECT_EQ(out.ee_entry, -1);  // absent -> wildcard sentinel
+  EXPECT_EQ(out.ee_exit, -1);
+  EXPECT_EQ(out.ee_min_len, 1);  // absent -> default 1
+  EXPECT_EQ(out.ee_max_len, -1);
+}
+
+TEST(StructFilterParse, DirectionRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 4;
+  in.type = LUMICE_FILTER_TYPE_DIRECTION;
+  in.dir_az = 120.0f;
+  in.dir_el = -15.0f;
+  in.dir_radii = 2.5f;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_DIRECTION);
+  EXPECT_FLOAT_EQ(out.dir_az, 120.0f);
+  EXPECT_FLOAT_EQ(out.dir_el, -15.0f);
+  EXPECT_FLOAT_EQ(out.dir_radii, 2.5f);
+}
+
+TEST(StructFilterParse, CrystalRoundTrip) {
+  LUMICE_FilterParam in{};
+  in.id = 5;
+  in.type = LUMICE_FILTER_TYPE_CRYSTAL;
+  in.crystal_id = 2;
+  auto out = RoundTripFilter(in);
+  EXPECT_EQ(out.type, LUMICE_FILTER_TYPE_CRYSTAL);
+  EXPECT_EQ(out.crystal_id, 2);
+}
+
+TEST(StructFilterParse, NonRaypathTypesNoLongerRejected) {
+  // Regression: pre-327.1, ParseConfigString rejected non-raypath filters with INVALID_VALUE.
+  auto json = FullConfigWithFilterJson(
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 }, { "exit", 5 } });
+  LUMICE_Config out{};
+  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_OK);
+  ASSERT_GE(out.filter_count, 1);
+  EXPECT_EQ(out.filters[0].type, LUMICE_FILTER_TYPE_ENTRY_EXIT);
+  EXPECT_EQ(out.filters[0].ee_entry, 3);
+  EXPECT_EQ(out.filters[0].ee_exit, 5);
+  EXPECT_EQ(out.filters[0].ee_min_len, 1);   // absent -> default
+  EXPECT_EQ(out.filters[0].ee_max_len, -1);  // absent
+}
+
+TEST(StructFilterParse, ComplexTypeStillRejected) {
+  // Complex struct encoding is task 327.3; parse must reject it explicitly (not silently).
+  auto json = FullConfigWithFilterJson({ { "id", 1 }, { "action", "filter_in" }, { "type", "complex" } });
+  LUMICE_Config out{};
+  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_INVALID_VALUE);
+}
+
+TEST(StructFilterParse, UnknownTypeRejected) {
+  // The default branch also covers arbitrary unknown type strings (not just "complex").
+  auto json = FullConfigWithFilterJson({ { "id", 1 }, { "action", "filter_in" }, { "type", "bogus" } });
+  LUMICE_Config out{};
+  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_INVALID_VALUE);
+}
+
+TEST(StructFilterParse, IllegalEntryExitValuePassesThroughLikeCore) {
+  // Decision (plan 327.1 §7 risk 2): parse does lossless mapping only; value validation
+  // (min_len >= 1) stays single-source in core and fires at commit. So parse of min_len=0
+  // must succeed and store it verbatim (core would likewise not reject at from_json time;
+  // it throws only later). This pins the "validation not duplicated in parse" contract.
+  auto json = FullConfigWithFilterJson(
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 }, { "min_len", 0 } });
+  LUMICE_Config out{};
+  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_OK);
+  ASSERT_GE(out.filter_count, 1);
+  EXPECT_EQ(out.filters[0].ee_min_len, 0);  // stored verbatim, not normalized/rejected here
+}
+
+// Parse cross-check against core from_json (source of truth): parsing a filter JSON via
+// LUMICE_ParseConfigString then re-emitting (LUMICE_ConfigToJson) must byte-match core's own
+// from_json -> to_json round-trip of the same JSON. Since 327.2 proved emit == core to_json,
+// equality here proves the parse direction also agrees with core from_json.
+namespace {
+void ExpectParseMatchesCore(const nlohmann::json& jf) {
+  // core path: from_json -> FilterConfig -> to_json
+  lumice::FilterConfig fc = jf.get<lumice::FilterConfig>();
+  nlohmann::json core_out = fc;
+  // my path: ParseConfigString -> struct -> LUMICE_ConfigToJson -> filter[0]
+  LUMICE_Config cfg{};
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFilterJson(jf).c_str(), &cfg), LUMICE_OK);
+  char buf[8192];
+  size_t len = 0;
+  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, buf, sizeof(buf), &len), LUMICE_OK);
+  auto my_root = nlohmann::json::parse(std::string(buf, len));
+  EXPECT_EQ(my_root.at("filter").at(0), core_out) << "mine:\n"
+                                                  << my_root.at("filter").at(0).dump(2) << "\ncore:\n"
+                                                  << core_out.dump(2);
+}
+}  // namespace
+
+TEST(StructFilterParseIsomorphism, Raypath) {
+  ExpectParseMatchesCore({ { "id", 1 },
+                           { "action", "filter_out" },
+                           { "type", "raypath" },
+                           { "raypath", { 3, 1, 5 } },
+                           { "symmetry", "PB" } });
+}
+TEST(StructFilterParseIsomorphism, None) {
+  ExpectParseMatchesCore({ { "id", 7 }, { "action", "filter_in" }, { "type", "none" }, { "symmetry", "" } });
+}
+TEST(StructFilterParseIsomorphism, EntryExit) {
+  ExpectParseMatchesCore({ { "id", 2 },
+                           { "action", "filter_in" },
+                           { "type", "entry_exit" },
+                           { "entry", 3 },
+                           { "exit", 5 },
+                           { "min_len", 2 },
+                           { "max_len", 8 },
+                           { "symmetry", "" } });
+}
+TEST(StructFilterParseIsomorphism, Direction) {
+  ExpectParseMatchesCore({ { "id", 4 },
+                           { "action", "filter_in" },
+                           { "type", "direction" },
+                           { "az", 120.0 },
+                           { "el", -15.0 },
+                           { "radii", 2.5 },
+                           { "symmetry", "" } });
+}
+TEST(StructFilterParseIsomorphism, Crystal) {
+  ExpectParseMatchesCore(
+      { { "id", 5 }, { "action", "filter_in" }, { "type", "crystal" }, { "crystal_id", 2 }, { "symmetry", "" } });
+}
+
+TEST(StructFilterParse, ConfigToJsonBufferTruncationContract) {
+  // Exercises the snprintf-style caller-buffer contract (buffer overrun handling is the
+  // highest-risk path for a new C ABI function; plan 327.1 Step 2 required this test).
+  LUMICE_FilterParam f{};
+  f.id = 1;
+  f.action = 0;
+  f.type = LUMICE_FILTER_TYPE_RAYPATH;
+  f.raypath_count = 2;
+  f.raypath[0] = 3;
+  f.raypath[1] = 5;
+  LUMICE_Config cfg = MakeOneFilterConfig(f);
+
+  // NULL config -> NULL_ARG.
+  size_t tmp = 0;
+  EXPECT_EQ(LUMICE_ConfigToJson(nullptr, nullptr, 0, &tmp), LUMICE_ERR_NULL_ARG);
+
+  // Query length only (out_buf == NULL, buf_size == 0).
+  size_t full_len = 0;
+  EXPECT_EQ(LUMICE_ConfigToJson(&cfg, nullptr, 0, &full_len), LUMICE_OK);
+  EXPECT_GT(full_len, size_t{ 8 });  // full JSON is well over 8 bytes
+
+  // Full (untruncated) reference output.
+  char full[8192];
+  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, full, sizeof(full), nullptr), LUMICE_OK);
+
+  // Truncate into a small buffer.
+  char small[8];
+  std::memset(small, 'X', sizeof(small));
+  size_t len = 0;
+  EXPECT_EQ(LUMICE_ConfigToJson(&cfg, small, sizeof(small), &len), LUMICE_OK);
+  EXPECT_EQ(len, full_len);                          // out_len = FULL length, not written count
+  EXPECT_GE(len, sizeof(small));                     // out_len >= buf_size signals truncation
+  EXPECT_EQ(small[sizeof(small) - 1], '\0');         // always NUL-terminated
+  EXPECT_EQ(std::strlen(small), sizeof(small) - 1);  // wrote exactly buf_size-1 chars
+  EXPECT_EQ(std::string(small, sizeof(small) - 1),   // truncated prefix matches full prefix
+            std::string(full, sizeof(small) - 1));
+}

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -8,12 +8,16 @@
 #include <fstream>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <set>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
+#include "config/filter_config.hpp"  // core FilterConfig + to_json, for emit isomorphism cross-check
 #include "core/crystal.hpp"
 #include "core/def.hpp"
 #include "include/lumice.h"
+#include "server/c_api_internal.hpp"  // ConfigToJson (test-only exposure) for emit-shape assertions
 
 // Regression guard (task-fix-stats-ray-count-u32-overflow): ray-count fields must be
 // 64-bit so totals > 2^32 never truncate on Windows, where `unsigned long` is 32-bit
@@ -544,7 +548,8 @@ TEST(ParseConfigApi, FullConfigWithPyramidAndFilter) {
 
   // Filter
   EXPECT_EQ(config.filter_count, 1);
-  EXPECT_EQ(config.filters[0].action, 0);  // filter_in
+  EXPECT_EQ(config.filters[0].type, LUMICE_FILTER_TYPE_RAYPATH);  // JsonToFilter sets discriminant
+  EXPECT_EQ(config.filters[0].action, 0);                         // filter_in
   EXPECT_EQ(config.filters[0].raypath_count, 2);
   EXPECT_EQ(config.filters[0].raypath[0], 3);
   EXPECT_EQ(config.filters[0].raypath[1], 5);
@@ -1330,4 +1335,360 @@ TEST(BackendAvailabilityApi, CachedAcrossCalls) {
   for (int i = 0; i < 8; ++i) {
     EXPECT_EQ(LUMICE_IsBackendAvailable(LUMICE_BACKEND_METAL), kFirst);
   }
+}
+
+// =====================================================================================
+// task-struct-simple-arms (327.2): LUMICE_FilterParam 5-arm tagged union.
+//
+// Emit-shape tests call ConfigToJson directly (via server/c_api_internal.hpp) and assert
+// the JSON field-by-field, so an emit-side field-name/condition error is caught HERE
+// rather than masked by core's lenient from_json (which would default missing fields and
+// still let LUMICE_CommitConfigStruct return OK). Commit tests then verify the end-to-end
+// ABI-safe path: valid simple types commit; UNSET(0)/out-of-range type -> INVALID_CONFIG
+// (via ConfigToJson throw + CommitConfigStruct catch), never a crash across the C ABI.
+// =====================================================================================
+
+namespace {
+// Minimal LUMICE_Config carrying exactly one filter, for ConfigToJson emit assertions.
+// Other sections stay empty (counts 0) so ConfigToJson's crystal/render/scatter loops are
+// no-ops; spectrum == nullptr resolves to "D65". ConfigToJson does not validate, so this
+// is enough to inspect the emitted filter shape without a server.
+LUMICE_Config MakeOneFilterConfig(const LUMICE_FilterParam& f) {
+  LUMICE_Config config{};
+  config.filter_count = 1;
+  config.filters[0] = f;
+  return config;
+}
+
+// Assert the emitted filter object has EXACTLY this key set — catches both a missing
+// field and an unexpected/cross-arm field (e.g. a Direction filter that wrongly carries
+// "raypath" or "entry"). Per-field EXPECT_EQ alone only checks presence, never absence.
+void ExpectFilterKeys(const nlohmann::json& jf, const std::set<std::string>& expected) {
+  std::set<std::string> actual;
+  for (auto it = jf.begin(); it != jf.end(); ++it) {
+    actual.insert(it.key());
+  }
+  EXPECT_EQ(actual, expected);
+}
+}  // namespace
+
+TEST(StructFilterEmit, None) {
+  LUMICE_FilterParam f{};
+  f.id = 7;
+  f.action = 0;  // filter_in
+  f.type = LUMICE_FILTER_TYPE_NONE;
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("id").get<int>(), 7);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "none");
+  EXPECT_EQ(jf.at("action").get<std::string>(), "filter_in");
+  // No symmetry bits set -> no "symmetry" key; no arm-specific fields for "none".
+  ExpectFilterKeys(jf, { "id", "action", "type", "symmetry" });
+}
+
+TEST(StructFilterEmit, Raypath) {
+  LUMICE_FilterParam f{};
+  f.id = 1;
+  f.action = 1;  // filter_out
+  f.type = LUMICE_FILTER_TYPE_RAYPATH;
+  f.raypath_count = 3;
+  f.raypath[0] = 3;
+  f.raypath[1] = 1;
+  f.raypath[2] = 5;
+  f.symmetry = 1 | 2;  // P | B
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "raypath");
+  EXPECT_EQ(jf.at("action").get<std::string>(), "filter_out");
+  ASSERT_TRUE(jf.at("raypath").is_array());
+  EXPECT_EQ(jf.at("raypath").size(), 3u);
+  EXPECT_EQ(jf.at("raypath")[0].get<int>(), 3);
+  EXPECT_EQ(jf.at("raypath")[2].get<int>(), 5);
+  EXPECT_EQ(jf.at("symmetry").get<std::string>(), "PB");
+  ExpectFilterKeys(jf, { "id", "action", "type", "raypath", "symmetry" });
+}
+
+TEST(StructFilterEmit, EntryExitAllFields) {
+  LUMICE_FilterParam f{};
+  f.id = 2;
+  f.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  f.ee_entry = 3;
+  f.ee_exit = 5;
+  f.ee_min_len = 2;
+  f.ee_max_len = 8;
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "entry_exit");
+  EXPECT_EQ(jf.at("entry").get<int>(), 3);
+  EXPECT_EQ(jf.at("exit").get<int>(), 5);
+  EXPECT_EQ(jf.at("min_len").get<int>(), 2);
+  EXPECT_EQ(jf.at("max_len").get<int>(), 8);
+  ExpectFilterKeys(jf, { "id", "action", "type", "symmetry", "entry", "exit", "min_len", "max_len" });
+}
+
+TEST(StructFilterEmit, EntryExitWildcardsOmitted) {
+  // -1 sentinels (wildcard entry/exit, no max_len) and min_len == 1 must be omitted,
+  // mirroring core to_json which only emits set / non-default optional fields.
+  LUMICE_FilterParam f{};
+  f.id = 2;
+  f.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  f.ee_entry = -1;
+  f.ee_exit = -1;
+  f.ee_min_len = 1;
+  f.ee_max_len = -1;
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "entry_exit");
+  EXPECT_FALSE(jf.contains("entry"));
+  EXPECT_FALSE(jf.contains("exit"));
+  EXPECT_FALSE(jf.contains("min_len"));
+  EXPECT_FALSE(jf.contains("max_len"));
+  ExpectFilterKeys(jf, { "id", "action", "type", "symmetry" });
+}
+
+TEST(StructFilterEmit, Direction) {
+  LUMICE_FilterParam f{};
+  f.id = 4;
+  f.type = LUMICE_FILTER_TYPE_DIRECTION;
+  f.dir_az = 120.0f;
+  f.dir_el = -15.0f;
+  f.dir_radii = 2.5f;
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "direction");
+  EXPECT_FLOAT_EQ(jf.at("az").get<float>(), 120.0f);
+  EXPECT_FLOAT_EQ(jf.at("el").get<float>(), -15.0f);
+  EXPECT_FLOAT_EQ(jf.at("radii").get<float>(), 2.5f);
+  ExpectFilterKeys(jf, { "id", "action", "type", "symmetry", "az", "el", "radii" });
+}
+
+TEST(StructFilterEmit, Crystal) {
+  LUMICE_FilterParam f{};
+  f.id = 5;
+  f.type = LUMICE_FILTER_TYPE_CRYSTAL;
+  f.crystal_id = 2;
+  auto root = ConfigToJson(MakeOneFilterConfig(f));
+  const auto& jf = root.at("filter").at(0);
+  EXPECT_EQ(jf.at("type").get<std::string>(), "crystal");
+  EXPECT_EQ(jf.at("crystal_id").get<int>(), 2);
+  ExpectFilterKeys(jf, { "id", "action", "type", "symmetry", "crystal_id" });
+}
+
+TEST(StructFilterEmit, UnsetTypeThrows) {
+  // Zero-init guard: type == UNSET(0) must throw, not silently emit "none".
+  LUMICE_FilterParam f{};  // type defaults to 0 == UNSET
+  f.id = 1;
+  EXPECT_THROW(ConfigToJson(MakeOneFilterConfig(f)), std::invalid_argument);
+}
+
+TEST(StructFilterEmit, OutOfRangeTypeThrows) {
+  LUMICE_FilterParam f{};
+  f.id = 1;
+  f.type = 99;  // out of range
+  EXPECT_THROW(ConfigToJson(MakeOneFilterConfig(f)), std::invalid_argument);
+}
+
+// --- Isomorphism cross-check against core's own to_json -------------------------------
+// The AC is "emit JSON isomorphic to filter_config.cpp::to_json". Rather than hand-copy
+// the expected field list (which twice missed the symmetry key-presence detail), build
+// the equivalent core lumice::FilterConfig, run core's to_json (the source of truth), and
+// assert byte-equality with ConfigToJson's filter object. This catches any future drift.
+
+namespace {
+void ExpectEmitMatchesCore(const LUMICE_FilterParam& lf, const lumice::FilterConfig& fc) {
+  nlohmann::json core_j = fc;  // ADL -> lumice::to_json(json&, const FilterConfig&)
+  auto my_j = ConfigToJson(MakeOneFilterConfig(lf)).at("filter").at(0);
+  EXPECT_EQ(my_j, core_j) << "C-API emit:\n" << my_j.dump(2) << "\ncore to_json:\n" << core_j.dump(2);
+}
+}  // namespace
+
+TEST(StructFilterEmitIsomorphism, None) {
+  lumice::FilterConfig fc;
+  fc.id_ = 7;
+  fc.symmetry_ = lumice::FilterConfig::kSymNone;
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.param_ = lumice::SimpleFilterParam{ lumice::NoneFilterParam{} };
+  LUMICE_FilterParam lf{};
+  lf.id = 7;
+  lf.action = 0;
+  lf.symmetry = 0;
+  lf.type = LUMICE_FILTER_TYPE_NONE;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+TEST(StructFilterEmitIsomorphism, RaypathWithSymmetry) {
+  lumice::FilterConfig fc;
+  fc.id_ = 1;
+  fc.symmetry_ = lumice::FilterConfig::kSymP | lumice::FilterConfig::kSymB;
+  fc.action_ = lumice::FilterConfig::kFilterOut;
+  fc.param_ = lumice::SimpleFilterParam{ lumice::RaypathFilterParam{ std::vector<lumice::IdType>{ 3, 1, 5 } } };
+  LUMICE_FilterParam lf{};
+  lf.id = 1;
+  lf.action = 1;
+  lf.symmetry = 1 | 2;
+  lf.type = LUMICE_FILTER_TYPE_RAYPATH;
+  lf.raypath_count = 3;
+  lf.raypath[0] = 3;
+  lf.raypath[1] = 1;
+  lf.raypath[2] = 5;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+TEST(StructFilterEmitIsomorphism, EntryExitFull) {
+  lumice::EntryExitFilterParam ee;
+  ee.entry_ = lumice::IdType{ 3 };
+  ee.exit_ = lumice::IdType{ 5 };
+  ee.min_len_ = 2;
+  ee.max_len_ = std::size_t{ 8 };
+  lumice::FilterConfig fc;
+  fc.id_ = 2;
+  fc.symmetry_ = lumice::FilterConfig::kSymNone;
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.param_ = lumice::SimpleFilterParam{ ee };
+  LUMICE_FilterParam lf{};
+  lf.id = 2;
+  lf.action = 0;
+  lf.symmetry = 0;
+  lf.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  lf.ee_entry = 3;
+  lf.ee_exit = 5;
+  lf.ee_min_len = 2;
+  lf.ee_max_len = 8;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+TEST(StructFilterEmitIsomorphism, EntryExitWildcardsWithSymmetry) {
+  // Covers "symmetry set + non-raypath type" (the combination prior tests skipped) AND
+  // the wildcard/omitted-field path, cross-checked against core.
+  lumice::EntryExitFilterParam ee;  // entry_/exit_/max_len_ = nullopt, min_len_ = 1
+  lumice::FilterConfig fc;
+  fc.id_ = 2;
+  fc.symmetry_ = lumice::FilterConfig::kSymP | lumice::FilterConfig::kSymB;
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.param_ = lumice::SimpleFilterParam{ ee };
+  LUMICE_FilterParam lf{};
+  lf.id = 2;
+  lf.action = 0;
+  lf.symmetry = 1 | 2;
+  lf.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  lf.ee_entry = -1;
+  lf.ee_exit = -1;
+  lf.ee_min_len = 1;
+  lf.ee_max_len = -1;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+TEST(StructFilterEmitIsomorphism, Direction) {
+  lumice::DirectionFilterParam dir;
+  dir.lon_ = 120.0f;
+  dir.lat_ = -15.0f;
+  dir.radii_ = 2.5f;
+  lumice::FilterConfig fc;
+  fc.id_ = 4;
+  fc.symmetry_ = lumice::FilterConfig::kSymNone;
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.param_ = lumice::SimpleFilterParam{ dir };
+  LUMICE_FilterParam lf{};
+  lf.id = 4;
+  lf.action = 0;
+  lf.symmetry = 0;
+  lf.type = LUMICE_FILTER_TYPE_DIRECTION;
+  lf.dir_az = 120.0f;
+  lf.dir_el = -15.0f;
+  lf.dir_radii = 2.5f;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+TEST(StructFilterEmitIsomorphism, Crystal) {
+  lumice::CrystalFilterParam cr;
+  cr.crystal_id_ = lumice::IdType{ 2 };
+  lumice::FilterConfig fc;
+  fc.id_ = 5;
+  fc.symmetry_ = lumice::FilterConfig::kSymNone;
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.param_ = lumice::SimpleFilterParam{ cr };
+  LUMICE_FilterParam lf{};
+  lf.id = 5;
+  lf.action = 0;
+  lf.symmetry = 0;
+  lf.type = LUMICE_FILTER_TYPE_CRYSTAL;
+  lf.crystal_id = 2;
+  ExpectEmitMatchesCore(lf, fc);
+}
+
+// --- End-to-end commit through LUMICE_CommitConfigStruct ------------------------------
+
+namespace {
+// Parse the full config (crystals + scene + one referenced filter), then replace that
+// filter (keeping its id, so the scattering reference stays valid) with `f` and shrink to
+// a fast finite sim. Returns the config ready for LUMICE_CommitConfigStruct.
+LUMICE_Config MakeCommitConfigWithFilter(const LUMICE_FilterParam& f) {
+  LUMICE_Config config{};
+  EXPECT_EQ(LUMICE_ParseConfigString(MakeFullConfigJson().c_str(), &config), LUMICE_OK);
+  EXPECT_GE(config.filter_count, 1);
+  const int fid = config.filters[0].id;
+  config.filters[0] = f;
+  config.filters[0].id = fid;
+  config.infinite = 0;
+  config.ray_num = 100;
+  return config;
+}
+
+int CommitFilter(const LUMICE_FilterParam& f) {
+  LUMICE_Config config = MakeCommitConfigWithFilter(f);
+  auto* server = LUMICE_CreateServer();
+  EXPECT_NE(server, nullptr);
+  int reused = -1;
+  auto err = LUMICE_CommitConfigStruct(server, &config, &reused);
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+  return err;
+}
+}  // namespace
+
+TEST(StructFilterCommit, EntryExitCommitsOk) {
+  LUMICE_FilterParam f{};
+  f.action = 0;
+  f.type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  f.ee_entry = 3;
+  f.ee_exit = 5;
+  f.ee_min_len = 1;
+  f.ee_max_len = -1;
+  EXPECT_EQ(CommitFilter(f), LUMICE_OK);
+}
+
+TEST(StructFilterCommit, DirectionCommitsOk) {
+  LUMICE_FilterParam f{};
+  f.action = 0;
+  f.type = LUMICE_FILTER_TYPE_DIRECTION;
+  f.dir_az = 22.0f;
+  f.dir_el = 0.0f;
+  f.dir_radii = 5.0f;
+  EXPECT_EQ(CommitFilter(f), LUMICE_OK);
+}
+
+TEST(StructFilterCommit, CrystalCommitsOk) {
+  LUMICE_FilterParam f{};
+  f.action = 0;
+  f.type = LUMICE_FILTER_TYPE_CRYSTAL;
+  f.crystal_id = 1;  // MakeFullConfigJson defines crystals with ids 1 and 2
+  EXPECT_EQ(CommitFilter(f), LUMICE_OK);
+}
+
+TEST(StructFilterCommit, UnsetTypeReturnsInvalidConfigNotCrash) {
+  // A construction site that forgot to set `type` zero-inits to UNSET(0). ConfigToJson
+  // throws; LUMICE_CommitConfigStruct must catch and return INVALID_CONFIG, never crash.
+  LUMICE_FilterParam f{};  // type == UNSET
+  f.action = 0;
+  f.type = LUMICE_FILTER_TYPE_UNSET;
+  f.raypath_count = 1;
+  f.raypath[0] = 3;
+  EXPECT_EQ(CommitFilter(f), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterCommit, OutOfRangeTypeReturnsInvalidConfigNotCrash) {
+  LUMICE_FilterParam f{};
+  f.action = 0;
+  f.type = 99;  // out of range
+  EXPECT_EQ(CommitFilter(f), LUMICE_ERR_INVALID_CONFIG);
 }

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1827,11 +1827,12 @@ TEST(StructFilterParse, NonRaypathTypesNoLongerRejected) {
   EXPECT_EQ(out.filters[0].ee_max_len, -1);  // absent
 }
 
-TEST(StructFilterParse, ComplexTypeStillRejected) {
-  // Complex struct encoding is task 327.3; parse must reject it explicitly (not silently).
+TEST(StructFilterParse, ComplexWithoutCompositionRejected) {
+  // As of 327.3, complex filters DO parse (see StructFilterComplex tests). But a complex
+  // filter missing its required "composition" array is rejected with MISSING_FIELD.
   auto json = FullConfigWithFilterJson({ { "id", 1 }, { "action", "filter_in" }, { "type", "complex" } });
   LUMICE_Config out{};
-  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_INVALID_VALUE);
+  EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_MISSING_FIELD);
 }
 
 TEST(StructFilterParse, UnknownTypeRejected) {
@@ -1946,4 +1947,240 @@ TEST(StructFilterParse, ConfigToJsonBufferTruncationContract) {
   EXPECT_EQ(std::strlen(small), sizeof(small) - 1);  // wrote exactly buf_size-1 chars
   EXPECT_EQ(std::string(small, sizeof(small) - 1),   // truncated prefix matches full prefix
             std::string(full, sizeof(small) - 1));
+}
+
+// =====================================================================================
+// task-complex-ref-encoding (327.3): complex (sum-of-products) filter, flat reference
+// encoding (separate compositions[] pool + composition_index; cells reference simple-filter
+// ids). Cross-checked against core ConfigManager's own two-pass resolution (source of truth).
+// =====================================================================================
+
+namespace {
+std::string FullConfigWithFiltersJson(const nlohmann::json& filter_array) {
+  auto root = nlohmann::json::parse(MakeFullConfigJson());
+  root["filter"] = filter_array;
+  return root.dump();
+}
+
+// Cross-check the C-API complex emit against core's own to_json (source of truth). Builds a
+// core FilterConfig with an equivalent ComplexFilterParam from the composition JSON and runs
+// core to_json; core emits only the referenced simple-filter ids (pair.first), so the
+// SimpleFilterParam content is irrelevant. Then parses the same config via the C API and
+// re-emits, and asserts the complex filter's JSON matches byte for byte. This proves parse +
+// emit of complex agree with core, without needing core's strict full-config ConfigManager
+// parse (which requires render/scene fields the lenient LUMICE parse does not).
+void ExpectComplexMatchesCore(const nlohmann::json& filter_array, int complex_id) {
+  nlohmann::json complex_jf;
+  for (const auto& jf : filter_array) {
+    if (jf.at("id").get<int>() == complex_id) {
+      complex_jf = jf;
+      break;
+    }
+  }
+  ASSERT_FALSE(complex_jf.is_null());
+
+  lumice::FilterConfig fc;
+  fc.id_ = static_cast<lumice::IdType>(complex_id);
+  fc.action_ = lumice::FilterConfig::kFilterIn;
+  fc.symmetry_ = lumice::FilterConfig::kSymNone;
+  lumice::ComplexFilterParam cp;
+  for (const auto& clause : complex_jf.at("composition")) {
+    std::vector<std::pair<lumice::IdType, lumice::SimpleFilterParam>> terms;
+    if (clause.is_array()) {
+      for (const auto& term : clause) {
+        terms.emplace_back(term.get<lumice::IdType>(), lumice::SimpleFilterParam{});
+      }
+    } else {
+      terms.emplace_back(clause.get<lumice::IdType>(), lumice::SimpleFilterParam{});
+    }
+    cp.filters_.emplace_back(terms);
+  }
+  fc.param_ = cp;
+  nlohmann::json core_j = fc;  // core to_json
+
+  LUMICE_Config cfg{};
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filter_array).c_str(), &cfg), LUMICE_OK);
+  char buf[16384];
+  size_t len = 0;
+  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, buf, sizeof(buf), &len), LUMICE_OK);
+  auto my_root = nlohmann::json::parse(std::string(buf, len));
+  nlohmann::json my_j;
+  for (const auto& jf : my_root.at("filter")) {
+    if (jf.at("id").get<int>() == complex_id) {
+      my_j = jf;
+      break;
+    }
+  }
+  ASSERT_FALSE(my_j.is_null());
+  EXPECT_EQ(my_j, core_j) << "mine:\n" << my_j.dump(2) << "\ncore:\n" << core_j.dump(2);
+}
+}  // namespace
+
+TEST(StructFilterComplex, OrOfRaypathsMatchesCore) {  // issue.md 场景: 多段 raypath = OR-of-raypaths
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 1, 4 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
+  });
+  ExpectComplexMatchesCore(filters, 3);
+}
+
+TEST(StructFilterComplex, OrOfEntryExitMatchesCore) {  // issue.md 场景: 多值 EE = OR-of-EE
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 }, { "exit", 5 } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 1 } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
+  });
+  ExpectComplexMatchesCore(filters, 3);
+}
+
+TEST(StructFilterComplex, CrossTypeWithAndClauseMatchesCore) {  // issue.md 场景: 跨 type 组合 + AND 子句
+  // composition = OR( AND(1,2), 1 ) — mixes a 2-term array clause and a bare-id clause.
+  nlohmann::json comp = nlohmann::json::array({ nlohmann::json::array({ 1, 2 }), 1 });
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", comp } },
+  });
+  ExpectComplexMatchesCore(filters, 3);
+}
+
+TEST(StructFilterComplex, StructRoundTrip) {
+  // Build a complex config struct directly, round-trip through the public serialize+parse
+  // APIs, and assert the composition survives (clause/term/id fidelity).
+  LUMICE_Config in{};
+  in.filter_count = 3;
+  in.filters[0].id = 1;
+  in.filters[0].type = LUMICE_FILTER_TYPE_RAYPATH;
+  in.filters[0].raypath_count = 2;
+  in.filters[0].raypath[0] = 3;
+  in.filters[0].raypath[1] = 5;
+  in.filters[1].id = 2;
+  in.filters[1].type = LUMICE_FILTER_TYPE_ENTRY_EXIT;
+  in.filters[1].ee_entry = 3;
+  in.filters[1].ee_exit = -1;
+  in.filters[1].ee_min_len = 1;
+  in.filters[1].ee_max_len = -1;
+  in.filters[2].id = 3;
+  in.filters[2].type = LUMICE_FILTER_TYPE_COMPLEX;
+  in.filters[2].composition_index = 0;
+  in.composition_count = 1;
+  in.compositions[0].clause_count = 2;
+  in.compositions[0].term_counts[0] = 2;  // AND(1,2)
+  in.compositions[0].clauses[0][0] = 1;
+  in.compositions[0].clauses[0][1] = 2;
+  in.compositions[0].term_counts[1] = 1;  // bare 1
+  in.compositions[0].clauses[1][0] = 1;
+
+  char buf[16384];
+  size_t len = 0;
+  ASSERT_EQ(LUMICE_ConfigToJson(&in, buf, sizeof(buf), &len), LUMICE_OK);
+  LUMICE_Config out{};
+  ASSERT_EQ(LUMICE_ParseConfigString(buf, &out), LUMICE_OK);
+
+  ASSERT_EQ(out.filter_count, 3);
+  ASSERT_EQ(out.filters[2].type, LUMICE_FILTER_TYPE_COMPLEX);
+  const auto& oc = out.compositions[out.filters[2].composition_index];
+  EXPECT_EQ(oc.clause_count, 2);
+  EXPECT_EQ(oc.term_counts[0], 2);
+  EXPECT_EQ(oc.clauses[0][0], 1);
+  EXPECT_EQ(oc.clauses[0][1], 2);
+  EXPECT_EQ(oc.term_counts[1], 1);
+  EXPECT_EQ(oc.clauses[1][0], 1);
+}
+
+TEST(StructFilterComplex, CommitStructEndToEnd) {
+  // Build the complex config via parse, commit through the struct path -> core consumes it.
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 1, 4 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
+  });
+  LUMICE_Config cfg{};
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
+  cfg.infinite = 0;
+  cfg.ray_num = 100;
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+  int reused = -1;
+  EXPECT_EQ(LUMICE_CommitConfigStruct(server, &cfg, &reused), LUMICE_OK);
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
+TEST(StructFilterComplex, DanglingReferenceRejected) {
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 99 } } },  // 99 not defined
+  });
+  LUMICE_Config cfg{};
+  EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterComplex, ReferenceToComplexRejected) {
+  // A composition term may only reference a SIMPLE filter, never another complex (no cycles).
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 2 } } },  // refs complex 2
+  });
+  LUMICE_Config cfg{};
+  EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterComplex, TooManyTermsRejected) {
+  // A clause with more than LUMICE_MAX_CONFIG_TERMS terms -> INVALID_CONFIG.
+  nlohmann::json simples = nlohmann::json::array();
+  nlohmann::json big_clause = nlohmann::json::array();
+  for (int i = 1; i <= LUMICE_MAX_CONFIG_TERMS + 1; i++) {
+    simples.push_back({ { "id", i }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } });
+    big_clause.push_back(i);
+  }
+  nlohmann::json filters = simples;
+  filters.push_back({ { "id", 100 },
+                      { "action", "filter_in" },
+                      { "type", "complex" },
+                      { "composition", nlohmann::json::array({ big_clause }) } });
+  LUMICE_Config cfg{};
+  EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterComplex, TooManyClausesRejected) {
+  // A composition with more than LUMICE_MAX_CONFIG_CLAUSES clauses -> INVALID_CONFIG.
+  nlohmann::json comp = nlohmann::json::array();
+  for (int i = 0; i < LUMICE_MAX_CONFIG_CLAUSES + 1; i++) {
+    comp.push_back(1);  // each clause references simple filter id 1
+  }
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", comp } },
+  });
+  LUMICE_Config cfg{};
+  EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterComplex, TooManyCompositionsRejected) {
+  // More than LUMICE_MAX_CONFIG_COMPLEX complex filters -> INVALID_CONFIG on the overflow one.
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+  });
+  for (int i = 0; i < LUMICE_MAX_CONFIG_COMPLEX + 1; i++) {
+    filters.push_back(
+        { { "id", 100 + i }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1 } } });
+  }
+  LUMICE_Config cfg{};
+  EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
+}
+
+TEST(StructFilterComplex, EmptyCompositionAccepted) {
+  // An empty composition ([]) is a degenerate but accepted "OR of nothing" (clause_count 0).
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", nlohmann::json::array() } },
+  });
+  LUMICE_Config cfg{};
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
+  ASSERT_GE(cfg.filter_count, 2);
+  EXPECT_EQ(cfg.filters[1].type, LUMICE_FILTER_TYPE_COMPLEX);
+  EXPECT_EQ(cfg.compositions[cfg.filters[1].composition_index].clause_count, 0);
 }

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -2108,6 +2108,40 @@ TEST(StructFilterComplex, CommitStructEndToEnd) {
   LUMICE_DestroyServer(server);
 }
 
+TEST(StructFilterComplex, ComplexFilterCommitReusesOnNonRendererChange) {
+  // The mechanism behind the 327.4 jank fix: a config carrying a COMPLEX filter can reuse
+  // consumers (out_reused == 1) on a subsequent non-renderer change, so the live-preview
+  // buffer is NOT torn. Before, GUI multi-segment/multi-value (complex) filters were forced
+  // onto the JSON commit path, which has no out_reused signal and always rebuilt — tearing
+  // the buffer on every crystal/sun slider drag. Routing complex through the typed struct
+  // (327.3/327.4) restores the reuse signal. The GUI-integration timing (poller not stopped
+  // on drag) is verified on-screen; this locks the underlying core contract headlessly.
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 1, 4 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
+  });
+  LUMICE_Config cfg{};
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
+  cfg.infinite = 0;
+  cfg.ray_num = 100;
+
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+  int reused = -1;
+  ASSERT_EQ(LUMICE_CommitConfigStruct(server, &cfg, &reused), LUMICE_OK);
+  EXPECT_EQ(reused, 0);  // first commit builds consumers
+
+  // Change only a non-renderer field (sun altitude); the complex filter is unchanged.
+  cfg.sun_altitude += 5.0f;
+  reused = -1;
+  ASSERT_EQ(LUMICE_CommitConfigStruct(server, &cfg, &reused), LUMICE_OK);
+  EXPECT_EQ(reused, 1);  // consumers reused despite the complex filter -> buffer not torn
+
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
 TEST(StructFilterComplex, DanglingReferenceRejected) {
   nlohmann::json filters = nlohmann::json::array({
       { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },


### PR DESCRIPTION
## 背景

filter 的程序化 commit 此前存在双路径：typed struct（`LUMICE_CommitConfigStruct`）只表达 raypath-only，一旦 filter 非 raypath / 多段 raypath（OR）/ 多值 EE，GUI 的 `IsTrivialFilterSet` 就踢到 stringly-typed 的 JSON commit。JSON 路径无 `out_reused` 出参 → 丢弃 server 的 `can_reuse` 信号 → GUI 保守全量重建 → 停 poller + 撕 buffer。副作用：设了 EE / 多段 raypath 的用户每次 slider 拖动都卡。

已定方向（owner）：typed struct = 设计强制力，JSON 是逃生口不承担 commit 角色；按 author 分工——程序内存构造→typed struct，人手写文本/文件 load→JSON，序列化/round-trip→显式的 `LUMICE_ParseConfigString` + `LUMICE_ConfigToJson`。

## 改动（scrum 327，4 子任务）

- **327.1** `serialize-completion`：`JsonToFilter` 扩全 5 type parse + 公开 `LUMICE_ConfigToJson`（snprintf caller-buffer + 截断契约）；emit/parse 恢复对称。
- **327.2** `struct-simple-arms`：`LUMICE_FilterParam` → 5-arm tagged union（`0=UNSET` 零初始化守卫 + `default: throw`）；`ConfigToJson` emit 与 core `to_json` 逐字节同构（6 处 isomorphism 交叉核对）。
- **327.3** `complex-ref-encoding`：Complex 扁平引用编码（独立 composition 池，ABI BREAKING v4.6）+ 两趟 parse（镜像 `config_manager`）+ 引用完整性校验（悬空 id / 越界 / 成环）。
- **327.4** `gui-struct-only`：删 `IsTrivialFilterSet` + JSON commit 分叉，GUI 全走 struct；新 `ExpandFilterToStruct`（`SerializeFilterForCore` 孪生）+ `FillLumiceConfig` 返 bool 超限 graceful 降级 + `filter_expand_struct_vs_json` 强制交叉核对测试；超限告警弹窗 fire-once（防高频 commit 重开抢占拖拽）。

真因闭环：双路径分叉从根删除 → 多段 raypath / 多值 EE 回到 struct 快路，`out_reused` 复用信号白拿，拖拽全量重建 jank 修掉。

## 附带修复（逻辑独立，先前就存在的 bug）

**`fix(gui): reset display epoch fence on backend swap`** —— 切换 CPU↔GPU 后台后点 Run，预览停在旧后端的图不刷新。根因：重构 server 会把 epoch 权威重置回 0，但 GUI 的显示防闪烁栅栏 `display_epoch_floor`（scrum-322）跨 server 携带，新后端的低 epoch 帧被旧栅栏永久挡住。这是 scrum-322 从未考虑"换后端"的盲区，非 327.4 引入。修复：重构 server 时重置显示世代（`ResetDisplayGenerationForBackendSwap`）+ 回归测试 `backend_swap_resets_epoch_fence`。

## 验证

- 各子任务 code-review 全 APPROVE（327.2 达 3 轮、327.4 达 4 轮，均 0 Critical / 0 Major）。
- 单测 + GUI 测通过（含新增 `filter_expand_struct_vs_json` / `gui_warning_dedup` / `backend_swap_resets_epoch_fence`）；format / policy（含 struct-layout-parity）全过。
- backend-swap 修复经 owner on-screen 人工确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)