### PR TITLE
feat(gui): Custom Spectrum modal Reset + overlimit warning polish (GUI small-fixes batch)

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -762,24 +762,18 @@ void DoRun() {
   LUMICE_Config config{};
   FilterOverflowInfo overflow;
   if (!FillLumiceConfig(g_state, &config, &overflow)) {
-    // Build a "where" locator from the overflow identity captured inside FillLumiceConfig.
-    // 1-based Layer/Entry to match the panel header convention (panels.cpp "Layer %d" uses
-    // layer_idx + 1); FilterConfig::name is optional so it is prepended only when non-empty.
-    std::string where;
-    if (!overflow.filter_name.empty()) {
-      where = " (filter \"" + overflow.filter_name + "\", Layer " + std::to_string(overflow.layer_index + 1) +
-              " / Entry " + std::to_string(overflow.entry_index + 1) + ")";
-    } else {
-      where = " (Layer " + std::to_string(overflow.layer_index + 1) + " / Entry " +
-              std::to_string(overflow.entry_index + 1) + ")";
-    }
+    // Locator ("filter \"NAME\", Layer L / Entry E", or "Layer L / Entry E" when unnamed)
+    // identifying which filter reference tripped the ABI bounds, captured inside
+    // FillLumiceConfig. Built by FormatOverflowLocator so the format is unit-testable
+    // (test_gui_import_export.cpp) rather than only exercised through on-screen GUI.
+    const std::string locator = FormatOverflowLocator(overflow);
     // User-visible prompt (the Log panel is collapsed by default): the edit did NOT apply and
     // the previous configuration was kept, so the user knows why nothing changed. The same
     // locator-bearing text drives both the modal and the Log line so the two channels stay in
     // sync (see Log-dedup comment below).
     std::string warning_msg = "This filter has too many OR segments / values to apply (limit " +
-                              std::to_string(LUMICE_MAX_CONFIG_CLAUSES) + ")" + where +
-                              ".\nThe previous configuration was kept. Simplify the filter and try again.";
+                              std::to_string(LUMICE_MAX_CONFIG_CLAUSES) + "; " + locator +
+                              ").\nThe previous configuration was kept. Simplify the filter and try again.";
     // Log-panel dedup: gate the Log write on the SAME state SetGuiWarning uses for modal dedup
     // (in-flight message equals the new one). Sharing the key intentionally couples the two
     // channels — a wording change (e.g. new Layer/Entry after the user switches which filter
@@ -787,9 +781,9 @@ void DoRun() {
     // why we did NOT introduce a separate `g_last_overlimit_log_msg` static variable.
     if (PeekGuiWarning() != warning_msg) {
       GUI_LOG_WARNING(
-          "[GUI] DoRun: filter exceeds ABI limits (too many OR segments/values){}; keeping the "
+          "[GUI] DoRun: filter exceeds ABI limits (too many OR segments/values; {}); keeping the "
           "previous configuration. Simplify the filter to apply the change.",
-          where);
+          locator);
     }
     SetGuiWarning(warning_msg);
     return;

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -760,15 +760,38 @@ void DoRun() {
   // (graceful degradation) — poller untouched, buffer not torn — rather than commit a
   // truncated config.
   LUMICE_Config config{};
-  if (!FillLumiceConfig(g_state, &config)) {
-    GUI_LOG_WARNING(
-        "[GUI] DoRun: filter exceeds ABI limits (too many OR segments/values); keeping the "
-        "previous configuration. Simplify the filter to apply the change.");
+  FilterOverflowInfo overflow;
+  if (!FillLumiceConfig(g_state, &config, &overflow)) {
+    // Build a "where" locator from the overflow identity captured inside FillLumiceConfig.
+    // 1-based Layer/Entry to match the panel header convention (panels.cpp "Layer %d" uses
+    // layer_idx + 1); FilterConfig::name is optional so it is prepended only when non-empty.
+    std::string where;
+    if (!overflow.filter_name.empty()) {
+      where = " (filter \"" + overflow.filter_name + "\", Layer " + std::to_string(overflow.layer_index + 1) +
+              " / Entry " + std::to_string(overflow.entry_index + 1) + ")";
+    } else {
+      where = " (Layer " + std::to_string(overflow.layer_index + 1) + " / Entry " +
+              std::to_string(overflow.entry_index + 1) + ")";
+    }
     // User-visible prompt (the Log panel is collapsed by default): the edit did NOT apply and
-    // the previous configuration was kept, so the user knows why nothing changed.
-    SetGuiWarning("This filter has too many OR segments / values to apply (limit " +
-                  std::to_string(LUMICE_MAX_CONFIG_CLAUSES) +
-                  ").\nThe previous configuration was kept. Simplify the filter and try again.");
+    // the previous configuration was kept, so the user knows why nothing changed. The same
+    // locator-bearing text drives both the modal and the Log line so the two channels stay in
+    // sync (see Log-dedup comment below).
+    std::string warning_msg = "This filter has too many OR segments / values to apply (limit " +
+                              std::to_string(LUMICE_MAX_CONFIG_CLAUSES) + ")" + where +
+                              ".\nThe previous configuration was kept. Simplify the filter and try again.";
+    // Log-panel dedup: gate the Log write on the SAME state SetGuiWarning uses for modal dedup
+    // (in-flight message equals the new one). Sharing the key intentionally couples the two
+    // channels — a wording change (e.g. new Layer/Entry after the user switches which filter
+    // triggers the overflow) counts as a fresh event and re-logs. See plan.md §7 risk 1 for
+    // why we did NOT introduce a separate `g_last_overlimit_log_msg` static variable.
+    if (PeekGuiWarning() != warning_msg) {
+      GUI_LOG_WARNING(
+          "[GUI] DoRun: filter exceeds ABI limits (too many OR segments/values){}; keeping the "
+          "previous configuration. Simplify the filter to apply the change.",
+          where);
+    }
+    SetGuiWarning(warning_msg);
     return;
   }
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1853,7 +1853,10 @@ void RenderSpectrumModal(GuiState& state) {
   }
 
   ImGui::SetNextWindowSize(ImVec2(480, 0), ImGuiCond_Appearing);
-  if (!ImGui::BeginPopupModal("Custom Spectrum##spectrum_modal", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+  // p_open (re-armed to true each frame) renders the title-bar × for style parity with the Edit Entry
+  // modal; clicking it sets title_x_open false and is handled as a Cancel-equivalent below.
+  bool title_x_open = true;
+  if (!ImGui::BeginPopupModal("Custom Spectrum##spectrum_modal", &title_x_open, ImGuiWindowFlags_AlwaysAutoResize)) {
     return;
   }
 
@@ -1917,18 +1920,11 @@ void RenderSpectrumModal(GuiState& state) {
                        kSpectrumSoftWarnCount);
   }
 
-  ImGui::Spacing();
-  if (ImGui::Button("Reset##spec_reset", ImVec2(80, 0))) {
-    // Reset-to-default (not revert-to-open-time): re-seed with the same uniform preset a freshly
-    // opened custom spectrum starts from. Only mutates the edit buffer — OK remains the sole commit
-    // point (see g_spectrum_edit_buf contract above); Cancel/Escape after Reset leaves committed
-    // state untouched.
-    g_spectrum_edit_buf = BuildPresetSeed();
-  }
-
   ImGui::Separator();
 
-  // OK / Cancel.
+  // Action row: OK / Cancel (dialog-terminating) on the left; Reset (a non-terminating edit action)
+  // right-aligned on the same row so it reads as a distinct class and resists being mis-clicked as a
+  // third confirm button.
   const bool ok_disabled = g_spectrum_edit_buf.empty();
   if (ok_disabled) {
     ImGui::BeginDisabled();
@@ -1958,6 +1954,27 @@ void RenderSpectrumModal(GuiState& state) {
   if (ImGui::Button(ICON_FA_XMARK " Cancel##spec_cancel", ImVec2(80, 0))) {
     // Nothing to restore: spectrum_index was never mutated on open (only OK commits it), so Cancel /
     // Escape / click-outside all naturally leave it at the prior valid preset. Just discard the buffer.
+    ImGui::CloseCurrentPopup();
+  }
+
+  // Reset##spec_reset, right-aligned on the same row. Reset-to-default (not revert-to-open-time):
+  // re-seed with the same uniform preset a freshly opened custom spectrum starts from. Only mutates
+  // the edit buffer — OK stays the sole commit point (see g_spectrum_edit_buf contract above).
+  // When the window is too narrow to right-align without overlapping Cancel, fall back to normal
+  // same-line placement (this converges in one frame under AlwaysAutoResize).
+  ImGui::SameLine();
+  constexpr float kResetBtnW = 80.0f;
+  const float reset_x = ImGui::GetWindowContentRegionMax().x - kResetBtnW;
+  if (reset_x > ImGui::GetCursorPosX()) {
+    ImGui::SetCursorPosX(reset_x);
+  }
+  if (ImGui::Button("Reset##spec_reset", ImVec2(kResetBtnW, 0))) {
+    g_spectrum_edit_buf = BuildPresetSeed();
+  }
+
+  // Title-bar × = Cancel-equivalent: discard the edit buffer without committing. spectrum_index was
+  // never mutated on open, so there is nothing to restore — same exit path as Cancel/Escape.
+  if (!title_x_open) {
     ImGui::CloseCurrentPopup();
   }
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1917,6 +1917,15 @@ void RenderSpectrumModal(GuiState& state) {
                        kSpectrumSoftWarnCount);
   }
 
+  ImGui::Spacing();
+  if (ImGui::Button("Reset##spec_reset", ImVec2(80, 0))) {
+    // Reset-to-default (not revert-to-open-time): re-seed with the same uniform preset a freshly
+    // opened custom spectrum starts from. Only mutates the edit buffer — OK remains the sole commit
+    // point (see g_spectrum_edit_buf contract above); Cancel/Escape after Reset leaves committed
+    // state untouched.
+    g_spectrum_edit_buf = BuildPresetSeed();
+  }
+
   ImGui::Separator();
 
   // OK / Cancel.

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1022,7 +1022,7 @@ static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMI
 // degradation), not commit `out`. Crystals still use the P+1 pool-id scheme; filters use a
 // running id counter (matching SerializeCoreConfig) because one GUI filter may expand into
 // N simple + 1 complex.
-bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
+bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out, FilterOverflowInfo* overflow) {
   std::memset(out, 0, sizeof(LUMICE_Config));
 
   // ID-pool model: walk entries, dedupe by pool id, emit one C crystal per reachable pool
@@ -1079,6 +1079,14 @@ bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out) {
             // Exceeded ABI bounds (composition pool / clause / filter capacity). Bail out
             // immediately with false so the caller keeps the old committed state rather than
             // commit a truncated config (no point finishing the rest of `out`, it is discarded).
+            // Capture the current (layer, entry, filter name) so the caller can locate the
+            // offending filter. Only the FIRST reference is reported — if the same filter pool
+            // id is used at multiple sites, later ones are not surfaced (they share content).
+            if (overflow != nullptr) {
+              overflow->layer_index = i;
+              overflow->entry_index = k;
+              overflow->filter_name = state.filters[fpool].name;
+            }
             return false;
           }
         }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1022,6 +1022,16 @@ static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMI
 // degradation), not commit `out`. Crystals still use the P+1 pool-id scheme; filters use a
 // running id counter (matching SerializeCoreConfig) because one GUI filter may expand into
 // N simple + 1 complex.
+std::string FormatOverflowLocator(const FilterOverflowInfo& overflow) {
+  // 1-based Layer/Entry to match the panel header convention (panels.cpp "Layer %d").
+  const std::string pos =
+      "Layer " + std::to_string(overflow.layer_index + 1) + " / Entry " + std::to_string(overflow.entry_index + 1);
+  if (!overflow.filter_name.empty()) {
+    return "filter \"" + overflow.filter_name + "\", " + pos;
+  }
+  return pos;
+}
+
 bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out, FilterOverflowInfo* overflow) {
   std::memset(out, 0, sizeof(LUMICE_Config));
 

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -33,6 +33,14 @@ struct FilterOverflowInfo {
 // message; the value is untouched on success.
 bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out, FilterOverflowInfo* overflow = nullptr);
 
+// Format a human-readable locator ("filter \"NAME\", Layer L / Entry E", or just
+// "Layer L / Entry E" when the filter is unnamed) from a FilterOverflowInfo, using 1-based
+// Layer/Entry to match the panel header convention (panels.cpp "Layer %d"). Extracted as a pure
+// function so the message format is unit-testable (test_gui_import_export.cpp) instead of only
+// exercised through on-screen GUI. Returns the inner text WITHOUT surrounding parentheses so the
+// caller can embed it inside its own "(limit N; ...)" grouping.
+std::string FormatOverflowLocator(const FilterOverflowInfo& overflow);
+
 // Serialize GuiState to Core JSON string (for .lmc save and CLI compatibility)
 std::string SerializeCoreConfig(const GuiState& state);
 

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -13,11 +13,25 @@ struct GuiState;
 struct PreviewViewport;
 class PreviewRenderer;
 
+// Identifies which filter reference triggered an ABI-bounds overflow inside FillLumiceConfig.
+// Populated only when FillLumiceConfig returns false AND the caller passed a non-null pointer.
+// Captures the FIRST reference walked in scattering-layer order — same filter pool id reused
+// across multiple (layer, entry) sites only reports the first, which is sufficient to locate
+// the offending filter (all sites share identical content).
+struct FilterOverflowInfo {
+  int layer_index = -1;     // 0-based scattering layer index (present to caller as +1)
+  int entry_index = -1;     // 0-based entry index within the layer (present to caller as +1)
+  std::string filter_name;  // FilterConfig::name (may be empty if user did not name the filter)
+};
+
 // Fill LUMICE_Config C struct from GuiState (for LUMICE_CommitConfigStruct, bypasses JSON serialization)
 // Fill a LUMICE_Config from GuiState for the typed-struct commit path. Returns false if a
 // filter expansion exceeded the ABI bounds (composition pool / clause / filter capacity),
 // in which case the caller must NOT commit `out` and should keep the prior committed state.
-bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out);
+// When `overflow` is non-null and the return is false, it receives the identity of the first
+// (layer, entry, filter name) that triggered the overflow so the caller can build a locating
+// message; the value is untouched on success.
+bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out, FilterOverflowInfo* overflow = nullptr);
 
 // Serialize GuiState to Core JSON string (for .lmc save and CLI compatibility)
 std::string SerializeCoreConfig(const GuiState& state);

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -1455,7 +1455,57 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         IM_CHECK_EQ(overflow.layer_index, 0);
         IM_CHECK_EQ(overflow.entry_index, 0);
         IM_CHECK_EQ(overflow.filter_name, std::string("OverflowFilter"));
+        // The locator string DoRun embeds in the modal + Log message (named filter form).
+        IM_CHECK_STR_EQ(gui::FormatOverflowLocator(overflow).c_str(), "filter \"OverflowFilter\", Layer 1 / Entry 1");
       }
+    };
+  }
+
+  // FormatOverflowLocator format contract (pure function, no GUI): the unnamed form drops the
+  // filter clause and keeps 1-based Layer/Entry, and the indices are presented as +1.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overflow_locator_format");
+    t->TestFunc = [](ImGuiTestContext*) {
+      gui::FilterOverflowInfo named;
+      named.layer_index = 2;
+      named.entry_index = 0;
+      named.filter_name = "MyFilter";
+      IM_CHECK_STR_EQ(gui::FormatOverflowLocator(named).c_str(), "filter \"MyFilter\", Layer 3 / Entry 1");
+      gui::FilterOverflowInfo unnamed;
+      unnamed.layer_index = 0;
+      unnamed.entry_index = 4;
+      // Empty filter_name -> no "filter \"...\"," clause, just the position.
+      IM_CHECK_STR_EQ(gui::FormatOverflowLocator(unnamed).c_str(), "Layer 1 / Entry 5");
+    };
+  }
+
+  // DoRun's Log-panel dedup gate (`PeekGuiWarning() != warning_msg`): a persistent overflow
+  // re-detected on every ~70ms debounce commit writes the Log line ONLY on the first detection
+  // (message unchanged -> gate closed), and re-opens (gate open) when the located filter/layer
+  // changes or after a successful commit clears the warning. This exercises the exact predicate
+  // DoRun uses so AC② (Log dedup) has automated coverage rather than only on-screen verification.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "overflow_log_dedup_gate");
+    t->TestFunc = [](ImGuiTestContext*) {
+      gui::ClearGuiWarning();
+      const std::string msg_a = "This filter has too many OR segments / values to apply (limit " +
+                                std::to_string(LUMICE_MAX_CONFIG_CLAUSES) +
+                                "; filter \"A\", Layer 1 / Entry 1).\nkept.";
+      // First detection: gate open -> would write the Log line.
+      IM_CHECK(gui::PeekGuiWarning() != msg_a);
+      gui::SetGuiWarning(msg_a);
+      // Same overflow re-detected on the next debounce commit: gate closed -> Log NOT re-written.
+      IM_CHECK(gui::PeekGuiWarning() == msg_a);
+      // User switches which filter overflows (new locator): gate open again -> re-logs.
+      const std::string msg_b = "This filter has too many OR segments / values to apply (limit " +
+                                std::to_string(LUMICE_MAX_CONFIG_CLAUSES) +
+                                "; filter \"B\", Layer 2 / Entry 1).\nkept.";
+      IM_CHECK(gui::PeekGuiWarning() != msg_b);
+      gui::SetGuiWarning(msg_b);
+      // A successful commit clears the warning: the same message would log again afterwards.
+      gui::ClearGuiWarning();
+      IM_CHECK(gui::PeekGuiWarning() != msg_a);
+      gui::ClearGuiWarning();
     };
   }
 

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -1401,6 +1401,14 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       ee_multi.max_len = 6;
       cross_check(ee_multi);
 
+      // Wildcard EE matrix: empty entry/exit strings map to LUMICE_EE_WILDCARD_SENTINEL and
+      // must survive struct↔JSON cross-check on both single and multi-value sides.
+      cross_check(gui::EntryExitParams{ "", "" });     // both wildcard -> 1 simple EE
+      cross_check(gui::EntryExitParams{ "", "5" });    // entry wildcard + single exit -> 1 simple EE
+      cross_check(gui::EntryExitParams{ "3", "" });    // single entry + exit wildcard -> 1 simple EE
+      cross_check(gui::EntryExitParams{ "3,5", "" });  // 2 entry values × wildcard exit -> 2 simple + 1 complex
+      cross_check(gui::EntryExitParams{ "", "3,5" });  // wildcard entry × 2 exit values -> 2 simple + 1 complex
+
       // Overflow: a raypath with more than LUMICE_MAX_CONFIG_CLAUSES OR segments exceeds the
       // composition ABI bounds -> FillLumiceConfig must return false (graceful degradation),
       // so app.cpp keeps the prior committed state instead of committing a truncated config.
@@ -1424,6 +1432,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
           too_many_segments += "3-5";
         }
         gui::FilterConfig f;
+        f.name = "OverflowFilter";  // named so overflow.filter_name assertion below is meaningful
         f.param = gui::RaypathParams{ too_many_segments };
         gui::g_state.filters.push_back(f);
         gui::Layer layer;
@@ -1435,11 +1444,17 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         layer.entries.push_back(e);
         gui::g_state.layers.push_back(layer);
         LUMICE_Config over{};
-        IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over));  // over ABI bounds -> false
+        gui::FilterOverflowInfo overflow;
+        IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over, &overflow));  // over ABI bounds -> false
         // "no partial writes on overflow" contract (ExpandFilterToStruct doc): the overflowing
         // filter bails before any filter/composition is written for it.
         IM_CHECK_EQ(over.filter_count, 0);
         IM_CHECK_EQ(over.composition_count, 0);
+        // Overflow identity: the first (layer 0, entry 0) reference is captured with the
+        // FilterConfig::name so the caller can locate the offending filter for the user.
+        IM_CHECK_EQ(overflow.layer_index, 0);
+        IM_CHECK_EQ(overflow.entry_index, 0);
+        IM_CHECK_EQ(overflow.filter_name, std::string("OverflowFilter"));
       }
     };
   }

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -3252,6 +3252,85 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_modal/spectrum_modal_reset_resets_to_preset_seed — inject a non-default custom
+  // spectrum baseline, open the modal, click Reset, OK to commit; verify the committed
+  // custom_spectrum matches the uniform 9-point 400–720nm/weight=1.0 preset seed
+  // (asserted against the construction formula, not BuildPresetSeed() itself, to keep
+  // the test independent of that private helper).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "spectrum_modal_reset_resets_to_preset_seed");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Step 1: establish a non-default custom-spectrum baseline via direct state
+      // injection (same technique as test_gui_import_export.cpp:262-263). Direct
+      // injection matches the "user already has a custom spectrum and clicks Edit
+      // to reopen it" scenario without depending on the Combo/button chain.
+      gui::g_state.sun.spectrum_index = gui::kCustomSpectrumIndex;
+      gui::g_state.sun.custom_spectrum = { { 450.0f, 0.5f }, { 550.0f, 1.0f }, { 650.0f, 0.7f } };
+
+      // Step 2: open the modal directly. See progress.md DECISION 2026-07-05: this
+      // is functionally equivalent to clicking "Edit spectrum...##spectrum_edit"
+      // (panels.cpp:965) but doesn't rely on the outer Combo showing that button.
+      gui::OpenSpectrumModal(gui::g_state);
+      ctx->Yield(3);
+
+      // Step 3: Reset + OK.
+      ctx->ItemClick("**/Reset##spec_reset");
+      ctx->Yield();
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##spec_ok");
+      ctx->Yield(2);
+
+      // Step 4: assert the committed spectrum matches the preset seed formula
+      // (9 points, 400–720 nm equidistant, weight=1.0). Independent of
+      // BuildPresetSeed() so a refactor of that helper can't silently drift this.
+      const auto& out = gui::g_state.sun.custom_spectrum;
+      IM_CHECK_EQ(gui::g_state.sun.spectrum_index, gui::kCustomSpectrumIndex);
+      IM_CHECK_EQ(out.size(), (size_t)9);
+      IM_CHECK_EQ(out.front().wavelength, 400.0f);
+      IM_CHECK_EQ(out.back().wavelength, 720.0f);
+      for (size_t i = 0; i < out.size(); ++i) {
+        const float expected_wl = 400.0f + static_cast<float>(i) * 40.0f;
+        IM_CHECK_EQ(out[i].wavelength, expected_wl);
+        IM_CHECK_EQ(out[i].weight, 1.0f);
+      }
+    };
+  }
+
+  // p2_modal/spectrum_modal_reset_then_cancel_keeps_state — Reset in the edit buffer,
+  // then Cancel; committed custom_spectrum and spectrum_index must stay at their
+  // pre-Reset values (transactional contract from task-323: OK is the sole commit).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "spectrum_modal_reset_then_cancel_keeps_state");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Baseline: a non-default committed custom spectrum.
+      const std::vector<gui::WlWeight> baseline = { { 450.0f, 0.5f }, { 550.0f, 1.0f }, { 650.0f, 0.7f } };
+      gui::g_state.sun.spectrum_index = gui::kCustomSpectrumIndex;
+      gui::g_state.sun.custom_spectrum = baseline;
+      const int baseline_index = gui::g_state.sun.spectrum_index;
+
+      // Open modal, Reset (mutates only the edit buffer), Cancel.
+      gui::OpenSpectrumModal(gui::g_state);
+      ctx->Yield(3);
+      ctx->ItemClick("**/Reset##spec_reset");
+      ctx->Yield();
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##spec_cancel");
+      ctx->Yield(2);
+
+      // Committed state must be untouched.
+      IM_CHECK_EQ(gui::g_state.sun.spectrum_index, baseline_index);
+      IM_CHECK_EQ(gui::g_state.sun.custom_spectrum.size(), baseline.size());
+      for (size_t i = 0; i < baseline.size(); ++i) {
+        IM_CHECK_EQ(gui::g_state.sun.custom_spectrum[i].wavelength, baseline[i].wavelength);
+        IM_CHECK_EQ(gui::g_state.sun.custom_spectrum[i].weight, baseline[i].weight);
+      }
+    };
+  }
+
   // p2_modal/filter_modal_ok_no_change_keeps_nullopt — open filter modal on empty
   // entry, click OK without touching anything: entry must stay nullopt (otherwise
   // a default-constructed filter "* In PBD" silently blocks all rays).

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -378,6 +378,7 @@ int main(int argc, char** argv) {
     // In fully headless CI `glfwGetMonitors` returns 0 → helper returns false
     // → caller falls back to FLT_MAX, matching the plan-intended behavior.
     gui::RenderEditModals(gui::g_state, window);
+    gui::RenderSpectrumModal(gui::g_state);
     gui::RenderUnsavedPopup(window);
 
     ImGui::Render();


### PR DESCRIPTION
GUI 小修 batch，两块独立的小改动一起走一个 PR。

## task-329 — Custom Spectrum modal Reset 按钮
- `Reset##spec_reset` 按钮恢复 `BuildPresetSeed()` 均匀种子；title-bar × + 右对齐 Reset 布局。
- 补齐 `test_gui_main.cpp` 缺失的 `RenderSpectrumModal` 渲染入口 + 2 条 GUI 交互测试。
- commits: `874bfeba`, `b53c903e`

## task-330 — filter 超 ABI 上限告警体验补齐（scrum-327.4 code-review 派生 3 子项）
- **① 提示文案标注触发的 filter/layer 身份**：`FillLumiceConfig` 新增可选 `FilterOverflowInfo` 出参，在展开失败现场就地捕获 `(layer, entry, filter name)`；`FormatOverflowLocator` 纯函数拼出 `filter "NAME", Layer L / Entry E`（1-based，与 panel 标题惯例一致），同一 locator 驱动弹窗与 Log。
- **② Log 面板超限去重**：`GUI_LOG_WARNING` 由 `PeekGuiWarning() != warning_msg` 门控，复用 `SetGuiWarning` 已有去重状态（不引第二状态源），持续超限期间只写一行。
- **③ 测试补齐**：`filter_expand_struct_vs_json` 加 overflow 身份 + wildcard EE cross-check；新增 `overflow_locator_format`（格式契约）与 `overflow_log_dedup_gate`（去重门控谓词）单测。
- commits: `32510b65`, `29ada5dc`, `ceb022f8`
- code-review round-2 APPROVE（Critical/Major=0）

## 验证
- `format.sh --check` / `check_policies.py` 全过。
- `gui_test`：`filter_expand` / `overflow_locator` / `overflow_log_dedup` / `gui_warning_dedup` 各 1/1；全量 304/306，2 fail 为已知 auto_ev 家族贴阈值随机 flake（重跑数据佐证，diff 零触碰渲染/EV/overlay 代码）。

## 遗留（owner on-screen 视觉验证）
超限告警的弹窗文案 + Log 面板行数在真实拖拽下的视觉呈现待人工确认（去重的决策逻辑已单测覆盖）。

core 语义零改动，改动均限于 `src/gui/` + 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)