### PR TITLE
Unify orientation latitude sampling to a cosine-measure inverse-CDF LUT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(lumice_core_src
   "${PROJ_SRC_DIR}/core/device_filter_desc.cpp"
   "${PROJ_SRC_DIR}/core/filter_spec.cpp"
   "${PROJ_SRC_DIR}/core/geo3d.cpp"
+  "${PROJ_SRC_DIR}/core/lat_lut.cpp"
   "${PROJ_SRC_DIR}/core/math.cpp"
   "${PROJ_SRC_DIR}/core/optics.cpp"
   "${PROJ_SRC_DIR}/core/projection.cpp"

--- a/doc/near-pole-area-measure-sampling.md
+++ b/doc/near-pole-area-measure-sampling.md
@@ -1,8 +1,16 @@
 # 近极面积测度采样设计（Near-Pole Area-Measure Sampling）
 
-> 状态：设计蓝图（explore-326 GO + scrum-328 子任务 328.1 收敛，2026-07-04）。
-> 改近极朝向采样 / GPU device gen sampler / Rayleigh 路 / `ComputeJacobianEnvelope` 前先读。
+> 状态：设计蓝图（explore-326 GO + scrum-328 子任务 328.1 收敛，2026-07-04）。**已被统一 LUT 取代并落地——见下方「收尾（330.x）」。**
+> 改近极朝向采样 / GPU device gen sampler / 统一 LUT 路 前先读。
 > 关联：`crystal-orientation-sampling.md`、`numerical-robustness.md`、`gpu-single-engine-implementation.md`。
+
+> ## 收尾（330.x：统一 inverse-CDF LUT 取代本文 §2 分支）
+>
+> scrum-unify-orientation-sampling-cosine-measure 用**单一数值 inverse-CDF 面积测度 LUT**（`kLutInverseCdf`）取代了本文 §2 描述的**每分布 tight-envelope 分支**（Rayleigh / Gamma(2,b)）**及** off-pole generic-rejection：
+> - 330.2 落地统一 LUT（`lat_lut.cpp::BuildLatLut` + `pcg_shared.h::invert_lat_lut`/`lat_lut_bin`），三后端验证（CPU + Metal + CUDA dev49 parity 10/10），并把 `SelectLatPath` 全部路由到 `kLutInverseCdf`。
+> - 330.3 **删除**已不可达的死分支：`sample_lat_lon_roll` / `SampleSphericalPointsSph` 的 Rayleigh / LaplacianTightEnvelope / GenericReject 分支体、`ComputeJacobianEnvelope` 及其 host 镜像、`pcg_sinc`/`pcg_gamma2` helper、`LatPathKind` 的 kRayleigh(2)/kGenericReject(4)/kLaplacianTightEnvelope(5) 枚举值与对应 `lm_pcg::kLatPath*` 常量（wire 数值 0/1/3/6 保持不变，2/4/5 留空位）。
+> - §2 的**精确性推导（`sinθ≤θ` 上界、`base_pdf·θ` 提案、`sinθ/θ` 接受）仍是 LUT 目标密度 `∝ base_pdf(θ)·sinθ` 的理论依据**，故本文保留作设计记录；但 §2/§4 描述的分支实现已不在代码中。
+> - `GenRootKernelParams` 的 `lat_dist_type`/`lat_rejection_m` 字段现为死字段（wire 布局冻结，标注 `// dead post-330.3`）。
 
 ## 1. 问题
 
@@ -53,17 +61,19 @@ proposed 采样器**有意偏离**当前采样器（更精确）：
 
 **故 parity 绝不可 bit/KS-match 当前采样器**——须对**解析目标 `∝exp(−θ/b)·sinθ`** 或 `current(M=1)`（无 clamp 参照）验证。天真"匹配旧行为"的 parity 测试会对正确改进的代码判 FAIL。
 
-## 4. 三后端接线矩阵
+## 4. 三后端接线矩阵（330.x 后：统一 LUT 单路径）
 
-| 层 | 位置 | 改动 |
+> 历史注：本节原描述 Rayleigh / Gamma(2,b) / generic-rejection 三分支 × 三后端的接线。330.2/330.3 后**只剩单一 LUT 路径**，下表为 as-built。
+
+| 层 | 位置 | 现状（统一 LUT） |
 |----|------|------|
-| **device sampler（单源→Metal shader+CUDA）** | `pcg_shared.h::sample_lat_lon_roll` L269-320 | Rayleigh 分支 L281-290 加 `sinθ/θ` 接受；新增 Laplacian Gamma(2,b) 分支 + `pcg_gamma2` helper；新/扩 `lat_path` 常量 |
-| **CPU sampler** | `math.cpp::SampleSphericalPointsSph` L444-534 | 镜像同上 |
-| **host path-selection ×3** | `math.cpp:462-475` / `metal_trace_backend.mm:1456-1484` / `cuda_trace_backend.cu:296-324` | 触发放宽（mean≈±90 任意 σ）；⭐建议下沉共享 `SelectLatPath(axis_dist)→{lat_path, rejection_m}` 消 3× 镜像 |
-| **envelope ×3** | `math.cpp:422` / `metal.mm:202` / `cuda.cu:256` | uniform P0 修（M=cos min纬）；tight-envelope 路 M=1 |
-| **struct 镜像** | `GenRootKernelParams`（pcg_shared.h）↔ `metal.mm:159` | 布局自动化门禁 |
+| **device sampler（单源→Metal shader+CUDA）** | `pcg_shared.h::sample_lat_lon_roll` | 仅 `kLatPathLutInverseCdf` 分支：`invert_lat_lut` + `lat_lut_bin`（一次 uniform draw，无拒绝循环）；另存 `kFullSphere`/`kNoRandom`/`kGaussLegacy` 退化路 |
+| **CPU sampler** | `math.cpp::SampleSphericalPointsSph` | 镜像同上（共享 `invert_lat_lut`/`lat_lut_bin`）|
+| **LUT 构建（host）** | `lat_lut.cpp::BuildLatLut` | 一次性 per-axis 构建 theta/cdf/flip 节点表（`lm_pcg::normalize_latitude` 单源折叠），线程本地缓存 |
+| **host path-selection ×3** | `lat_path::SelectLatPath`（`lat_path_selection.hpp`，单源） | 非退化分布 → `{kLutInverseCdf, 1.0f}`；三后端各调同一函数 |
+| **struct 镜像** | `GenRootKernelParams`（pcg_shared.h）↔ `metal.mm` | 布局冻结（`lat_dist_type`/`lat_rejection_m` 死字段）；LUT 数组走独立 device buffer（不入 setBytes struct）|
 
-> `pcg_shared.h` 被 `lumice_trace.metal`(shader) + `cuda_trace_backend.cu` + `metal_trace_backend.mm` 同编 → device sampler 一处即两 GPU 后端；但 host 触发/envelope 三后端手工镜像。
+> `pcg_shared.h` 被 `lumice_trace.metal`(shader) + `cuda_trace_backend.cu` + `metal_trace_backend.mm` 同编 → device sampler 一处即两 GPU 后端；`SelectLatPath` 已在 `lat_path_selection.hpp` 单源，不再三后端手工镜像。
 
 ## 5. device RNG-stream 可观测性设施 co-design
 

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -954,7 +954,7 @@ __global__ void transit_multi_ms_kernel(
   float roll = 0.0f;
   // scrum-328.2 Step 1: transit does not (yet) surface attempt-count — the
   // near-pole acceptance-rate observation is anchored to the gen sampler.
-  lm_pcg::sample_lat_lon_roll(stream, gp, lon, lat, roll, nullptr);
+  lm_pcg::sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll, nullptr);  // 330.2 S3: LUT buffers pending S3b
 
   float mat9[9];
   lm_pcg::build_crystal_rotation_9(lon, lat, roll, mat9);
@@ -1117,7 +1117,8 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
   // Pass `&attempts_local` only when the sibling buffer is bound — the branch
   // predicts trivially in production (d_lat_attempts always nullptr), and the
   // per-ray write below is likewise short-circuited.
-  lm_pcg::sample_lat_lon_roll(stream, gp, lon, lat, roll,
+  // 330.2 S3: LUT arrays nullptr until buffers bound (S3b); branch dormant until S5.
+  lm_pcg::sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll,
                               d_lat_attempts != nullptr ? &attempts_local : nullptr);
   if (d_lat_attempts != nullptr) {
     d_lat_attempts[tid + attempts_ci_start] = attempts_local;

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -81,7 +81,7 @@
 #include "core/projection.hpp"  // ComputeEARScale (dual-fisheye r_scale derivation)
 #include "core/shared/accum_shared.h"  // AccumXyzToPixel (S2 device-fused emit gate)
 #include "core/shared/filter_shared.h"
-#include "core/shared/lat_path_selection.hpp"  // SelectLatPath / ComputeJacobianEnvelope (single source)
+#include "core/shared/lat_path_selection.hpp"  // SelectLatPath (single source)
 #include "core/shared/optics_shared.h"
 #include "core/shared/pcg_shared.h"
 #include "core/shared/projection_shared.h"  // RectangularForward / FisheyeEqualAreaForward
@@ -261,15 +261,8 @@ static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kFullSphere) == lm_pc
               "LatPathKind::kFullSphere must match lm_pcg::kLatPathFullSphere");
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kNoRandom) == lm_pcg::kLatPathNoRandom,
               "LatPathKind::kNoRandom must match lm_pcg::kLatPathNoRandom");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kRayleigh) == lm_pcg::kLatPathRayleigh,
-              "LatPathKind::kRayleigh must match lm_pcg::kLatPathRayleigh");
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kGaussLegacy) == lm_pcg::kLatPathGaussLegacy,
               "LatPathKind::kGaussLegacy must match lm_pcg::kLatPathGaussLegacy");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kGenericReject) == lm_pcg::kLatPathGenericReject,
-              "LatPathKind::kGenericReject must match lm_pcg::kLatPathGenericReject");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kLaplacianTightEnvelope) ==
-                  lm_pcg::kLatPathLaplacianTightEnvelope,
-              "LatPathKind::kLaplacianTightEnvelope must match lm_pcg::kLatPathLaplacianTightEnvelope");
 
 // Build the transit-form GenRootKernelParams. Mirrors Metal's
 // `BuildTransitRootParams` (metal_trace_backend.mm:1593): orientation +
@@ -1070,8 +1063,8 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
                                 //                       d_rng_probe[tid + probe_ci_start]. Used for
                                 //                       RngProbeStream::kGen isolation.
                                 //   d_lat_attempts    — non-null → each thread writes its
-                                //                       kLatPathGenericReject inner-loop iteration
-                                //                       count (1 for direct-path) to
+                                //                       rejection-loop iteration count (always 1
+                                //                       since 330.3; every path rejection-free) to
                                 //                       d_lat_attempts[tid + attempts_ci_start].
                                 //                       Consumer: near-pole acceptance-rate smoke.
                                 float* __restrict__ d_rng_probe,
@@ -1318,8 +1311,9 @@ struct CudaTraceBackend::Impl {
   size_t probe_ci_start_ = 0;  // ci-window offset applied at probe write (see EnableRngProbeForTest hpp doc)
   // [TEST-ONLY] scrum-328.2 Step 1: per-ray attempt-count sibling buffer
   // (nullptr in production; allocated by EnableGenAttemptCountForTest). Bound
-  // → gen_root_kernel writes each ray's kLatPathGenericReject iteration count
-  // via sample_lat_lon_roll's out_attempts arg. Independent of the RNG probe.
+  // → gen_root_kernel writes each ray's rejection-loop iteration count (always
+  // 1 since 330.3) via sample_lat_lon_roll's out_attempts arg. Independent of
+  // the RNG probe.
   int* d_lat_attempts_ = nullptr;
   size_t lat_attempts_cap_ = 0;
   size_t lat_attempts_ci_start_ = 0;

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -75,6 +75,7 @@
 #include "core/math.hpp"
 #include "core/raypath.hpp"
 #include "core/geo3d.hpp"  // Rotation (camera rotation for BuildProjParams)
+#include "core/lat_lut.hpp"          // BuildLatLut / LatLut (330.2 unified LUT sampler)
 #include "core/lens_proj_build.hpp"  // BuildProjParams / ProjParams (315.3 unified render projection)
 #include "core/math.hpp"  // math::kDegreeToRad
 #include "core/projection.hpp"  // ComputeEARScale (dual-fisheye r_scale derivation)
@@ -299,6 +300,10 @@ lm_pcg::GenRootKernelParams BuildTransitGpParams(const AxisDistribution& axis_di
   gp.lat_mean_rad    = lat_mean_rad;
   gp.lat_std_rad     = lat_std_rad;
   gp.lat_rejection_m = decision.rejection_m;
+  // 330.2 S6: node count is the device signal that the LUT buffers hold valid
+  // data (0 on every non-LUT path). The arrays themselves are passed as separate
+  // kernel pointer args. Mirrors Metal BuildGenRootParams.
+  gp.lat_lut_n = (decision.kind == lat_path::LatPathKind::kLutInverseCdf) ? LatLut::kNodes : 0u;
 
   gp.az_type     = static_cast<uint32_t>(axis_dist.azimuth_dist.type);
   gp.az_mean_rad = axis_dist.azimuth_dist.mean * math::kDegreeToRad;
@@ -909,6 +914,10 @@ __global__ void transit_multi_ms_kernel(
     const float* __restrict__ d_tri_norm,         // 3 × tri_cnt (outward triangle normal)
     const float* __restrict__ d_tri_area,         // tri_cnt
     const uint16_t* __restrict__ d_tri_to_poly,   // tri_cnt (kInvalidId on coplanar miss)
+    // 330.2 S6: unified latitude LUT (read only when gp.lat_lut_n > 0).
+    const float* __restrict__ d_lat_lut_theta,
+    const float* __restrict__ d_lat_lut_cdf,
+    const float* __restrict__ d_lat_lut_flip,
     lm_pcg::GenRootKernelParams gp,
     uint32_t n_rays,
     // [TEST-ONLY] nullptr in production. task-gpu-rng-ray-index-uint64 white-box
@@ -954,7 +963,7 @@ __global__ void transit_multi_ms_kernel(
   float roll = 0.0f;
   // scrum-328.2 Step 1: transit does not (yet) surface attempt-count — the
   // near-pole acceptance-rate observation is anchored to the gen sampler.
-  lm_pcg::sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll, nullptr);  // 330.2 S3: LUT buffers pending S3b
+  lm_pcg::sample_lat_lon_roll(stream, gp, d_lat_lut_theta, d_lat_lut_cdf, d_lat_lut_flip, lon, lat, roll, nullptr);  // 330.2 S6
 
   float mat9[9];
   lm_pcg::build_crystal_rotation_9(lon, lat, roll, mat9);
@@ -1047,6 +1056,10 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
                                 const float* __restrict__ d_tri_area,   // tri_cnt
                                 const uint16_t* __restrict__ d_tri_to_poly,  // tri_cnt
                                 const WlEntry* __restrict__ d_wl_pool,  // wl_pool_size entries
+                                // 330.2 S6: unified latitude LUT (read only when gp.lat_lut_n > 0).
+                                const float* __restrict__ d_lat_lut_theta,
+                                const float* __restrict__ d_lat_lut_cdf,
+                                const float* __restrict__ d_lat_lut_flip,
                                 lm_pcg::GenRootKernelParams gp,
                                 uint32_t n_rays,
                                 // [TEST-ONLY] scrum-328.2 Step 1 RNG-probe / attempt-count observability
@@ -1117,8 +1130,8 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
   // Pass `&attempts_local` only when the sibling buffer is bound — the branch
   // predicts trivially in production (d_lat_attempts always nullptr), and the
   // per-ray write below is likewise short-circuited.
-  // 330.2 S3: LUT arrays nullptr until buffers bound (S3b); branch dormant until S5.
-  lm_pcg::sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll,
+  // 330.2 S6: unified LUT arrays (consumed only on the kLutInverseCdf branch).
+  lm_pcg::sample_lat_lon_roll(stream, gp, d_lat_lut_theta, d_lat_lut_cdf, d_lat_lut_flip, lon, lat, roll,
                               d_lat_attempts != nullptr ? &attempts_local : nullptr);
   if (d_lat_attempts != nullptr) {
     d_lat_attempts[tid + attempts_ci_start] = attempts_local;
@@ -1310,6 +1323,15 @@ struct CudaTraceBackend::Impl {
   int* d_lat_attempts_ = nullptr;
   size_t lat_attempts_cap_ = 0;
   size_t lat_attempts_ci_start_ = 0;
+
+  // 330.2 S6: unified area-measure inverse-CDF latitude LUT (theta/cdf/flip),
+  // three fixed-size (LatLut::kNodes float) device buffers rebuilt per-ci by
+  // UploadLatLut when the axis distribution routes to kLatPathLutInverseCdf.
+  // gen_root_kernel / transit_multi_ms_kernel read them only when
+  // gp.lat_lut_n > 0 (mirrors Metal lat_lut_*_buf_ at buffer 14/15/16).
+  float* d_lat_lut_theta_ = nullptr;
+  float* d_lat_lut_cdf_   = nullptr;
+  float* d_lat_lut_flip_  = nullptr;
   float* d_pos_ = nullptr;
   float* d_ws_ = nullptr;
   uint32_t* d_from_poly_ = nullptr;  // per-ray entry-face polygon id
@@ -1544,6 +1566,12 @@ struct CudaTraceBackend::Impl {
   void EnsureGeomCapacity(size_t poly_cnt, size_t tri_cnt);
   void UploadCrystalGeometry(const Crystal& crystal);
 
+  // 330.2 S6: lazily cudaMalloc the three fixed-size LUT buffers (called from
+  // UploadLatLut). Rebuild + H2D-copy the LUT for the given axis distribution
+  // when it routes to kLutInverseCdf; per-ci cadence covers gen + transit.
+  void EnsureLatLutBuffers();
+  void UploadLatLut(const AxisDistribution& axis);
+
   // scrum-306.2: build the per-(layer,ci) geometry pool once (device-gen path).
   // Consumes rng_ via MakeCrystal in the EXACT ci-loop order (layers outer, ci
   // inner) so pooled shapes are byte-identical to the prior per-batch upload.
@@ -1568,6 +1596,11 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
   d_lat_attempts_ = nullptr;
   lat_attempts_cap_ = 0;
   lat_attempts_ci_start_ = 0;
+  // 330.2 S6: release the unified LUT buffers on teardown; EnsureLatLutBuffers
+  // re-allocates lazily on the next session's first UploadLatLut.
+  cudaFree(d_lat_lut_theta_); d_lat_lut_theta_ = nullptr;
+  cudaFree(d_lat_lut_cdf_);   d_lat_lut_cdf_ = nullptr;
+  cudaFree(d_lat_lut_flip_);  d_lat_lut_flip_ = nullptr;
   //
   // scrum-cuda-async-engine-port (304.2): per-batch EndSession passes
   // keep_persistent_buffers=true so the large device + pinned buffers
@@ -1767,6 +1800,41 @@ void CudaTraceBackend::Impl::UploadCrystalGeometry(const Crystal& crystal) {
 
   poly_cnt_ = static_cast<uint32_t>(poly_cnt);
   tri_cnt_  = static_cast<uint32_t>(tri_cnt);
+}
+
+// 330.2 S6: allocate the three fixed-size LUT device buffers if not present.
+// gen/transit kernels always receive these pointers; their contents are read
+// only when gp.lat_lut_n > 0. Mirrors Metal EnsureLatLutBuffers.
+void CudaTraceBackend::Impl::EnsureLatLutBuffers() {
+  constexpr size_t kBytes = static_cast<size_t>(LatLut::kNodes) * sizeof(float);
+  if (d_lat_lut_theta_ == nullptr) {
+    CheckCuda(cudaMalloc(&d_lat_lut_theta_, kBytes), "EnsureLatLutBuffers cudaMalloc d_lat_lut_theta");
+  }
+  if (d_lat_lut_cdf_ == nullptr) {
+    CheckCuda(cudaMalloc(&d_lat_lut_cdf_, kBytes), "EnsureLatLutBuffers cudaMalloc d_lat_lut_cdf");
+  }
+  if (d_lat_lut_flip_ == nullptr) {
+    CheckCuda(cudaMalloc(&d_lat_lut_flip_, kBytes), "EnsureLatLutBuffers cudaMalloc d_lat_lut_flip");
+  }
+}
+
+// 330.2 S6: rebuild the latitude LUT for this ci's axis distribution and H2D-copy
+// the three arrays. Only the LUT-routed families consume the contents; other
+// paths leave stale data (never read). Per-ci cadence covers gen + transit.
+// Mirrors Metal UploadLatLut.
+void CudaTraceBackend::Impl::UploadLatLut(const AxisDistribution& axis) {
+  EnsureLatLutBuffers();
+  if (lat_path::SelectLatPath(axis).kind != lat_path::LatPathKind::kLutInverseCdf) {
+    return;
+  }
+  LatLut lut = BuildLatLut(axis.latitude_dist);
+  constexpr size_t kBytes = static_cast<size_t>(LatLut::kNodes) * sizeof(float);
+  CheckCuda(cudaMemcpy(d_lat_lut_theta_, lut.theta.data(), kBytes, cudaMemcpyHostToDevice),
+            "UploadLatLut cudaMemcpy d_lat_lut_theta");
+  CheckCuda(cudaMemcpy(d_lat_lut_cdf_, lut.cdf.data(), kBytes, cudaMemcpyHostToDevice),
+            "UploadLatLut cudaMemcpy d_lat_lut_cdf");
+  CheckCuda(cudaMemcpy(d_lat_lut_flip_, lut.flip_prob.data(), kBytes, cudaMemcpyHostToDevice),
+            "UploadLatLut cudaMemcpy d_lat_lut_flip");
 }
 
 void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene) {
@@ -2632,6 +2700,12 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       geom_tri_cnt = impl_->pool_tri_cnt_[slot];
     }
 
+    // 330.2 S6: rebuild the latitude LUT for this ci's axis distribution before
+    // the gen/transit dispatch (mirrors Metal ResolveLayerCrystalForCi's
+    // per-ci UploadLatLut). Depends only on the axis dist; the device-gen gen
+    // kernel and every layer's transit kernel of this ci read the same table.
+    impl_->UploadLatLut(ms_setting.crystal_.axis_);
+
     // ── Generate / transit this ci's root rays into root buf [0, ci_n) ──────
     if (first_ms && !impl_->disable_device_gen_) {
       // Device root-gen (296.6): samples orientation + sun-cone dir + entry point
@@ -2661,7 +2735,9 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       gen_root_kernel<<<grid, 256, 0, impl_->stream_>>>(impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
                                      impl_->d_rot_c2w_, impl_->d_root_wl_idx_, geom_tri_vtx,
                                      geom_tri_norm, geom_tri_area, geom_tri_to_poly,
-                                     impl_->d_wl_pool_, gp, cin,
+                                     impl_->d_wl_pool_,
+                                     impl_->d_lat_lut_theta_, impl_->d_lat_lut_cdf_, impl_->d_lat_lut_flip_,
+                                     gp, cin,
                                      gen_probe_arg,
                                      static_cast<uint32_t>(impl_->probe_ci_start_ + probe_win_off),
                                      impl_->d_lat_attempts_,
@@ -2741,6 +2817,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
           impl_->d_dirs_, impl_->d_pos_, impl_->d_ws_, impl_->d_from_poly_,
           impl_->d_rot_c2w_, impl_->d_root_wl_idx_,
           geom_tri_vtx, geom_tri_norm, geom_tri_area, geom_tri_to_poly,
+          impl_->d_lat_lut_theta_, impl_->d_lat_lut_cdf_, impl_->d_lat_lut_flip_,
           gp, cin, transit_probe_arg,
           static_cast<uint32_t>(impl_->probe_ci_start_ + probe_win_off));
       ck_reset(cudaPeekAtLastError(), "transit kernel launch");

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -34,6 +34,7 @@
 #include "core/exit_seam.hpp"
 #include "core/filter_spec.hpp"
 #include "core/geo3d.hpp"
+#include "core/lat_lut.hpp"          // BuildLatLut / LatLut (330.2 unified LUT sampler)
 #include "core/lens_proj_build.hpp"  // BuildProjParams / ProjParams (315.3 unified render projection)
 #include "core/math.hpp"
 #include "core/metal_filter_match_src.hpp"
@@ -572,6 +573,16 @@ struct MetalTraceBackend::Impl {
   id<MTLBuffer> tri_to_poly_buf_ = nil;  // N_tri × 1 uint16 (kInvalidId on miss)
   size_t        tri_buf_capacity_ = 0;
 
+  // Unified area-measure inverse-CDF latitude LUT (330.2). Three fixed-size
+  // (LatLut::kNodes float) shared buffers rebuilt per-ci by UploadLatLut when the
+  // orientation distribution routes to kLatPathLutInverseCdf. Metal forbids nil
+  // bindings, so the buffers are always allocated (EnsureLatLutBuffers) and bound
+  // at indices 14/15/16 in gen_root/transit_root; their CONTENTS are only read by
+  // the shader when gp.lat_path == kLatPathLutInverseCdf (gp.lat_lut_n > 0).
+  id<MTLBuffer> lat_lut_theta_buf_ = nil;  // LatLut::kNodes float (colatitude nodes)
+  id<MTLBuffer> lat_lut_cdf_buf_   = nil;  // LatLut::kNodes float (CDF)
+  id<MTLBuffer> lat_lut_flip_buf_  = nil;  // LatLut::kNodes float (flip prob)
+
   // Continuation ping-pong (indexed by ms_idx & 1).
   // scrum-267 task-fused-emit-gate Step 4b: the parallel cont_crystal_id /
   // cont_face_seq_* buffers (formerly slots 24-26) are removed — the emit gate
@@ -696,6 +707,12 @@ struct MetalTraceBackend::Impl {
   void EnsureFilterBuffers(const SessionSpec& session_spec);  // scrum-267.1
   void EnsureWlPoolBuffer();  // scrum-268.8 (DR-3) per-ray wavelength pool
   void UploadCrystal(const Crystal& crystal);
+  // 330.2 S3b: lazily allocate the three fixed-size (LatLut::kNodes float) shared
+  // LUT buffers (always bound, so they must always exist).
+  void EnsureLatLutBuffers();
+  // 330.2 S3b: rebuild + upload the latitude LUT for the given axis distribution
+  // when it routes to kLatPathLutInverseCdf (per-ci cadence; covers gen + transit).
+  void UploadLatLut(const AxisDistribution& axis);
   void ResolveLayerCrystalForCi(const ScatteringSetting& setting, bool use_host,
                                 const HostRayBatch& host_batch);
   size_t GenerateFirstLayerRootsForCi(const ScatteringSetting& setting,
@@ -1241,6 +1258,42 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
   }
 }
 
+// 330.2 S3b: allocate the three fixed-size shared LUT buffers if not yet present.
+// Metal validation forbids nil bindings, so gen_root/transit_root always bind
+// these at 14/15/16 even for non-LUT paths; their contents are read only when
+// gp.lat_path == kLatPathLutInverseCdf. The size never varies (LatLut::kNodes).
+void MetalTraceBackend::Impl::EnsureLatLutBuffers() {
+  constexpr NSUInteger kLen = static_cast<NSUInteger>(LatLut::kNodes) * sizeof(float);
+  if (lat_lut_theta_buf_ == nil) {
+    lat_lut_theta_buf_ = [device newBufferWithLength:kLen options:MTLResourceStorageModeShared];
+    assert(lat_lut_theta_buf_ != nil);
+  }
+  if (lat_lut_cdf_buf_ == nil) {
+    lat_lut_cdf_buf_ = [device newBufferWithLength:kLen options:MTLResourceStorageModeShared];
+    assert(lat_lut_cdf_buf_ != nil);
+  }
+  if (lat_lut_flip_buf_ == nil) {
+    lat_lut_flip_buf_ = [device newBufferWithLength:kLen options:MTLResourceStorageModeShared];
+    assert(lat_lut_flip_buf_ != nil);
+  }
+}
+
+// 330.2 S3b: rebuild the latitude LUT for this ci's orientation distribution and
+// memcpy the three arrays into the shared buffers. Only the LUT-routed families
+// consume the contents; other paths leave stale buffer data (never read). Called
+// at per-ci cadence from ResolveLayerCrystalForCi (covers gen AND transit).
+void MetalTraceBackend::Impl::UploadLatLut(const AxisDistribution& axis) {
+  EnsureLatLutBuffers();
+  if (lat_path::SelectLatPath(axis).kind != lat_path::LatPathKind::kLutInverseCdf) {
+    return;
+  }
+  LatLut lut = BuildLatLut(axis.latitude_dist);
+  constexpr size_t kLen = static_cast<size_t>(LatLut::kNodes) * sizeof(float);
+  std::memcpy([lat_lut_theta_buf_ contents], lut.theta.data(), kLen);
+  std::memcpy([lat_lut_cdf_buf_ contents], lut.cdf.data(), kLen);
+  std::memcpy([lat_lut_flip_buf_ contents], lut.flip_prob.data(), kLen);
+}
+
 void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& setting,
                                                         bool use_host,
                                                         const HostRayBatch& host_batch) {
@@ -1259,6 +1312,10 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
   }
   have_crystal = true;
   UploadCrystal(current_crystal);
+  // 330.2 S3b: rebuild the latitude LUT at the same per-ci cadence — it depends
+  // only on the axis distribution and is shared by the gen and transit passes of
+  // this ci. EnsureLatLutBuffers (inside) keeps the buffers non-nil for binding.
+  UploadLatLut(setting.crystal_.axis_);
   // scrum-268.8 (DR-3): pool upload moved to BeginSession — Crystal::
   // GetRefractiveIndex delegates to a global IceRefractiveIndex::Get so the
   // refractive index per wavelength is identical across every crystal shape
@@ -1468,6 +1525,11 @@ GenRootKernelParams MetalTraceBackend::Impl::BuildGenRootParams(
   gp.lat_mean_rad    = lat_mean_rad;
   gp.lat_std_rad     = lat_std_rad;
   gp.lat_rejection_m = decision.rejection_m;
+  // 330.2 S3b: node count is the shader-side signal that the LUT buffers hold
+  // valid data (0 for every non-LUT path). The arrays themselves bind separately.
+  gp.lat_lut_n = (decision.kind == lat_path::LatPathKind::kLutInverseCdf)
+                     ? lumice::LatLut::kNodes
+                     : 0u;
 
   gp.az_type     = static_cast<uint32_t>(axis_dist.azimuth_dist.type);
   gp.az_mean_rad = axis_dist.azimuth_dist.mean * math::kDegreeToRad;
@@ -1490,6 +1552,9 @@ GenRootKernelParams MetalTraceBackend::Impl::BuildGenRootParams(
 void MetalTraceBackend::Impl::EncodeGenRoot(id<MTLCommandBuffer> cb,
                                             const GenRootKernelParams& gp) {
   @autoreleasepool {
+    // 330.2 S3b: guarantee the LUT buffers exist before binding (Metal forbids
+    // nil bindings even on the non-LUT paths that never read their contents).
+    EnsureLatLutBuffers();
     id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
     [enc setComputePipelineState:gen_root_pso_];
     [enc setBuffer:root_d_buf     offset:0 atIndex:0];
@@ -1521,6 +1586,10 @@ void MetalTraceBackend::Impl::EncodeGenRoot(id<MTLCommandBuffer> cb,
     uint attempts_ctrl[2] = { attempts_enabled_ ? 1u : 0u,
                               static_cast<uint>(pending_attempts_ci_start_) };
     [enc setBytes:attempts_ctrl length:sizeof(attempts_ctrl) atIndex:13];
+    // 330.2 S3b: unified latitude LUT arrays (read only when lat_path==LutInverseCdf).
+    [enc setBuffer:lat_lut_theta_buf_ offset:0 atIndex:14];
+    [enc setBuffer:lat_lut_cdf_buf_   offset:0 atIndex:15];
+    [enc setBuffer:lat_lut_flip_buf_  offset:0 atIndex:16];
     NSUInteger threads = 64;
     NSUInteger groups = (static_cast<NSUInteger>(gp.num_rays) + threads - 1) / threads;
     [enc dispatchThreadgroups:MTLSizeMake(groups, 1, 1)
@@ -1582,6 +1651,8 @@ void MetalTraceBackend::Impl::EncodeTransitRoot(
   assert(cont_d[in_slot] != nil && cont_w[in_slot] != nil &&
          "EncodeTransitRoot: cont buffers must be allocated by EnsureContBuffer");
   @autoreleasepool {
+    // 330.2 S3b: guarantee the LUT buffers exist before binding (see EncodeGenRoot).
+    EnsureLatLutBuffers();
     id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
     [enc setComputePipelineState:transit_root_pso_];
     NSUInteger d_off = static_cast<NSUInteger>(ci_start) * 3u * sizeof(float);
@@ -1603,6 +1674,10 @@ void MetalTraceBackend::Impl::EncodeTransitRoot(
     NSUInteger wl_off = static_cast<NSUInteger>(ci_start) * sizeof(uint32_t);
     [enc setBuffer:cont_wl_idx_buf_[in_slot] offset:wl_off atIndex:12];
     [enc setBuffer:root_wl_idx_buf_          offset:0      atIndex:13];
+    // 330.2 S3b: unified latitude LUT arrays (read only when lat_path==LutInverseCdf).
+    [enc setBuffer:lat_lut_theta_buf_        offset:0      atIndex:14];
+    [enc setBuffer:lat_lut_cdf_buf_          offset:0      atIndex:15];
+    [enc setBuffer:lat_lut_flip_buf_         offset:0      atIndex:16];
     NSUInteger threads = 64;
     NSUInteger groups  = (static_cast<NSUInteger>(gp.num_rays) + threads - 1) / threads;
     [enc dispatchThreadgroups:MTLSizeMake(groups, 1, 1)

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -41,7 +41,7 @@
 #include "core/backend/metal_trace_backend.hpp"
 #include "core/backend/metal_trace_backend_test_hooks.hpp"  // scrum-328.2 Step 3
 #include "core/backend/wl_pool.hpp"  // WlEntry / ComputeWlPool / ResolveWlPoolSize (296.6 single-sourced)
-#include "core/shared/lat_path_selection.hpp"  // SelectLatPath / ComputeJacobianEnvelope (single source)
+#include "core/shared/lat_path_selection.hpp"  // SelectLatPath (single source)
 #include "core/shared/pcg_shared.h"             // lm_pcg::kLatPath* (device sink values)
 // task-#283 (metal-build-time-metallib): build-generated headers — wrap their
 // content in `namespace lumice { ... }`, so they are #included at file scope
@@ -132,15 +132,8 @@ static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kFullSphere) == lm_pc
               "LatPathKind::kFullSphere must match lm_pcg::kLatPathFullSphere");
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kNoRandom) == lm_pcg::kLatPathNoRandom,
               "LatPathKind::kNoRandom must match lm_pcg::kLatPathNoRandom");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kRayleigh) == lm_pcg::kLatPathRayleigh,
-              "LatPathKind::kRayleigh must match lm_pcg::kLatPathRayleigh");
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kGaussLegacy) == lm_pcg::kLatPathGaussLegacy,
               "LatPathKind::kGaussLegacy must match lm_pcg::kLatPathGaussLegacy");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kGenericReject) == lm_pcg::kLatPathGenericReject,
-              "LatPathKind::kGenericReject must match lm_pcg::kLatPathGenericReject");
-static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kLaplacianTightEnvelope) ==
-                  lm_pcg::kLatPathLaplacianTightEnvelope,
-              "LatPathKind::kLaplacianTightEnvelope must match lm_pcg::kLatPathLaplacianTightEnvelope");
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kLutInverseCdf) == lm_pcg::kLatPathLutInverseCdf,
               "LatPathKind::kLutInverseCdf must match lm_pcg::kLatPathLutInverseCdf");
 
@@ -171,10 +164,10 @@ struct GenRootKernelParams {
   // per-batch `ray_weight` (now per-ray from wl_pool[wl_idx].spd_weight).
   uint32_t wl_pool_size;
   uint32_t lat_path;
-  uint32_t lat_dist_type;   // DistributionType cast to uint
+  uint32_t lat_dist_type;   // dead post-330.3 (retired GenericReject path); wire layout frozen
   float    lat_mean_rad;
   float    lat_std_rad;
-  float    lat_rejection_m;
+  float    lat_rejection_m; // dead post-330.3 (surviving paths rejection-free); wire layout frozen
   uint32_t lat_lut_n;       // node count for kLatPathLutInverseCdf (330.2); LUT arrays bound separately
   uint32_t az_type;
   float    az_mean_rad;

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -140,6 +140,8 @@ static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kGenericReject) == lm
 static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kLaplacianTightEnvelope) ==
                   lm_pcg::kLatPathLaplacianTightEnvelope,
               "LatPathKind::kLaplacianTightEnvelope must match lm_pcg::kLatPathLaplacianTightEnvelope");
+static_assert(lat_path::ToWireValue(lat_path::LatPathKind::kLutInverseCdf) == lm_pcg::kLatPathLutInverseCdf,
+              "LatPathKind::kLutInverseCdf must match lm_pcg::kLatPathLutInverseCdf");
 
 // Mirror of the Metal-side GenRootKernelParams (host layout MUST match the
 // MSL struct field-for-field — all 4-byte scalars, natural alignment).
@@ -172,6 +174,7 @@ struct GenRootKernelParams {
   float    lat_mean_rad;
   float    lat_std_rad;
   float    lat_rejection_m;
+  uint32_t lat_lut_n;       // node count for kLatPathLutInverseCdf (330.2); LUT arrays bound separately
   uint32_t az_type;
   float    az_mean_rad;
   float    az_std_rad;
@@ -181,7 +184,7 @@ struct GenRootKernelParams {
   float    roll_std_rad;
   float    roll_pad;
 };
-static_assert(sizeof(GenRootKernelParams) == 88u,
+static_assert(sizeof(GenRootKernelParams) == 92u,
               "GenRootKernelParams size mismatch — update host struct to match Metal-side layout");
 
 size_t ComputeOutCap(size_t n, size_t max_hits) {

--- a/src/core/lat_lut.cpp
+++ b/src/core/lat_lut.cpp
@@ -1,0 +1,180 @@
+#include "core/lat_lut.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "core/shared/pcg_shared.h"  // lm_pcg::normalize_latitude — single-source fold (device-matched)
+
+namespace lumice {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kHalfPi = kPi / 2.0;
+constexpr double kDeg2Rad = kPi / 180.0;
+
+// Fine grids: histogram bins over colatitude [0, pi] and quadrature samples of the proposal.
+// Both are deterministic (no RNG). kQuad dominates build cost (~one-time per distribution).
+constexpr int kFine = 4096;
+constexpr int kQuad = 1 << 16;
+
+// Deterministic per-family latitude proposal transform L(U), U in (0,1), returns RADIANS.
+// Mirrors lm_pcg::pcg_get_dist / RandomNumberGenerator::Get (identical closed forms) so the LUT
+// target uses the SAME proposal the samplers draw. Gaussian is handled separately (analytic
+// normal-pdf quadrature) because its draw is Box-Muller, not a single-uniform inverse CDF.
+double ProposalLatFromU(DistributionType type, double mean_rad, double scale_rad, double u) {
+  switch (type) {
+    case DistributionType::kUniform:
+      return (u - 0.5) * scale_rad + mean_rad;
+    case DistributionType::kZigzag:
+      return std::abs(scale_rad * std::sin(u * 2.0 * kPi) + mean_rad);
+    case DistributionType::kLaplacian: {
+      const double sgn = (u < 0.5) ? -1.0 : 1.0;
+      const double arg = std::max(1.0 - 2.0 * std::abs(u - 0.5), 1e-30);
+      return mean_rad - scale_rad * sgn * std::log(arg);
+    }
+    default:
+      return mean_rad;  // unreachable for the U-quadrature families
+  }
+}
+
+// Linear interpolation of a cumulative array (size kFine+1, indexed by fine colatitude bin)
+// at an arbitrary colatitude theta in [0, pi].
+double LerpCum(const std::vector<double>& cum, double theta) {
+  const double x = theta / (kPi / kFine);
+  int i = static_cast<int>(x);
+  if (i < 0) {
+    return cum.front();
+  }
+  if (i >= kFine) {
+    return cum.back();
+  }
+  const double f = x - i;
+  return cum[i] * (1.0 - f) + cum[i + 1] * f;
+}
+
+// A degenerate but valid LUT (all mass at a single colatitude) for the guard path.
+LatLut DegenerateLut(double colat) {
+  LatLut lut;
+  const float c = static_cast<float>(std::min(std::max(colat, 0.0), kPi));
+  for (uint32_t i = 0; i < LatLut::kNodes; ++i) {
+    lut.theta[i] = c;
+    lut.cdf[i] = static_cast<float>(i) / static_cast<float>(LatLut::kNodes - 1);
+    lut.flip_prob[i] = 0.0f;
+  }
+  return lut;
+}
+
+}  // namespace
+
+LatLut BuildLatLut(const Distribution& lat_dist) {
+  const double mean_rad = static_cast<double>(lat_dist.mean) * kDeg2Rad;
+  const double scale_rad = static_cast<double>(lat_dist.std) * kDeg2Rad;
+  const DistributionType type = lat_dist.type;
+  const double dtheta = kPi / kFine;
+
+  // --- Deterministic quadrature: area-measure mass + flipped mass over colatitude bins. ---
+  std::vector<double> mass(kFine, 0.0);
+  std::vector<double> flip_mass(kFine, 0.0);
+
+  auto accumulate = [&](double lat_rad, double weight) {
+    float phi_out = 0.0f;
+    bool flip = false;
+    lm_pcg::normalize_latitude(static_cast<float>(lat_rad), phi_out, flip);
+    const double theta_z = kHalfPi - static_cast<double>(phi_out);  // colatitude-from-zenith [0, pi]
+    const double w = weight * std::sin(theta_z);                    // area Jacobian (= cos(latitude))
+    if (w <= 0.0) {
+      return;
+    }
+    int bin = static_cast<int>(theta_z / dtheta);
+    bin = std::min(std::max(bin, 0), kFine - 1);
+    mass[bin] += w;
+    if (flip) {
+      flip_mass[bin] += w;
+    }
+  };
+
+  if (type == DistributionType::kGaussian) {
+    // Analytic normal-pdf quadrature over latitude L in [mean - 12 sigma, mean + 12 sigma].
+    const double lo = mean_rad - 12.0 * scale_rad;
+    const double hi = mean_rad + 12.0 * scale_rad;
+    const double dL = (hi - lo) / kQuad;
+    const double inv2s2 = (scale_rad > 0.0) ? 1.0 / (2.0 * scale_rad * scale_rad) : 0.0;
+    for (int i = 0; i < kQuad; ++i) {
+      const double L = lo + (i + 0.5) * dL;
+      const double d = L - mean_rad;
+      accumulate(L, std::exp(-d * d * inv2s2) * dL);  // unnormalized normal (normalized below)
+    }
+  } else {
+    // U-quadrature: X = g(U), U ~ Uniform(0,1); each dU carries uniform weight. Exact for the
+    // transform-based families (uniform / laplacian / zigzag) and reuses their exact closed form.
+    const double dU = 1.0 / kQuad;
+    for (int i = 0; i < kQuad; ++i) {
+      const double u = (i + 0.5) * dU;
+      accumulate(ProposalLatFromU(type, mean_rad, scale_rad, u), dU);
+    }
+  }
+
+  // --- Cumulative arrays + total. ---
+  std::vector<double> cum_mass(kFine + 1, 0.0);
+  std::vector<double> cum_flip(kFine + 1, 0.0);
+  for (int i = 0; i < kFine; ++i) {
+    cum_mass[i + 1] = cum_mass[i] + mass[i];
+    cum_flip[i + 1] = cum_flip[i] + flip_mass[i];
+  }
+  const double total = cum_mass[kFine];
+  if (!(total > 0.0)) {
+    // No area-measure mass (e.g. scale == 0). Fall back to a delta at the folded mean colatitude.
+    float phi_out = 0.0f;
+    bool flip = false;
+    lm_pcg::normalize_latitude(static_cast<float>(mean_rad), phi_out, flip);
+    return DegenerateLut(kHalfPi - static_cast<double>(phi_out));
+  }
+
+  // --- Bracket the mass: [theta_lo, theta_hi] where the CDF crosses [1e-7, 1 - 1e-7]. ---
+  double theta_lo = 0.0;
+  double theta_hi = kPi;
+  for (int i = 0; i <= kFine; ++i) {
+    if (cum_mass[i] / total >= 1e-7) {
+      theta_lo = i * dtheta;
+      break;
+    }
+  }
+  for (int i = kFine; i >= 0; --i) {
+    if (cum_mass[i] / total <= 1.0 - 1e-7) {
+      theta_hi = i * dtheta;
+      break;
+    }
+  }
+  if (!(theta_hi > theta_lo)) {
+    return DegenerateLut(0.5 * (theta_lo + theta_hi));
+  }
+
+  // --- Resample kNodes uniform-theta nodes; CDF via interp; flip_prob per node interval. ---
+  LatLut lut;
+  const double span = theta_hi - theta_lo;
+  for (uint32_t n = 0; n < LatLut::kNodes; ++n) {
+    const double t = theta_lo + span * n / (LatLut::kNodes - 1);
+    lut.theta[n] = static_cast<float>(t);
+    lut.cdf[n] = static_cast<float>(LerpCum(cum_mass, t) / total);
+  }
+  // Enforce strict monotonicity so the binary search predicate is total and interpolation never
+  // divides by zero (fp32 CDF increments can underflow to bit-equal in low-density regions).
+  for (uint32_t n = 1; n < LatLut::kNodes; ++n) {
+    if (lut.cdf[n] <= lut.cdf[n - 1]) {
+      lut.cdf[n] = std::nextafter(lut.cdf[n - 1], std::numeric_limits<float>::infinity());
+    }
+  }
+  for (uint32_t n = 0; n + 1 < LatLut::kNodes; ++n) {
+    const double t0 = lut.theta[n];
+    const double t1 = lut.theta[n + 1];
+    const double m = LerpCum(cum_mass, t1) - LerpCum(cum_mass, t0);
+    const double fm = LerpCum(cum_flip, t1) - LerpCum(cum_flip, t0);
+    lut.flip_prob[n] = (m > 0.0) ? static_cast<float>(std::min(std::max(fm / m, 0.0), 1.0)) : 0.0f;
+  }
+  lut.flip_prob[LatLut::kNodes - 1] = lut.flip_prob[LatLut::kNodes - 2];
+  return lut;
+}
+
+}  // namespace lumice

--- a/src/core/lat_lut.hpp
+++ b/src/core/lat_lut.hpp
@@ -1,0 +1,46 @@
+#ifndef LM_LAT_LUT_H_
+#define LM_LAT_LUT_H_
+
+#include <array>
+#include <cstdint>
+
+#include "core/math.hpp"
+
+namespace lumice {
+
+// Precomputed inverse-CDF lookup table for unified area-measure latitude sampling
+// (330.2 core-lut-sampler; design: doc/near-pole-area-measure-sampling.md + explore
+// unify-orientation-sampling-cosine-measure). One branchless path replaces the near-pole
+// tight-envelope (Rayleigh/Gamma) and off-pole generic-rejection latitude samplers.
+//
+//   theta[i]      colatitude-from-zenith nodes, UNIFORMLY spaced over
+//                 [theta[0], theta[kNodes-1]] (the mass-bracketing sub-interval of [0, pi]).
+//                 Consumed by lm_pcg::invert_lat_lut (fixed 8-step binary search + interp).
+//   cdf[i]        strictly-increasing CDF of the folded area-measure target at theta[i].
+//   flip_prob[i]  P(flip = true | colatitude in [theta[i], theta[i+1])), i in [0, kNodes-2];
+//                 flip_prob[kNodes-1] is unused. flip rotates azimuth/roll by pi downstream,
+//                 so it must be reproduced (for a symmetric near-pole proposal P(flip)~0.5,
+//                 and a non-uniform azimuth would be wrongly un-symmetrized if flip were dropped).
+//
+// The target is built by DETERMINISTIC quadrature that pushes the exact per-family latitude
+// proposal through the SAME fold the samplers use (lm_pcg::normalize_latitude) and weights by
+// sin(theta) (= cos(latitude), the spherical area Jacobian) — so the LUT reproduces the folded
+// semantics exactly, not an idealized unfolded distribution. Sampling from it is exact up to
+// the node resolution (explore exp3: uniform-theta + binary search is tail-exact at N=256).
+struct LatLut {
+  static constexpr uint32_t kNodes = 257;  // 256 intervals: power of two -> constant 8-step search
+  std::array<float, kNodes> theta{};
+  std::array<float, kNodes> cdf{};
+  std::array<float, kNodes> flip_prob{};
+};
+
+// Build the LUT for a latitude Distribution (mean/std in DEGREES, axis-dist convention).
+// Host-only, build-time, deterministic (no RNG); amortized once per orientation distribution
+// (per-ci/per-layer, cached — never per ray). Intended for the LUT-routed families
+// (kGaussian / kUniform / kZigzag / kLaplacian); kNoRandom / kGaussianLegacy / full-sphere are
+// handled by their own paths and are not passed here.
+LatLut BuildLatLut(const Distribution& lat_dist);
+
+}  // namespace lumice
+
+#endif  // LM_LAT_LUT_H_

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -442,41 +442,30 @@ void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, 
                                              const LatLut* lat_lut) {
   auto& rng = RandomNumberGenerator::GetInstance();
 
-  // Jacobian correction for latitude sampling.
-  // Target distribution: p(phi) ∝ proposal(phi) × cos(phi)
-  // where cos(phi) = sin(colatitude) is the spherical area element Jacobian.
-  //
-  // Three paths:
-  //   1. Rayleigh (Gaussian near-pole only): 2D Gaussian → Rayleigh, exact for sin(θ)≈θ.
-  //   2. Generic rejection: propose from distribution, accept with prob cos(phi)/M.
-  //      Covers kGaussian (non-Rayleigh), kUniform, kZigzag, and future types.
-  //   3. kNoRandom: single deterministic orientation, no Jacobian needed.
-  constexpr int kMaxRejectionAttempts = 1000;
-
+  // Latitude sampling with the spherical-area Jacobian p(phi) ∝ proposal(phi) × cos(phi),
+  // where cos(phi) = sin(colatitude) is the area element. Since 330.3 every non-degenerate
+  // distribution routes to the unified inverse-CDF area-measure LUT (kLutInverseCdf); the
+  // remaining explicit paths are kGaussianLegacy (legacy no-Jacobian Gaussian) and kNoRandom
+  // (single deterministic orientation, no Jacobian needed). Path selection is single-sourced
+  // with the two GPU backends via lat_path::SelectLatPath (scrum-328.2 Step 4).
   auto lat_type = axis_dist.latitude_dist.type;
-
-  // Path selection + envelope constant M share a single source with the two
-  // GPU backends via lat_path::SelectLatPath (scrum-328.2 Step 4). Derive the
-  // host-side booleans (use_rayleigh / skip_jacobian equivalents) + the
-  // Rayleigh branch's cached mean_rad/sigma_rad from the decision result.
   auto decision = lat_path::SelectLatPath(axis_dist);
-  bool use_rayleigh = (decision.kind == lat_path::LatPathKind::kRayleigh);
-  bool use_laplacian_tight = (decision.kind == lat_path::LatPathKind::kLaplacianTightEnvelope);
-  float rejection_m = decision.rejection_m;
-  // Cached radian versions of mean/scale, shared by the two tight-envelope branches.
-  // For kGaussian this holds (mean, sigma); for kLaplacian this holds (mean, b) —
-  // the two Distribution types are mutually exclusive per call, so the same pair
-  // of locals safely serves both. `lat_scale_rad` was renamed from `sigma_rad`
-  // (which read as Gaussian-specific) after the Laplacian branch was added.
-  bool cache_needed = (lat_type == DistributionType::kGaussian) || (lat_type == DistributionType::kLaplacian);
-  float latitude_mean_rad = cache_needed ? axis_dist.latitude_dist.mean * math::kDegreeToRad : 0.0f;
-  float lat_scale_rad = cache_needed ? axis_dist.latitude_dist.std * math::kDegreeToRad : 0.0f;
 
   for (size_t i = 0; i < num; i++) {
     float phi = 0;
     bool flip = false;
 
-    if (decision.kind == lat_path::LatPathKind::kLutInverseCdf) {
+    if (decision.kind == lat_path::LatPathKind::kFullSphere) {
+      // Full-sphere uniform (IsFullSphereUniform()==true) reaching the parameterized overload —
+      // e.g. the Jacobian-correction unit test; production routes such axes through the dedicated
+      // SampleSphericalPointsSph(full-sphere) overload from simulator.cpp. Sample latitude directly
+      // with the area measure: phi = asin(u), u ~ U(-1,1), giving the uniform-on-sphere
+      // distribution. Matches the device sample_lat_lon_roll kLatPathFullSphere branch
+      // (pcg_shared.h). Before 330.3 this case fell through to the generic Jacobian-rejection branch
+      // (now retired), which reached the same distribution via cos(phi) rejection.
+      float u = std::max(-1.0f, std::min(1.0f, rng.GetUniform() * 2.0f - 1.0f));
+      phi = std::asin(u);
+    } else if (decision.kind == lat_path::LatPathKind::kLutInverseCdf) {
       // Unified area-measure inverse-CDF LUT (330.2). One uniform draw + fixed binary search
       // (no rejection loop); flip reproduces the pole-crossing azimuth flip via the per-bin
       // flip probability. The LUT is amortized once per axis distribution (passed-in or cached),
@@ -487,88 +476,12 @@ void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, 
       phi = math::kPi_2 - theta_z;
       const uint32_t bin = lm_pcg::lat_lut_bin(theta_z, lut.theta.data(), LatLut::kNodes);
       flip = rng.GetUniform() < lut.flip_prob[bin];
-    } else if (lat_type == DistributionType::kGaussian && use_rayleigh) {
-      // Tight-envelope area-measure Rayleigh path (doc/near-pole-area-measure-sampling.md §2).
-      // Propose colatitude ~ Rayleigh(sigma) via the 2D-Gaussian norm form (numerically
-      // identical to theta = sigma*sqrt(-2 ln u)); accept with sin(theta)/theta (M=1,
-      // exact, never clamp). Mirrors pcg_shared.h::sample_lat_lon_roll kLatPathRayleigh
-      // branch; kMaxRejectionAttempts safety valve shared with the generic branch below.
-      int attempts = 0;
-      float colatitude = 0.0f;
-      bool accept = false;
-      do {
-        float dx = rng.GetGaussian() * lat_scale_rad;
-        float dy = rng.GetGaussian() * lat_scale_rad;
-        colatitude = std::sqrt(dx * dx + dy * dy);
-        ++attempts;
-        if (attempts >= kMaxRejectionAttempts) {
-          LOG_WARNING("SampleSphericalPointsSph: Rayleigh safety valve triggered (mean={}, std={})",
-                      axis_dist.latitude_dist.mean, axis_dist.latitude_dist.std);
-          break;
-        }
-        accept = rng.GetUniform() < lm_pcg::pcg_sinc(colatitude);
-      } while (!accept);
-      phi = std::copysign(math::kPi_2 - colatitude, latitude_mean_rad);
-      phi = std::max(-math::kPi_2, std::min(math::kPi_2, phi));
-      if (latitude_mean_rad < 0) {
-        // South-pole Rayleigh: fold phi to positive latitude and set flip=true to trigger
-        // lambda/roll += π downstream. Semantically identical to NormalizeLatitude, but not
-        // delegated there because Rayleigh phi is computed from copysign+clamp (never outside
-        // [-π/2, π/2]), so the NormalizeLatitude loop/reflection logic is unnecessary here.
-        phi = std::abs(phi);
-        flip = true;
-      }
-    } else if (lat_type == DistributionType::kLaplacian && use_laplacian_tight) {
-      // Tight-envelope area-measure Laplacian path (doc/near-pole-area-measure-sampling.md §2.1).
-      // Propose colatitude ~ Gamma(2, b) via closed form theta = -b(ln u1 + ln u2); accept with
-      // sin(theta)/theta (M=1, exact, never clamp). Mirrors pcg_shared.h::sample_lat_lon_roll
-      // kLatPathLaplacianTightEnvelope branch. copysign/clamp/flip semantics identical to
-      // Rayleigh branch above — they depend on the geometric fold, not on the proposal family.
-      int attempts = 0;
-      float colatitude = 0.0f;
-      bool accept = false;
-      do {
-        // 1e-7f floor matches the device-side pcg_gamma2 (pcg_shared.h) so CPU and GPU
-        // samplers see identical tail behavior; floating to the tiniest normal float would
-        // let -log(u) reach ~87, producing colatitude proposals ~87*b beyond legal domain.
-        float u1 = std::max(rng.GetUniform(), 1e-7f);
-        float u2 = std::max(rng.GetUniform(), 1e-7f);
-        colatitude = -lat_scale_rad * (std::log(u1) + std::log(u2));
-        ++attempts;
-        if (attempts >= kMaxRejectionAttempts) {
-          LOG_WARNING("SampleSphericalPointsSph: Laplacian tight-envelope safety valve triggered (mean={}, std={})",
-                      axis_dist.latitude_dist.mean, axis_dist.latitude_dist.std);
-          break;
-        }
-        accept = rng.GetUniform() < lm_pcg::pcg_sinc(colatitude);
-      } while (!accept);
-      phi = std::copysign(math::kPi_2 - colatitude, latitude_mean_rad);
-      phi = std::max(-math::kPi_2, std::min(math::kPi_2, phi));
-      if (latitude_mean_rad < 0) {
-        phi = std::abs(phi);
-        flip = true;
-      }
     } else if (lat_type == DistributionType::kGaussianLegacy) {
       // Legacy Gaussian: sample without Jacobian rejection (reproduces old behavior).
       phi = rng.Get(axis_dist.latitude_dist) * math::kDegreeToRad;
       auto [norm_phi, norm_flip] = detail::NormalizeLatitude(phi);
       phi = norm_phi;
       flip = norm_flip;
-    } else if (lat_type != DistributionType::kNoRandom) {
-      // Generic Jacobian rejection path (kGaussian non-Rayleigh, kUniform, kZigzag, etc.).
-      int attempts = 0;
-      do {
-        phi = rng.Get(axis_dist.latitude_dist) * math::kDegreeToRad;
-        auto [norm_phi, norm_flip] = detail::NormalizeLatitude(phi);
-        phi = norm_phi;
-        flip = norm_flip;
-        ++attempts;
-        if (attempts >= kMaxRejectionAttempts) {
-          LOG_WARNING("SampleSphericalPointsSph: rejection safety valve triggered (mean={}, std={})",
-                      axis_dist.latitude_dist.mean, axis_dist.latitude_dist.std);
-          break;
-        }
-      } while (rng.GetUniform() >= std::cos(phi) / rejection_m);
     } else {
       // kNoRandom: no Jacobian needed (single deterministic orientation).
       phi = rng.Get(axis_dist.latitude_dist) * math::kDegreeToRad;

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <memory>
 
+#include "core/lat_lut.hpp"
 #include "core/shared/lat_path_selection.hpp"
 #include "core/shared/pcg_shared.h"
 #include "util/logger.hpp"
@@ -415,7 +416,30 @@ void RandomSampler::SampleSphericalPointsSph(float* data, size_t num, size_t ste
 }
 
 
-void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, float* data, size_t num) {
+namespace {
+// Thread-local most-recent LUT cache (330.2, plan-review C1): BuildLatLut is amortized once per
+// axis distribution, never per ray. Callers may pass a prebuilt LUT to bypass this; otherwise the
+// sampler caches the most recently used latitude distribution per worker thread. InitRay_rot
+// processes one crystal_axis per batch, so this is one build per batch on the cache-miss path.
+const LatLut& CachedLatLut(const Distribution& d) {
+  thread_local LatLut cached;
+  thread_local bool valid = false;
+  thread_local DistributionType key_type = DistributionType::kNoRandom;
+  thread_local float key_mean = 0.0f;
+  thread_local float key_std = 0.0f;
+  if (!valid || key_type != d.type || key_mean != d.mean || key_std != d.std) {
+    cached = BuildLatLut(d);
+    valid = true;
+    key_type = d.type;
+    key_mean = d.mean;
+    key_std = d.std;
+  }
+  return cached;
+}
+}  // namespace
+
+void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, float* data, size_t num,
+                                             const LatLut* lat_lut) {
   auto& rng = RandomNumberGenerator::GetInstance();
 
   // Jacobian correction for latitude sampling.
@@ -452,7 +476,18 @@ void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, 
     float phi = 0;
     bool flip = false;
 
-    if (lat_type == DistributionType::kGaussian && use_rayleigh) {
+    if (decision.kind == lat_path::LatPathKind::kLutInverseCdf) {
+      // Unified area-measure inverse-CDF LUT (330.2). One uniform draw + fixed binary search
+      // (no rejection loop); flip reproduces the pole-crossing azimuth flip via the per-bin
+      // flip probability. The LUT is amortized once per axis distribution (passed-in or cached),
+      // never per ray. Shares lm_pcg::invert_lat_lut / lat_lut_bin with the device kernels.
+      const LatLut& lut = (lat_lut != nullptr) ? *lat_lut : CachedLatLut(axis_dist.latitude_dist);
+      const float xi = rng.GetUniform();
+      const float theta_z = lm_pcg::invert_lat_lut(xi, lut.theta.data(), lut.cdf.data(), LatLut::kNodes);
+      phi = math::kPi_2 - theta_z;
+      const uint32_t bin = lm_pcg::lat_lut_bin(theta_z, lut.theta.data(), LatLut::kNodes);
+      flip = rng.GetUniform() < lut.flip_prob[bin];
+    } else if (lat_type == DistributionType::kGaussian && use_rayleigh) {
       // Tight-envelope area-measure Rayleigh path (doc/near-pole-area-measure-sampling.md §2).
       // Propose colatitude ~ Rayleigh(sigma) via the 2D-Gaussian norm form (numerically
       // identical to theta = sigma*sqrt(-2 ln u)); accept with sin(theta)/theta (M=1,

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -158,6 +158,8 @@ class RandomNumberGenerator {
 };
 
 
+struct LatLut;  // core/lat_lut.hpp — prebuilt inverse-CDF table for kLutInverseCdf sampling.
+
 class RandomSampler {
  public:
   /*! @brief Generate points distributed uniformly on sphere, in spherical form, (lon, lat).
@@ -174,9 +176,14 @@ class RandomSampler {
    * @param data output data, (lon, lat, roll), in rad. Roll is sampled from axis_dist.roll_dist and
    *   adjusted by +π when a latitude fold (pole crossing) occurs, keeping roll coupled to the fold.
    * @param num number of points.
+   * @param lat_lut optional prebuilt inverse-CDF LUT (330.2). When SelectLatPath routes the
+   *   latitude distribution to kLutInverseCdf, the caller builds the LUT ONCE (per axis
+   *   distribution, amortized — never per ray) and passes it here. Ignored for other paths;
+   *   must be non-null when the path is kLutInverseCdf.
    * @note Caller must provide a buffer of at least 3×num floats.
    */
-  static void SampleSphericalPointsSph(const AxisDistribution& axis_dist, float* data, size_t num = 1);
+  static void SampleSphericalPointsSph(const AxisDistribution& axis_dist, float* data, size_t num = 1,
+                                       const LatLut* lat_lut = nullptr);
 
   RandomSampler() = delete;
 };

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -853,7 +853,8 @@ kernel void gen_root_kernel(
   // 1. Sample crystal orientation (lon, lat, roll) → 3×3 rotation.
   float lon, lat, roll;
   // scrum-328.2 Step 1: attempt-count observability — writes the per-ray
-  // kLatPathGenericReject iteration count when the sibling buffer is armed
+  // rejection-loop iteration count when the sibling buffer is armed (always 1
+  // since 330.3; every path is rejection-free).
   // (attempts_ctrl.x!=0). ctrl.y is the multi-ci write-offset. Production:
   // ctrl.x==0 → &attempts_local skipped, branch predicted off.
   thread int attempts_local = 1;

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -852,7 +852,9 @@ kernel void gen_root_kernel(
   // (attempts_ctrl.x!=0). ctrl.y is the multi-ci write-offset. Production:
   // ctrl.x==0 → &attempts_local skipped, branch predicted off.
   thread int attempts_local = 1;
-  sample_lat_lon_roll(stream, gp, lon, lat, roll,
+  // 330.2 S3: LUT arrays are nullptr until the buffers are bound (S3b) — safe because the
+  // kLatPathLutInverseCdf branch is dormant until SelectLatPath is flipped (S5).
+  sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll,
                       attempts_ctrl.x != 0u ? &attempts_local : nullptr);
   if (attempts_ctrl.x != 0u) {
     lat_attempts[tid + attempts_ctrl.y] = attempts_local;
@@ -959,7 +961,7 @@ kernel void transit_root_kernel(
   float lon, lat, roll;
   // scrum-328.2 Step 1: transit surface does not carry attempt-count today
   // (near-pole acceptance-rate observation is anchored to the gen kernel).
-  sample_lat_lon_roll(stream, gp, lon, lat, roll, nullptr);
+  sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll, nullptr);  // 330.2 S3: LUT buffers pending S3b
   float mat9[9];
   build_crystal_rotation_9(lon, lat, roll, mat9);
 

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -797,6 +797,11 @@ kernel void gen_root_kernel(
     // ctrl.x==0 → the branch below skips both the pointer arg and the write.
     device int*             lat_attempts  [[buffer(12)]],
     constant uint2&         attempts_ctrl [[buffer(13)]],
+    // 330.2 S3b: unified area-measure inverse-CDF latitude LUT (read only when
+    // gp.lat_path == kLatPathLutInverseCdf). Always bound (Metal forbids nil).
+    device const float*     lat_lut_theta [[buffer(14)]],
+    device const float*     lat_lut_cdf   [[buffer(15)]],
+    device const float*     lat_lut_flip  [[buffer(16)]],
     uint tid [[thread_position_in_grid]])
 {
   if (tid >= gp.num_rays) {
@@ -854,7 +859,7 @@ kernel void gen_root_kernel(
   thread int attempts_local = 1;
   // 330.2 S3: LUT arrays are nullptr until the buffers are bound (S3b) — safe because the
   // kLatPathLutInverseCdf branch is dormant until SelectLatPath is flipped (S5).
-  sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll,
+  sample_lat_lon_roll(stream, gp, lat_lut_theta, lat_lut_cdf, lat_lut_flip, lon, lat, roll,
                       attempts_ctrl.x != 0u ? &attempts_local : nullptr);
   if (attempts_ctrl.x != 0u) {
     lat_attempts[tid + attempts_ctrl.y] = attempts_local;
@@ -939,6 +944,10 @@ kernel void transit_root_kernel(
     // trace kernel reads the same lifetime tag.
     device const uint*   cont_wl_idx_in   [[buffer(12)]],
     device uint*         root_wl_idx_out  [[buffer(13)]],
+    // 330.2 S3b: unified latitude LUT (read only when lat_path==LutInverseCdf).
+    device const float*  lat_lut_theta    [[buffer(14)]],
+    device const float*  lat_lut_cdf      [[buffer(15)]],
+    device const float*  lat_lut_flip     [[buffer(16)]],
     uint tid [[thread_position_in_grid]])
 {
   if (tid >= gp.num_rays || gp.tri_count == 0u) {
@@ -961,7 +970,7 @@ kernel void transit_root_kernel(
   float lon, lat, roll;
   // scrum-328.2 Step 1: transit surface does not carry attempt-count today
   // (near-pole acceptance-rate observation is anchored to the gen kernel).
-  sample_lat_lon_roll(stream, gp, nullptr, nullptr, nullptr, lon, lat, roll, nullptr);  // 330.2 S3: LUT buffers pending S3b
+  sample_lat_lon_roll(stream, gp, lat_lut_theta, lat_lut_cdf, lat_lut_flip, lon, lat, roll, nullptr);  // 330.2 S3b
   float mat9[9];
   build_crystal_rotation_9(lon, lat, roll, mat9);
 

--- a/src/core/shared/lat_path_selection.hpp
+++ b/src/core/shared/lat_path_selection.hpp
@@ -38,6 +38,8 @@ enum class LatPathKind : uint32_t {
   kGaussLegacy = 3u,
   kGenericReject = 4u,           // kGaussian / kUniform / kZigzag / kLaplacian
   kLaplacianTightEnvelope = 5u,  // kLaplacian near-pole optimization (Gamma(2,b) proposal)
+  kLutInverseCdf = 6u,           // unified area-measure inverse-CDF LUT (330.2); numeric value
+                                 // MUST match lm_pcg::kLatPathLutInverseCdf (pcg_shared.h)
 };
 
 // Near-pole colatitude trigger threshold for tight-envelope area-measure

--- a/src/core/shared/lat_path_selection.hpp
+++ b/src/core/shared/lat_path_selection.hpp
@@ -1,26 +1,26 @@
-// Host-side latitude sampling path decision + Jacobian rejection envelope.
+// Host-side latitude sampling path decision.
 //
-// Single source (scrum-328.2 Step 4) for the three previously mirrored copies
-// of the Rayleigh/GenericReject/GaussLegacy/NoRandom branch selection and the
-// envelope constant M used as the acceptance ratio cos(phi)/M:
-//   - math.cpp:416-441 file-static ComputeJacobianEnvelope (host CPU sampler)
-//   - metal_trace_backend.mm:186-214 ComputeJacobianEnvelopeForDeviceGen
-//   - cuda_trace_backend.cu:254-273 CudaJacobianEnvelopeForDeviceGen
+// Single source (scrum-328.2 Step 4) for the latitude path selection shared by
+// the host CPU sampler (math.cpp::SampleSphericalPointsSph) and the two device
+// backends (metal_trace_backend.mm / cuda_trace_backend.cu BuildGenRootParams).
+//
+// 330.3: the Rayleigh / Laplacian-tight-envelope / generic-rejection branches
+// were retired — every non-degenerate latitude distribution now routes to the
+// unified inverse-CDF area-measure LUT (kLutInverseCdf, landed 330.2). The
+// Jacobian rejection envelope (ComputeJacobianEnvelope) is gone with them; the
+// LUT is rejection-free so rejection_m is a constant 1.0 on every path.
 //
 // Design invariant: this header is HOST-ONLY. It is called BEFORE kernel
-// dispatch (to populate GenRootKernelParams.lat_path / lat_rejection_m), never
-// from Metal shader / CUDA device code. Device kernels consume the numeric
-// wire value via `GenRootKernelParams::lat_path` — see
-// src/core/shared/pcg_shared.h's `lm_pcg::kLatPath*` constants for the
-// device-side sink of these values. The numeric encoding (0..4) is asserted
-// pairwise identical between LatPathKind and lm_pcg::kLatPath* by the two
-// device-backend TUs (metal_trace_backend.mm / cuda_trace_backend.cu) that
-// include both headers.
+// dispatch (to populate GenRootKernelParams.lat_path), never from Metal shader
+// / CUDA device code. Device kernels consume the numeric wire value via
+// `GenRootKernelParams::lat_path` — see src/core/shared/pcg_shared.h's
+// `lm_pcg::kLatPath*` constants for the device-side sink of these values. The
+// numeric encoding is asserted pairwise identical between LatPathKind and
+// lm_pcg::kLatPath* by the two device-backend TUs (metal_trace_backend.mm /
+// cuda_trace_backend.cu) that include both headers.
 #ifndef LM_LAT_PATH_SELECTION_H_
 #define LM_LAT_PATH_SELECTION_H_
 
-#include <algorithm>
-#include <cmath>
 #include <cstdint>
 
 #include "core/math.hpp"
@@ -30,89 +30,35 @@ namespace lat_path {
 
 // Latitude-sampling path taxonomy — numeric values MUST match lm_pcg::kLatPath*
 // in src/core/shared/pcg_shared.h (device-side). See device-backend TUs for the
-// pairwise static_assert.
+// pairwise static_assert. Values 2/4/5 (retired Rayleigh / GenericReject /
+// LaplacianTightEnvelope, 330.3) are intentionally left as gaps so the wire
+// encoding of the surviving kinds does not shift.
 enum class LatPathKind : uint32_t {
   kFullSphere = 0u,
   kNoRandom = 1u,
-  kRayleigh = 2u,  // kGaussian near-pole optimization
   kGaussLegacy = 3u,
-  kGenericReject = 4u,           // kGaussian / kUniform / kZigzag / kLaplacian
-  kLaplacianTightEnvelope = 5u,  // kLaplacian near-pole optimization (Gamma(2,b) proposal)
-  kLutInverseCdf = 6u,           // unified area-measure inverse-CDF LUT (330.2); numeric value
-                                 // MUST match lm_pcg::kLatPathLutInverseCdf (pcg_shared.h)
+  kLutInverseCdf = 6u,  // unified area-measure inverse-CDF LUT (330.2); numeric value
+                        // MUST match lm_pcg::kLatPathLutInverseCdf (pcg_shared.h)
 };
-
-// Near-pole colatitude trigger threshold for tight-envelope area-measure
-// sampling — shared between the kGaussian (Rayleigh) and kLaplacian (Gamma(2,b))
-// branches of SelectLatPath. The threshold is a property of the sin(theta) <= theta
-// upper bound (doc/near-pole-area-measure-sampling.md §2.2), independent of the
-// proposal distribution family.
-constexpr float kPolarThresholdRad = 0.5f * math::kDegreeToRad;
-
-// Scale upper bounds for the two tight-envelope branches.
-// - Gaussian sigma cap 60° (doc §附录 MC-validated).
-// - Laplacian b cap 60° (scrum-328.4 Step 1 calibration exp4: safety_hit_pct=0
-//   at b=90° with N=100k; mean_attempts stays <= 2 within cap. 60° chosen to
-//   mirror the Gaussian cap for reader-side symmetry, not because Laplacian
-//   fails at b>60°).
-constexpr float kMaxTightEnvelopeSigmaRad = 60.0f * math::kDegreeToRad;
-constexpr float kMaxTightEnvelopeLaplacianBRad = 60.0f * math::kDegreeToRad;
 
 constexpr uint32_t ToWireValue(LatPathKind kind) {
   return static_cast<uint32_t>(kind);
 }
 
-// Host-side rejection envelope constant M for Jacobian rejection sampling of
-// latitude. `dist` uses degrees (mean/std in the AxisDistribution unit
-// convention); output is dimensionless (cos-space M used as the acceptance
-// ratio accept_ratio = cos(phi_rad) / M).
-//
-// Branch semantics (kept bit-identical to the three mirrors that were removed):
-//   - kGaussian:  proposal range ~ [mean-3σ, mean+3σ] → M = cos(max(|mean|-3σ, 0)°)
-//   - kZigzag:    proposal range |std·sin(2πU)+mean| → M = cos(max(|mean|-std, 0)°)
-//   - kLaplacian: 5b cutoff (covers 99.3% of Laplace mass) → cos(max(|mean|-5b, 0)°)
-//   - kUniform:   proposal support is exactly [mean-std/2, mean+std/2] (uniform
-//     GetUniform() maps to (u-0.5)*std+mean; see math.cpp RandomNumberGenerator::Get
-//     and pcg_get_dist mirror). Tight-envelope M = cos(max(|mean|-std/2, 0)°) is
-//     exact (not an approximation): when the support brackets the equator the
-//     max()-clamp yields M=1 (bit-identical to the prior behavior); when the
-//     support is bounded away from equator M<1 lifts the acceptance rate.
-//     Full-sphere uniform (IsFullSphereUniform()==true) is routed to
-//     kFullSphere in SelectLatPath and does not reach this branch.
-//   - default: unknown/future type → conservative M = 1.
-inline float ComputeJacobianEnvelope(const Distribution& dist) {
-  switch (dist.type) {
-    case DistributionType::kGaussian:
-      return std::cos(std::max(std::abs(dist.mean) - 3.0f * dist.std, 0.0f) * math::kDegreeToRad);
-    case DistributionType::kZigzag:
-      return std::cos(std::max(std::abs(dist.mean) - dist.std, 0.0f) * math::kDegreeToRad);
-    case DistributionType::kLaplacian:
-      return std::cos(std::max(std::abs(dist.mean) - 5.0f * dist.std, 0.0f) * math::kDegreeToRad);
-    case DistributionType::kUniform:
-      return std::cos(std::max(std::abs(dist.mean) - 0.5f * dist.std, 0.0f) * math::kDegreeToRad);
-    default:
-      return 1.0f;
-  }
-}
-
 struct LatPathDecision {
   LatPathKind kind;
-  float rejection_m;  // 1.0 for all paths except kGenericReject
+  float rejection_m;  // always 1.0 (the surviving paths are all rejection-free); retained
+                      // because the device wire field GenRootKernelParams::lat_rejection_m
+                      // still carries it (dead post-330.3, struct layout frozen).
 };
 
-// Select latitude-sampling path + rejection envelope for a given axis
-// distribution. Mirrors the branch structure at
-// RandomSampler::SampleSphericalPointsSph setup (math.cpp:437,
-// metal_trace_backend.mm:1455, cuda_trace_backend.cu:290).
+// Select latitude-sampling path for a given axis distribution. Shared single
+// source for the host CPU sampler and both GPU backends (scrum-328.2 Step 4).
 //
-// Rayleigh threshold: colatitude_center < 0.5° (sigma-independent). The
-// tight-envelope Rayleigh sampler in pcg_shared.h::sample_lat_lon_roll is
-// exact (accept = sin(theta)/theta, M=1) for any sigma up to ~60°
-// (doc/near-pole-area-measure-sampling.md §附录, validated by MC), so the
-// previous "colatitude_center + 3sigma < 0.5°" guard (which the tight sampler
-// no longer needs) was relaxed. The prior guard misrouted typical near-pole
-// Parhelia/Parry configurations (mean=90°, sigma=5°, colatitude_center=0 but
-// 3sigma=15°) to kLatPathGenericReject with a ~27% acceptance rate.
+// 330.3: kGaussian / kLaplacian / kUniform / kZigzag all route to the unified
+// inverse-CDF LUT (kLutInverseCdf). Only the degenerate paths keep dedicated
+// handling: full-sphere uniform (kFullSphere), single deterministic orientation
+// (kNoRandom), and the legacy no-Jacobian Gaussian (kGaussLegacy).
 inline LatPathDecision SelectLatPath(const AxisDistribution& axis_dist) {
   if (axis_dist.IsFullSphereUniform()) {
     return { LatPathKind::kFullSphere, 1.0f };
@@ -124,36 +70,7 @@ inline LatPathDecision SelectLatPath(const AxisDistribution& axis_dist) {
   if (lat_type == DistributionType::kGaussianLegacy) {
     return { LatPathKind::kGaussLegacy, 1.0f };
   }
-  if (lat_type == DistributionType::kGaussian) {
-    float lat_mean_rad = axis_dist.latitude_dist.mean * math::kDegreeToRad;
-    float lat_std_rad = axis_dist.latitude_dist.std * math::kDegreeToRad;
-    float colatitude_center = math::kPi_2 - std::abs(lat_mean_rad);
-    bool use_rayleigh = colatitude_center < kPolarThresholdRad && lat_std_rad < kMaxTightEnvelopeSigmaRad;
-    if (use_rayleigh) {
-      // 330.2 S5: unified LUT path replaces the near-pole Rayleigh optimization.
-      return { LatPathKind::kLutInverseCdf, 1.0f };
-    }
-    // 330.2 S5: unified LUT path replaces the off-pole generic-rejection sampler.
-    return { LatPathKind::kLutInverseCdf, 1.0f };
-  }
-  if (lat_type == DistributionType::kLaplacian) {
-    // Laplacian tight-envelope branch (scrum-328.4). Trigger uses the same
-    // colatitude_center threshold as the Gaussian branch — the sin(theta) <= theta
-    // upper bound is a geometric property, not proposal-family-dependent. The scale
-    // (b) cap is a separate constant validated by MC in exp4 (see comment beside
-    // kMaxTightEnvelopeLaplacianBRad).
-    float lat_mean_rad = axis_dist.latitude_dist.mean * math::kDegreeToRad;
-    float lat_scale_rad = axis_dist.latitude_dist.std * math::kDegreeToRad;  // Distribution.std carries Laplace b
-    float colatitude_center = math::kPi_2 - std::abs(lat_mean_rad);
-    bool use_laplacian_tight = colatitude_center < kPolarThresholdRad && lat_scale_rad < kMaxTightEnvelopeLaplacianBRad;
-    if (use_laplacian_tight) {
-      // 330.2 S5: unified LUT path replaces the near-pole Gamma(2,b) optimization.
-      return { LatPathKind::kLutInverseCdf, 1.0f };
-    }
-    // 330.2 S5: unified LUT path replaces the off-pole generic-rejection sampler.
-    return { LatPathKind::kLutInverseCdf, 1.0f };
-  }
-  // kUniform / kZigzag — 330.2 S5: unified LUT path replaces generic rejection.
+  // kGaussian / kLaplacian / kUniform / kZigzag → unified area-measure LUT (330.2).
   return { LatPathKind::kLutInverseCdf, 1.0f };
 }
 

--- a/src/core/shared/lat_path_selection.hpp
+++ b/src/core/shared/lat_path_selection.hpp
@@ -130,9 +130,11 @@ inline LatPathDecision SelectLatPath(const AxisDistribution& axis_dist) {
     float colatitude_center = math::kPi_2 - std::abs(lat_mean_rad);
     bool use_rayleigh = colatitude_center < kPolarThresholdRad && lat_std_rad < kMaxTightEnvelopeSigmaRad;
     if (use_rayleigh) {
-      return { LatPathKind::kRayleigh, 1.0f };
+      // 330.2 S5: unified LUT path replaces the near-pole Rayleigh optimization.
+      return { LatPathKind::kLutInverseCdf, 1.0f };
     }
-    return { LatPathKind::kGenericReject, ComputeJacobianEnvelope(axis_dist.latitude_dist) };
+    // 330.2 S5: unified LUT path replaces the off-pole generic-rejection sampler.
+    return { LatPathKind::kLutInverseCdf, 1.0f };
   }
   if (lat_type == DistributionType::kLaplacian) {
     // Laplacian tight-envelope branch (scrum-328.4). Trigger uses the same
@@ -145,12 +147,14 @@ inline LatPathDecision SelectLatPath(const AxisDistribution& axis_dist) {
     float colatitude_center = math::kPi_2 - std::abs(lat_mean_rad);
     bool use_laplacian_tight = colatitude_center < kPolarThresholdRad && lat_scale_rad < kMaxTightEnvelopeLaplacianBRad;
     if (use_laplacian_tight) {
-      return { LatPathKind::kLaplacianTightEnvelope, 1.0f };
+      // 330.2 S5: unified LUT path replaces the near-pole Gamma(2,b) optimization.
+      return { LatPathKind::kLutInverseCdf, 1.0f };
     }
-    return { LatPathKind::kGenericReject, ComputeJacobianEnvelope(axis_dist.latitude_dist) };
+    // 330.2 S5: unified LUT path replaces the off-pole generic-rejection sampler.
+    return { LatPathKind::kLutInverseCdf, 1.0f };
   }
-  // kUniform / kZigzag
-  return { LatPathKind::kGenericReject, ComputeJacobianEnvelope(axis_dist.latitude_dist) };
+  // kUniform / kZigzag — 330.2 S5: unified LUT path replaces generic rejection.
+  return { LatPathKind::kLutInverseCdf, 1.0f };
 }
 
 }  // namespace lat_path

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -142,6 +142,7 @@ struct GenRootKernelParams {
   float lat_mean_rad;
   float lat_std_rad;
   float lat_rejection_m;
+  uint32_t lat_lut_n;  // node count for kLatPathLutInverseCdf (330.2); LUT arrays bound separately
   uint32_t az_type;
   float az_mean_rad;
   float az_std_rad;
@@ -359,8 +360,9 @@ LM_FN uint32_t lat_lut_bin(float theta, LM_DEVICE const float* theta_nodes, uint
 // off; production keeps passing null so the observation is compiled out at
 // the call site.
 LM_FN void sample_lat_lon_roll(LM_THREAD PcgStream& s, LM_CONSTANT_REF GenRootKernelParams& gp,
-                               LM_THREAD float& out_lon, LM_THREAD float& out_lat, LM_THREAD float& out_roll,
-                               LM_THREAD int* out_attempts) {
+                               LM_DEVICE const float* lat_lut_theta, LM_DEVICE const float* lat_lut_cdf,
+                               LM_DEVICE const float* lat_lut_flip, LM_THREAD float& out_lon, LM_THREAD float& out_lat,
+                               LM_THREAD float& out_roll, LM_THREAD int* out_attempts) {
   float phi = 0.0f;
   bool flip = false;
   float lon = 0.0f;
@@ -432,6 +434,17 @@ LM_FN void sample_lat_lon_roll(LM_THREAD PcgStream& s, LM_CONSTANT_REF GenRootKe
   } else if (gp.lat_path == kLatPathGaussLegacy) {
     float raw = pcg_get_dist(s, kDistGaussianLegacy, gp.lat_mean_rad, gp.lat_std_rad);
     normalize_latitude(raw, phi, flip);
+  } else if (gp.lat_path == kLatPathLutInverseCdf) {
+    // Unified area-measure inverse-CDF LUT (330.2). One uniform draw + fixed binary search (no
+    // rejection loop, attempts_total stays 1); flip via the per-bin probability reproduces the
+    // pole-crossing azimuth flip. Same single-source invert_lat_lut / lat_lut_bin as the CPU
+    // sampler (math.cpp). The three LUT arrays are bound as separate device buffers (they cannot
+    // live inside the setBytes-uploaded GenRootKernelParams struct).
+    float xi = pcg_uniform(s);
+    float colatitude = invert_lat_lut(xi, lat_lut_theta, lat_lut_cdf, gp.lat_lut_n);
+    phi = LM_PI_2F - colatitude;  // colatitude-from-zenith (theta_z in [0,pi]) -> latitude in [-pi/2,pi/2]
+    uint32_t bin = lat_lut_bin(colatitude, lat_lut_theta, gp.lat_lut_n);
+    flip = pcg_uniform(s) < lat_lut_flip[bin];
   } else {
     // kLatPathGenericReject (math.cpp:503-517).
     int attempts = 0;

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -51,17 +51,16 @@ namespace lm_pcg {
 // `lat_path` discriminator (mirrors host SampleSphericalPointsSph code paths,
 // math.cpp:404/444). Selecting a path is a host-side decision based on
 // axis_dist; the kernel only dispatches.
+// Values 2/4/5 (retired Rayleigh / GenericReject / LaplacianTightEnvelope, 330.3)
+// are intentionally omitted so the surviving wire values do not shift.
 LM_CONSTANT uint32_t kLatPathFullSphere = 0u;  // axis_dist.IsFullSphereUniform()
 LM_CONSTANT uint32_t kLatPathNoRandom = 1u;
-LM_CONSTANT uint32_t kLatPathRayleigh = 2u;                // kGaussian near-pole optimization
-LM_CONSTANT uint32_t kLatPathGaussLegacy = 3u;             // kGaussianLegacy
-LM_CONSTANT uint32_t kLatPathGenericReject = 4u;           // kGaussian/kUniform/kZigzag/kLaplacian
-LM_CONSTANT uint32_t kLatPathLaplacianTightEnvelope = 5u;  // kLaplacian near-pole optimization
-LM_CONSTANT uint32_t kLatPathLutInverseCdf = 6u;           // unified area-measure inverse-CDF LUT (330.2)
+LM_CONSTANT uint32_t kLatPathGaussLegacy = 3u;    // kGaussianLegacy
+LM_CONSTANT uint32_t kLatPathLutInverseCdf = 6u;  // unified area-measure inverse-CDF LUT (330.2)
 
-// DistributionType enum values (must match src/core/math.hpp). Crystal-rot
-// parity REQUIRES the GenericReject path know the actual proposal type, so
-// lat_dist_type is carried separately from lat_path.
+// DistributionType enum values (must match src/core/math.hpp). Still used for
+// the az_type / roll_type draws in pcg_get_dist; the lat_dist_type wire field is
+// dead post-330.3 (only the retired GenericReject path read it).
 LM_CONSTANT uint32_t kDistNoRandom = 0u;
 LM_CONSTANT uint32_t kDistUniform = 1u;
 LM_CONSTANT uint32_t kDistGaussian = 2u;
@@ -138,11 +137,11 @@ struct GenRootKernelParams {
   float sun_half_angle;    // (sun.diameter / 2) in radians
   uint32_t wl_pool_size;   // hashes a global ray index into [0, wl_pool_size)
   uint32_t lat_path;       // see kLatPath* above
-  uint32_t lat_dist_type;  // axis_dist.latitude_dist.type (cast to uint32_t)
+  uint32_t lat_dist_type;  // dead post-330.3 (only the retired GenericReject path read it); wire layout frozen
   float lat_mean_rad;
   float lat_std_rad;
-  float lat_rejection_m;
-  uint32_t lat_lut_n;  // node count for kLatPathLutInverseCdf (330.2); LUT arrays bound separately
+  float lat_rejection_m;  // dead post-330.3 (surviving paths are rejection-free, always 1.0); wire layout frozen
+  uint32_t lat_lut_n;     // node count for kLatPathLutInverseCdf (330.2); LUT arrays bound separately
   uint32_t az_type;
   float az_mean_rad;
   float az_std_rad;
@@ -163,16 +162,6 @@ LM_FN uint32_t pcg_hash(uint32_t x) {
 
 LM_FN float u01_from_hash(uint32_t h) {
   return static_cast<float>(h >> 8) * (1.0f / 16777216.0f);
-}
-
-// Precise acceptance ratio for tight-envelope area-measure sampling near the
-// pole (doc/near-pole-area-measure-sampling.md §2). Returns sin(theta)/theta;
-// the theta->0 limit is 1.0. The 1e-6f guard only fires when a uniform draw
-// floor drives the proposed colatitude toward 0 (see kLatPathRayleigh branch
-// in sample_lat_lon_roll). Domain is theta in [0, pi]: within it sin(theta) is
-// non-negative, so the returned ratio is in [0, 1] and is a valid probability.
-LM_FN float pcg_sinc(float theta) {
-  return theta > 1e-6f ? LM_SIN(theta) / theta : 1.0f;
 }
 
 struct PcgStream {
@@ -236,19 +225,6 @@ LM_FN float pcg_gaussian(LM_THREAD PcgStream& s) {
   float u1 = LM_FMAX(pcg_uniform(s), 1e-7f);
   float u2 = pcg_uniform(s);
   return LM_SQRT(-2.0f * LM_LOG(u1)) * LM_COS(2.0f * LM_PI_F * u2);
-}
-
-// Gamma(shape=2, scale=b) via the sum-of-two-Exp(1/b) closed form:
-//   theta = -b * (ln u1 + ln u2), u1,u2 ~ U(0,1)
-// Used by the Laplacian tight-envelope area-measure sampler
-// (doc/near-pole-area-measure-sampling.md §2.1): theta = colatitude ~ Gamma(2,b)
-// paired with sin(theta)/theta acceptance is EXACT (M=1) for the target
-// p(theta) ∝ exp(-theta/b) * sin(theta). u_i floored at 1e-7 (same as
-// pcg_gaussian) to keep log() finite. Consumes 2 uniform slots per call.
-LM_FN float pcg_gamma2(LM_THREAD PcgStream& s, float b) {
-  float u1 = LM_FMAX(pcg_uniform(s), 1e-7f);
-  float u2 = LM_FMAX(pcg_uniform(s), 1e-7f);
-  return -b * (LM_LOG(u1) + LM_LOG(u2));
 }
 
 // Mirrors RandomNumberGenerator::Get (math.cpp:365-389). mean / std are in
@@ -350,15 +326,13 @@ LM_FN uint32_t lat_lut_bin(float theta, LM_DEVICE const float* theta_nodes, uint
 // the host so the kernel does no degree↔radian conversions.
 //
 // `out_attempts` (scrum-328.2 Step 1 attempt-count observability, plan §5):
-// non-null → the caller receives this ray's rejection-loop iteration count
-// (1 for direct/analytic paths kFullSphere/kNoRandom/kRayleigh/kGaussLegacy;
-// N for kLatPathGenericReject, capped at kMaxRejectionAttempts). The caller
-// uses `mean(attempts)` as the empirical `1/accept_ratio` — the ONLY route
-// to a per-ray acceptance-rate observation on device (the host-side
-// SelectLatPath / ComputeJacobianEnvelope decision is deterministic and
-// cannot substitute). null → no write, hot-path cost is one branch predicted
-// off; production keeps passing null so the observation is compiled out at
-// the call site.
+// non-null → the caller receives this ray's rejection-loop iteration count.
+// Since 330.3 every surviving path is rejection-free, so this is always 1; the
+// facility is retained because a future rejection-based path would surface its
+// acceptance rate here (the host-side SelectLatPath decision is deterministic
+// and cannot substitute). null → no write, hot-path cost is one branch
+// predicted off; production keeps passing null so the observation is compiled
+// out at the call site.
 LM_FN void sample_lat_lon_roll(LM_THREAD PcgStream& s, LM_CONSTANT_REF GenRootKernelParams& gp,
                                LM_DEVICE const float* lat_lut_theta, LM_DEVICE const float* lat_lut_cdf,
                                LM_DEVICE const float* lat_lut_flip, LM_THREAD float& out_lon, LM_THREAD float& out_lat,
@@ -366,7 +340,7 @@ LM_FN void sample_lat_lon_roll(LM_THREAD PcgStream& s, LM_CONSTANT_REF GenRootKe
   float phi = 0.0f;
   bool flip = false;
   float lon = 0.0f;
-  int attempts_total = 1;  // direct-path default; kLatPathGenericReject overwrites below
+  int attempts_total = 1;  // every surviving path is rejection-free (330.3): always 1 attempt
   if (gp.lat_path == kLatPathFullSphere) {
     float u = pcg_uniform(s) * 2.0f - 1.0f;
     u = LM_CLAMP(u, -1.0f, 1.0f);
@@ -374,92 +348,21 @@ LM_FN void sample_lat_lon_roll(LM_THREAD PcgStream& s, LM_CONSTANT_REF GenRootKe
     lon = pcg_uniform(s) * 2.0f * LM_PI_F;
   } else if (gp.lat_path == kLatPathNoRandom) {
     phi = gp.lat_mean_rad;
-  } else if (gp.lat_path == kLatPathRayleigh) {
-    // Tight-envelope area-measure sampling (doc/near-pole-area-measure-sampling.md
-    // §2). Propose colatitude ~ Rayleigh(sigma) via the 2D-Gaussian norm form
-    // (numerically identical to theta = sigma*sqrt(-2 ln u)); accept with
-    // sin(theta)/theta (M=1, exact, never clamp). Consumes 2 gaussian slots +
-    // 1 uniform slot per attempt; expected ~1.002 attempts for sigma <= 60°
-    // (doc §附录). attempts_total is populated so the scrum-328.2 attempt-count
-    // observability facility (EnableGenAttemptCountForTest / ReadbackGenAttemptCountForTest)
-    // measures the tight-envelope acceptance rate directly.
-    int attempts = 0;
-    float colatitude = 0.0f;
-    bool accept = false;
-    do {
-      float dx = pcg_gaussian(s) * gp.lat_std_rad;
-      float dy = pcg_gaussian(s) * gp.lat_std_rad;
-      colatitude = LM_SQRT(dx * dx + dy * dy);
-      attempts++;
-      if (attempts >= kMaxRejectionAttempts) {
-        break;
-      }
-      accept = pcg_uniform(s) < pcg_sinc(colatitude);
-    } while (!accept);
-    attempts_total = attempts;
-    phi = LM_COPYSIGN(LM_PI_2F - colatitude, gp.lat_mean_rad);
-    phi = LM_CLAMP(phi, -LM_PI_2F, LM_PI_2F);
-    if (gp.lat_mean_rad < 0.0f) {
-      phi = LM_FABS(phi);
-      flip = true;
-    }
-  } else if (gp.lat_path == kLatPathLaplacianTightEnvelope) {
-    // Tight-envelope area-measure sampling for Laplacian near-pole
-    // (doc/near-pole-area-measure-sampling.md §2.1). Propose colatitude ~
-    // Gamma(2, b) via pcg_gamma2 (closed form theta = -b(ln u1 + ln u2)); accept
-    // with sin(theta)/theta (M=1, exact, never clamp). Structurally mirrors the
-    // kLatPathRayleigh branch above — same copysign/clamp/flip semantics for
-    // colatitude → phi (they depend only on the geometric fold, not on which
-    // proposal distribution generated theta). Consumes 2 uniform slots per
-    // attempt (pcg_gamma2) + 1 uniform slot (accept draw); expected ~1.007
-    // attempts for b <= 60° (scrum-328.4 Step 1 calibration, exp4).
-    int attempts = 0;
-    float colatitude = 0.0f;
-    bool accept = false;
-    do {
-      colatitude = pcg_gamma2(s, gp.lat_std_rad);
-      attempts++;
-      if (attempts >= kMaxRejectionAttempts) {
-        break;
-      }
-      accept = pcg_uniform(s) < pcg_sinc(colatitude);
-    } while (!accept);
-    attempts_total = attempts;
-    phi = LM_COPYSIGN(LM_PI_2F - colatitude, gp.lat_mean_rad);
-    phi = LM_CLAMP(phi, -LM_PI_2F, LM_PI_2F);
-    if (gp.lat_mean_rad < 0.0f) {
-      phi = LM_FABS(phi);
-      flip = true;
-    }
   } else if (gp.lat_path == kLatPathGaussLegacy) {
     float raw = pcg_get_dist(s, kDistGaussianLegacy, gp.lat_mean_rad, gp.lat_std_rad);
     normalize_latitude(raw, phi, flip);
   } else if (gp.lat_path == kLatPathLutInverseCdf) {
-    // Unified area-measure inverse-CDF LUT (330.2). One uniform draw + fixed binary search (no
-    // rejection loop, attempts_total stays 1); flip via the per-bin probability reproduces the
-    // pole-crossing azimuth flip. Same single-source invert_lat_lut / lat_lut_bin as the CPU
-    // sampler (math.cpp). The three LUT arrays are bound as separate device buffers (they cannot
-    // live inside the setBytes-uploaded GenRootKernelParams struct).
+    // Unified area-measure inverse-CDF LUT (330.2; sole non-degenerate path since 330.3). One
+    // uniform draw + fixed binary search (no rejection loop, attempts_total stays 1); flip via the
+    // per-bin probability reproduces the pole-crossing azimuth flip. Same single-source
+    // invert_lat_lut / lat_lut_bin as the CPU sampler (math.cpp). The three LUT arrays are bound as
+    // separate device buffers (they cannot live inside the setBytes-uploaded GenRootKernelParams
+    // struct).
     float xi = pcg_uniform(s);
     float colatitude = invert_lat_lut(xi, lat_lut_theta, lat_lut_cdf, gp.lat_lut_n);
     phi = LM_PI_2F - colatitude;  // colatitude-from-zenith (theta_z in [0,pi]) -> latitude in [-pi/2,pi/2]
     uint32_t bin = lat_lut_bin(colatitude, lat_lut_theta, gp.lat_lut_n);
     flip = pcg_uniform(s) < lat_lut_flip[bin];
-  } else {
-    // kLatPathGenericReject (math.cpp:503-517).
-    int attempts = 0;
-    bool accept = false;
-    do {
-      float raw = pcg_get_dist(s, gp.lat_dist_type, gp.lat_mean_rad, gp.lat_std_rad);
-      normalize_latitude(raw, phi, flip);
-      attempts++;
-      if (attempts >= kMaxRejectionAttempts) {
-        break;
-      }
-      float accept_u = pcg_uniform(s);
-      accept = accept_u < LM_COS(phi) / gp.lat_rejection_m;
-    } while (!accept);
-    attempts_total = attempts;
   }
   if (gp.lat_path != kLatPathFullSphere) {
     lon = pcg_get_dist(s, gp.az_type, gp.az_mean_rad, gp.az_std_rad);

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -329,6 +329,21 @@ LM_FN float invert_lat_lut(float xi, LM_DEVICE const float* theta_nodes, LM_DEVI
   return theta_nodes[lo] + w * (theta_nodes[lo + 1u] - theta_nodes[lo]);
 }
 
+// Flip-table bin index for a colatitude sampled from the uniform-theta LUT (330.2).
+// theta_nodes are UNIFORMLY spaced over [theta_nodes[0], theta_nodes[n-1]], so the
+// containing interval is a direct O(1) computation (no search). Returns an index in
+// [0, n_nodes-2]; the caller reads flip_prob[idx] and draws a Bernoulli flip bit. Host and
+// device compute the same index this way, keeping the flip semantics single-sourced.
+LM_FN uint32_t lat_lut_bin(float theta, LM_DEVICE const float* theta_nodes, uint32_t n_nodes) {
+  float span = theta_nodes[n_nodes - 1u] - theta_nodes[0];
+  float t = span > 0.0f ? (theta - theta_nodes[0]) / span : 0.0f;
+  int idx = static_cast<int>(t * static_cast<float>(n_nodes - 1u));
+  idx = idx < 0 ? 0 : idx;
+  int last = static_cast<int>(n_nodes) - 2;
+  idx = idx > last ? last : idx;
+  return static_cast<uint32_t>(idx);
+}
+
 // Replicates InitRay_rot + SampleSphericalPointsSph (simulator.cpp:138-150 +
 // math.cpp:404/444). All distribution params are pre-converted to radians on
 // the host so the kernel does no degree↔radian conversions.

--- a/src/core/shared/pcg_shared.h
+++ b/src/core/shared/pcg_shared.h
@@ -57,6 +57,7 @@ LM_CONSTANT uint32_t kLatPathRayleigh = 2u;                // kGaussian near-pol
 LM_CONSTANT uint32_t kLatPathGaussLegacy = 3u;             // kGaussianLegacy
 LM_CONSTANT uint32_t kLatPathGenericReject = 4u;           // kGaussian/kUniform/kZigzag/kLaplacian
 LM_CONSTANT uint32_t kLatPathLaplacianTightEnvelope = 5u;  // kLaplacian near-pole optimization
+LM_CONSTANT uint32_t kLatPathLutInverseCdf = 6u;           // unified area-measure inverse-CDF LUT (330.2)
 
 // DistributionType enum values (must match src/core/math.hpp). Crystal-rot
 // parity REQUIRES the GenericReject path know the actual proposal type, so
@@ -285,6 +286,47 @@ LM_FN void normalize_latitude(float phi, LM_THREAD float& phi_out, LM_THREAD boo
     theta = 2.0f * LM_PI_F - theta;
   }
   phi_out = LM_PI_2F - theta;
+}
+
+// Unified area-measure latitude sampler (330.2 core-lut-sampler; design:
+// doc/near-pole-area-measure-sampling.md + explore unify-orientation-sampling-cosine-measure).
+// Numerical inverse-CDF over a uniform-theta node table: theta_nodes[i] / cdf_nodes[i]
+// for i in [0, n_nodes-1], with cdf_nodes STRICTLY increasing (BuildLatLut enforces the
+// monotonicity lift; both the search predicate and the interpolation denominator rely on
+// it). Given a uniform draw xi, returns colatitude theta = F^-1(xi) by binary search +
+// linear interpolation.
+//
+// RNG-agnostic single source: the host CPU sampler (RandomNumberGenerator) and the device
+// gen/transit kernels (PcgStream) each draw their own xi and call THIS one function — the
+// mirrored rejection loops disappear. Pointers are LM_DEVICE so the table lives in a Metal
+// `device` buffer bound separately (NOT embedded in the setBytes GenRootKernelParams
+// struct, which cannot carry device pointers) / a plain CUDA/host pointer.
+//
+// Node placement is uniform-theta (NOT equal-xi) with a fixed binary search: explore
+// exp3/exp5 showed equal-xi O(1) indexing smears the extreme tail and a guide table has a
+// warp-stalling worst case, while uniform-theta + binary search is tail-exact at N=256.
+// With (n_nodes-1) a power of two (256 intervals) the `hi-lo>1` loop runs a constant 8
+// iterations for every xi → warp-uniform, no control divergence. xi is clamped into the
+// representable CDF span so the (possibly lifted) endpoints and xi==1.0 resolve cleanly;
+// the denom>0 guard makes a degenerate (bit-equal) bin return its lower node instead of NaN.
+LM_FN float invert_lat_lut(float xi, LM_DEVICE const float* theta_nodes, LM_DEVICE const float* cdf_nodes,
+                           uint32_t n_nodes) {
+  xi = LM_CLAMP(xi, cdf_nodes[0], cdf_nodes[n_nodes - 1u]);
+  uint32_t lo = 0u;
+  uint32_t hi = n_nodes - 1u;
+  while (hi - lo > 1u) {
+    uint32_t mid = (lo + hi) >> 1u;
+    if (cdf_nodes[mid] <= xi) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  float c0 = cdf_nodes[lo];
+  float c1 = cdf_nodes[lo + 1u];
+  float denom = c1 - c0;
+  float w = denom > 0.0f ? (xi - c0) / denom : 0.0f;
+  return theta_nodes[lo] + w * (theta_nodes[lo + 1u] - theta_nodes[lo]);
 }
 
 // Replicates InitRay_rot + SampleSphericalPointsSph (simulator.cpp:138-150 +

--- a/test/parity-cross-backend/backend/test_metal_root_gen.cpp
+++ b/test/parity-cross-backend/backend/test_metal_root_gen.cpp
@@ -821,19 +821,13 @@ TEST(RngObservabilityFacilitySmoke, NearPoleUniformAcceptanceRateBeatsBaseline) 
   const AttemptStats stats = ComputeAttemptStats(attempts);
   EXPECT_EQ(stats.safety_valve_hits, 0u);
 
-  // Theoretical mean(attempts) ≈ 1.996 with new tight M; ±15% band absorbs MC
-  // noise + the exact fold-integral approximation. Tight enough to reject the
-  // old M=1.0 baseline (which would give ~15).
-  constexpr double kAnchor = 1.996;
-  const double lo = kAnchor * 0.85;
-  const double hi = kAnchor * 1.15;
-  EXPECT_GE(stats.mean, lo) << "uniform-near-pole mean(attempts)=" << stats.mean << " below anchor±15% [" << lo << ", "
-                            << hi << "] (anchor=" << kAnchor << ").";
-  EXPECT_LE(stats.mean, hi) << "uniform-near-pole mean(attempts)=" << stats.mean << " above anchor±15% [" << lo << ", "
-                            << hi << "] (anchor=" << kAnchor << ").";
-  // Independent rejection of old-M=1.0 baseline (would give ~15 attempts).
-  EXPECT_LT(stats.mean, 6.0) << "uniform-near-pole mean(attempts)=" << stats.mean
-                             << " — tight envelope not active? old M=1.0 baseline would give ~15.";
+  // 330.2 S5: the unified inverse-CDF LUT has NO rejection loop — every ray is exactly one draw,
+  // so mean(attempts) == 1 exactly. This is the strongest possible "beats baseline": the near-pole
+  // rejection cost (old rejection sampler gave ~2 at best, ~15 for the M=1.0 degenerate) is fully
+  // eliminated. attempts==1 also confirms the device LUT branch is active (any rejection path would
+  // report >1).
+  EXPECT_NEAR(stats.mean, 1.0, 1e-6) << "unified LUT is rejection-free → mean(attempts) must be 1; got " << stats.mean
+                                     << " (>1 would mean the device LUT branch is not active).";
 }
 
 // scrum-328.3 Step 4(c) — device (Metal) vs CPU (math.cpp::SampleSphericalPointsSph)

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -1,11 +1,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
+#include <vector>
 
 #include "core/crystal.hpp"
 #include "core/math.hpp"
 #include "core/shared/lat_path_selection.hpp"
+#include "core/shared/pcg_shared.h"
 #include "util/threading_pool.hpp"
 
 namespace {
@@ -1339,6 +1342,72 @@ TEST_F(RngTest, LaplacianJsonRoundTrip) {
   EXPECT_EQ(parsed.type, DistributionType::kLaplacian);
   EXPECT_FLOAT_EQ(parsed.mean, 45.0f);
   EXPECT_FLOAT_EQ(parsed.std, 3.0f);
+}
+
+// --- 330.2 invert_lat_lut (unified area-measure inverse-CDF LUT) --------------
+// Pins the numeric contract of the pure single-source inversion used by BOTH the
+// CPU sampler and the device gen/transit kernels, independent of the
+// distribution-specific BuildLatLut (330.2 S2). Covers analytic tables with known
+// inverses + the fp32 monotonicity guards (degenerate bin, xi clamp at lifted
+// endpoints). Uniform-theta + fixed binary search (explore exp3/exp5).
+namespace {
+constexpr float kHalfPiF = 1.5707963267948966f;
+}
+
+TEST(InvertLatLutTest, LinearCdfIsLinearInverse) {
+  constexpr uint32_t kN = 257;  // 256 intervals (power of two -> constant 8-iter search)
+  std::vector<float> theta(kN), cdf(kN);
+  for (uint32_t i = 0; i < kN; ++i) {
+    const float t = static_cast<float>(i) / static_cast<float>(kN - 1);
+    theta[i] = kHalfPiF * t;
+    cdf[i] = t;  // linear CDF -> exact linear inverse
+  }
+  for (float xi : { 0.0f, 0.1f, 0.25f, 0.5f, 0.75f, 0.9f, 1.0f }) {
+    const float got = lm_pcg::invert_lat_lut(xi, theta.data(), cdf.data(), kN);
+    EXPECT_NEAR(got, xi * kHalfPiF, 1e-5f) << "xi=" << xi;
+  }
+}
+
+TEST(InvertLatLutTest, ClampsOutOfRangeAndLiftedEndpoints) {
+  // Endpoints deliberately != 0/1 (as after a monotonicity lift): xi outside
+  // [cdf[0], cdf[N-1]] must clamp to the boundary nodes, not read out of range.
+  constexpr uint32_t kN = 5;
+  const std::vector<float> theta = { 0.0f, 0.25f, 0.5f, 0.75f, 1.0f };
+  const std::vector<float> cdf = { 0.1f, 0.3f, 0.6f, 0.8f, 0.95f };
+  EXPECT_FLOAT_EQ(lm_pcg::invert_lat_lut(-1.0f, theta.data(), cdf.data(), kN), 0.0f);
+  EXPECT_FLOAT_EQ(lm_pcg::invert_lat_lut(2.0f, theta.data(), cdf.data(), kN), 1.0f);
+  EXPECT_FLOAT_EQ(lm_pcg::invert_lat_lut(0.1f, theta.data(), cdf.data(), kN), 0.0f);
+  EXPECT_FLOAT_EQ(lm_pcg::invert_lat_lut(0.95f, theta.data(), cdf.data(), kN), 1.0f);
+}
+
+TEST(InvertLatLutTest, DegenerateBinNoNaN) {
+  // A flat CDF region (c1 == c0) must not divide by zero; returns a finite node value.
+  constexpr uint32_t kN = 5;
+  const std::vector<float> theta = { 0.0f, 0.25f, 0.5f, 0.75f, 1.0f };
+  const std::vector<float> cdf = { 0.0f, 0.5f, 0.5f, 0.5f, 1.0f };  // flat middle
+  const float got = lm_pcg::invert_lat_lut(0.5f, theta.data(), cdf.data(), kN);
+  EXPECT_TRUE(std::isfinite(got));
+  EXPECT_GE(got, 0.0f);
+  EXPECT_LE(got, 1.0f);
+}
+
+TEST(InvertLatLutTest, MonotoneAndConvexCdfInverse) {
+  // Convex CDF F=t^2 (theta=kHalfPi*t) => inverse theta = kHalfPi*sqrt(xi).
+  constexpr uint32_t kN = 257;
+  std::vector<float> theta(kN), cdf(kN);
+  for (uint32_t i = 0; i < kN; ++i) {
+    const float t = static_cast<float>(i) / static_cast<float>(kN - 1);
+    theta[i] = kHalfPiF * t;
+    cdf[i] = t * t;
+  }
+  float prev = -1.0f;
+  for (int k = 0; k <= 100; ++k) {
+    const float xi = static_cast<float>(k) / 100.0f;
+    const float got = lm_pcg::invert_lat_lut(xi, theta.data(), cdf.data(), kN);
+    EXPECT_GE(got, prev - 1e-6f) << "non-monotone at xi=" << xi;
+    prev = got;
+  }
+  EXPECT_NEAR(lm_pcg::invert_lat_lut(0.25f, theta.data(), cdf.data(), kN), kHalfPiF * 0.5f, 2e-3f);
 }
 
 

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -849,11 +849,12 @@ TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeExactness) {
   axis.latitude_dist = { lumice::DistributionType::kLaplacian, 90.0f, 5.0f };
   axis.azimuth_dist = { lumice::DistributionType::kUniform, 0.0f, 360.0f };
 
-  // Sanity: confirm this config actually routes to the new path (else the test measures GenericReject).
+  // 330.2 S5: all Laplacian latitudes now route to the unified inverse-CDF LUT. The rest of this
+  // test is the valuable part — it validates the sampled colatitude against the ANALYTIC target
+  // p(θ) ∝ exp(-θ/b)·sin(θ) (the scrum-328 AC), which the LUT reproduces exactly.
   auto decision = lumice::lat_path::SelectLatPath(axis);
-  ASSERT_EQ(decision.kind, lumice::lat_path::LatPathKind::kLaplacianTightEnvelope)
-      << "Test configuration must trigger the tight-envelope branch; otherwise this test measures a different code "
-         "path.";
+  ASSERT_EQ(decision.kind, lumice::lat_path::LatPathKind::kLutInverseCdf)
+      << "Test configuration must route to the unified LUT path.";
 
   auto& rng = lumice::RandomNumberGenerator::GetInstance();
   rng.SetSeed(1234);
@@ -937,31 +938,33 @@ TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeExactness) {
 // silently accepting a possibly-unsafe wide-b tight-envelope. Also confirms the runtime
 // sampler still produces valid latitudes (no safety-valve corruption).
 TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeCrossoverFallback) {
-  // b=70° > 60° cap.
+  // 330.2 S5: the tight-envelope↔generic-reject CROSSOVER (b-cap, polar threshold) is unified
+  // away — every Laplacian latitude, near-pole / off-pole / wide-b alike, now routes to the single
+  // kLutInverseCdf path (the b cap + threshold distinctions only mattered for the retired branches;
+  // 330.3 may drop this test entirely). What remains worth guarding: all these configs route to the
+  // LUT and produce valid finite orientations. b=70° > old 60° cap.
   lumice::AxisDistribution axis;
   axis.latitude_dist = { lumice::DistributionType::kLaplacian, 90.0f, 70.0f };
   axis.azimuth_dist = { lumice::DistributionType::kUniform, 0.0f, 360.0f };
 
   auto decision = lumice::lat_path::SelectLatPath(axis);
-  EXPECT_EQ(decision.kind, lumice::lat_path::LatPathKind::kGenericReject)
-      << "Beyond the b cap, SelectLatPath must fall back to GenericReject.";
+  EXPECT_EQ(decision.kind, lumice::lat_path::LatPathKind::kLutInverseCdf)
+      << "Wide-b Laplacian must route to the unified LUT.";
 
-  // Also confirm the config just below the cap (b=59°) still triggers tight-envelope.
   lumice::AxisDistribution axis_within;
   axis_within.latitude_dist = { lumice::DistributionType::kLaplacian, 90.0f, 59.0f };
   axis_within.azimuth_dist = { lumice::DistributionType::kUniform, 0.0f, 360.0f };
   auto decision_within = lumice::lat_path::SelectLatPath(axis_within);
-  EXPECT_EQ(decision_within.kind, lumice::lat_path::LatPathKind::kLaplacianTightEnvelope)
-      << "Just below the b cap the tight-envelope branch must remain active.";
+  EXPECT_EQ(decision_within.kind, lumice::lat_path::LatPathKind::kLutInverseCdf)
+      << "Near-pole Laplacian must route to the unified LUT.";
 
-  // Boundary-miss config: mean=80° → colatitude_center=10° > kPolarThresholdRad=0.5° → GenericReject
-  // even at b=5°. Guards against the polar threshold being accidentally widened.
+  // Off-pole (mean=80° → colatitude_center=10°) also routes to the LUT now (previously GenericReject).
   lumice::AxisDistribution axis_offpole;
   axis_offpole.latitude_dist = { lumice::DistributionType::kLaplacian, 80.0f, 5.0f };
   axis_offpole.azimuth_dist = { lumice::DistributionType::kUniform, 0.0f, 360.0f };
   auto decision_offpole = lumice::lat_path::SelectLatPath(axis_offpole);
-  EXPECT_EQ(decision_offpole.kind, lumice::lat_path::LatPathKind::kGenericReject)
-      << "Off-pole Laplacian (colatitude_center=10°) must not trigger tight-envelope.";
+  EXPECT_EQ(decision_offpole.kind, lumice::lat_path::LatPathKind::kLutInverseCdf)
+      << "Off-pole Laplacian must route to the unified LUT.";
 
   // Runtime sanity for the wide-b GenericReject config: no NaN, latitudes in [-π/2, π/2].
   auto& rng = lumice::RandomNumberGenerator::GetInstance();
@@ -1211,9 +1214,12 @@ TEST(FoldRollFlipBalanceTest, RayleighNegativeMean) {
   }
 
   float flip_frac = static_cast<float>(flip_count) / kN;
-  // All samples near south pole → flip=true for all → roll≈π
-  EXPECT_GT(flip_frac, 0.99f) << "Rayleigh south-pole path must set flip=true for all samples";
-  EXPECT_EQ(negative_lat_count, 0) << "Rayleigh south-pole path must fold phi to positive";
+  // 330.2: the unified LUT PRESERVES the southern hemisphere. The retired Rayleigh abs() fold
+  // mapped a down-pointing c-axis to up (+ roll π) — an up/down-symmetry assumption that is wrong
+  // for up/down-asymmetric crystals (owner-confirmed 2026-07-05). So a mean=-89.9° c-axis stays at
+  // negative latitude, and with σ=0.01° no sample crosses the south pole → no fold, roll stays 0.
+  EXPECT_GT(negative_lat_count, kN * 99 / 100) << "unified LUT must keep down c-axis DOWN (negative latitude)";
+  EXPECT_LT(flip_frac, 0.01f) << "no south-pole crossing at σ=0.01° → flip≈0 (roll stays 0, not π)";
 }
 
 // Step 5 regression: positive-mean Rayleigh (north pole) must NOT trigger flip.
@@ -1287,8 +1293,11 @@ TEST(FoldRollFlipBalanceTest, LaplacianTightEnvelopeNegativeMean) {
     }
   }
   float flip_frac = static_cast<float>(flip_count) / kN;
-  EXPECT_GT(flip_frac, 0.99f) << "Laplacian tight-envelope south-pole path must set flip=true";
-  EXPECT_EQ(negative_lat_count, 0) << "Laplacian tight-envelope south-pole path must fold phi to positive";
+  // 330.2: unified LUT preserves the southern hemisphere (see RayleighNegativeMean). A down-pointing
+  // Laplacian c-axis (mean=-89.9°) stays at negative latitude; with b=0.01° no sample crosses the
+  // south pole → no fold. (Retired behavior folded it to positive latitude + flip.)
+  EXPECT_GT(negative_lat_count, kN * 99 / 100) << "unified LUT must keep down c-axis DOWN (negative latitude)";
+  EXPECT_LT(flip_frac, 0.05f) << "negligible south-pole crossing at b=0.01° → flip≈0";
 }
 
 

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "core/crystal.hpp"
+#include "core/lat_lut.hpp"
 #include "core/math.hpp"
 #include "core/shared/lat_path_selection.hpp"
 #include "core/shared/pcg_shared.h"
@@ -1408,6 +1409,126 @@ TEST(InvertLatLutTest, MonotoneAndConvexCdfInverse) {
     prev = got;
   }
   EXPECT_NEAR(lm_pcg::invert_lat_lut(0.25f, theta.data(), cdf.data(), kN), kHalfPiF * 0.5f, 2e-3f);
+}
+
+
+// --- 330.2 BuildLatLut: colatitude-marginal parity vs the real sampler ---------
+// The LUT's core job is to reproduce the folded area-measure colatitude distribution.
+// This marginal is flip-independent (flip rotates azimuth/roll, not latitude), so it
+// isolates the BuildLatLut quadrature/fold construction from the flip question.
+namespace {
+double KsStat(std::vector<double> a, std::vector<double> b) {
+  std::sort(a.begin(), a.end());
+  std::sort(b.begin(), b.end());
+  std::vector<double> all;
+  all.reserve(a.size() + b.size());
+  all.insert(all.end(), a.begin(), a.end());
+  all.insert(all.end(), b.begin(), b.end());
+  std::sort(all.begin(), all.end());
+  double d = 0.0;
+  for (double v : all) {
+    double ca = static_cast<double>(std::upper_bound(a.begin(), a.end(), v) - a.begin()) / a.size();
+    double cb = static_cast<double>(std::upper_bound(b.begin(), b.end(), v) - b.begin()) / b.size();
+    d = std::max(d, std::abs(ca - cb));
+  }
+  return d;
+}
+}  // namespace
+
+TEST(LatLutColatitudeTest, MatchesRealSamplerColatitudeMarginal) {
+  using lumice::AxisDistribution;
+  using lumice::DistributionType;
+  struct Cfg {
+    float mean;
+    float std;
+    DistributionType type;
+    const char* label;
+  };
+  const Cfg cfgs[] = {
+    { 90.0f, 5.0f, DistributionType::kGaussian, "gauss near-pole (real=Rayleigh)" },
+    { 60.0f, 5.0f, DistributionType::kGaussian, "gauss off-pole (real=generic)" },
+    { 30.0f, 8.0f, DistributionType::kGaussian, "gauss mid-latitude" },
+    { 90.0f, 5.0f, DistributionType::kLaplacian, "laplacian near-pole (real=tight)" },
+    { 0.0f, 20.0f, DistributionType::kUniform, "uniform band" },
+  };
+  constexpr int kN = 500000;
+  const double crit = 1.63 * std::sqrt(2.0 / kN);
+  auto& rng = lumice::RandomNumberGenerator::GetInstance();
+  rng.SetSeed(20260705);
+
+  for (const auto& c : cfgs) {
+    SCOPED_TRACE(c.label);
+    AxisDistribution axis;
+    axis.latitude_dist = lumice::Distribution{ c.type, c.mean, c.std };
+    axis.azimuth_dist.type = DistributionType::kUniform;  // uniform az: flip is a no-op here
+
+    std::vector<double> real(kN);
+    float lon_lat[3];
+    for (int i = 0; i < kN; ++i) {
+      lumice::RandomSampler::SampleSphericalPointsSph(axis, lon_lat);
+      real[i] = lumice::math::kPi_2 - lon_lat[1];  // colatitude-from-zenith
+    }
+
+    const lumice::LatLut table = lumice::BuildLatLut(axis.latitude_dist);
+    std::vector<double> lut(kN);
+    for (int i = 0; i < kN; ++i) {
+      const float xi = rng.GetUniform();
+      lut[i] = lm_pcg::invert_lat_lut(xi, table.theta.data(), table.cdf.data(), lumice::LatLut::kNodes);
+    }
+
+    // Allow a small slack over the two-sample KS crit for LUT node-resolution + fp32.
+    EXPECT_LT(KsStat(real, lut), crit * 2.0) << c.label;
+  }
+}
+
+// Full-direction parity for the COMMON regime (mean>0, uniform azimuth): the LUT must be
+// distributionally identical to the current sampler there — same colatitude AND same azimuth.
+// (For the edge regimes — southern near-pole, or near-pole + non-uniform azimuth — the LUT
+// intentionally diverges toward correctness: it preserves the up/down hemisphere the Rayleigh
+// abs() fold collapses, and keeps the over-vertical azimuth population Rayleigh drops. Those
+// are validated against the analytic target, not the old sampler, per the scrum-328 AC.)
+TEST(LatLutColatitudeTest, CommonRegimeAzimuthUnchanged) {
+  using lumice::AxisDistribution;
+  using lumice::DistributionType;
+  auto wrap = [](double a) {
+    const double two_pi = 2.0 * lumice::math::kPi;
+    a = std::fmod(a, two_pi);
+    return a < 0 ? a + two_pi : a;
+  };
+  const float means[] = { 90.0f, 60.0f, 30.0f };
+  constexpr int kN = 400000;
+  const double crit = 1.63 * std::sqrt(2.0 / kN);
+  auto& rng = lumice::RandomNumberGenerator::GetInstance();
+  rng.SetSeed(999);
+  for (float mean : means) {
+    SCOPED_TRACE(mean);
+    AxisDistribution axis;
+    axis.latitude_dist = lumice::Distribution{ DistributionType::kGaussian, mean, 5.0f };
+    // Full-circle uniform azimuth (std=360°) — the common near-pole case; flip is a no-op here.
+    // (A degenerate std=0 would fix azimuth at 0°, which IS the non-uniform edge case where the
+    // LUT intentionally diverges, so it must not be used to assert common-regime equivalence.)
+    axis.azimuth_dist = lumice::Distribution{ DistributionType::kUniform, 0.0f, 360.0f };
+    const lumice::LatLut table = lumice::BuildLatLut(axis.latitude_dist);
+
+    std::vector<double> az_real(kN), az_lut(kN);
+    float lon_lat[3];
+    for (int i = 0; i < kN; ++i) {
+      lumice::RandomSampler::SampleSphericalPointsSph(axis, lon_lat);
+      az_real[i] = wrap(lon_lat[0]);
+    }
+    for (int i = 0; i < kN; ++i) {
+      const float xi = rng.GetUniform();
+      const float th = lm_pcg::invert_lat_lut(xi, table.theta.data(), table.cdf.data(), lumice::LatLut::kNodes);
+      const uint32_t bin = lm_pcg::lat_lut_bin(th, table.theta.data(), lumice::LatLut::kNodes);
+      const bool flip = rng.GetUniform() < table.flip_prob[bin];
+      float az = rng.Get(axis.azimuth_dist) * lumice::math::kDegreeToRad;
+      if (flip) {
+        az += lumice::math::kPi;
+      }
+      az_lut[i] = wrap(az);
+    }
+    EXPECT_LT(KsStat(az_real, az_lut), crit * 2.0) << "azimuth must stay uniform (flip is a no-op here)";
+  }
 }
 
 

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -831,13 +831,12 @@ TEST_F(SphericalSamplingTest, LaplacianHeavierTailThanGaussian) {
 }
 
 
-// scrum-328.4 (Laplacian tight-envelope area-measure sampling). Verifies the CPU sampler
-// reproduces the ANALYTICAL target p(theta) ∝ exp(-theta/b) · sin(theta) on the near-pole
-// tight-envelope branch (mean=90°, colatitude_center=0 → routes to kLaplacianTightEnvelope).
-// Deliberately NOT a KS-match against the pre-existing GenericReject Laplacian sampler,
-// which has a known M=cos(5b) tail-clamp bias (scrum-328.1 exp1); the tight-envelope path
-// is exact by construction (M=1), so matching the old sampler would flag a valid improvement
-// as regression (issue.md AC hardline).
+// scrum-328.4 / 330.2 (unified area-measure LUT). Verifies the CPU sampler reproduces the
+// ANALYTICAL target p(theta) ∝ exp(-theta/b) · sin(theta) for a near-pole Laplacian
+// (mean=90°, colatitude_center=0 → routes to the unified inverse-CDF LUT, kLutInverseCdf).
+// Deliberately NOT a KS-match against the retired GenericReject Laplacian sampler, which had a
+// known M=cos(5b) tail-clamp bias (scrum-328.1 exp1); the LUT is exact by construction, so
+// matching the old sampler would flag a valid improvement as regression (issue.md AC hardline).
 //
 // Uses moment + CDF-quantile matching against the analytical target rather than bin-by-bin
 // density matching — the latter suffers from bin-boundary MC artifacts at the θ→0 corner
@@ -933,16 +932,12 @@ TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeExactness) {
 }
 
 
-// scrum-328.4 (crossover cap fallback). Verifies that when Laplacian scale exceeds
-// kMaxTightEnvelopeLaplacianBRad, SelectLatPath routes to kGenericReject rather than
-// silently accepting a possibly-unsafe wide-b tight-envelope. Also confirms the runtime
-// sampler still produces valid latitudes (no safety-valve corruption).
-TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeCrossoverFallback) {
-  // 330.2 S5: the tight-envelope↔generic-reject CROSSOVER (b-cap, polar threshold) is unified
-  // away — every Laplacian latitude, near-pole / off-pole / wide-b alike, now routes to the single
-  // kLutInverseCdf path (the b cap + threshold distinctions only mattered for the retired branches;
-  // 330.3 may drop this test entirely). What remains worth guarding: all these configs route to the
-  // LUT and produce valid finite orientations. b=70° > old 60° cap.
+// 330.3 (post branch-retirement smoke). The tight-envelope↔generic-reject crossover (b-cap,
+// polar threshold) it originally guarded no longer exists — every Laplacian latitude, near-pole
+// / off-pole / wide-b alike, routes to the single unified LUT path (kLutInverseCdf). What remains
+// worth guarding: all these configs route to the LUT and produce valid finite orientations.
+TEST_F(SphericalSamplingTest, LaplacianAllConfigsRouteToLut) {
+  // Wide b=70° (> old 60° cap): still routes to the LUT.
   lumice::AxisDistribution axis;
   axis.latitude_dist = { lumice::DistributionType::kLaplacian, 90.0f, 70.0f };
   axis.azimuth_dist = { lumice::DistributionType::kUniform, 0.0f, 360.0f };
@@ -966,7 +961,7 @@ TEST_F(SphericalSamplingTest, LaplacianTightEnvelopeCrossoverFallback) {
   EXPECT_EQ(decision_offpole.kind, lumice::lat_path::LatPathKind::kLutInverseCdf)
       << "Off-pole Laplacian must route to the unified LUT.";
 
-  // Runtime sanity for the wide-b GenericReject config: no NaN, latitudes in [-π/2, π/2].
+  // Runtime sanity for the wide-b config: no NaN, latitudes in [-π/2, π/2].
   auto& rng = lumice::RandomNumberGenerator::GetInstance();
   rng.SetSeed(2024);
   float lon_lat[3];


### PR DESCRIPTION
Unifies the three latitude orientation samplers (near-pole Rayleigh/Gamma tight-envelope + off-pole constant-M generic-rejection) into a **single** `u=cosθ` area-measure numerical inverse-CDF LUT (uniform-θ nodes + fixed-step binary search), retiring the near-pole/off-pole hard branch. Scrum `unify-orientation-sampling-cosine-measure` (330.1 explore → 330.2 impl → 330.3 retire).

## What & why
- `sinθ` is the measure Jacobian of the θ parameterization; the substitution `u=cosθ` makes the spherical area measure flat, collapsing near-pole and off-pole into one 1-D problem "sample from `∝ base_pdf(arccos u)`". One branchless path replaces three.
- Node placement is **uniform-θ + fixed binary search** (tail-exact at N=256); equal-ξ O(1)-index (extreme-tail smear) and guide-tables (warp-stalling worst case) and vMF (only covers Gaussian) were evaluated and rejected in the explore.
- `invert_lat_lut` / `lat_lut_bin` are a single RNG-agnostic source compiled on host + Metal + CUDA; the LUT eliminates the previously-mirrored rejection loops.

## Behavior
- **Common configs unchanged**: `mean>0` + full-circle uniform azimuth (the near-pole plate mainstream) is distributionally identical to the previous sampler (colatitude + azimuth KS both green).
- **Edge cases change, toward correctness** (validated against the analytic target `∝ base_pdf(θ)·sinθ`, not the old approximation): the fold-based LUT strictly **preserves the up/down hemisphere** (a down-pointing c-axis stays down) — the retired near-pole Rayleigh `abs()` folded south→north assuming up/down symmetry, which is wrong for up/down-asymmetric crystals. The over-vertical (pole-crossing) azimuth population is also preserved.

## Validation
- CPU + Metal (local): ctest 4/4 + Metal device-gen parity 13/13 + LatLut unit tests + fast e2e.
- CUDA (dev49, RTX 4060Ti): parity battery 10/10 (exit-seam 2 + filter 4 + multi-MS 4), identical to pre-unification numbers; multi-MS independently re-run to confirm.
- 330.3 removes the dead branches (−274 LOC) with all parity numbers unchanged (pure dead-code removal + one `kFullSphere` completion of the parameterized CPU overload).

## Notes
- `GenRootKernelParams.lat_rejection_m`/`lat_dist_type` are now dead (commented) but left in place to avoid a cross-backend wire-layout re-validation; a minor future cleanup.
- CUDA compiled + validated on dev49 (sm_86) + CI multi-arch fatbin covers sm_61; 1070Ti runtime not run (LUT wiring is arch-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)