### PR TITLE
chore: local cleanup sweep — popcount gate, sibling-race, filter test, doc fixup (scrum-357)

### DIFF
--- a/doc/accumulator-consumer-architecture.md
+++ b/doc/accumulator-consumer-architecture.md
@@ -60,7 +60,7 @@ Two concrete implementations:
 
 - **`RenderConsumer`**: projects rays through the lens model, accumulates into
   `internal_xyz_`, snapshots to `snapshot_xyz_`, converts to sRGB in
-  `PostSnapshot()`. Also manages the anchor lane for filter-independent EV.
+  `PostSnapshot()`.
 - **`StatsConsumer`**: counts `total_rays_`, `sim_rays_`, `crystals_`.
 
 Both are held via `shared_ptr<IConsume>` in `ServerImpl::consumers_`.
@@ -129,7 +129,7 @@ State flags:
 
 | Lock | Type | Guards | Writer thread | Reader thread |
 |------|------|--------|---------------|---------------|
-| `consumer_mutex_` | `TicketMutex` (FIFO) | `consumers_` list, all consumer mutable state (`internal_xyz_`, `total_intensity_`, anchor buffers) | `ConsumeData` thread (high frequency) | Poller → `GetRawXyzResults` (low frequency); `CommitConfig` caller (rebuild/reset) |
+| `consumer_mutex_` | `TicketMutex` (FIFO) | `consumers_` list, all consumer mutable state (`internal_xyz_`, `total_intensity_`) | `ConsumeData` thread (high frequency) | Poller → `GetRawXyzResults` (low frequency); `CommitConfig` caller (rebuild/reset) |
 | `snapshot_mutex_` | `std::mutex` | `cached_render_results_`, `cached_stats_result_` | `DoSnapshot` / `GetRawXyzResults` (after snapshot) | `Get*Results` callers |
 
 **Why TicketMutex**: on Windows, `std::mutex` uses SRWLOCK which provides no
@@ -250,25 +250,10 @@ destroying and reconstructing consumers (~0.5ms vs. ~30ms for full rebuild).
 | `snapshot_xyz_` size = `W × H × 3` floats | `render.cpp:325` (constructor) | Same allocation as internal |
 | `snapshot_work_` size = `W × H × 3` floats | `render.cpp:326` (constructor) | Preserves `snapshot_xyz_` during `PostSnapshot` |
 | `snapshot_image_buffer_` size = `W × H × 3` bytes | `render.cpp:327` (constructor) | sRGB output for CLI |
-| Anchor buffers size = `W × H × 3` floats | `render.cpp:506–513` (lazy alloc) | Only allocated on first filter-fail emission |
 | `d_buf_`/`w_buf_`/`xy_buf_`/`overlap_w_buf_` capacity ≥ max(rays, outgoing) | `render.cpp:347–354` | Grow-only; never shrink |
 | `snapshot_xyz_` read-only between `PrepareSnapshot()` calls | `render.cpp:674` (`GetRawXyzResult` returns raw pointer) | Enables lock-free read in Phase 1.5 and result delivery |
 | `snapshot_image_buffer_` valid until next `GetRenderResults`/`CommitConfig` | `server.hpp` (`RenderResult` doc) | Pointer-based result; caller must consume before next snapshot |
 | StatsConsumer snapshot fields zeroed on `Reset()` | `stats.cpp:23–30` | Both accumulation and snapshot counters cleared |
-
-### §6.1 Anchor Buffer Lifecycle
-
-Anchor buffers (`anchor_internal_xyz_`, `anchor_snapshot_xyz_`) follow a lazy
-allocation pattern:
-
-1. **Constructor**: not allocated (null). Zero cost when no filter is configured.
-2. **First filter-fail emission** (`render.cpp:506–513`): allocated at
-   `W × H × 3` floats, matching the main buffer size.
-3. **Reset()**: if allocated, zeroed via `memset` but **not deallocated**.
-   This preserves the allocation across `ResetWith` cycles. If
-   `anchor_internal_xyz_` is null, it stays null — the no-filter zero-cost
-   path is preserved.
-4. **Destruction**: freed with the `RenderConsumer` (unique_ptr).
 
 ---
 
@@ -286,25 +271,31 @@ When a filter spec changes:
 1. `CommitConfig` is called with new config.
 2. `Stop()` drains all threads.
 3. `NeedsRebuild` returns `false` (filter is not in `RenderConfig`).
-4. `ResetWith` resets accumulators (zeros `internal_xyz_`, anchor buffers).
+4. `ResetWith` resets accumulators (zeros `internal_xyz_`).
 5. `Start()` resumes simulation with new scene config (new filter).
-6. New simulation rounds fill `anchor_d_` / `anchor_w_` according to the new
-   filter (ON mode: empty anchor, OFF mode: filter-fail rays populate anchor).
+6. Filter-fail rays terminate in the simulator (`w_ = -1.0f` TIR sentinel) and
+   never reach the consumer — `outgoing_*` only ever carries filter-pass
+   emission (`doc/filter-architecture.md §7`). The accumulator therefore always
+   describes the currently visible (filtered) image; there is no separate
+   filter-independent lane to fill.
 
-### §7.2 Anchor Lane Design
+### §7.2 EV Reference: The Visible Framebuffer, Not a Filter-Independent Lane
 
-The anchor lane accumulates filter-fail emission to provide a
-filter-independent EV reference. Key properties:
+**Note (scrum-237, 2026-05-28)**: an earlier design accumulated filter-fail
+emission into a separate "anchor lane" (`anchor_internal_xyz_` /
+`anchor_snapshot_xyz_`) to provide a filter-independent EV reference. That
+lane was removed — filter-fail rays now terminate immediately in
+`CollectData` and never reach the consumer at all (`doc/filter-architecture.md
+§7`).
 
-- **ON mode** (filter active): `anchor_d_`/`anchor_w_` from simulator carry
-  filter-fail rays → accumulated into `anchor_internal_xyz_`.
-- **OFF mode** (no filter): simulator produces no filter-fail rays →
-  `anchor_d_` stays empty → anchor buffers remain null (zero cost).
-- **At snapshot time**: combined emission = filter-pass (`snapshot_xyz_`) +
-  filter-fail (`anchor_snapshot_xyz_`), yielding filter-independent total
-  intensity and P99.5 Y for stable EV anchoring across filter toggles.
+Under the current design (Design A) there is no separate filter-independent
+statistic — the EV always anchors on the visible (filtered) framebuffer:
+`snapshot_xyz_`, its P99 anchor, and `snapshot_intensity` all describe exactly
+what filter-pass emission produced. Switching filters changes the EV anchor
+because the visible image changed; this is intentional.
 
-See `doc/ev-pipeline-architecture.md §2` for the full EV data flow.
+See `doc/ev-pipeline-architecture.md §5` for the full before/after rationale
+and `§2` for the EV data flow.
 
 ---
 

--- a/doc/raypath-rayseg-architecture.md
+++ b/doc/raypath-rayseg-architecture.md
@@ -254,7 +254,7 @@ stateless — no per-ray mutation.
 ### Cross-References
 
 - Raypath face-number encoding and PBD symmetry: `doc/raypath-symmetry.md`
-- Filter routing design (Design A), anchor-lane semantics: `doc/filter-architecture.md §2/§7`
+- Filter routing design (Design A), post-anchor-lane-removal branch table: `doc/filter-architecture.md §2/§7`
 - Filter JSON configuration schema: `doc/configuration.md`
 - Crystal orientation sampling: `doc/crystal-orientation-sampling.md`
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -36,6 +36,13 @@ Checks:
      Closes the "unregistered field silently escapes governance" loophole
      that scrum-gui-state-reconcile T0 (reconcile-foundation) was built to
      prevent (doc/gui-state-governance.md).
+  8. no-msvc-unsafe-builtin — MSVC does not recognise the GCC/Clang
+     `__builtin_popcount*` / `__builtin_ctz*` / `__builtin_clz*` intrinsic
+     families and reports C3861. src/ and test/ must route through
+     `lumice::PopCount` (src/util/bit_utils.hpp) or an equivalent portable
+     implementation. Scope is intentionally narrow: only the popcount/ctz/clz
+     families are pinned (task-popcount-helper), extend the regex when a new
+     MSVC-unsafe `__builtin_*` family surfaces.
 
 Add a new check as a function returning a list of Violation and append it to
 CHECKS. Keep each check deterministic and artifact-inspecting.
@@ -153,6 +160,11 @@ GETENV_LUMICE = re.compile(r'getenv\s*\(\s*"(LUMICE_[A-Z0-9_]+)"')
 # (core|config) keeps it from matching substrings like "score/" or "mycore/".
 GUI_FORBIDDEN_INCLUDE = re.compile(r'#\s*include\s*[<"][^">]*\b(core|config)/')
 USING_NAMESPACE = re.compile(r"\busing\s+namespace\b")
+# `\w*` after the family root absorbs all known length suffixes (`ll`, `l`,
+# `s`, `g`) without enumerating each. Only the popcount/ctz/clz families are
+# pinned: PR#182 was specifically about `__builtin_popcountll`; extend the
+# alternation when a new MSVC-unsafe family surfaces.
+MSVC_UNSAFE_BUILTIN = re.compile(r"\b__builtin_(?:popcount|ctz|clz)\w*")
 
 
 def check_getenv_centralization() -> list[Violation]:
@@ -739,6 +751,39 @@ def check_gui_state_field_tier_registration() -> list[Violation]:
     return out
 
 
+def check_no_msvc_unsafe_builtin() -> list[Violation]:
+    out: list[Violation] = []
+    for path in cxx_sources(SRC):
+        for lineno, _orig, code in code_lines(path):
+            if MSVC_UNSAFE_BUILTIN.search(code):
+                out.append(
+                    Violation(
+                        path,
+                        lineno,
+                        "no-msvc-unsafe-builtin",
+                        "`__builtin_popcount`/`ctz`/`clz` are GCC/Clang-only "
+                        "(MSVC reports C3861); use `lumice::PopCount` "
+                        "(src/util/bit_utils.hpp) or an equivalent portable helper.",
+                    )
+                )
+    test_root = REPO_ROOT / "test"
+    if test_root.exists():
+        for path in cxx_sources(test_root):
+            for lineno, _orig, code in code_lines(path):
+                if MSVC_UNSAFE_BUILTIN.search(code):
+                    out.append(
+                        Violation(
+                            path,
+                            lineno,
+                            "no-msvc-unsafe-builtin",
+                            "`__builtin_popcount`/`ctz`/`clz` are GCC/Clang-only "
+                            "(MSVC reports C3861); use `lumice::PopCount` "
+                            "(src/util/bit_utils.hpp) or an equivalent portable helper.",
+                        )
+                    )
+    return out
+
+
 CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
@@ -747,6 +792,7 @@ CHECKS = [
     check_struct_layout_parity,
     check_no_config_by_value_copy,
     check_gui_state_field_tier_registration,
+    check_no_msvc_unsafe_builtin,
 ]
 
 
@@ -769,7 +815,7 @@ def main() -> int:
     print(
         "Policy check passed (env centralization, knob registration, GUI API boundary, "
         "using-namespace, struct-layout parity, no-config-by-value-copy, "
-        "gui-state-field-tier-registration)."
+        "gui-state-field-tier-registration, no-msvc-unsafe-builtin)."
     )
     return 0
 

--- a/src/util/bit_utils.hpp
+++ b/src/util/bit_utils.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lumice {
+
+// Portable constexpr population count for a 64-bit unsigned value.
+//
+// Why SWAR (and not __builtin_popcountll / MSVC __popcnt64):
+//   - __builtin_popcountll is a GCC/Clang extension; MSVC reports C3861. This
+//     helper exists specifically to prevent that class of regression (PR#182).
+//   - MSVC __popcnt64 requires SSE4.2 (POPCNT) at runtime and is not constexpr,
+//     so it would need per-compiler #ifdef and would still be unusable in
+//     constant-evaluated contexts.
+//   - Standard 64-bit SWAR (4 mask-shift-add groups) has no CPU-feature
+//     dependency, is constexpr-friendly under C++17, and is fast enough for
+//     the cold call sites where PopCount is used.
+//
+// Return type is `int` to match the C++20 std::popcount signature; callers
+// comparing against unsigned counters (size_t, etc.) must cast at the call
+// site. On C++20 migration, this whole file collapses to a one-line
+// #include <bit> + `constexpr int PopCount(uint64_t x) { return std::popcount(x); }`.
+constexpr int PopCount(uint64_t x) {
+  x = x - ((x >> 1) & 0x5555555555555555ULL);
+  x = (x & 0x3333333333333333ULL) + ((x >> 2) & 0x3333333333333333ULL);
+  x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0fULL;
+  return static_cast<int>((x * 0x0101010101010101ULL) >> 56);
+}
+
+}  // namespace lumice

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/util/test_queue.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/util/test_threading_pool.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/util/test_cpu_info.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/util/test_bit_utils.cpp"
   # gui/
   "${PROJ_TEST_DIR}/unit-correctness/gui/test_axis_presets.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/gui/test_slider_mapping.cpp"

--- a/test/gui/functional/test_gui_composite_preview.cpp
+++ b/test/gui/functional/test_gui_composite_preview.cpp
@@ -1709,6 +1709,13 @@ void RegisterCompositePreviewTests(ImGuiTestEngine* engine) {
     // Void output-param idiom (not a bool-returning lambda): IM_CHECK's failure path is a bare
     // `return;`, which cannot coexist with a non-void lambda return type.
     auto ReadRedBlueSums = [&](unsigned long long& sum_r, unsigned long long& sum_b) {
+      // task-composite-preview-sibling-race: Stop() the global poller so its background
+      // DoSnapshot() cannot race the synchronous LUMICE_GetCompositeResults() call below.
+      // Same Stop()-before-read serialization as ReadComposite() above; see the essay on
+      // that lambda (task-fix-composite-byte-identical-flake) for the full race explanation
+      // — this test has 3 direct composite reads (below at L1726/L1737/L1746) all funneled
+      // through here, so one Stop() at the lambda head covers them all.
+      gui::g_server_poller.Stop();
       LUMICE_RenderResult comp[LUMICE_MAX_RENDER_RESULTS + 1]{};
       IM_CHECK_EQ(LUMICE_GetCompositeResults(gui::g_server, comp, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
       IM_CHECK(comp[0].img_buffer != nullptr);
@@ -1809,6 +1816,13 @@ void RegisterCompositePreviewTests(ImGuiTestEngine* engine) {
     IM_CHECK_EQ(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kDone));
 
     auto ReadRedGreenSums = [&](unsigned long long& sum_r, unsigned long long& sum_g) {
+      // task-composite-preview-sibling-race: Stop() the global poller so its background
+      // DoSnapshot() cannot race the synchronous LUMICE_GetCompositeResults() call below.
+      // Same Stop()-before-read serialization as ReadComposite() above; see the essay on
+      // that lambda (task-fix-composite-byte-identical-flake) for the full race explanation
+      // — this test has 3 direct composite reads (below at L1826/L1835/L1846) all funneled
+      // through here, so one Stop() at the lambda head covers them all.
+      gui::g_server_poller.Stop();
       LUMICE_RenderResult comp[LUMICE_MAX_RENDER_RESULTS + 1]{};
       IM_CHECK_EQ(LUMICE_GetCompositeResults(gui::g_server, comp, LUMICE_MAX_RENDER_RESULTS), LUMICE_OK);
       IM_CHECK(comp[0].img_buffer != nullptr);

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -1723,6 +1723,66 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // chore-filter-reconstruct-empty-raypath-test (scrum-333/334 residual debt C):
+  // an empty `raypath:[]` term (match-all wildcard) co-existing with a non-empty
+  // raypath term as separate OR clauses of the SAME complex filter. Behavior is
+  // already correct (TryReconstructComplexFilter's raypath branch treats an
+  // empty/absent array as the match-all wildcard factor) — this pins it with a
+  // regression test so future reconstruct-logic changes can't silently break it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "complex_match_all_and_nonempty_raypath_coexist");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+      gui::ClearImportComplexFilterWarning();
+
+      // Hand-authored core JSON: 2 raypath simples (one match-all via empty
+      // `raypath: []`, one non-empty) OR'd via a 2-clause composition.
+      const std::string core_json = R"({
+        "crystal": [
+          {"id": 1, "type": "Prism", "height": 1.0,
+           "face_distance": [1,1,1,1,1,1]}
+        ],
+        "filter": [
+          {"id": 1, "type": "raypath", "action": "filter_in", "raypath": []},
+          {"id": 2, "type": "raypath", "action": "filter_in", "raypath": [3, 5]},
+          {"id": 3, "type": "complex", "action": "filter_in",
+           "composition": [[1], [2]]}
+        ],
+        "scene": {
+          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "ray_num": 1000,
+          "max_hits": 8,
+          "scattering": [
+            {"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0, "filter": 3}]}
+          ]
+        }
+      })";
+
+      gui::GuiState loaded = gui::InitDefaultState();
+      bool ok = gui::DeserializeFromJson(core_json, loaded);
+      IM_CHECK(ok);
+      IM_CHECK_EQ(static_cast<int>(loaded.layers.size()), 1);
+      const auto& loaded_entry = loaded.layers[0].entries[0];
+      // The complex reconstructs — the entry references it.
+      IM_CHECK(loaded_entry.filter_id.has_value());
+      const auto& lf = loaded.filters[*loaded_entry.filter_id];
+      // 2 clauses -> 2 rows: row 0 = match-all wildcard (empty text), row 1 = "3-5".
+      IM_CHECK_EQ(static_cast<int>(lf.param.size()), 2);
+      IM_CHECK_EQ(static_cast<int>(lf.param[0].factors.size()), 1);
+      IM_CHECK(std::holds_alternative<gui::RaypathParams>(lf.param[0].factors[0]));
+      IM_CHECK(std::get<gui::RaypathParams>(lf.param[0].factors[0]).raypath_text.empty());
+      IM_CHECK_STR_EQ(lf.param[0].text.c_str(), "");
+      IM_CHECK_STR_EQ(lf.param[1].text.c_str(), "3-5");
+      // Legal form (match-all is a first-class wildcard factor) — no warning.
+      IM_CHECK(gui::PeekImportComplexFilterWarning().empty());
+      // Re-serialize equivalence: back to the identical 2 raypath + 1 complex form.
+      const auto j_orig = nlohmann::json::parse(core_json);
+      const auto j_reser = nlohmann::json::parse(gui::SerializeCoreConfig(loaded));
+      IM_CHECK(j_orig["filter"] == j_reser["filter"]);
+    };
+  }
+
   // task-serialization-bidirectional: genuinely non-representable complex inputs
   // still loudly reject (GUI `Factor` has only raypath / entry_exit arms). These
   // KEEP the explore-271 anti-silent-miscull contract for the unsupported cases:

--- a/test/unit-correctness/config/test_color_class_table.cpp
+++ b/test/unit-correctness/config/test_color_class_table.cpp
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 
-#include <bitset>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -29,6 +28,7 @@
 #include "config/proj_config.hpp"
 #include "config/raypath_color_config.hpp"
 #include "core/def.hpp"
+#include "util/bit_utils.hpp"
 
 namespace {
 
@@ -46,6 +46,7 @@ using lumice::IdType;
 using lumice::MsInfo;
 using lumice::NeedsRebuild;
 using lumice::NoneFilterParam;
+using lumice::PopCount;
 using lumice::RaypathColorConfig;
 using lumice::RaypathColorRef;
 using lumice::ScatteringSetting;
@@ -146,7 +147,7 @@ TEST(BuildColorClassTable, CrossLayerAllBitsAreDistinct) {
   ASSERT_EQ(ct.classes_.size(), 1u);
   EXPECT_EQ(ct.classes_[0].combine_, ColorClassCombine::kAll);
   uint64_t bits = ct.classes_[0].member_bits_;
-  EXPECT_EQ(std::bitset<64>(bits).count(), 2u);
+  EXPECT_EQ(static_cast<size_t>(PopCount(bits)), 2u);
   EXPECT_EQ(bits, (static_cast<uint64_t>(1) << 0) | (static_cast<uint64_t>(1) << 1));
 }
 
@@ -218,7 +219,7 @@ TEST(BuildColorClassTable, KNoBitOverflowClassRetainedWithZeroBits) {
   EXPECT_NO_THROW(ct = BuildColorClassTable(cfg, scene, gate));
   ASSERT_EQ(ct.classes_.size(), 1u);
   // 64 real bits + 1 skipped kNoBit — member_bits_ has 64 bits set.
-  EXPECT_EQ(std::bitset<64>(ct.classes_[0].member_bits_).count(), ComponentTable::kMaxBits);
+  EXPECT_EQ(static_cast<size_t>(PopCount(ct.classes_[0].member_bits_)), ComponentTable::kMaxBits);
 }
 
 // ---- explicit empty match → class retained with 0 bits ----
@@ -250,8 +251,8 @@ TEST(BuildColorClassTable, SamePredicateDifferentSymmetryResolvesToOwnBit) {
   auto ct = BuildColorClassTable(cfg, scene, gate);
   ASSERT_EQ(ct.classes_.size(), 2u);
   // Each class references a single bit; the two bits are disjoint.
-  EXPECT_EQ(std::bitset<64>(ct.classes_[0].member_bits_).count(), 1u);
-  EXPECT_EQ(std::bitset<64>(ct.classes_[1].member_bits_).count(), 1u);
+  EXPECT_EQ(static_cast<size_t>(PopCount(ct.classes_[0].member_bits_)), 1u);
+  EXPECT_EQ(static_cast<size_t>(PopCount(ct.classes_[1].member_bits_)), 1u);
   EXPECT_EQ(ct.classes_[0].member_bits_ & ct.classes_[1].member_bits_, 0u);
   // referenced_mask is the union.
   EXPECT_EQ(ct.referenced_mask_, ct.classes_[0].member_bits_ | ct.classes_[1].member_bits_);

--- a/test/unit-correctness/util/test_bit_utils.cpp
+++ b/test/unit-correctness/util/test_bit_utils.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <bitset>
+#include <cstdint>
+
+#include "util/bit_utils.hpp"
+
+namespace lumice {
+namespace {
+
+// Compile-time proof that PopCount is genuinely constexpr — a runtime-only
+// implementation would not compile here.
+static_assert(PopCount(0ull) == 0, "PopCount(0) must be 0");
+static_assert(PopCount(~0ull) == 64, "PopCount(~0) must be 64");
+static_assert(PopCount(0x1ull) == 1, "PopCount(bit 0) must be 1");
+static_assert(PopCount(0xDEADBEEFull) == 24, "PopCount(0xDEADBEEF) must be 24");
+
+TEST(PopCount, Zero) {
+  EXPECT_EQ(PopCount(0ull), 0);
+}
+
+TEST(PopCount, AllOnes) {
+  EXPECT_EQ(PopCount(~0ull), 64);
+}
+
+TEST(PopCount, SingleBit) {
+  EXPECT_EQ(PopCount(1ull << 0), 1);
+  EXPECT_EQ(PopCount(1ull << 31), 1);
+  EXPECT_EQ(PopCount(1ull << 63), 1);
+}
+
+TEST(PopCount, SparseValuesCrossValidate) {
+  constexpr uint64_t kValues[] = {
+    0x0ull,
+    0x1ull,
+    0xDEADBEEFull,
+    0xF0F0F0F0F0F0F0F0ull,
+    0x0F0F0F0F0F0F0F0Full,
+    0xAAAAAAAAAAAAAAAAull,
+    0x5555555555555555ull,
+    0x8000000000000001ull,
+    0xFFFFFFFF00000000ull,
+    0x00000000FFFFFFFFull,
+    ~0ull,
+  };
+  for (uint64_t x : kValues) {
+    const int kExpected = static_cast<int>(std::bitset<64>(x).count());
+    EXPECT_EQ(PopCount(x), kExpected) << "x=0x" << std::hex << x;
+  }
+}
+
+}  // namespace
+}  // namespace lumice


### PR DESCRIPTION
## 概要

本机 Metal-only 窗口清一批**不涉及 GPU、颗粒度小**的 backlog 债（owner 从 backlog 盘点后选定核心 4 条）。**零 core/config/C-API/server 生产逻辑改动**——全部落在 `src/util`(新 helper) + `scripts`(门禁) + `test/` + `doc/`。

## 子任务（4/4）

- **357.1 popcount-helper**：新增 `src/util/bit_utils.hpp::PopCount`（constexpr SWAR，C++20 起可换 `std::popcount`）+ 迁移 4 处 test call site（去散落的 `std::bitset<64>().count()`）+ `check_policies.py` 新增 `no-msvc-unsafe-builtin` 门禁（扫 src/+test/，拦 `__builtin_(popcount|ctz|clz)`）。**固化 a09**——PR#182 正被这类 `__builtin_popcountll`（MSVC C3861）拦过，本地 clang 测不出，现有门禁兜。
- **357.2 composite-preview-sibling-race**：`test_gui_composite_preview.cpp` 两姊妹测试（`revert_repushes_server_display_state` / `zorder_priority_persists_across_rerun`）的 composite 读 lambda 加 `g_server_poller.Stop()` 序列化（同 task-355 `ReadComposite` 模式），结构性消除测试线程与 poller 并发调 `DoSnapshot()` 的潜在竞态（非再靠 sleep 概率兜底）。test-only +14/−0。
- **357.3 filter-reconstruct-empty-raypath-test**：补 `TryReconstructComplexFilter` 空 `raypath:[]`(match-all) + 非空 term 共存的 hand-authored core-JSON 回归钉子（`complex_match_all_and_nonempty_raypath_coexist`）。test-only。
- **357.4 anchor-lane-doc-fixup**：`accumulator-consumer-architecture.md` + `raypath-rayseg-architecture.md` 的 anchor-lane stale 措辞改为历史框架（scrum-237 已删该 lane）。doc-only。

## 验证

- unit-correctness + parity + golden-analytic + cuda：**4/4 套件通过**。
- 全量 `gui_test` **443/443**（不带 `--filter`；含 357.2/357.3 改动）。
- `format.sh --check` + `check_policies.py`（9 项门禁含新增 `no-msvc-unsafe-builtin`）全绿。
- 各子任务 code-review APPROVE（0 Critical/Major）/ chore DONE。

## 影响面

- 无对外接口变化（内部 helper + 门禁 + 测试 + 文档）。5 commits，9 文件，+238/−42。

🤖 Generated with [Claude Code](https://claude.com/claude-code)