### PR TITLE
fix(gui): stop edit-modal state leaking across crystal entries

### DIFF
--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1295,20 +1295,53 @@ void RenderModalTabBar(GuiState& state, const char* crystal_label, const char* a
   // Note: H/V layout toggle relocated to the bottom button row alongside the
   // Immediate checkbox for visual consistency (both are view-preference
   // toggles; gui-polish-v15 round 2 UX feedback). See RenderEditModals below.
+  //
+  // task-fix-modal-edit-state-leak — per-entry ID scope for all tab *content*.
+  // The "Edit Entry" window is a single persistent ImGui window reused for every
+  // entry, and the content widgets carry entry-agnostic IDs: filter rows reset
+  // their uid counter to 0 on each OpenEditModal (so the first row is always
+  // "##row_text_0"), and Crystal/Axis fields use fixed labels ("##Height##..").
+  // In Immediate mode the "Edit Entry" window is non-blocking, so a crystal-card
+  // click (a raw hit-test in panels.cpp — never a real ImGui widget) can switch
+  // the modal to another entry while an InputText is still mid-edit. Because the
+  // new entry's widget reuses the SAME ImGuiID, ImGui treats it as the same
+  // control and replays the previous entry's edit into it via
+  // g.InputTextDeactivatedState (the deferred deactivation-writeback path,
+  // imgui_widgets.cpp: "Handle reapplying final data on deactivation") — the
+  // uncommitted text leaks into the newly selected entry. Scoping each tab's
+  // content by (layer, entry) makes the IDs differ across entries, so none of
+  // ImGui's per-ID caches (ActiveId / InputTextState / InputTextDeactivatedState)
+  // can bleed one entry's edit into another. The TabBar / TabItem IDs are left
+  // unscoped on purpose — the tab-selection state machine (g_pending_tab_select
+  // + ImGuiTabItemFlags_SetSelected) is delicate and must keep a stable identity.
+  const int entry_layer = g_modal_layer_idx;
+  const int entry_index = g_modal_entry_idx;
   if (ImGui::BeginTabBar("##edit_modal_tabs")) {
     if (ImGui::BeginTabItem(crystal_label, nullptr, crystal_flags)) {
       g_active_tab = ActiveTab::kCrystal;
+      ImGui::PushID(entry_layer);
+      ImGui::PushID(entry_index);
       RenderCrystalModal(state);
+      ImGui::PopID();
+      ImGui::PopID();
       ImGui::EndTabItem();
     }
     if (ImGui::BeginTabItem(axis_label, nullptr, axis_flags)) {
       g_active_tab = ActiveTab::kAxis;
+      ImGui::PushID(entry_layer);
+      ImGui::PushID(entry_index);
       RenderAxisModal(state);
+      ImGui::PopID();
+      ImGui::PopID();
       ImGui::EndTabItem();
     }
     if (ImGui::BeginTabItem(filter_label, nullptr, filter_flags)) {
       g_active_tab = ActiveTab::kFilter;
+      ImGui::PushID(entry_layer);
+      ImGui::PushID(entry_index);
       RenderFilterModal();
+      ImGui::PopID();
+      ImGui::PopID();
       ImGui::EndTabItem();
     }
     ImGui::EndTabBar();

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -572,6 +572,135 @@ void RegisterP1Tests(ImGuiTestEngine* engine) {
     };
   }
 
+  // P1: task-fix-modal-edit-state-leak (AC1, Filter tab) — in Immediate mode,
+  // switching to another entry while a filter InputText is mid-edit (cursor
+  // never left the box) must NOT carry the uncommitted text into the new entry.
+  // Root cause: crystal-card clicks are a raw hit-test (never a real ImGui
+  // widget), so the mid-edit InputText is never deactivated the normal way;
+  // SetRowsFromSop resets the row uid to 0 so the next entry's first row reuses
+  // the same InputText ID ("##row_text_0"), and ImGui replays the previous
+  // entry's text into it via g.InputTextDeactivatedState (deferred deactivation-
+  // writeback). Fix = per-(layer,entry) PushID scope around each tab's content
+  // in RenderModalTabBar, so the new entry's widget gets a DIFFERENT ID and none
+  // of ImGui's per-ID caches match. (ClearActiveID() does NOT fix this — it is
+  // what populates InputTextDeactivatedState.) Reproduced pre-fix (progress.md
+  // bisect); guards the fix from regressing.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit_modal", "filter_edit_not_leaked_on_entry_switch");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = true;  // bug is Immediate-mode only
+
+      // Add a second entry bound to a DISTINCT crystal. This is load-bearing:
+      // entries that SHARE a crystal_id are an intentional "linked group" that
+      // shares filters atomically (ApplyBuffersToEntry::propagate_filter_id_to_
+      // linked), so a shared crystal would propagate entry 0's filter to entry 1
+      // by design and mask the actual bug. The reported bug is two DISTINCT
+      // crystals, where no such linking applies.
+      gui::CrystalConfig c_second;
+      c_second.height = 5.0f;
+      gui::EntryCard e_second;
+      e_second.crystal_id = static_cast<int>(gui::g_state.crystals.size());
+      gui::g_state.crystals.push_back(c_second);
+      gui::g_state.layers[0].entries.push_back(e_second);
+      ctx->Yield(2);
+      IM_CHECK(!gui::g_state.layers[0].entries[0].filter_id.has_value());
+      IM_CHECK(!gui::g_state.layers[0].entries[1].filter_id.has_value());
+
+      // Open entry 0's Filter tab and type into the first summand row WITHOUT
+      // committing (KeyCharsAppend does not send Enter, so the box stays active).
+      gui::EditRequest req0{ gui::EditTarget::kFilter, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req0, gui::g_state);
+      ctx->Yield(4);
+      ctx->ItemClick("**/##row_text_0");
+      ctx->KeyCharsAppend("3-5");
+      ctx->Yield(2);
+
+      // L1 precondition A: Immediate mode commits every frame, so entry 0 now
+      // actually carries the "3-5" filter (proves the input landed).
+      IM_CHECK(gui::g_state.layers[0].entries[0].filter_id.has_value());
+      IM_CHECK_STR_EQ(gui::g_state.filters[*gui::g_state.layers[0].entries[0].filter_id].RaypathText().c_str(), "3-5");
+      // L1 precondition B: the InputText is still the active item (cursor未离开).
+      IM_CHECK(ImGui::GetActiveID() != 0);
+
+      // Switch to entry 1's Filter tab without leaving the box — the exact user
+      // path (clicking another crystal routes through OpenEditModal).
+      gui::EditRequest req1{ gui::EditTarget::kFilter, /*layer_idx=*/0, /*entry_idx=*/1 };
+      gui::OpenEditModal(req1, gui::g_state);
+      ctx->Yield(4);
+
+      // Core AC1: entry 1 must stay filter-less — "3-5" must not have bled in.
+      IM_CHECK(!gui::g_state.layers[0].entries[1].filter_id.has_value());
+
+      ctx->ItemClick("**/Close##edit_modal");  // Immediate mode: single Close button
+      ctx->Yield(2);
+    };
+  }
+
+  // P1: task-fix-modal-edit-state-leak (AC2, Crystal tab) — the same leak is a
+  // mechanism-level defect (not filter-specific): Crystal/Axis tab inputs use
+  // fixed, entry-agnostic widget IDs (e.g. "##Height##modal_cr_input"), so an
+  // uncommitted Height edit also carries across an entry switch via the same
+  // g.InputTextDeactivatedState replay. The per-(layer,entry) PushID scope is a
+  // single mechanism-level fix that covers all three tabs. This test proves
+  // AC2's "统一性" (unified coverage beyond the Filter tab).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p1_edit_modal", "crystal_edit_not_leaked_on_entry_switch");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = true;
+
+      // Seed a second crystal with a distinct height so "unchanged" is a strong
+      // assertion, and bind a second entry to it.
+      gui::CrystalConfig c_second;
+      c_second.height = 5.0f;  // distinct from entry 0's default (1.0)
+      gui::EntryCard e_second;
+      e_second.crystal_id = static_cast<int>(gui::g_state.crystals.size());
+      gui::g_state.crystals.push_back(c_second);
+      gui::g_state.layers[0].entries.push_back(e_second);
+      ctx->Yield(2);
+      const int cid1 = gui::g_state.layers[0].entries[1].crystal_id;
+      const float orig_h1 = gui::g_state.crystals[cid1].height;
+      IM_CHECK_EQ(orig_h1, 5.0f);
+
+      // Open entry 0's Crystal tab, focus Height and type without committing.
+      gui::EditRequest req0{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req0, gui::g_state);
+      ctx->Yield(4);
+      ctx->ItemClick("**/##Height##modal_cr_input");
+      ctx->KeyCharsAppend("9");
+      ctx->Yield(2);
+      // Precondition: the Height input SPECIFICALLY is the active edit target, so
+      // the "9" keystroke actually landed in the leak source (an InputFloat
+      // commits on deactivation, not live, so we can't assert entry 0's height
+      // changed yet — instead pin the active item to Height's resolved ID). If
+      // the click/type ever stops landing, this fails loudly rather than letting
+      // the core assertion below pass vacuously.
+      const ImGuiID height_id = ctx->ItemInfo("**/##Height##modal_cr_input").ID;
+      IM_CHECK(height_id != 0);
+      IM_CHECK_EQ(ImGui::GetActiveID(), height_id);
+
+      // Switch to entry 1's Crystal tab, then deactivate the (pre-fix still
+      // active) Height input via Enter to force the InputFloat writeback. With
+      // the fix, entry 1's Height input has a different ID than entry 0's pending
+      // edit, so InputTextDeactivatedState never matches and Enter is a no-op.
+      gui::EditRequest req1{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/1 };
+      gui::OpenEditModal(req1, gui::g_state);
+      ctx->Yield(4);
+      ctx->KeyPress(ImGuiKey_Enter);
+      ctx->Yield(2);
+
+      // Core AC2: entry 1's crystal height must be unchanged (not polluted by
+      // the "9" typed into entry 0's Height field).
+      IM_CHECK_EQ(gui::g_state.crystals[cid1].height, orig_h1);
+
+      ctx->ItemClick("**/Close##edit_modal");  // Immediate mode: single Close button
+      ctx->Yield(2);
+    };
+  }
+
   // P1: Edit modal OK without any change must NOT clear the rendered preview
   // or arm Revert. Regression guard for scrum-gui-polish-v7 152.2: previously
   // CommitAllBuffers unconditionally MarkFilterDirty()'d after any OK,


### PR DESCRIPTION
## Problem
In **Immediate mode** the "Edit Entry" modal is a non-blocking `ImGui::Begin` window, so clicking another crystal card (a raw hit-test in `panels.cpp`, never a real ImGui widget) switches the modal to a different entry while an InputText is still mid-edit. Because tab-content widgets reuse the **same ImGuiID** across entries (filter rows reset their uid to 0 → `##row_text_0`; Crystal/Axis use fixed labels like `##Height##modal_cr_input`), ImGui replays the previous entry's uncommitted text into the new entry via `g.InputTextDeactivatedState` (the deferred deactivation-writeback path). Result: a typed-but-uncommitted value (e.g. a filter `3-5`, or a Height edit) leaks into the newly selected crystal.

## Root cause (white-box, ImGui source level)
`g.InputTextDeactivatedState` carries the final text keyed by widget ID, and the next **same-ID** InputText applies it to its buffer (`imgui_widgets.cpp` ~5095, `IsItemDeactivatedAfterEdit()` path). The entry switch reuses the same widget IDs, so the replay fires.

Note: `ImGui::ClearActiveID()` does **not** fix this — it is precisely what *populates* `InputTextDeactivatedState` (`SetActiveID` → `InputTextDeactivateHook`), so the leak survives. Breaking the ID collision is the actual fix.

## Fix
Scope each tab's **content** (`RenderCrystalModal` / `RenderAxisModal` / `RenderFilterModal`) by a per-`(layer, entry)` `PushID` in `RenderModalTabBar`. Different entries get distinct widget IDs, so none of ImGui's per-ID caches (ActiveId / InputTextState / InputTextDeactivatedState) can bleed across entries.

- **TabBar / TabItem IDs are left unscoped** on purpose — the tab-selection state machine (`g_pending_tab_select` + `ImGuiTabItemFlags_SetSelected`) is delicate and must keep a stable identity.
- **Per-entry key is `(layer, entry)`, not `crystal_id`** — entries sharing a `crystal_id` are an intentional "linked group" that shares filters (`ApplyBuffersToEntry::propagate_filter_id_to_linked`), so a `crystal_id` key would still collide within a linked group.
- Public API only (`PushID`); no `imgui_internal.h`, no `ClearActiveID` (and thus no modal-external side effect).

`core/config` unchanged — GUI-only.

## Tests
Two `p1_edit_modal` regression tests (Filter tab AC1 + Crystal tab AC2), both using **distinct crystals** (a shared crystal would trigger the legitimate linked-group filter propagation and mask the bug). Verified by bisect: without the fix both fail (filter leaks `3-5`; crystal Height leaks `1.009`); with the fix both pass. All 24 existing `p1_edit` modal tests pass; full GUI suite 312/313 (the one miss is the known `overlay_ea` auto_ev stochastic flake, 3/3 on standalone re-run). format + policy clean. Owner verified on-screen (Filter/Crystal/Axis all no longer leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)