### PR TITLE
perf(latlut): fix mixed-axis multi-crystal LUT rebuild thrash (~20x)

### DIFF
--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1994,13 +1994,15 @@ void CudaTraceBackend::Impl::UploadLatLut(const AxisDistribution& axis) {
   if (lat_path::SelectLatPath(axis).kind != lat_path::LatPathKind::kLutInverseCdf) {
     return;
   }
-  LatLut lut = BuildLatLut(axis.latitude_dist);
+  // task-335: shared build-once cache (was per-ci BuildLatLut = a full 65536-sample
+  // quadrature rebuilt on every crystal switch). Only the H2D copy stays per ci.
+  const LatLut* lut = GetSharedLatLut(axis.latitude_dist);
   constexpr size_t kBytes = static_cast<size_t>(LatLut::kNodes) * sizeof(float);
-  CheckCuda(cudaMemcpy(d_lat_lut_theta_, lut.theta.data(), kBytes, cudaMemcpyHostToDevice),
+  CheckCuda(cudaMemcpy(d_lat_lut_theta_, lut->theta.data(), kBytes, cudaMemcpyHostToDevice),
             "UploadLatLut cudaMemcpy d_lat_lut_theta");
-  CheckCuda(cudaMemcpy(d_lat_lut_cdf_, lut.cdf.data(), kBytes, cudaMemcpyHostToDevice),
+  CheckCuda(cudaMemcpy(d_lat_lut_cdf_, lut->cdf.data(), kBytes, cudaMemcpyHostToDevice),
             "UploadLatLut cudaMemcpy d_lat_lut_cdf");
-  CheckCuda(cudaMemcpy(d_lat_lut_flip_, lut.flip_prob.data(), kBytes, cudaMemcpyHostToDevice),
+  CheckCuda(cudaMemcpy(d_lat_lut_flip_, lut->flip_prob.data(), kBytes, cudaMemcpyHostToDevice),
             "UploadLatLut cudaMemcpy d_lat_lut_flip");
 }
 

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1375,11 +1375,13 @@ void MetalTraceBackend::Impl::UploadLatLut(const AxisDistribution& axis) {
   if (lat_path::SelectLatPath(axis).kind != lat_path::LatPathKind::kLutInverseCdf) {
     return;
   }
-  LatLut lut = BuildLatLut(axis.latitude_dist);
+  // task-335: shared build-once cache (was per-ci BuildLatLut = a full 65536-sample
+  // quadrature rebuilt on every crystal switch). Only the 3 KB memcpy stays per ci.
+  const LatLut* lut = GetSharedLatLut(axis.latitude_dist);
   constexpr size_t kLen = static_cast<size_t>(LatLut::kNodes) * sizeof(float);
-  std::memcpy([lat_lut_theta_buf_ contents], lut.theta.data(), kLen);
-  std::memcpy([lat_lut_cdf_buf_ contents], lut.cdf.data(), kLen);
-  std::memcpy([lat_lut_flip_buf_ contents], lut.flip_prob.data(), kLen);
+  std::memcpy([lat_lut_theta_buf_ contents], lut->theta.data(), kLen);
+  std::memcpy([lat_lut_cdf_buf_ contents], lut->cdf.data(), kLen);
+  std::memcpy([lat_lut_flip_buf_ contents], lut->flip_prob.data(), kLen);
 }
 
 void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& setting,

--- a/src/core/lat_lut.cpp
+++ b/src/core/lat_lut.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include "core/shared/pcg_shared.h"  // lm_pcg::normalize_latitude — single-source fold (device-matched)
@@ -175,6 +178,45 @@ LatLut BuildLatLut(const Distribution& lat_dist) {
   }
   lut.flip_prob[LatLut::kNodes - 1] = lut.flip_prob[LatLut::kNodes - 2];
   return lut;
+}
+
+namespace {
+
+// Cache key: the (type, mean, std) triple that fully determines a LatLut. Exact
+// float bit-equality matches the semantics of the old single-entry cache (a
+// re-configured but numerically identical distribution reuses the same LUT).
+struct LatLutKey {
+  DistributionType type;
+  float mean;
+  float std;
+  bool operator==(const LatLutKey& o) const { return type == o.type && mean == o.mean && std == o.std; }
+};
+
+struct LatLutKeyHash {
+  size_t operator()(const LatLutKey& k) const {
+    size_t h = std::hash<int>{}(static_cast<int>(k.type));
+    h = h * 1000003u ^ std::hash<float>{}(k.mean);
+    h = h * 1000003u ^ std::hash<float>{}(k.std);
+    return h;
+  }
+};
+
+}  // namespace
+
+const LatLut* GetSharedLatLut(const Distribution& lat_dist) {
+  // Process-lifetime memoization. unique_ptr gives a stable pointee address
+  // (unordered_map never rehashes the managed object, and we never erase), so
+  // the returned pointer stays valid and the immutable LatLut is safe to read
+  // concurrently without the lock. The mutex only serializes lookup/insert.
+  static std::mutex mu;
+  static std::unordered_map<LatLutKey, std::unique_ptr<LatLut>, LatLutKeyHash> cache;
+  const LatLutKey key{ lat_dist.type, lat_dist.mean, lat_dist.std };
+  std::lock_guard<std::mutex> lock(mu);
+  auto it = cache.find(key);
+  if (it == cache.end()) {
+    it = cache.emplace(key, std::make_unique<LatLut>(BuildLatLut(lat_dist))).first;
+  }
+  return it->second.get();
 }
 
 }  // namespace lumice

--- a/src/core/lat_lut.hpp
+++ b/src/core/lat_lut.hpp
@@ -41,6 +41,24 @@ struct LatLut {
 // handled by their own paths and are not passed here.
 LatLut BuildLatLut(const Distribution& lat_dist);
 
+// Thread-safe, process-lifetime, build-once memoized accessor for the unified
+// area-measure latitude LUT, keyed on (type, mean, std). This is the SINGLE
+// source that amortizes BuildLatLut across all legacy-CPU worker threads and
+// both GPU backends (task-335). It replaced the per-thread single-entry cache
+// whose most-recent-only policy thrashed catastrophically when a worker's
+// crystal loop interleaved distinct latitude distributions (e.g. a plate
+// zenith~=90 alternating with a column zenith~=0): every crystal switch missed
+// and rebuilt the 65536-sample quadrature (measured 250000 builds / ~20x
+// slowdown on an 8-crystal mixed config).
+//
+// The returned pointer is stable (map elements are never erased) and the LatLut
+// is immutable once built, so callers may read it concurrently WITHOUT holding
+// any lock. The internal mutex only guards the lookup/insert, which happens once
+// per crystal-batch on CPU / once per ci on GPU — never per ray, so contention
+// is negligible. Intended for the LUT-routed families only (kGaussian / kUniform
+// / kZigzag / kLaplacian); callers gate on lat_path::SelectLatPath first.
+const LatLut* GetSharedLatLut(const Distribution& lat_dist);
+
 }  // namespace lumice
 
 #endif  // LM_LAT_LUT_H_

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -416,28 +416,6 @@ void RandomSampler::SampleSphericalPointsSph(float* data, size_t num, size_t ste
 }
 
 
-namespace {
-// Thread-local most-recent LUT cache (330.2, plan-review C1): BuildLatLut is amortized once per
-// axis distribution, never per ray. Callers may pass a prebuilt LUT to bypass this; otherwise the
-// sampler caches the most recently used latitude distribution per worker thread. InitRay_rot
-// processes one crystal_axis per batch, so this is one build per batch on the cache-miss path.
-const LatLut& CachedLatLut(const Distribution& d) {
-  thread_local LatLut cached;
-  thread_local bool valid = false;
-  thread_local DistributionType key_type = DistributionType::kNoRandom;
-  thread_local float key_mean = 0.0f;
-  thread_local float key_std = 0.0f;
-  if (!valid || key_type != d.type || key_mean != d.mean || key_std != d.std) {
-    cached = BuildLatLut(d);
-    valid = true;
-    key_type = d.type;
-    key_mean = d.mean;
-    key_std = d.std;
-  }
-  return cached;
-}
-}  // namespace
-
 void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, float* data, size_t num,
                                              const LatLut* lat_lut) {
   auto& rng = RandomNumberGenerator::GetInstance();
@@ -468,9 +446,12 @@ void RandomSampler::SampleSphericalPointsSph(const AxisDistribution& axis_dist, 
     } else if (decision.kind == lat_path::LatPathKind::kLutInverseCdf) {
       // Unified area-measure inverse-CDF LUT (330.2). One uniform draw + fixed binary search
       // (no rejection loop); flip reproduces the pole-crossing azimuth flip via the per-bin
-      // flip probability. The LUT is amortized once per axis distribution (passed-in or cached),
-      // never per ray. Shares lm_pcg::invert_lat_lut / lat_lut_bin with the device kernels.
-      const LatLut& lut = (lat_lut != nullptr) ? *lat_lut : CachedLatLut(axis_dist.latitude_dist);
+      // flip probability. The LUT is amortized once per axis distribution, never per ray.
+      // Shares lm_pcg::invert_lat_lut / lat_lut_bin with the device kernels. Production
+      // (InitRay_rot) resolves the LUT once per crystal-batch and passes it in; the nullptr
+      // fallback routes to the shared build-once cache (task-335) so low-frequency callers
+      // (unit tests) still share one LUT instead of thrashing the old single-entry cache.
+      const LatLut& lut = (lat_lut != nullptr) ? *lat_lut : *GetSharedLatLut(axis_dist.latitude_dist);
       const float xi = rng.GetUniform();
       const float theta_z = lm_pcg::invert_lat_lut(xi, lut.theta.data(), lut.cdf.data(), LatLut::kNodes);
       phi = math::kPi_2 - theta_z;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -26,8 +26,10 @@
 #include "core/buffer.hpp"
 #include "core/crystal.hpp"
 #include "core/filter_spec.hpp"
+#include "core/lat_lut.hpp"
 #include "core/math.hpp"
 #include "core/optics.hpp"
+#include "core/shared/lat_path_selection.hpp"
 #include "util/env_knobs.hpp"
 #include "util/illuminant.hpp"
 #include "util/logger.hpp"
@@ -163,9 +165,21 @@ Rotation BuildCrystalRotation(float azimuth_rad, float latitude_rad, float roll_
 void InitRay_rot(RandomNumberGenerator& rng, const AxisDistribution& crystal_axis,  // input
                  RayBuffer buffer_data[2]) {                                        // output
   float lon_lat_roll[3]{};
+  // Resolve the shared latitude LUT ONCE per crystal-batch: crystal_axis is
+  // constant across this buffer, so a per-ray cache lookup (the old CachedLatLut)
+  // is wasteful, and — worse — pulling the shared build-once cache on every ray
+  // would serialize all worker threads on its mutex. Resolve here, pass the
+  // pointer into the per-ray sampler (task-335). Only the LUT-routed families
+  // need it; full-sphere / legacy-gauss / no-random take their own sampler
+  // branch and ignore a nullptr.
+  const bool full_sphere = crystal_axis.IsFullSphereUniform();
+  const LatLut* lat_lut = nullptr;
+  if (!full_sphere && lat_path::SelectLatPath(crystal_axis).kind == lat_path::LatPathKind::kLutInverseCdf) {
+    lat_lut = GetSharedLatLut(crystal_axis.latitude_dist);
+  }
   for (auto& r : buffer_data[0]) {
-    if (!crystal_axis.IsFullSphereUniform()) {
-      RandomSampler::SampleSphericalPointsSph(crystal_axis, lon_lat_roll);
+    if (!full_sphere) {
+      RandomSampler::SampleSphericalPointsSph(crystal_axis, lon_lat_roll, 1, lat_lut);
     } else {
       // Randomly sample on sphere (with asin(u) Jacobian correction); roll sampled separately below.
       RandomSampler::SampleSphericalPointsSph(lon_lat_roll);

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -1535,5 +1535,41 @@ TEST(LatLutColatitudeTest, CommonRegimeAzimuthUnchanged) {
   }
 }
 
+// task-335: GetSharedLatLut is the single build-once cache that replaced the
+// per-thread single-entry cache whose most-recent-only policy thrashed when a
+// worker's crystal loop interleaved distinct latitude distributions. Lock its
+// contract: (1) same key -> same stable pointer (memoized, not rebuilt);
+// (2) distinct keys -> distinct entries; (3) content is bit-identical to a
+// direct BuildLatLut (memoization must not perturb the numeric result -> parity
+// preserved). Regression guard against reintroducing a thrashing / rebuilding cache.
+TEST(SharedLatLutTest, MemoizesAndMatchesBuildLatLut) {
+  using lumice::Distribution;
+  using lumice::DistributionType;
+
+  const Distribution plate{ DistributionType::kGaussian, 90.0f, 0.3f };
+  const Distribution column{ DistributionType::kGaussian, 0.0f, 0.3f };
+
+  // (1) Same key returns the same cached pointer across repeated (and interleaved) calls.
+  const lumice::LatLut* p1 = lumice::GetSharedLatLut(plate);
+  const lumice::LatLut* c1 = lumice::GetSharedLatLut(column);
+  const lumice::LatLut* p2 = lumice::GetSharedLatLut(plate);  // interleaved re-request
+  const lumice::LatLut* c2 = lumice::GetSharedLatLut(column);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(c1, nullptr);
+  EXPECT_EQ(p1, p2) << "same distribution must reuse the cached LUT (no rebuild)";
+  EXPECT_EQ(c1, c2) << "same distribution must reuse the cached LUT (no rebuild)";
+
+  // (2) Distinct keys map to distinct entries.
+  EXPECT_NE(p1, c1) << "distinct distributions must not collide to one entry";
+
+  // (3) Cached content is bit-identical to a fresh direct build (parity guarantee).
+  const lumice::LatLut fresh = lumice::BuildLatLut(plate);
+  for (uint32_t i = 0; i < lumice::LatLut::kNodes; ++i) {
+    EXPECT_EQ(p1->theta[i], fresh.theta[i]) << "theta[" << i << "]";
+    EXPECT_EQ(p1->cdf[i], fresh.cdf[i]) << "cdf[" << i << "]";
+    EXPECT_EQ(p1->flip_prob[i], fresh.flip_prob[i]) << "flip_prob[" << i << "]";
+  }
+}
+
 
 }  // namespace


### PR DESCRIPTION
## Problem

Owner found a GUI performance regression: in a multi-crystal scene, as soon as **one** crystal uses `axis=plate` (with the others non-plate) it becomes much slower; all-plate or all-non-plate stay fast.

## Root cause

The unified area-measure latitude sampler (scrum-328/330/332) precomputes a per-distribution inverse-CDF LUT via `BuildLatLut` (a 65536-sample quadrature). On the legacy CPU path it was memoized by a `thread_local`, single-entry, **most-recent-only** cache (`CachedLatLut`). A worker's crystal loop processes crystals sequentially; when it interleaves two distinct latitude distributions — e.g. a plate crystal (zenith≈90) alternating with a column crystal (zenith≈0), both routed to the LUT — every crystal switch missed and rebuilt the table. The GPU backends were worse: `UploadLatLut` rebuilt unconditionally per ci with no cache at all.

### Evidence (8-crystal configs, identical geometry, axis-only difference)

| config | wall | CPU | `BuildLatLut` calls |
|--------|------|-----|---------------------|
| all-plate | 1.05s | 8.9s | 12 |
| all-column | 1.02s | 8.9s | 12 |
| **mixed** (before) | **20.70s** | **216s** | **250000** |
| **mixed** (after) | **1.03s** | **8.9s** | **2** |

## Fix

Introduce `GetSharedLatLut`: a process-lifetime, thread-safe, build-once memoized cache keyed on `(type, mean, std)`, stored as `unordered_map<Key, unique_ptr<LatLut>>` (stable pointee + immutable after build → safe to read concurrently without a lock). It is the single source consumed by all three backends (CPU / Metal / CUDA).

The CPU path resolves the LUT **once per crystal-batch** in `InitRay_rot` (`crystal_axis` is constant across the buffer) and passes it into the per-ray sampler via the pre-existing `const LatLut*` parameter — so the shared cache's mutex is touched once per batch, never per ray. The deleted `CachedLatLut` single-entry cache is replaced; the nullptr fallback also routes to the shared cache.

LUT contents are bit-identical to a direct `BuildLatLut`, so the sampled distribution and RNG draw order are unchanged (parity preserved).

## Verification

- **Perf**: mixed config 20.70s → 1.03s (matches homogeneous); `BuildLatLut` 250000 → 2 (shared across all 12 workers).
- **Parity**: existing LUT moment-match / Jacobian / Metal root-gen parity tests pass unchanged; new `SharedLatLutTest` locks the memoize / distinct-key / bit-identical-content contract.
- **Gates**: unit + parity + policy + format all green (macOS).
- CUDA change is a pure host-side substitution equivalent to the (verified) Metal change; dev49 parity battery running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)