### PR TITLE
fix(gpu-color): device Y-lane accumulator persist across batches (multi-batch density loss)

### DIFF
--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -33,12 +33,22 @@
   `rsync -az --delete src/ 49-GPU:/home/work/zjj/ice-halo-sim/src/` + 同理 test/，
   排除 `__pycache__`/`references/`）。非 git 仓，rsync 覆盖即可。
 - **CUDA docker 镜像**：
-  `registry.cn-zhangjiakou.aliyuncs.com/weizhendev/wzffm-centos7-cuda11.6:20250811T094454Z-e7555768`
-  （CUDA 11.6）。
+  - ⭐**优先用本地镜像 `lumice-cuda-test:11.6-py`**（dev49 本地 tag，`docker images` 可见）。它 = 下方 base 镜像 **+ 预装 `pytest`/`numpy`/`Pillow`**（explore-359 打的，避免每次 `docker run` 重装；`--rm` 只删容器不删镜像故持久留存）。**用它就不用再写 `pip install` 行**。
+  - base 镜像（新镜像的 FROM、也是纯 build 用）：
+    `registry.cn-zhangjiakou.aliyuncs.com/weizhendev/wzffm-centos7-cuda11.6:20250811T094454Z-e7555768`（CUDA 11.6）。
+  - **若本地镜像丢失（换机/清 docker）→ 一条命令重建**：
+    ```bash
+    ssh 49-GPU 'mkdir -p /tmp/lumice-img-build && printf "%s\n%s\n" \
+      "FROM registry.cn-zhangjiakou.aliyuncs.com/weizhendev/wzffm-centos7-cuda11.6:20250811T094454Z-e7555768" \
+      "RUN python3 -m pip install --no-cache-dir pytest numpy Pillow" \
+      > /tmp/lumice-img-build/Dockerfile && \
+      docker build -t lumice-cuda-test:11.6-py /tmp/lumice-img-build'
+    ```
+    baked 版本（首建时）：pytest 8.4.2 / numpy 2.0.2 / Pillow 11.3.0。
 - **build dir**：`build/cmake_build_cuda`（已配好，Ninja，`LUMICE_CUDA_ENABLED=ON`，86-virtual PTX）。
 - **build**：
   ```bash
-  ssh 49-GPU 'cd /home/work/zjj/ice-halo-sim && IMG=<镜像> && \
+  ssh 49-GPU 'cd /home/work/zjj/ice-halo-sim && IMG=lumice-cuda-test:11.6-py && \
     docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work \
       -w /work/build/cmake_build_cuda $IMG bash -lc "ninja"'
   ```
@@ -46,17 +56,27 @@
   ninja <该 .o target>`；grep `177-D`/`declared but never referenced` 查死代码告警
   （既有噪声：spdlog/fmt 的 `#128-D loop is not reachable`、`trace_backend.hpp` multi-line comment，
   与改动无关）。
-- **parity**：docker 默认 `/usr/local/bin/python3` **无 pytest/numpy**，需一次性装：
+- **parity（⭐首选 C++ gtest，不是 pytest）**：dev49 上 **pytest CUDA parity battery 会 `Fatal Python error: Aborted`（`free(): invalid next size`）**——backlog #1 记录的既存 ctypes teardown 堆污染，a01 已复核 pre-existing、与改动无关，但它会**吞掉 pytest 的 pass/fail 汇总**（尤其 `-q` 下崩在 summary 前）。**CLI 直跑和 C++ gtest 都不触发此崩溃**，故 parity 回归门走 gtest `parity_test`（用新镜像，无需 pip install）：
   ```bash
-  docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work -w /work $IMG bash -lc '
-    python3 -m pip install -q pytest numpy Pillow
+  docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work -w /work lumice-cuda-test:11.6-py bash -lc '
+    export LUMICE_HAS_CUDA=1 LUMICE_CUDA_ENABLED=1
+    export LD_LIBRARY_PATH=/work/build/Release/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+    /work/build/Release/bin/parity_test --gtest_filter="Cuda*:*ComponentMask*"'
+  ```
+  覆盖 `CudaRichExit`（2 个 in-test `GTEST_SKIP`）、`CudaBackendCrystalCount`、`CudaRngHiWiring`(4)、
+  `CudaComponentMaskParity`(6，染色 parity)。**判据 = 进程退出码 0 且 0 failed**（skip 不算失败）。耗时 ~2s。
+- **pytest parity（仅当必须，明知会 teardown 崩）**：用新镜像 + `-v -p no:faulthandler` 让每条 `PASSED`
+  在崩溃前流式打出（`-q` 下崩溃会让你什么都看不到）：
+  ```bash
+  docker run --rm --gpus all -v /home/work/zjj/ice-halo-sim:/work -w /work lumice-cuda-test:11.6-py bash -lc '
     export LUMICE_HAS_CUDA=1 LUMICE_CUDA_ENABLED=1
     export LUMICE_LIB=/work/build/Release/lib/liblumice.so
     export LD_LIBRARY_PATH=/work/build/Release/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
-    python3 -m pytest -v test/parity-cross-backend/backend/test_cuda_{exit_seam,filter,multi_ms}_parity.py'
+    python3 -m pytest -v -p no:faulthandler test/parity-cross-backend/backend/test_cuda_{exit_seam,filter,multi_ms}_parity.py'
   ```
-  （ctest 的 `CudaMultiMsParity` 因 cmake `PYTEST_EXECUTABLE` cache 指向不存在路径会 Not Run，
-  直接 `python3 -m pytest` 绕过。）耗时 ~7min。
+  （ctest 的 `CudaMultiMsParity` 因 cmake `PYTEST_EXECUTABLE` cache 指向不存在路径会 Not Run；直接 `python3 -m pytest` 绕过。）
+- **染色密度验证（本 bug / 任何 Y-lane composite 改动的功能门，parity 只测 mask 是盲区）**：three_arcs 2M
+  跑 `--backend cuda` vs `--backend cpu`，比 `img_01_components.jpg` 的 lit-px 密度（用新镜像，`test/e2e/image_utils.py::classify_pixels_by_color_direction`）。修复后 CUDA≈CPU（~100k）；explore-359 pre-fix 塌到 65k(CUDA)/3k(Metal)。
 - **CLI 冒烟**：`Lumice -f examples/config_example.json --backend cuda -o /tmp`
   （`-o` 是**目录**不是文件），grep `Stats: ... crystals=N`。
 - **坑**：shared 机 CPU 争用使 host-bound 吞吐剧烈抖动（只信 interleaved，perf 才在意）；

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -2540,12 +2540,21 @@ void CudaTraceBackend::Impl::EnsureClassLaneBuf(int w, int h) {
   };
   const size_t pix = static_cast<size_t>(std::max(w, 0)) * static_cast<size_t>(std::max(h, 0));
   const size_t needed_elems = (class_count_ == 0) ? 1u : (class_count_ * pix);
+  // explore-359 FIX (mirror Metal metal_trace_backend.mm EnsureClassLaneBuf):
+  // zero ONLY on (re)allocation, NOT every BeginSession. d_class_lane_buf_ is a
+  // scrum-312 third-clock PERSISTENT accumulator (twin of d_xyz_buf_): it
+  // accumulates across batches within a drain window and is reset per-window by
+  // ReadbackClassLanes' post-read cudaMemset. BeginSession runs PER BATCH, so an
+  // unconditional memset here wiped prior batches' lanes for any ray_num >
+  // LUMICE_DISPATCH_RAY_NUM (multiple batches/drain), leaving only the LAST batch
+  // (d_xyz_buf_ had no such bug — persistent, shape-change-only reset). Symptom:
+  // CUDA-color composites 30-50× sparser than CPU while full-spectrum matched.
   if (d_class_lane_buf_ == nullptr || needed_elems > class_lane_pix_capacity_) {
     cudaFree(d_class_lane_buf_); d_class_lane_buf_ = nullptr;
     ck(cudaMalloc(&d_class_lane_buf_, needed_elems * sizeof(float)), "cudaMalloc d_class_lane_buf");
     class_lane_pix_capacity_ = needed_elems;
+    ck(cudaMemset(d_class_lane_buf_, 0, needed_elems * sizeof(float)), "cudaMemset d_class_lane_buf");
   }
-  ck(cudaMemset(d_class_lane_buf_, 0, needed_elems * sizeof(float)), "cudaMemset d_class_lane_buf");
 }
 
 // EnsureFilterBuffers — mirror of Metal `EnsureFilterBuffers`

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1093,15 +1093,25 @@ void MetalTraceBackend::Impl::EnsureClassLaneBuf(int w, int h) {
   // requested layout would need more floats than the current allocation.
   const size_t pix = static_cast<size_t>(w) * static_cast<size_t>(h);
   const size_t needed_elems = (class_count_ == 0) ? 1u : (class_count_ * pix);
+  // explore-359 FIX: zero ONLY on (re)allocation — NOT every BeginSession.
+  // class_lane_buf_ is a scrum-312 third-clock PERSISTENT accumulator (twin of
+  // xyz_image): it accumulates across batches within a drain window and is
+  // reset per-window by ReadbackClassLanes' post-read memset (mm:3122).
+  // The old code memset'd every BeginSession — but BeginSession runs PER BATCH,
+  // so with ray_num > LUMICE_DISPATCH_RAY_NUM (multiple batches per drain) every
+  // batch wiped the prior batches' lane accumulation, leaving only the LAST
+  // batch. xyz_image did NOT have this bug (EnsureImage only zeroes on a shape
+  // change, which rides a generation flush/drain). Net effect: device Y-lanes
+  // delivered ~1/N_batches of the energy → GPU-color composites 30-50× sparser
+  // than CPU while full-spectrum matched. Mirror EnsureImage: zero on alloc,
+  // let the drain own the per-window reset.
   if (class_lane_buf_ == nil || needed_elems > class_lane_pix_capacity_) {
     class_lane_buf_ = [device newBufferWithLength:needed_elems * sizeof(float)
                                           options:MTLResourceStorageModeShared];
     assert(class_lane_buf_ != nil);
     class_lane_pix_capacity_ = needed_elems;
+    std::memset([class_lane_buf_ contents], 0, needed_elems * sizeof(float));
   }
-  // Zero the active region every BeginSession (mirrors the twin
-  // xyz_image/landed_weight_buf_ reset in EnsureImage).
-  std::memset([class_lane_buf_ contents], 0, needed_elems * sizeof(float));
 }
 
 void MetalTraceBackend::Impl::EnsurePolyBuffers(size_t poly_cnt) {

--- a/test/e2e-correctness/test_raypath_color.py
+++ b/test/e2e-correctness/test_raypath_color.py
@@ -153,6 +153,59 @@ class TestRaypathColor(LumiceTestCase):
                 f"composite PSNR {psnr:.1f} dB < threshold {PSNR_THRESHOLD} dB",
             )
 
+    def test_metal_device_lane_multibatch_density(self):
+        """explore-359 regression: the device per-color-class Y-lane accumulator
+        (class_lane_buf_) MUST persist across trace batches within a drain window.
+
+        The original task-358.1 EnsureClassLaneBuf memset'd class_lane_buf_ on
+        EVERY BeginSession — but BeginSession runs PER BATCH, so for
+        ray_num > LUMICE_DISPATCH_RAY_NUM (multiple batches per drain) every batch
+        wiped the prior batches' lane accumulation, leaving only the LAST batch.
+        The XYZ accumulator (xyz_image / d_xyz_buf_) had no such bug — it's a
+        scrum-312 persistent accumulator (shape-change-only reset) — so
+        FULL-SPECTRUM matched CPU while the COLOR composite came out ~30-50x
+        sparser. The parity harness never caught it: it validates the per-ray
+        MASK, not the Y-lane accumulation.
+
+        three_arcs has ray_num=2M >> the ~32768 dispatch size, so it exercises
+        the multi-batch path. Post-fix the Metal composite lights ~102k pixels
+        (≈ CPU); the bug collapsed it to ~3k. Metal-only (skips off macOS; on
+        Linux CI Metal is unavailable → --backend metal falls back to CPU, which
+        is the correct reference so the density floor still holds).
+        """
+        if not HAS_PILLOW:
+            self.skipTest("Pillow not available")
+        if not CONFIG.exists():
+            self.skipTest(f"{CONFIG} not found")
+
+        result = self.run_lumice(
+            ["-f", str(CONFIG), "-o", self.output_dir, "--backend", "metal"]
+        )
+        self.assertEqual(
+            result.returncode, 0, f"Lumice (metal) failed:\n{result.stderr}"
+        )
+        composite = Path(self.output_dir) / "img_01_components.jpg"
+        self.assertTrue(
+            composite.exists(), f"metal composite not produced: {composite}"
+        )
+
+        # three_arcs classes: RED / GREEN / BLUE (see raypath_color_three_arcs.json).
+        three_arcs_colors = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+        res = classify_pixels_by_color_direction(
+            str(composite), three_arcs_colors, cos_similarity_tol=0.90
+        )
+        lit = sum(res["per_class"])
+        # Correct density ~102k lit px; the multi-batch-loss bug collapsed it to
+        # ~3k. Floor at 40000 catches the regression with huge margin while
+        # tolerating single-path-vs-fan-out MC noise + JPEG chroma bleed.
+        self.assertGreater(
+            lit,
+            40000,
+            f"Metal color composite only {lit} lit pixels (expected ~100k) — the "
+            f"device Y-lane multi-batch accumulation regressed; see explore-359 / "
+            f"EnsureClassLaneBuf (metal_trace_backend.mm / cuda_trace_backend.cu).",
+        )
+
 
 class TestRaypathColorMultiLayer(LumiceTestCase):
     """CLI end-to-end for the 2-MS-layer full-semantics composite (task-339.5).


### PR DESCRIPTION
## 根因（explore-359）

scrum-358 GPU 染色合入 main（#190）后，owner on-screen 发现 **GPU 染色 composite 比 CPU 稀疏 30-50×、画面明显噪**，而**全光谱正常**。

白盒逐步定位到根因：`EnsureClassLaneBuf` 在**每次 `BeginSession`（=每 batch）无条件 `memset`** 掉 per-color-class 的 Y-lane 累加器（Metal `class_lane_buf_` / CUDA `d_class_lane_buf_`）。但 `BeginSession` 是**按 batch** 调用的——当 `ray_num > LUMICE_DISPATCH_RAY_NUM`（32768，多 batch/drain）时，每个 batch 清空了前面各 batch 的 lane 累加，**只剩最后一个 batch**。而 XYZ 累加器（`xyz_image`/`d_xyz_buf_`）是 scrum-312 的**持久累加器**（仅 shape 变时 reset），所以**全光谱匹配 CPU 而染色 composite 稀疏**。倍数随 batch 数恶化。358.1 写 lane buffer 时注释误以为 "mirrors xyz_image"，实则不然。

## 修复

`memset` 移进 `if((重)分配)` 分支，per-window 重置交给已有的 `ReadbackClassLanes` 尾部 zero（镜像 `xyz_image` 的持久语义）。shape/config 变化 ride generation flush→drain→zero，已覆盖。Metal + CUDA 同款修复。

## 验证

**Metal（本机）**：min1 sweep 100K/500K lane==xyzY 逐值 1.00×（修复前 59×）；three_arcs 2M 染色 lit_px 2939→102615（≈CPU 102705）；全量 gtest 4/4 绿；owner on-screen 复验通过。

**CUDA（dev49 RTX 4060 Ti + win-builder GTX 1070 Ti）**：
- 密度（three_arcs 2M，CLI `--backend cuda` vs `--backend cpu`）：fixed CUDA lit=**100079** ≈ CPU **99896**（差 0.2%，逐类吻合）。pre-fix 重建 lit=**64971**（−35%）证明修复 load-bearing。
- ⚠️ 量级不对称：CUDA pre-fix 仅 −35%，远比 Metal 35× 温和——`ReadbackClassLanes`（drain）由 host consumer 层调度、backend 无关，但 CUDA exit-buffer 填满更快 → drain 更频繁 → 丢失窗口更小。**fixed==CPU 证明修复在 CUDA 上完整闭合缺口**。
- parity 回归门（C++ gtest `parity_test`，`Cuda*:*ComponentMask*`）：**11 passed / 2 skipped / 0 failed**，含 6 个 `CudaComponentMaskParity` 染色 parity 全绿。
- win-builder GUI 构建 + owner 人工复核通过。

## parity 盲区回归

GPU parity harness 只测 per-ray **mask**、从不测 device **Y-lane 累加**——这是 scrum-358 三轮 code-review + parity 全绿仍漏此 bug 的根源。新增 e2e 回归 `test_metal_device_lane_multibatch_density`（three_arcs 2M composite lit_px > 40000 floor）填补盲区。

## 附带

`doc/gpu-remote-cuda-build-testing.md` 更新：dev49 预装 python 依赖的新镜像 `lumice-cuda-test:11.6-py`（免每次 pip install）+ parity 走不崩溃的 C++ gtest 路径 + 新增染色密度验证门。

🤖 Generated with [Claude Code](https://claude.com/claude-code)