### PR TITLE
fix(gui-state): view/lens/hemisphere changes must not trigger re-sim

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -850,8 +850,10 @@ void DoRun() {
   // Renderer comparison uses RenderConfigResimEqual (gui_state.hpp) — same helper used by
   // gui_state_reconcile.cpp::DiffAgainstCommitBaseline, so this predicate and the reconciler's
   // resim/dirty verdict stay in lock-step (single source of truth; see T2 plan §3 design 1).
-  // Excludes exposure_offset because EV is display-time only (§6.5) — dragging the EV slider
-  // must not cause a poller Stop here.
+  // Excludes all T-view fields (lens_type / fov / elevation / azimuth / roll / visible / front /
+  // exposure_offset) because they are client-side reprojection only — the sim renders a fixed
+  // full-sky dual-fisheye and the GUI reprojects it (see gui_state.hpp comment). Dragging the
+  // view / switching the lens / toggling the hemisphere clip must not cause a poller Stop here.
   bool expect_rebuild = backend_reconstructed || !g_state.last_committed_state.has_value() ||
                         !RenderConfigResimEqual(g_state.renderer, g_state.last_committed_state->renderer);
 

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -228,19 +228,32 @@ struct RenderConfig {
   bool operator!=(const RenderConfig& o) const { return !(*this == o); }
 };
 
-// task-classic-params-migration (T2) — resim-eligibility comparator for RenderConfig.
-// Compares every field EXCEPT `exposure_offset`. Rationale: EV is a pure display-time
-// parameter (doc/ev-pipeline-architecture.md §6.4/§6.5 — GUI Run path never bakes EV; the
-// core-side NeedsRebuild() already lists intensity_factor / opacity / background / ray_color
-// as appearance-only). Among those, only `exposure_offset` has no need to travel through a
-// commit at all (it is pushed every frame via RefreshPreviewParams / LUMICE_SetCompositeExposure),
-// so it is the single field that should be excluded from the resim/rebuild diff.
+// resim-eligibility comparator for RenderConfig. Compares ONLY fields whose change genuinely
+// requires re-running / rebuilding the simulation. Everything else is client-side display state.
+//
+// EXCLUDED — T-view fields (doc/gui-state-governance.md §2 row "T-view"): the simulation always
+// renders a fixed full-sky dual-fisheye and the GUI reprojects it in the preview GL shader, so
+// these are pure client-side reprojection / crop parameters uploaded as shader uniforms
+// (preview_renderer.cpp: u_lens_type / u_visible / u_front) and never travel to the server:
+//   lens_type, fov, elevation, azimuth, roll  — camera view angle + projection (mouse orbit /
+//                                                lens combo). Including them made every drag /
+//                                                lens switch falsely trigger a re-sim (auto-restart
+//                                                in infinite-rays mode; "Configuration changed" in
+//                                                finite mode). That was the scrum-353 T2 regression:
+//                                                only exposure_offset had been carved out.
+//   visible, front                            — upper/lower/full hemisphere clip (display crop).
+//   exposure_offset                           — EV (doc/ev-pipeline-architecture.md §6.4/§6.5;
+//                                                pushed every frame via LUMICE_SetCompositeExposure).
+//
+// INCLUDED — sim_resolution_index (changes the sim render grid → genuine re-sim) plus the
+// appearance fields the core NeedsRebuild() treats as appearance-only but which currently reach
+// the server only through the commit payload (background / ray_color / opacity); leave them in so
+// they still get applied on Run until they gain a display-time push path.
+//
 // Callers: gui_state_reconcile.cpp::DiffAgainstCommitBaseline and app.cpp::DoRun expect_rebuild
 // (single source of truth — do not fork).
 inline bool RenderConfigResimEqual(const RenderConfig& a, const RenderConfig& b) {
-  return a.lens_type == b.lens_type && a.fov == b.fov && a.elevation == b.elevation && a.azimuth == b.azimuth &&
-         a.roll == b.roll && a.sim_resolution_index == b.sim_resolution_index && a.visible == b.visible &&
-         a.front == b.front && std::equal(a.background, a.background + 3, b.background) &&
+  return a.sim_resolution_index == b.sim_resolution_index && std::equal(a.background, a.background + 3, b.background) &&
          std::equal(a.ray_color, a.ray_color + 3, b.ray_color) && a.opacity == b.opacity;
 }
 

--- a/test/gui/functional/test_gui_state_reconcile.cpp
+++ b/test/gui/functional/test_gui_state_reconcile.cpp
@@ -199,15 +199,45 @@ void RegisterStateReconcileTests(ImGuiTestEngine* engine) {
       IM_CHECK(!e.need_hard_reset);
       IM_CHECK(!e.need_display_push);
     }
-    // Non-EV renderer field (fov) still drives re-sim (regression pin for the T2 default
-    // assumption — pre-T2 there was no dedicated coverage for fov / elevation / azimuth /
-    // roll / lens_type, they relied on the whole-struct comparison).
+    // fix/gui-view-lens-no-resim (regression pin): the T-view fields — camera view angle,
+    // lens/projection, fov, roll, and the hemisphere clip (visible / front) — are pure client-side
+    // reprojection (the sim renders a fixed full-sky dual-fisheye; the GUI reprojects it in the
+    // preview shader). Mutating any of them alone MUST NOT drive re-sim / hard-reset / display-push.
+    // Before the fix, dragging the view or switching the lens falsely re-triggered the sim
+    // (auto-restart in infinite-rays mode; "Configuration changed" in finite mode) because
+    // RenderConfigResimEqual compared these fields. This pin prevents a silent re-add.
+    {
+      struct ViewMutator {
+        const char* field;
+        void (*apply)(GuiState&);
+      };
+      const ViewMutator kViewMutators[] = {
+        { "lens_type", [](GuiState& s) { s.renderer.lens_type = 1; } },  // was 0
+        { "fov", [](GuiState& s) { s.renderer.fov = 45.0f; } },          // was 90.0f
+        { "elevation", [](GuiState& s) { s.renderer.elevation = 15.0f; } },
+        { "azimuth", [](GuiState& s) { s.renderer.azimuth = 30.0f; } },
+        { "roll", [](GuiState& s) { s.renderer.roll = 10.0f; } },
+        { "visible", [](GuiState& s) { s.renderer.visible = 0; } },  // was 2 (full)
+        { "front", [](GuiState& s) { s.renderer.front = !s.renderer.front; } },
+      };
+      for (const auto& mut : kViewMutators) {
+        GuiState s = MakeBaselineState();
+        mut.apply(s);
+        GuiEffects e = ReconcileGuiEffects(s);
+        IM_CHECK(!e.need_resim);
+        IM_CHECK(!e.need_hard_reset);
+        IM_CHECK(!e.need_display_push);
+        IM_UNUSED(mut.field);  // name is here for debug-print if IM_CHECK fires
+      }
+    }
+    // Counterpart: sim_resolution_index is the one RenderConfig field that IS structural — it must
+    // still drive re-sim (already covered by the soft-tier renderer case above, restated here so the
+    // T-view exclusions above cannot be over-broadened to swallow the whole struct).
     {
       GuiState s = MakeBaselineState();
-      s.renderer.fov = 45.0f;  // was 90.0f
+      s.renderer.sim_resolution_index += 1;
       GuiEffects e = ReconcileGuiEffects(s);
       IM_CHECK(e.need_resim);
-      IM_CHECK(!e.need_hard_reset);
     }
 
     // task-classic-params-migration (T2 Step 2 / AC2): filter presence-toggle at same-shape


### PR DESCRIPTION
## 问题

操作 GUI 时，拖动鼠标改变视角、切换镜头投影、或切换上下半球裁剪，都会弹 "Configuration changed"；在 infinite-rays 模式下仿真被每个 commit interval 自动重启。这些是纯前端行为，不应触发仿真。

## 根因（scrum-353 T2 回归）

`RenderConfigResimEqual`（判断是否需要重跑仿真的单源比较器，`DiffAgainstCommitBaseline` 与 `DoRun` 的 `expect_rebuild` 共用）把 T-view 字段 `lens_type / fov / elevation / azimuth / roll / visible / front` 也算进了 re-sim 差异。

这些字段是纯客户端重投影：仿真永远产出固定的全天空 dual-fisheye，GUI 在 preview GL shader 里重投影（`u_lens_type / u_visible / u_front`），从不下发给 server。按 `doc/gui-state-governance.md` §2 它们属 **T-view**，不应 dirty。T2 迁移当时只挖掉了 `exposure_offset`，把其余 view 字段漏在了 diff 里。

## 修复

- 收窄 `RenderConfigResimEqual`：只比较真正需要重跑的字段（`sim_resolution_index` + 目前仅经 commit payload 下发的外观字段 `background / ray_color / opacity`）。
- 同步更新 `DoRun` 的 `expect_rebuild` 注释。
- 翻转 `test_gui_state_reconcile.cpp` 中**锁定了 bug 行为**的测试 pin（原断言 "fov 触发 re-sim"）→ 改为 7 字段回归 pin（view/lens/hemisphere 改动均无 effect），并补一条 `sim_resolution_index` 仍触发 re-sim 的对照 pin。

## 验证

- `gui_test` 446/446 通过（含新回归 pin）
- `./scripts/format.sh --check` + `scripts/check_policies.py` 均绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)