### PR TITLE
perf(gui-test): decouple frame budget from wall-clock (--fixed-dt, 16x faster correctness pool)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,25 @@ build() {
     else
       GUI_TEST_BIN="${ROOT_DIR}/build/${BUILD_TYPE}/bin/gui_test"
       if [[ -x "$GUI_TEST_BIN" ]]; then
-        echo "Running GUI tests..."
-        "$GUI_TEST_BIN"
+        # Two pools (see scratchpad/task-gui-test-fixed-dt):
+        #  1. Correctness pool: --fixed-dt injects a deterministic 1/60s frame dt
+        #     and skips the frame-limit sleep, so functional/visual tests run at
+        #     full wall-clock speed.
+        #  2. Real-timing pool: real frame timing + real dt, run in isolation.
+        #     Holds tests whose meaning depends on real wall-clock:
+        #       - perf_test: measures main-loop FPS / rays-per-sec.
+        #       - save_open_visual_consistency: compares the live poller preview
+        #         (which converges over ~30 frames of real wall-clock simulation)
+        #         against the saved snapshot; fixed-dt starves that accumulation
+        #         and drops its PSNR ~7 dB below threshold.
+        echo "Running GUI correctness tests (fixed-dt, fast)..."
+        "$GUI_TEST_BIN" --fixed-dt --filter "-perf_test,-save_open_visual_consistency"
         ret=$?
+        if [[ $ret == 0 ]]; then
+          echo "Running GUI real-timing tests (perf + wall-clock-dependent, isolated)..."
+          "$GUI_TEST_BIN" --filter "perf_test,save_open_visual_consistency"
+          ret=$?
+        fi
       else
         echo "Warning: $GUI_TEST_BIN not found, skipping GUI tests"
       fi

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -53,6 +53,13 @@ int g_main_loop_restart_count = 0;
 unsigned long g_main_loop_cumulative_rays = 0;
 // Set by --keep-export-png; used by scripts/regen_gui_test_refs.py to collect per-run PNGs.
 bool g_keep_export_png = false;
+// Set by --fixed-dt: inject a deterministic per-frame dt (1/60s) and skip the
+// frame-limit sleep. Decouples VSync frame-budget semantics from wall-clock cost
+// so correctness tests run at full speed. See scratchpad/task-gui-test-fixed-dt.
+bool g_enable_fixed_dt = false;
+// Set by --export-junit <path>: emit per-test results as JUnit XML (general
+// CI/regression-diff capability, not throwaway scaffolding).
+const char* g_export_junit_path = nullptr;
 
 // Synthetic texture for export tests
 std::vector<unsigned char> g_synth_tex;
@@ -134,6 +141,15 @@ int main(int argc, char** argv) {
     } else if (strcmp(argv[i], "--keep-export-png") == 0) {
       // Suppress std::remove in CheckAgainstReference so regen_gui_test_refs.py can collect PNGs.
       g_keep_export_png = true;
+    } else if (strcmp(argv[i], "--fixed-dt") == 0) {
+      // Inject deterministic 16.67ms per-frame dt via the test engine and skip
+      // the frame-limit sleep (decouples VSync frame-budget semantics from
+      // wall-clock cost). Used by the build.sh correctness pool.
+      g_enable_fixed_dt = true;
+      g_enable_frame_limit = false;
+    } else if (strcmp(argv[i], "--export-junit") == 0 && i + 1 < argc) {
+      // Emit per-test results as JUnit XML for per-case pass/fail diffing.
+      g_export_junit_path = argv[++i];
     } else if (strcmp(argv[i], "--log-level") == 0 && i + 1 < argc) {
       // Set both core and GUI log level: trace/debug/info/warning/error/off
       const char* level = argv[++i];
@@ -209,6 +225,9 @@ int main(int argc, char** argv) {
     fprintf(stderr, "[DIAG] Frame limit mode enabled: %dms target frame time (simulates VSync)\n",
             gui::kTargetFrameTimeMs);
   }
+  if (g_enable_fixed_dt) {
+    fprintf(stderr, "[DIAG] Fixed-dt mode enabled: dt=16.67ms injected per frame, frame-limit sleep skipped\n");
+  }
 
   if (!gui::InitGLLoader()) {
     glfwDestroyWindow(window);
@@ -279,6 +298,19 @@ int main(int argc, char** argv) {
   test_io.ConfigLogToTTY = true;
   test_io.ConfigRunSpeed = ImGuiTestRunSpeed_Fast;
   test_io.ConfigNoThrottle = true;
+  // Fixed-dt mode: inject a deterministic 1/60s dt every frame (applied via
+  // PostSwap's ConfigFixedDeltaTime path) instead of deriving dt from the real
+  // frame clock. Paired with the skipped frame-limit sleep, correctness tests get
+  // production-faithful 60fps frame-budget semantics at full wall-clock speed.
+  if (g_enable_fixed_dt) {
+    test_io.ConfigFixedDeltaTime = 1.0f / 60.0f;
+  }
+  // JUnit XML export (opt-in via --export-junit). ImGuiTestEngine_Export() runs
+  // automatically at batch end / engine stop, so setting these fields suffices.
+  if (g_export_junit_path != nullptr) {
+    test_io.ExportResultsFilename = g_export_junit_path;
+    test_io.ExportResultsFormat = ImGuiTestEngineExportFormat_JUnitXml;
+  }
 
   ImGuiTestEngine_Start(engine, ImGui::GetCurrentContext());
   ImGuiTestEngine_InstallDefaultCrashHandler();

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -578,6 +578,13 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
   // End-to-end: Run simulation → Save → Open → verify visual consistency.
   // Tests the actual user workflow: the reopened file should look the same as the live display.
   // Regression test for PostSnapshot using stale CommitConfig-time EV instead of current GUI EV.
+  //
+  // REAL-TIMING TEST: this case compares the live poller preview (which converges over the ~30
+  // Yield()s below via real wall-clock simulation) against the saved snapshot, so it needs real
+  // frame timing. build.sh runs it in the isolated real-timing pool, NOT the --fixed-dt pool
+  // (fixed-dt skips the frame-limit sleep and starves that accumulation, dropping PSNR ~7 dB).
+  // If this test is renamed, update the --filter lists in scripts/build.sh. See
+  // scratchpad/task-gui-test-fixed-dt.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "visual", "save_open_visual_consistency");
     t->GuiFunc = [](ImGuiTestContext* /*ctx*/) {


### PR DESCRIPTION
## 问题
本地 `gui_test` 一轮墙钟很长且 CPU 占用低。根因:默认 `g_enable_frame_limit=true` 每帧尾部
sleep 到 `kTargetFrameTimeMs=16ms` 模拟 VSync,功能测试为此白睡 8–18× 墙钟,而它们对帧时长无断言依赖。

## 方案
- **harness `--fixed-dt`**:设 `test_io.ConfigFixedDeltaTime=1/60` 注入确定性帧 dt + 跳过 frame-limit sleep。
  比裸 `--no-frame-limit` 更正确 —— 后者让 `io.DeltaTime` 变机器相关(引擎默认用真实 glfw 帧间隔),
  fixed-dt 给恒定 0.016667(已插桩实测)。
- **`build.sh` 拆两桶**:正确性池(fixed-dt,快)+ 真实时序池(perf + 依赖墙钟的测试,独占)。
- **`--export-junit <path>`**:逐 case JUnit 导出(通用 CI/回归对比能力)。

均为 opt-in;默认无参行为不变;`core/`/`config/` 零改。

## 关键数据
- 正确性池 `--fixed-dt --filter "-perf_test,-save_open_visual_consistency"`:**115s → 7s(16×)**,310/310 × 3 次稳定。
- 真实时序池:3/3,`save_open` 30.99dB / perf steady_state 57.5 FPS(真实时序生效)。
- `./scripts/build.sh -gtj release` 端到端:unit 4/4 + 正确性 310/310 + 真实时序 3/3 + EXIT=0。

## 一个白盒发现(唯一实施偏离)
三跑受控对照(JUnit 逐 case 名集 diff + PSNR 值 diff)抓到全 313 测试里**唯一 1 个**回归:
`visual/save_open_visual_consistency` 在 fixed-dt 下系统性 −7.6dB 而挂。根因:它固定 yield 30 帧靠
**真实墙钟** sim 累积("实时 poller 纹理 vs 更收敛的保存快照"),fixed-dt 跳 sleep 后累积不足。
→ 路由到真实时序池(与 perf 同理:断言只在有真实累积时才有意义),并在测试注册处加 grep 锚点注释。
auto_ev 经各模式多次分布对比裁定为纯随机噪声,不受影响。

## 后续(非本 PR)
多进程分片(崩溃隔离 + 进一步提速)、gui_test 偶发 SIGILL 排查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)