### PR TITLE
refactor(gui): 统一 filter 语法 validate/parse 的 flush_ee 遍历骨架

### DIFF
--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -446,6 +446,88 @@ inline bool IsEeToken(const std::string& tok) {
   return StartsWith(tok, "entry:") || StartsWith(tok, "exit:") || StartsWith(tok, "len:");
 }
 
+// Callback return value for WalkSummandEeFlush. Uniform semantics across all
+// four callbacks — kAbort stops traversal, kContinue proceeds. No polarity
+// inversion between callbacks (see plan.md §3 truth table).
+enum class WalkAction { kContinue, kAbort };
+
+// Shared token traversal for ValidateSummandText (strict) and ParseSummandText
+// (tolerant). The skeleton owns the EE accumulation state (ee_builder /
+// entry_set / exit_set / len_set / ee_started) and drives:
+//   - empty-token dispatch  → on_empty_token()
+//   - EE token merge         → MergeEeToken(); on success sets ee_started, on
+//                              failure calls on_ee_merge_fail (skeleton itself
+//                              does NOT touch EE state on failure, preserving
+//                              first-wins accumulation across a mid-run skip)
+//   - raypath token          → on_flush (only if ee_started), then reset EE
+//                              state, then on_raypath_token
+//   - end of loop            → one trailing on_flush (only if ee_started)
+// The four callbacks decide policy at each decision point; the skeleton is
+// oblivious to whether the caller is a validator or a parser. See plan.md §3
+// truth table for validate/parse callback semantics.
+// Return value: true if the traversal completed without any kAbort; false if
+// some callback requested kAbort (caller's state — result / out — has been
+// mutated by the callback before it returned kAbort).
+template <typename OnEmptyToken, typename OnEeMergeFail, typename OnFlush, typename OnRaypathToken>
+inline bool WalkSummandEeFlush(const std::vector<std::string>& tokens,
+                               OnEmptyToken&& on_empty_token,      // () -> WalkAction
+                               OnEeMergeFail&& on_ee_merge_fail,   // (const std::string& tok,
+                                                                   //  const std::string& err) -> WalkAction
+                               OnFlush&& on_flush,                 // (const EntryExitParams& ee,
+                                                                   //  bool entry_set, bool exit_set) -> WalkAction
+                               OnRaypathToken&& on_raypath_token)  // (const std::string& tok) -> WalkAction
+{
+  EntryExitParams ee_builder;
+  bool entry_set = false;
+  bool exit_set = false;
+  bool len_set = false;
+  bool ee_started = false;
+  auto reset_ee = [&]() {
+    ee_builder = EntryExitParams{};
+    entry_set = false;
+    exit_set = false;
+    len_set = false;
+    ee_started = false;
+  };
+  for (const auto& tok : tokens) {
+    if (tok.empty()) {
+      if (on_empty_token() == WalkAction::kAbort) {
+        return false;
+      }
+      continue;
+    }
+    if (IsEeToken(tok)) {
+      std::string err;
+      if (MergeEeToken(tok, ee_builder, entry_set, exit_set, len_set, err)) {
+        ee_started = true;
+      } else if (on_ee_merge_fail(tok, err) == WalkAction::kAbort) {
+        return false;
+      }
+      // On merge failure with kContinue: intentionally leave EE state untouched
+      // so a subsequent valid EE token can accumulate into the same factor
+      // (first-wins across a mid-run skip, per plan §3).
+      continue;
+    }
+    // Raypath token: flush any in-flight EE factor (validate its facelists or
+    // emit it), then reset EE state, then hand the raypath token off.
+    if (ee_started) {
+      if (on_flush(ee_builder, entry_set, exit_set) == WalkAction::kAbort) {
+        return false;
+      }
+      reset_ee();
+    }
+    if (on_raypath_token(tok) == WalkAction::kAbort) {
+      return false;
+    }
+  }
+  if (ee_started) {
+    if (on_flush(ee_builder, entry_set, exit_set) == WalkAction::kAbort) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace detail
 
 // Strict validation of a summand row against the AND grammar. Empty input →

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -533,10 +533,10 @@ inline bool WalkSummandEeFlush(const std::vector<std::string>& tokens,
 // Strict validation of a summand row against the AND grammar. Empty input →
 // kValid (means "no filter" at the row level). Uses LUMICE_ValidateRaypathText
 // for raypath tokens and GuiValidateFaceNumberListText for entry:/exit:
-// facelists so the messages match the surrounding single-value paths.
-// Inherent grammar state-machine (token loop + EE flush/validate); NOLINTed per
-// the project convention of not fragmenting dense validators.
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+// facelists so the messages match the surrounding single-value paths. Shares
+// the EE-flush traversal state machine with ParseSummandText via
+// detail::WalkSummandEeFlush; policy differences (strict vs tolerant) live in
+// the four callbacks below.
 inline GuiValidationResult ValidateSummandText(const std::string& text, LUMICE_CrystalKind kind) {
   GuiValidationResult result;
   auto trimmed = TrimRaypathSegment(text);
@@ -567,78 +567,52 @@ inline GuiValidationResult ValidateSummandText(const std::string& text, LUMICE_C
   }
 
   auto tokens = detail::SplitSummandTokens(trimmed);
-  EntryExitParams ee_builder;
-  bool entry_set = false;
-  bool exit_set = false;
-  bool len_set = false;
-  bool ee_started = false;
-  // Validate the in-flight EE facelists, then reset the EE state. Mirrors the
-  // flush_ee reset in ParseSummandText so the validator AGREES with the parser:
-  // a raypath token ends the current EE factor, and a following entry:/exit:
-  // begins a fresh EE factor (not a "duplicate" of the prior one). Without this,
-  // "entry:2 & 5 & entry:3" would be parsed+round-tripped fine but rejected here.
-  auto flush_ee = [&]() -> bool {
-    if (ee_started) {
-      if (entry_set) {
-        auto sr = GuiValidateFaceNumberListText(ee_builder.entry_text, kind);
-        if (sr.state != LUMICE_RAYPATH_VALID) {
-          result = sr;
-          return false;
-        }
-      }
-      if (exit_set) {
-        auto sr = GuiValidateFaceNumberListText(ee_builder.exit_text, kind);
-        if (sr.state != LUMICE_RAYPATH_VALID) {
-          result = sr;
-          return false;
-        }
-      }
-      ee_builder = EntryExitParams{};
-      entry_set = false;
-      exit_set = false;
-      len_set = false;
-      ee_started = false;
-    }
-    return true;
-  };
-  for (const auto& tok : tokens) {
-    if (tok.empty()) {
-      result.state = LUMICE_RAYPATH_INVALID;
-      result.message = "Empty AND factor";
-      return result;
-    }
-    if (detail::IsEeToken(tok)) {
-      ee_started = true;
-      std::string err;
-      if (!detail::MergeEeToken(tok, ee_builder, entry_set, exit_set, len_set, err)) {
+  const bool ok = detail::WalkSummandEeFlush(
+      tokens,
+      [&]() -> detail::WalkAction {
+        result.state = LUMICE_RAYPATH_INVALID;
+        result.message = "Empty AND factor";
+        return detail::WalkAction::kAbort;
+      },
+      [&](const std::string& /*tok*/, const std::string& err) -> detail::WalkAction {
         result.state = LUMICE_RAYPATH_INVALID;
         result.message = err;
-        return result;
-      }
-    } else {
-      // Raypath token ends the current EE factor (flush + validate), then
-      // validate the raypath. A raypath token MAY contain ';' as a summand-level
-      // OR alternative (H-A, 334.3): `1-3;3-5 & entry:2` distributes to
-      // `(1-3 & entry:2) OR (3-5 & entry:2)` in ExpandSopToClauses. We delegate
-      // to ValidateRaypathTextMultiSegment (already covered by 11 unit tests)
-      // which rejects leading/trailing/consecutive ';' and validates each
-      // segment via LUMICE_ValidateRaypathText — no new validation logic.
-      if (!flush_ee()) {
-        return result;
-      }
-      auto seg_result = ValidateRaypathTextMultiSegment(tok, kind);
-      if (seg_result.state != LUMICE_RAYPATH_VALID) {
-        result = seg_result;
-        return result;
-      }
-    }
-  }
-
-  // Validate the trailing EE factor (if the row ended mid-EE).
-  if (!flush_ee()) {
+        return detail::WalkAction::kAbort;
+      },
+      [&](const EntryExitParams& ee, bool entry_set, bool exit_set) -> detail::WalkAction {
+        if (entry_set) {
+          auto sr = GuiValidateFaceNumberListText(ee.entry_text, kind);
+          if (sr.state != LUMICE_RAYPATH_VALID) {
+            result = sr;
+            return detail::WalkAction::kAbort;
+          }
+        }
+        if (exit_set) {
+          auto sr = GuiValidateFaceNumberListText(ee.exit_text, kind);
+          if (sr.state != LUMICE_RAYPATH_VALID) {
+            result = sr;
+            return detail::WalkAction::kAbort;
+          }
+        }
+        return detail::WalkAction::kContinue;
+      },
+      [&](const std::string& tok) -> detail::WalkAction {
+        // A raypath token MAY contain ';' as a summand-level OR alternative
+        // (H-A, 334.3): `1-3;3-5 & entry:2` distributes to
+        // `(1-3 & entry:2) OR (3-5 & entry:2)` in ExpandSopToClauses. We
+        // delegate to ValidateRaypathTextMultiSegment (already covered by 11
+        // unit tests) which rejects leading/trailing/consecutive ';' and
+        // validates each segment via LUMICE_ValidateRaypathText.
+        auto seg_result = ValidateRaypathTextMultiSegment(tok, kind);
+        if (seg_result.state != LUMICE_RAYPATH_VALID) {
+          result = seg_result;
+          return detail::WalkAction::kAbort;
+        }
+        return detail::WalkAction::kContinue;
+      });
+  if (!ok) {
     return result;
   }
-
   result.state = LUMICE_RAYPATH_VALID;
   return result;
 }

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -619,7 +619,10 @@ inline GuiValidationResult ValidateSummandText(const std::string& text, LUMICE_C
 
 // Tolerant parse of a summand row into a Factor vector. Mirrors the
 // ParseRaypathTextMultiSegment "skip invalid tokens" philosophy. Empty input
-// → empty vector.
+// → empty vector. Shares the EE-flush traversal state machine with
+// ValidateSummandText via detail::WalkSummandEeFlush; every callback here
+// returns kContinue (parse never aborts) — the only policy differences from
+// the validator live in what each callback does.
 inline std::vector<Factor> ParseSummandText(const std::string& text) {
   std::vector<Factor> out;
   auto trimmed = TrimRaypathSegment(text);
@@ -627,44 +630,30 @@ inline std::vector<Factor> ParseSummandText(const std::string& text) {
     return out;
   }
   auto tokens = detail::SplitSummandTokens(trimmed);
-  EntryExitParams ee_builder;
-  bool ee_started = false;
-  bool entry_set = false;
-  bool exit_set = false;
-  bool len_set = false;
-  auto flush_ee = [&]() {
-    if (ee_started) {
-      out.emplace_back(ee_builder);
-      ee_builder = EntryExitParams{};
-      ee_started = false;
-      entry_set = false;
-      exit_set = false;
-      len_set = false;
-    }
-  };
-  for (const auto& tok : tokens) {
-    if (tok.empty()) {
-      continue;
-    }
-    if (detail::IsEeToken(tok)) {
-      std::string err;
-      // Tolerant parse: a token that fails to merge (duplicate / bad lengthspec)
-      // is SKIPPED — it must NOT fabricate a factor. Only mark the EE factor
-      // "started" once a field was actually set, so an all-invalid EE run (e.g.
-      // "len:abc") yields no factor rather than a match-everything wildcard EE.
-      // Mirrors ValidateSummandText, which rejects such tokens (code-review-02
-      // Major 1).
-      if (detail::MergeEeToken(tok, ee_builder, entry_set, exit_set, len_set, err)) {
-        ee_started = true;
-      }
-    } else {
-      flush_ee();
-      RaypathParams rp;
-      rp.raypath_text = tok;
-      out.emplace_back(std::move(rp));
-    }
-  }
-  flush_ee();
+  detail::WalkSummandEeFlush(
+      tokens,
+      []() -> detail::WalkAction {
+        // Empty AND factor: silently skip (tolerant).
+        return detail::WalkAction::kContinue;
+      },
+      [](const std::string& /*tok*/, const std::string& /*err*/) -> detail::WalkAction {
+        // Merge failure: skip the token. Skeleton preserves EE state so that a
+        // subsequent valid EE token still accumulates into the same factor
+        // (first-wins across a mid-run skip); an all-invalid EE run yields no
+        // factor rather than a match-everything wildcard EE (code-review-02
+        // Major 1).
+        return detail::WalkAction::kContinue;
+      },
+      [&](const EntryExitParams& ee, bool /*entry_set*/, bool /*exit_set*/) -> detail::WalkAction {
+        out.emplace_back(ee);
+        return detail::WalkAction::kContinue;
+      },
+      [&](const std::string& tok) -> detail::WalkAction {
+        RaypathParams rp;
+        rp.raypath_text = tok;
+        out.emplace_back(std::move(rp));
+        return detail::WalkAction::kContinue;
+      });
   return out;
 }
 

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -448,7 +448,8 @@ inline bool IsEeToken(const std::string& tok) {
 
 // Callback return value for WalkSummandEeFlush. Uniform semantics across all
 // four callbacks — kAbort stops traversal, kContinue proceeds. No polarity
-// inversion between callbacks (see plan.md §3 truth table).
+// inversion between callbacks: the validator returns kAbort on any rejection
+// and kContinue otherwise; the parser returns kContinue from every callback.
 enum class WalkAction { kContinue, kAbort };
 
 // Shared token traversal for ValidateSummandText (strict) and ParseSummandText
@@ -463,8 +464,13 @@ enum class WalkAction { kContinue, kAbort };
 //                              state, then on_raypath_token
 //   - end of loop            → one trailing on_flush (only if ee_started)
 // The four callbacks decide policy at each decision point; the skeleton is
-// oblivious to whether the caller is a validator or a parser. See plan.md §3
-// truth table for validate/parse callback semantics.
+// oblivious to whether the caller is a validator or a parser. Callback
+// semantics: the validator returns kAbort on the first rejection (empty token,
+// EE merge failure, invalid entry/exit facelist, or invalid raypath) and
+// kContinue otherwise; the parser returns kContinue from every callback,
+// skipping invalid tokens and emitting factors via side effects. on_ee_merge_fail
+// receives (tok, err); current callers read only err — tok is available for
+// future error-context use.
 // Return value: true if the traversal completed without any kAbort; false if
 // some callback requested kAbort (caller's state — result / out — has been
 // mutated by the callback before it returned kAbort).
@@ -505,7 +511,7 @@ inline bool WalkSummandEeFlush(const std::vector<std::string>& tokens,
       }
       // On merge failure with kContinue: intentionally leave EE state untouched
       // so a subsequent valid EE token can accumulate into the same factor
-      // (first-wins across a mid-run skip, per plan §3).
+      // (first-wins across a mid-run skip).
       continue;
     }
     // Raypath token: flush any in-flight EE factor (validate its facelists or
@@ -640,8 +646,7 @@ inline std::vector<Factor> ParseSummandText(const std::string& text) {
         // Merge failure: skip the token. Skeleton preserves EE state so that a
         // subsequent valid EE token still accumulates into the same factor
         // (first-wins across a mid-run skip); an all-invalid EE run yields no
-        // factor rather than a match-everything wildcard EE (code-review-02
-        // Major 1).
+        // factor rather than a match-everything wildcard EE.
         return detail::WalkAction::kContinue;
       },
       [&](const EntryExitParams& ee, bool /*entry_set*/, bool /*exit_set*/) -> detail::WalkAction {

--- a/test/unit-correctness/gui/test_filter_sop_grammar.cpp
+++ b/test/unit-correctness/gui/test_filter_sop_grammar.cpp
@@ -509,6 +509,29 @@ TEST(FilterSopGrammar, DuplicateEeTokenParserFirstWinsValidatorRejects) {
   EXPECT_EQ(std::get<EntryExitParams>(dup_len[0]).min_len, 3);
 }
 
+// Contract lock (task-gui-filter-grammar-statemachine-unify): after unifying
+// Validate/Parse onto detail::WalkSummandEeFlush, a merge-failed EE token in
+// the MIDDLE of an EE run must NOT terminate the run for the parser — the
+// skeleton leaves EE state untouched on merge failure, so a subsequent valid
+// EE token (`exit:3` here) still accumulates into the same factor as the
+// prior valid token (`entry:2`). Validator rejects at the failed token.
+// Existing "entry:2 & len:abc" (ParseSkipsAllInvalidEeRun) is a TAIL failure,
+// not mid-run; this locks the mid-run case that had no coverage before.
+TEST(FilterSopGrammar, MidRunEeMergeSkipDoesNotTerminateFactor) {
+  // Validator: rejects at the `len:abc` token.
+  auto v = ValidateSummandText("entry:2 & len:abc & exit:3", LUMICE_CRYSTAL_PRISM);
+  EXPECT_EQ(v.state, LUMICE_RAYPATH_INVALID);
+  // Parser: skips `len:abc`, accumulates `entry:2` + `exit:3` into ONE factor
+  // (not two — mid-run merge failure must not fabricate a factor boundary).
+  auto parsed = ParseSummandText("entry:2 & len:abc & exit:3");
+  ASSERT_EQ(parsed.size(), 1u);
+  ASSERT_TRUE(std::holds_alternative<EntryExitParams>(parsed[0]));
+  const auto& ee = std::get<EntryExitParams>(parsed[0]);
+  EXPECT_EQ(ee.entry_text, "2");
+  EXPECT_EQ(ee.exit_text, "3");
+  EXPECT_EQ(ee.length_mode, 0);  // bad len skipped, no length constraint
+}
+
 TEST(FilterSopGrammar, ParseLengthSpecStrict) {
   int mode = 0;
   int min_len = 0;


### PR DESCRIPTION
## 背景

`src/gui/raypath_segments.hpp` 的 `ValidateSummandText`(strict) 与 `ParseSummandText`(tolerant) 各自手写一份结构同构的 AND 小语法 EE-flush 遍历状态机。scrum-333 两轮 code-review 抓到的两个 Major（validator 比 parser 严 / parser 比 validator 松）都是这两份拷贝语义漂移的实例。本 PR 抽取共享骨架从结构上根治（backlog scrum-333 残余债 A 项，`/backlog-pick` 立项 task-361）。

## 改动

- 新增 `detail::WalkSummandEeFlush` 模板骨架 + `enum class WalkAction { kContinue, kAbort }`；骨架自持 EE 累加态、驱动 `MergeEeToken`/flush 时机/reset，`ValidateSummandText`/`ParseSummandText` 只提供四个回调。
- **四回调统一返回 `WalkAction`（非 bool）**：真值表证明 validate 每行"失败→kAbort/成功→kContinue"、parse 每行恒 kContinue，极性天然统一、无一需反转（bool 版本会在 `on_ee_merge_fail` 上诱发极性混淆）。
- `ee_started` 统一为"仅 merge 成功后置位"，保留 first-wins mid-run 累加（白盒论证可观察行为不变）。
- 删除 `ValidateSummandText` 上不再必要的 `NOLINT(readability-function-cognitive-complexity)` 豁免。
- 新增回归 `MidRunEeMergeSkipDoesNotTerminateFactor`：锁 `entry:2 & len:abc & exit:3` 的 mid-run merge-skip 契约（validate 拒绝 / parse 跳过 len:abc 并把 entry:2+exit:3 合进同一 factor），填补既有 tail-failure 用例的盲区。

## 范围

生产改动仅 `src/gui/raypath_segments.hpp`（+156/−111）+ `test/unit-correctness/gui/test_filter_sop_grammar.cpp`（+23 回归用例）。无 core/config/C-API/server 改动；`WalkAction`/`WalkSummandEeFlush` 限定 `detail` 命名空间，公开签名/返回语义不变。

## 验证

- unit-correctness（ctest）100% pass / 0 failed
- gui_test 446/446 + 5/5
- grammar filter 31/31（含 3 个 divergence 回归 + 8 个 SoP 用例，零回归）
- `format.sh --check` + `check_policies.py` 绿

## 非目标（遗留 backlog/未来）

- backlog 同条目 B 项（`SimpleTermDesc`→`std::variant`）触发未满足，仍在 backlog。
- `raypath_segments.hpp:292`/`:671` 有 2 处 pre-existing 悬空 scratchpad 引用（来自 task-gui-sop-data-model/scrum-333），本次刻意不越界修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)