### PR TITLE
fix(gui): correct crystal-preview face labels + reset pose on card switch (task-337)

### DIFF
--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -190,6 +190,16 @@ bool BuildCrystalMeshData(const CrystalConfig& cr, LUMICE_CrystalMesh* out) {
       n[2] = -ny;
     }
   }
+  // Same Y-Z swap for per-face unit normals so face_number_overlay.cpp reads
+  // them in the same GL frame as `vertices` (both feed into ProjectLabelToScreen
+  // together — mixed frames flip front/back on the fixed 90° offset).
+  for (int fi = 0; fi < out->face_count; fi++) {
+    float* n = &out->face_normals[fi * 3];
+    float ny = n[1];
+    float nz = n[2];
+    n[1] = nz;
+    n[2] = -ny;
+  }
 
   // AABB normalization: scale to fit unit cube
   if (out->vertex_count > 0) {

--- a/src/gui/crystal_renderer.cpp
+++ b/src/gui/crystal_renderer.cpp
@@ -325,6 +325,12 @@ void CrystalRenderer::UpdateMesh(const float* vertices, int vertex_count, const 
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, triangle_count * 3 * sizeof(int), triangles, GL_DYNAMIC_DRAW);
 }
 
+void CrystalRenderer::ComputeEyeRotation(const float model_rotation[16], float out_m_eye[16]) {
+  float v_rot[16];
+  BuildViewRotation(v_rot);
+  Mul4x4Rot(v_rot, model_rotation, out_m_eye);
+}
+
 float CrystalRenderer::ComputeDist(float zoom) {
   float half_tan = std::tan(kFovDeg * kDeg2Rad * 0.5f);
   return zoom / half_tan;
@@ -355,11 +361,9 @@ void CrystalRenderer::ComputeMvp(const float model_rotation[16], float zoom, int
   // model_rotation is the user-controlled crystal orientation in world
   // coordinates. Mouse-drag mutates the model matrix (left-multiplied by
   // world-axis Rodrigues), so the camera stays put.
-  float v_rot[16];
-  BuildViewRotation(v_rot);
   float view[16];
-  Mul4x4Rot(v_rot, model_rotation, view);  // 3x3 rotation; translation=0
-  view[14] = -dist;                        // append camera-back translation
+  ComputeEyeRotation(model_rotation, view);  // 3x3 rotation; translation=0
+  view[14] = -dist;                          // append camera-back translation
 
   // MVP = proj * view
   for (int i = 0; i < 4; i++) {
@@ -404,10 +408,8 @@ void CrystalRenderer::Render(const float rotation[16], float zoom, CrystalStyle 
   // the shader uniform stays a pure rotation since dFdx/dFdy are
   // translation-invariant.
   float dist = ComputeDist(zoom);
-  float v_rot[16];
-  BuildViewRotation(v_rot);
   float m_eye[16];
-  Mul4x4Rot(v_rot, rotation, m_eye);  // 3x3 rotation, translation=0
+  ComputeEyeRotation(rotation, m_eye);  // 3x3 rotation, translation=0
   float view[16];
   std::memcpy(view, m_eye, 16 * sizeof(float));
   view[14] = -dist;  // append camera-back translation for eye-space midpoint

--- a/src/gui/crystal_renderer.hpp
+++ b/src/gui/crystal_renderer.hpp
@@ -39,6 +39,14 @@ class CrystalRenderer {
   // coordinates; changing this function must keep Render's internal use in sync.
   static void ComputeMvp(const float rotation[16], float zoom, int width, int height, float out_mvp[16]);
 
+  // Compose the model → eye rotation used for eye-space front/back classification.
+  // out_m_eye = V_rot(Rx(+kCameraTiltDeg)) · model_rotation (3×3 rotation part;
+  // translation left at 0, homogeneous slot at 1). Both Render() (edge cull)
+  // and face_number_overlay's ProjectLabelToScreen must use this same matrix —
+  // using the raw model_rotation drops the fixed camera tilt and mislabels
+  // faces near the horizon.
+  static void ComputeEyeRotation(const float model_rotation[16], float out_m_eye[16]);
+
   // Get the rendered texture ID for ImGui::Image()
   uintptr_t GetTextureId() const;
 

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -73,6 +73,10 @@ constexpr float kEditModalMinHeightVertical = 0.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;
+// Tracks the crystal_id currently loaded into the preview trackball state so we
+// can detect card-to-card switches inside OpenEditModal (see Bug 2 fix). -1 =
+// no crystal loaded yet; cleared in ResetModalState alongside layer/entry idx.
+static int g_modal_view_crystal_id = -1;
 static int g_modal_entry_idx = -1;
 
 // Active tab is updated each frame inside the corresponding BeginTabItem true-branch
@@ -373,6 +377,19 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   // Pick-mode push_back paths (Link / Unlink / Duplicate) happen *after* the
   // modal closes, when no external references are held.
   const CrystalConfig& src_crystal = state.crystals[entry.crystal_id];
+
+  // Bug 2 fix: card-to-card switch must reset preview pose to the target
+  // crystal's axis default. Compare crystal_id (not layer/entry index) so that
+  // two linked entries backed by the same pool crystal don't spuriously reset
+  // (their trackball history is meaningful shared state). Skip when opening
+  // the same crystal_id we already had loaded — preserves the trackball state
+  // for "close then re-open the same entry" flows and keeps this idempotent
+  // relative to the existing pick-link-completion reset in app_panels.cpp:429.
+  if (entry.crystal_id != g_modal_view_crystal_id) {
+    ResetCrystalViewToCrystal(src_crystal);
+    g_modal_view_crystal_id = entry.crystal_id;
+  }
+
   g_crystal_buf = src_crystal;
   g_axis_buf[0] = src_crystal.zenith;
   g_axis_buf[1] = src_crystal.azimuth;
@@ -996,6 +1013,7 @@ void ResetModalState() {
   g_state.modal_immediate_mode = false;
   g_modal_layer_idx = -1;
   g_modal_entry_idx = -1;
+  g_modal_view_crystal_id = -1;
   g_crystal_buf = {};
   g_axis_buf[0] = {};
   g_axis_buf[1] = {};

--- a/src/gui/face_number_overlay.cpp
+++ b/src/gui/face_number_overlay.cpp
@@ -392,24 +392,23 @@ bool ProjectLabelToScreen(const FaceLabel* label, const float rotation[16], cons
   // NDC.y is Y-up; screen is Y-down.
   *out_screen_y = image_pos_y + (1.0f - (ndc_y + 1.0f) * 0.5f) * image_height;
 
-  // Front-face test mirrors crystal_renderer.cpp:358-385 (dot(n_eye,p_eye)<0).
-  // `view_rot` = rotation(3x3) + translate (0,0,-dist); only the translation
-  // contributes beyond the rotated center.
-  //
-  // DO NOT modify this formula independently of crystal_renderer.cpp:358-385 —
-  // change crystal_renderer first, then sync here. The reason not to share a
-  // helper: crystal_renderer operates on edge midpoint + dual edge-face-normal,
-  // while face_number uses face center + single face normal. Correspondence
-  // is mechanically guarded by test
-  // `unit/face_number_cull_matches_crystal_renderer_formula`.
+  // Front-face test: dot(n_eye, p_eye) < 0 in the SAME model→eye frame the
+  // renderer uses for edge classification (crystal_renderer.cpp::Render). The
+  // eye rotation is composed via the shared CrystalRenderer::ComputeEyeRotation
+  // (V_rot · model), so the fixed camera tilt kCameraTiltDeg is applied here
+  // too — a bare `rotation` would sit in the pre-tilt model frame and mislabel
+  // faces near the horizon. Correspondence with the renderer's per-edge cull
+  // is mechanically guarded by unit/face_number_cull_matches_crystal_renderer_formula.
   const float* n = label->display_normal;
   float dist = CrystalRenderer::ComputeDist(zoom);
-  float px = rotation[0] * p[0] + rotation[4] * p[1] + rotation[8] * p[2];
-  float py = rotation[1] * p[0] + rotation[5] * p[1] + rotation[9] * p[2];
-  float pz = rotation[2] * p[0] + rotation[6] * p[1] + rotation[10] * p[2] - dist;
-  float nxe = rotation[0] * n[0] + rotation[4] * n[1] + rotation[8] * n[2];
-  float nye = rotation[1] * n[0] + rotation[5] * n[1] + rotation[9] * n[2];
-  float nze = rotation[2] * n[0] + rotation[6] * n[1] + rotation[10] * n[2];
+  float m_eye[16];
+  CrystalRenderer::ComputeEyeRotation(rotation, m_eye);
+  float px = m_eye[0] * p[0] + m_eye[4] * p[1] + m_eye[8] * p[2];
+  float py = m_eye[1] * p[0] + m_eye[5] * p[1] + m_eye[9] * p[2];
+  float pz = m_eye[2] * p[0] + m_eye[6] * p[1] + m_eye[10] * p[2] - dist;
+  float nxe = m_eye[0] * n[0] + m_eye[4] * n[1] + m_eye[8] * n[2];
+  float nye = m_eye[1] * n[0] + m_eye[5] * n[1] + m_eye[9] * n[2];
+  float nze = m_eye[2] * n[0] + m_eye[6] * n[1] + m_eye[10] * n[2];
   *out_front_facing = (nxe * px + nye * py + nze * pz) < 0.0f;
 
   return true;

--- a/test/gui/functional/test_gui_face_number_overlay.cpp
+++ b/test/gui/functional/test_gui_face_number_overlay.cpp
@@ -745,4 +745,81 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
       }
     };
   }
+
+  // task-fix-crystal-preview-thumbnail Bug 1a: face_normals must be Y-Z swapped
+  // in the same coordinate frame as vertices before being handed to the overlay.
+  // Regression that ran without this test: BuildCrystalMeshData swapped
+  // vertices + edge_face_normals into GL frame but left face_normals in core
+  // frame, so ProjectLabelToScreen's front/back test compared a GL-frame center
+  // against a core-frame normal → systematic 90° error.
+  //
+  // Uses a view-independent geometric invariant instead of hard-coded face_number
+  // expectations (which are fragile against mesh topology changes): for a convex
+  // solid, every face normal must point away from the mesh centroid, i.e.
+  // dot(normal, center - centroid) > 0. This holds in ANY consistent frame; it
+  // fails only if the two vectors sit in different frames (the exact bug).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "unit", "face_number_normal_matches_center_frame");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      lumice::gui::ResetLastCrystalMesh();
+
+      // Two convex crystals of different topologies, exercising both prism
+      // faces and pyramid slanted faces so a partial swap (e.g. side faces only)
+      // would still trigger.
+      struct Case {
+        const char* label;
+        lumice::gui::CrystalConfig cfg;
+      };
+      lumice::gui::CrystalConfig prism_cfg;
+      prism_cfg.type = lumice::gui::CrystalType::kPrism;
+      prism_cfg.height = 1.0f;
+      lumice::gui::CrystalConfig pyramid_cfg;
+      pyramid_cfg.type = lumice::gui::CrystalType::kPyramid;
+      pyramid_cfg.prism_h = 1.0f;
+      pyramid_cfg.upper_h = 0.5f;
+      pyramid_cfg.lower_h = 0.5f;
+      pyramid_cfg.upper_alpha = 60.0f;
+      pyramid_cfg.lower_alpha = 60.0f;
+      const Case cases[] = { { "prism", prism_cfg }, { "pyramid", pyramid_cfg } };
+
+      for (const auto& c : cases) {
+        LUMICE_CrystalMesh mesh{};
+        IM_CHECK(lumice::gui::BuildCrystalMeshData(c.cfg, &mesh));
+        IM_CHECK_GT(mesh.face_count, 0);
+
+        // Centroid over the GL-frame vertex buffer (already swapped + AABB-
+        // normalized inside BuildCrystalMeshData).
+        float centroid[3] = { 0.0f, 0.0f, 0.0f };
+        for (int i = 0; i < mesh.vertex_count; ++i) {
+          centroid[0] += mesh.vertices[i * 3 + 0];
+          centroid[1] += mesh.vertices[i * 3 + 1];
+          centroid[2] += mesh.vertices[i * 3 + 2];
+        }
+        float inv_v = 1.0f / static_cast<float>(mesh.vertex_count);
+        centroid[0] *= inv_v;
+        centroid[1] *= inv_v;
+        centroid[2] *= inv_v;
+
+        FaceLabel labels[lumice::gui::kMaxFaceLabels] = {};
+        int n = AggregateFaceLabelsFromTopology(
+            mesh.vertices, mesh.vertex_count, mesh.face_count, mesh.face_numbers_by_face, mesh.face_vtx_offsets,
+            mesh.face_vtx_counts, mesh.face_vtx_pool, mesh.face_normals, labels, lumice::gui::kMaxFaceLabels);
+        IM_CHECK_GT(n, 0);
+
+        for (int i = 0; i < n; ++i) {
+          const float* ctr = labels[i].display_center;
+          const float* nrm = labels[i].display_normal;
+          float dx = ctr[0] - centroid[0];
+          float dy = ctr[1] - centroid[1];
+          float dz = ctr[2] - centroid[2];
+          float dot = nrm[0] * dx + nrm[1] * dy + nrm[2] * dz;
+          if (dot <= 0.0f) {
+            IM_ERRORF("crystal=%s face=%d dot(normal, center-centroid)=%f (must be > 0; frame mismatch)", c.label,
+                      labels[i].face_number, static_cast<double>(dot));
+          }
+        }
+      }
+    };
+  }
 }

--- a/test/gui/functional/test_gui_face_number_overlay.cpp
+++ b/test/gui/functional/test_gui_face_number_overlay.cpp
@@ -29,24 +29,48 @@ void RotX180(float m[16]) {
   m[15] = 1.0f;
 }
 
-// Reference front-face test mirroring crystal_renderer.cpp:358-385 verbatim.
-// Adapted from the edge-midpoint + dual edge-face-normal path to the
-// face-center + single face-normal case (see F7 notes in plan.md). Formula is
-// structurally identical: p_eye = rotation_3x3 * center + (0, 0, -dist);
-// n_eye = rotation_3x3 * normal; front = dot(n_eye, p_eye) < 0.
+// Reference front-face test — INDEPENDENTLY re-derives the same eye-space
+// front/back formula the renderer uses, so this test mechanically guards
+// cross-file drift instead of being a tautology on the production helper.
 //
-// DO NOT modify this reference formula independently of
-// crystal_renderer.cpp:358-385 — change crystal_renderer first, then sync
-// here. The test face_number_cull_matches_crystal_renderer_formula uses this
-// to mechanically guard cross-file formula drift.
+// Formula: m_eye = Rx(+kCameraTiltDeg) · rotation; p_eye = m_eye · center +
+// (0, 0, -dist); n_eye = m_eye · normal; front = dot(n_eye, p_eye) < 0.
+//
+// The Rx(+kCameraTiltDeg) 3×3 components are hand-written here (NOT via
+// CrystalRenderer::ComputeEyeRotation) so a wrong tilt sign / missing V_rot /
+// swapped composition order in the production side is caught by
+// face_number_cull_matches_crystal_renderer_formula rather than silently
+// mirrored.
 bool ReferenceFrontFacing(const float rotation[16], float zoom, const float center[3], const float normal[3]) {
+  const float angle = lumice::gui::kCameraTiltDeg * lumice::gui::CrystalRenderer::kDeg2Rad;
+  const float c = std::cos(angle);
+  const float s = std::sin(angle);
+  // V_rot = Rx(+kCameraTiltDeg), column-major 3×3 (padded to 4×4 semantics).
+  // Row 0: (1, 0, 0), Row 1: (0, c, -s), Row 2: (0, s, c).
+  const float v_rot[9] = {
+    1.0f, 0.0f, 0.0f,  // col 0
+    0.0f, c,    s,     // col 1
+    0.0f, -s,   c,     // col 2
+  };
+  // m_eye_3x3 = v_rot * rotation_3x3, column-major.
+  float m_eye[9] = {};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      float sum = 0.0f;
+      for (int k = 0; k < 3; ++k) {
+        // rotation is column-major 4×4 so column k lives at [k*4 + row].
+        sum += v_rot[i + k * 3] * rotation[k + j * 4];
+      }
+      m_eye[i + j * 3] = sum;
+    }
+  }
   float dist = lumice::gui::CrystalRenderer::ComputeDist(zoom);
-  float px = rotation[0] * center[0] + rotation[4] * center[1] + rotation[8] * center[2];
-  float py = rotation[1] * center[0] + rotation[5] * center[1] + rotation[9] * center[2];
-  float pz = rotation[2] * center[0] + rotation[6] * center[1] + rotation[10] * center[2] - dist;
-  float nx = rotation[0] * normal[0] + rotation[4] * normal[1] + rotation[8] * normal[2];
-  float ny = rotation[1] * normal[0] + rotation[5] * normal[1] + rotation[9] * normal[2];
-  float nz = rotation[2] * normal[0] + rotation[6] * normal[1] + rotation[10] * normal[2];
+  float px = m_eye[0] * center[0] + m_eye[3] * center[1] + m_eye[6] * center[2];
+  float py = m_eye[1] * center[0] + m_eye[4] * center[1] + m_eye[7] * center[2];
+  float pz = m_eye[2] * center[0] + m_eye[5] * center[1] + m_eye[8] * center[2] - dist;
+  float nx = m_eye[0] * normal[0] + m_eye[3] * normal[1] + m_eye[6] * normal[2];
+  float ny = m_eye[1] * normal[0] + m_eye[4] * normal[1] + m_eye[7] * normal[2];
+  float nz = m_eye[2] * normal[0] + m_eye[5] * normal[1] + m_eye[8] * normal[2];
   return (nx * px + ny * py + nz * pz) < 0.0f;
 }
 
@@ -453,10 +477,13 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
   }
 
   // Cross-file formula parity: ProjectLabelToScreen's front-face test must
-  // match the reference formula lifted from crystal_renderer.cpp:358-385
-  // (see ReferenceFrontFacing above). Three fixed input vectors spanning
-  // identity / off-axis / 180°-flipped configurations; **no randomness** to
-  // avoid CI flakiness.
+  // match the reference formula composed from CrystalRenderer::ComputeEyeRotation
+  // (see ReferenceFrontFacing above — independently re-derived, not a direct
+  // call, so the test guards drift rather than mirroring it). Four fixed
+  // cases spanning identity / off-axis / 180°-flipped / tilt-sensitive
+  // configurations; **no randomness** to avoid CI flakiness. Each case also
+  // carries an explicit `expected_front` so a bug that drops V_rot on BOTH
+  // sides is caught — pure ref==prod comparison alone would be a tautology.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "unit", "face_number_cull_matches_crystal_renderer_formula");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -468,36 +495,43 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
         float zoom;
         float center[3];
         float normal[3];
+        bool expected_front;
       };
-      std::array<Case, 3> cases{};
-      // Case 1: identity, center at origin, +Z normal → both say front.
+      std::array<Case, 4> cases{};
+      // Case 1: identity, center at origin, +Z normal → n_eye rotated by +15°
+      // pitches slightly downward but +Z dominance survives; still front.
       Identity4x4(cases[0].rot);
       cases[0].zoom = 2.0f;
-      cases[0].center[0] = 0.0f;
-      cases[0].center[1] = 0.0f;
       cases[0].center[2] = 0.0f;
-      cases[0].normal[0] = 0.0f;
-      cases[0].normal[1] = 0.0f;
       cases[0].normal[2] = 1.0f;
-      // Case 2: identity, off-axis center + tilted normal → both say back
-      // (matches the off_axis_back_facing test setup).
+      cases[0].expected_front = true;
+      // Case 2: identity, off-axis center + tilted normal → back
+      // (matches the off_axis_back_facing test setup; V_rot doesn't flip it
+      // because the +Y tilt of both p and n is small relative to the X terms).
       Identity4x4(cases[1].rot);
       cases[1].zoom = 0.5f;
       cases[1].center[0] = 0.8f;
-      cases[1].center[1] = 0.0f;
-      cases[1].center[2] = 0.0f;
       cases[1].normal[0] = 3.0f;
-      cases[1].normal[1] = 0.0f;
       cases[1].normal[2] = 1.0f;
-      // Case 3: X-180°, +Z normal → both say back.
+      cases[1].expected_front = false;
+      // Case 3: X-180°, +Z normal at origin → back.
       RotX180(cases[2].rot);
       cases[2].zoom = 2.0f;
-      cases[2].center[0] = 0.0f;
-      cases[2].center[1] = 0.0f;
-      cases[2].center[2] = 0.0f;
-      cases[2].normal[0] = 0.0f;
-      cases[2].normal[1] = 0.0f;
       cases[2].normal[2] = 1.0f;
+      cases[2].expected_front = false;
+      // Case 4 (tilt-sensitive): identity rotation, normal at 80° above the
+      // "back" hemisphere (0, sin80°, -cos80°) ≈ (0, 0.985, -0.174). Without
+      // V_rot, n_eye = normal, p_eye = (0,0,-dist), dot = +0.174·dist > 0 → back.
+      // With V_rot (Rx(+15°)), the normal tilts to θ=80°+15°=95° from +Z, giving
+      // a slightly forward-facing z-component, so dot flips to < 0 → front.
+      // A production regression that drops V_rot flips only prod's output;
+      // the reference (still composing V_rot) stays FRONT; IM_CHECK_EQ fires.
+      Identity4x4(cases[3].rot);
+      cases[3].zoom = 2.0f;
+      constexpr float kTiltCase4 = 80.0f * lumice::gui::CrystalRenderer::kDeg2Rad;
+      cases[3].normal[1] = std::sin(kTiltCase4);
+      cases[3].normal[2] = -std::cos(kTiltCase4);
+      cases[3].expected_front = true;
 
       for (const auto& c : cases) {
         FaceLabel label{};
@@ -513,6 +547,7 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
             ProjectLabelToScreen(&label, c.rot, mvp, c.zoom, 0.0f, 0.0f, 320.0f, 320.0f, &sx, &sy, &front_under_test));
         bool front_reference = ReferenceFrontFacing(c.rot, c.zoom, c.center, c.normal);
         IM_CHECK_EQ(front_under_test, front_reference);
+        IM_CHECK_EQ(front_under_test, c.expected_front);
       }
     };
   }

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -480,6 +480,98 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
     };
   }
 
+  // P1: task-fix-crystal-preview-thumbnail Bug 2 — opening the Edit modal on a
+  // different crystal card must snap the preview pose to the target crystal's
+  // axis default (equivalent to auto-clicking Reset View). Opening the SAME
+  // crystal_id twice in a row must preserve the trackball pose (so a user who
+  // dragged, closed, then re-opened the same entry sees the same view). The
+  // switch judge is crystal_id, not (layer_idx, entry_idx), so two entries
+  // sharing one pool crystal (Link scenario) share trackball history.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit_modal", "preview_pose_follows_crystal_switch");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Seed a second crystal in the pool with Column-preset axis params, then
+      // add a second entry bound to it. Entry 0 keeps the default (Random)
+      // crystal that DoNew() emits.
+      const gui::AxisDist az_full{ gui::AxisDistType::kUniform, 0.0f, 360.0f };
+      const gui::AxisDist roll_full{ gui::AxisDistType::kUniform, 0.0f, 360.0f };
+      const gui::AxisDist zenith_column{ gui::AxisDistType::kGauss, 90.0f, 1.0f };
+
+      gui::CrystalConfig c_column;
+      c_column.zenith = zenith_column;
+      c_column.azimuth = az_full;
+      c_column.roll = roll_full;
+      IM_CHECK_EQ(static_cast<int>(gui::ClassifyAxisPreset(c_column.zenith, c_column.azimuth, c_column.roll)),
+                  static_cast<int>(gui::AxisPreset::kColumn));
+
+      gui::EntryCard e_column;
+      e_column.crystal_id = static_cast<int>(gui::g_state.crystals.size());
+      gui::g_state.crystals.push_back(c_column);
+      gui::g_state.layers[0].entries.push_back(e_column);
+      ctx->Yield(2);
+
+      // Expected default poses for each entry's crystal.
+      const auto& cr0 = gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      gui::AxisDist params0[3] = { cr0.zenith, cr0.azimuth, cr0.roll };
+      float expected0[16] = { 0 };
+      gui::DefaultPreviewRotation(gui::ClassifyAxisPreset(cr0.zenith, cr0.azimuth, cr0.roll), params0, expected0);
+
+      gui::AxisDist params1[3] = { c_column.zenith, c_column.azimuth, c_column.roll };
+      float expected1[16] = { 0 };
+      gui::DefaultPreviewRotation(gui::AxisPreset::kColumn, params1, expected1);
+
+      // Open entry 0 (Random) via OpenEditModal (bypasses the Edit button so
+      // the assertion isolates OpenEditModal's own reset logic rather than the
+      // card-router indirection). The preview must snap to entry 0's default.
+      gui::EditRequest req0{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req0, gui::g_state);
+      ctx->Yield(2);
+      for (int i = 0; i < 16; ++i) {
+        if (gui::g_crystal_rotation[i] != expected0[i]) {
+          IM_ERRORF("entry0 (Random) idx=%d actual=%f expected=%f", i, static_cast<double>(gui::g_crystal_rotation[i]),
+                    static_cast<double>(expected0[i]));
+        }
+      }
+
+      // Simulate user trackball drag on entry 0's pose so we can prove entry 1
+      // opens with a DIFFERENT (target-specific) rotation, not the leftover.
+      gui::ApplyTrackballRotation(60.0f, 0.0f);
+      IM_CHECK(std::memcmp(gui::g_crystal_rotation, expected0, sizeof(expected0)) != 0);
+
+      // Direct card-to-card switch WITHOUT Cancel/OK — this is the exact user
+      // path the bug reproduces. Opening entry 1 must overwrite g_crystal_rotation
+      // with the Column default, discarding the dragged pose.
+      gui::EditRequest req1{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/1 };
+      gui::OpenEditModal(req1, gui::g_state);
+      ctx->Yield(2);
+      for (int i = 0; i < 16; ++i) {
+        if (gui::g_crystal_rotation[i] != expected1[i]) {
+          IM_ERRORF("entry1 (Column) idx=%d actual=%f expected=%f", i, static_cast<double>(gui::g_crystal_rotation[i]),
+                    static_cast<double>(expected1[i]));
+        }
+      }
+
+      // Re-open the same entry 1 after dragging: crystal_id matches the loaded
+      // one, so the trackball must survive (idempotent re-open). This is the
+      // invariant that makes the crystal_id judge distinct from a
+      // "always reset" fix — and protects the "same-entry Cancel then reopen"
+      // UX and the linked-entries share-history semantics.
+      gui::ApplyTrackballRotation(30.0f, 20.0f);
+      float after_drag[16];
+      std::memcpy(after_drag, gui::g_crystal_rotation, sizeof(after_drag));
+      IM_CHECK(std::memcmp(after_drag, expected1, sizeof(expected1)) != 0);
+      gui::OpenEditModal(req1, gui::g_state);
+      ctx->Yield(2);
+      IM_CHECK(std::memcmp(gui::g_crystal_rotation, after_drag, sizeof(after_drag)) == 0);
+
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
   // P1: Edit modal OK without any change must NOT clear the rendered preview
   // or arm Revert. Regression guard for scrum-gui-polish-v7 152.2: previously
   // CommitAllBuffers unconditionally MarkFilterDirty()'d after any OK,


### PR DESCRIPTION
## 背景

crystal 编辑弹窗左侧的晶体预览小图有两处独立缺陷（owner 2026-07-07 自查发现，task-337）：

- **Bug 1 — 面编号标注错误**：axis=random 默认/reset view 后标注 1/4/5/6，但实际可见面应为 1/6/7/8；axis=column 默认状态完全无编号。
- **Bug 2 — 切换 crystal card 姿态不重置**：从 A(axis=random) 切到 B(axis=column)，预览仍停在 random 姿态，必须手动点 Reset View。

纯 GUI 层修复，`src/core/`、`src/config/` 零改。

## 根因与修复（白盒定位到具体机制）

**Bug 1 两处叠加根因（必须一起修）：**
- **1a 坐标系不一致**：`BuildCrystalMeshData` 把网格转 GL 预览帧时只对 `vertices`/`edge_face_normals` 做了 Y-Z swap，**漏了 `face_normals`** → label 中心在 GL 帧、法向仍在 core 帧，差 90°，front/back 判定系统性出错。修复：为 `face_normals` 补齐同构 Y-Z swap。
- **1b 缺失机位倾角**：面标注 front-face 判定 `ProjectLabelToScreen` 只用裸 `rotation`，未复合渲染实际用的机位倾角 `V_rot`(15°)。修复：抽取共享 `CrystalRenderer::ComputeEyeRotation` 单源，`Render()` 与 overlay 同时复用；并修正一处误导性行号注释 + 一个沦为重言式的参考测试公式。

**Bug 2**：`OpenEditModal` 切换 card 时未调既有单源 `ResetCrystalViewToCrystal`。修复：以 `crystal_id`（非 layer/entry 索引）为判据，仅在目标 crystal 变化时重置预览姿态，兼顾 Link 共享同一 pool crystal 的场景。

## 测试

- 新增/修正 GUI 单元 + 交互测试：prism(8面)+pyramid(20面) 逐面几何不变量断言（替代脆弱的硬编码面号）；tilt-sensitive case（无 V_rot 时必失败，防测试退化为重言式）；`preview_pose_follows_crystal_switch` 覆盖 Bug 2 真实场景。
- 既有 face_number / interaction / crystal_renderer 回归通过；visual PSNR 全 >40dB，截图基准无需重生。
- **AC4 owner 实机视觉核验通过**（两处修复均确认正确）。

详见 `scratchpad/task-fix-crystal-preview-thumbnail/SUMMARY.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)