### PR TITLE
fix(gui-test): guard optimistic_async_stop against no-GL-context coroutine upload

### DIFF
--- a/test/gui/functional/test_gui_lifecycle.cpp
+++ b/test/gui/functional/test_gui_lifecycle.cpp
@@ -546,6 +546,19 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     IM_CHECK(!gui::g_stop_inflight.load());  // background thread returned ⇒ backend drained
     // The intent-advance lives after the reconcile line in SyncFromPoller, so it takes two frames to
     // reach the terminal display: frame 1 advances kStopping→kStopped, frame 2 reconciles to kDone.
+    //
+    // GL-upload guard: this terminal reconcile drives SyncFromPoller() directly on the ImGui
+    // test-engine coroutine thread, which has NO current GL context (the context is current on the
+    // main frame-loop thread — see the app.hpp SyncFromPoller note). If a fresh, not-yet-uploaded
+    // XYZ payload is staged, SyncFromPoller's upload branch reaches UploadXyzTexture → glClientWaitSync,
+    // which dereferences a null GL dispatch table → intermittent EXC_BAD_ACCESS. Unlike
+    // terminal_idle_reaches_done (test 1 section B), which drives the poller manually and can guard
+    // with InvalidateStagedTexture() alone, this test runs a LIVE poller, so we must first Stop() it
+    // (Stop() waits for the worker to leave the poll loop) so no background WorkerLoop can re-stage a
+    // fresh payload after we drop it, THEN drop the staged texture. Reconcile only reads run_intent /
+    // committed_epoch / the (surviving) snapshot, so pausing the poller does not affect the assertions.
+    gui::g_server_poller.Stop();
+    gui::g_server_poller.InvalidateStagedTexture();
     for (int i = 0; i < 4 && gui::g_state.sim_state != SimState::kDone; ++i) {
       gui::SyncFromPoller();
     }


### PR DESCRIPTION
## 问题

本地全套 `gui_test` 偶发崩溃（backlog 记为 SIGILL rc−4，~10-20%，恒在 auto_ev 测试之后），曾静默掩盖真实通过状态、甚至致 `build.sh install` 被跳过。

## 根因（`lldb` 首手捕获，白盒确认）

`gui_lifecycle` 的 **`optimistic_async_stop` (t5)** 测试为拿确定性单帧 reconcile，从 ImGui test-engine **协程线程**直调 `gui::SyncFromPoller()`。该函数内含 GL 纹理上传分支（`app.cpp:1196 → UploadXyzTexture`），其首个 GL 调用 `glClientWaitSync`（`preview_renderer.cpp:684`）在**无当前 GL 上下文的协程线程**（GL 上下文只 current 于主帧循环线程 #1）上解引用空 GL dispatch 表 → 间歇 `EXC_BAD_ACCESS`（`x8=0`，fault addr `0x1878`）。竞态触发（后台 poller 新 payload ∧ 活 PBO fence）→ 间歇性。

```
#0 glClientWaitSync            (EXC_BAD_ACCESS, x8=0)
#1 PreviewRenderer::UploadXyzTexture   preview_renderer.cpp:684
#2 SyncFromPoller()                     app.cpp:1196
#3 gui_lifecycle 'optimistic_async_stop'  test_gui_lifecycle.cpp
```

**这是测试-侧 bug，非生产 bug**——生产路径与测试 harness 主循环都在主线程调 `SyncFromPoller`；代码库早已文档化此约束（`app.hpp:228`）。backlog 记录的「512KB 栈溢出 / SIGILL」假设不成立（真信号是 SEGV 类；task-344 的 `___chkstk_darwin` 是另一类已修 bug；NDEBUG release 下 `IM_ASSERT` 编译为 no-op）。

## 修复

t5 终端 reconcile 循环前加两行守卫：`g_server_poller.Stop()`（等 worker 离开 poll 循环，杜绝后台重新 stage）+ `InvalidateStagedTexture()`（置空 payload，令 `SyncFromPoller` 走 reconcile-only 路，不触 GL）。复刻 `terminal_idle_reaches_done` (t1) 既有守卫范式；t1 是 manual poller、单 `InvalidateStagedTexture()` 即可，t5 跑 live poller 故额外需 `Stop()`。reconcile 只读 `run_intent`/`committed_epoch`/快照，暂停 poller 不影响断言。

其余同类直调点已核实安全：t1 已守卫、t6b `PublishValidResetForTest()` 置 valid=false → `SyncFromPoller` 在 `!snap->valid` 早退不达上传分支、其余皆主线程调用。

## 验证

- **`lldb` repro loop 60/60 clean**（fix 后），基线在 `lldb` 下 1/13 复现
- fixed-dt pool **441/441**（含 optimistic_async_stop），无回归
- 方法学：非-`lldb` 50/50 全绿 vs `lldb` 1/13 → 间歇崩溃是时序竞态、`lldb` 扰动抬高复现率，故验证在 `lldb` 条件下才有区分力
- **零 core/生产 diff**，仅 `test/gui/functional/test_gui_lifecycle.cpp`（+13 行）；format `--check` + policy gate 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)