### PR TITLE
fix(gpu): layer-0 color-class mask cross-batch leak (Metal + CUDA)

### DIFF
--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -3315,25 +3315,23 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
   ck_reset(cudaMemset(impl_->d_cont_count_[out_slot], 0, sizeof(uint32_t)),
            "cudaMemset d_cont_count_[out_slot]");
 
-  // task-331.6 (test-only) component-mask capture setup:
-  //   - Layer 0's root rays start with an all-zero carried mask; memset here
-  //     (transit_multi_ms_kernel overwrites d_root_component_ for layer≥1).
-  //     Gen/host-gen paths do NOT write d_root_component_, so this memset is the
-  //     sole initializer for the first layer.
-  //   - Reset the capture-ring counter so each layer's emits append from 0; the
-  //     per-layer drain after the ci-loop reads exactly this layer's count.
-  // explore-365 FIX: the layer-0 carried-mask reset MUST run in production too,
-  // not only under the test-only capture_ray_mask_ path. The trace kernel always
-  // reads d_root_component[tid] as the carried mask (production color path), and
-  // d_root_component_ is REUSED across per-batch BeginSession cycles — layer≥1's
-  // transit kernel writes it, so without a per-first-layer memset batch N's
-  // layer-0 rays inherit batch N-1's final-layer carried color bits, merging
-  // color-class masks across batches (only visible with multi-crystal L0 +
-  // multi-batch). Mirrors the MetalTraceBackend fix at the same site.
+  // Layer-0 root rays must start with an all-zero carried color-class mask.
+  // d_root_component_ is reused across per-batch BeginSession cycles and the
+  // trace kernel reads it on the production color path (transit_multi_ms_kernel
+  // overwrites it for layer≥1; gen/host-gen paths do NOT write it, so this is the
+  // sole first-layer initializer), so this reset MUST be unconditional — NOT
+  // gated on the test-only capture path below — or batch N's layer-0 rays inherit
+  // batch N-1's carried bits and color-class masks merge across batches
+  // (observable only with multi-crystal L0 + multi-batch). Mirrors MetalTraceBackend.
   if (first_ms && impl_->d_root_component_ != nullptr) {
     ck_reset(cudaMemset(impl_->d_root_component_, 0, n * sizeof(unsigned long long)),
              "cudaMemset d_root_component (layer 0)");
   }
+  // task-331.6: test-only capture-ring maintenance for the whole block below —
+  // (re)allocate the capture buffers AND reset the ring counter so each layer's
+  // emits append from 0 (the per-layer drain after the ci-loop reads exactly this
+  // layer's count). Entirely gated on the test-only capture path; a disjoint
+  // buffer set from the production reset above.
   if (impl_->capture_ray_mask_) {
     impl_->EnsureComponentCaptureBuffers(ComputeContCap(n, impl_->scene_->max_hits_));
     ck_reset(cudaMemset(impl_->d_exit_comp_cnt_, 0, sizeof(uint32_t)), "cudaMemset d_exit_comp_cnt");

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -3322,12 +3322,20 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
   //     sole initializer for the first layer.
   //   - Reset the capture-ring counter so each layer's emits append from 0; the
   //     per-layer drain after the ci-loop reads exactly this layer's count.
+  // explore-365 FIX: the layer-0 carried-mask reset MUST run in production too,
+  // not only under the test-only capture_ray_mask_ path. The trace kernel always
+  // reads d_root_component[tid] as the carried mask (production color path), and
+  // d_root_component_ is REUSED across per-batch BeginSession cycles — layer≥1's
+  // transit kernel writes it, so without a per-first-layer memset batch N's
+  // layer-0 rays inherit batch N-1's final-layer carried color bits, merging
+  // color-class masks across batches (only visible with multi-crystal L0 +
+  // multi-batch). Mirrors the MetalTraceBackend fix at the same site.
+  if (first_ms && impl_->d_root_component_ != nullptr) {
+    ck_reset(cudaMemset(impl_->d_root_component_, 0, n * sizeof(unsigned long long)),
+             "cudaMemset d_root_component (layer 0)");
+  }
   if (impl_->capture_ray_mask_) {
     impl_->EnsureComponentCaptureBuffers(ComputeContCap(n, impl_->scene_->max_hits_));
-    if (first_ms && impl_->d_root_component_ != nullptr) {
-      ck_reset(cudaMemset(impl_->d_root_component_, 0, n * sizeof(unsigned long long)),
-               "cudaMemset d_root_component (layer 0)");
-    }
     ck_reset(cudaMemset(impl_->d_exit_comp_cnt_, 0, sizeof(uint32_t)), "cudaMemset d_exit_comp_cnt");
   }
 

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -2765,23 +2765,21 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
     impl_->last_stats = LayerStats{};
     impl_->cont_counts[out_slot] = 0;
 
-    // task-331.5: per-layer component-mask setup (test-only capture path).
-    //   - Layer 0's root rays start with an all-zero carried mask; memset here
-    //     (transit_root_kernel overwrites root_component for layer≥1).
-    //   - Reset the capture-ring counter so each layer's emits append from 0;
-    //     the per-layer drain after the ci loop reads exactly this layer's count.
-    // explore-365 FIX: the layer-0 carried-mask reset MUST run in production
-    // too, not only under the test-only capture_ray_mask_ path. The trace kernel
-    // always reads root_component[tid] as the carried mask (production color
-    // path), and root_component_buf_ is REUSED across per-batch BeginSession
-    // cycles — layer≥1's transit_root_kernel writes it, so without a per-first-
-    // layer memset batch N's layer-0 rays inherit batch N-1's final-layer carried
-    // color bits, merging color-class masks across batches (only visible with
-    // multi-crystal L0 + multi-batch; parity harness masked it by enabling
-    // capture_ray_mask_, which used to gate this reset).
+    // Layer-0 root rays must start with an all-zero carried color-class mask.
+    // root_component_buf_ is reused across per-batch BeginSession cycles and the
+    // trace kernel reads it on the production color path (transit_root_kernel
+    // overwrites it for layer≥1), so this reset MUST be unconditional for the
+    // first layer — NOT gated on the test-only capture path below — or batch N's
+    // layer-0 rays inherit batch N-1's carried bits and color-class masks merge
+    // across batches (observable only with multi-crystal L0 + multi-batch).
     if (first_ms && impl_->root_component_buf_ != nil) {
       std::memset([impl_->root_component_buf_ contents], 0, total_ray_num * sizeof(uint64_t));
     }
+    // task-331.5: test-only capture-ring maintenance for the whole block below —
+    // (re)allocate the capture buffers AND reset the ring counter so each layer's
+    // emits append from 0 (the per-layer drain after the ci loop reads exactly
+    // this layer's count). Entirely gated on the test-only capture path; a
+    // disjoint buffer set from the production reset above.
     if (impl_->capture_ray_mask_) {
       impl_->EnsureComponentCaptureBuffers(impl_->out_cap);
       *static_cast<uint32_t*>([impl_->exit_comp_cnt_buf_ contents]) = 0u;

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -2770,11 +2770,20 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
     //     (transit_root_kernel overwrites root_component for layer≥1).
     //   - Reset the capture-ring counter so each layer's emits append from 0;
     //     the per-layer drain after the ci loop reads exactly this layer's count.
+    // explore-365 FIX: the layer-0 carried-mask reset MUST run in production
+    // too, not only under the test-only capture_ray_mask_ path. The trace kernel
+    // always reads root_component[tid] as the carried mask (production color
+    // path), and root_component_buf_ is REUSED across per-batch BeginSession
+    // cycles — layer≥1's transit_root_kernel writes it, so without a per-first-
+    // layer memset batch N's layer-0 rays inherit batch N-1's final-layer carried
+    // color bits, merging color-class masks across batches (only visible with
+    // multi-crystal L0 + multi-batch; parity harness masked it by enabling
+    // capture_ray_mask_, which used to gate this reset).
+    if (first_ms && impl_->root_component_buf_ != nil) {
+      std::memset([impl_->root_component_buf_ contents], 0, total_ray_num * sizeof(uint64_t));
+    }
     if (impl_->capture_ray_mask_) {
       impl_->EnsureComponentCaptureBuffers(impl_->out_cap);
-      if (first_ms && impl_->root_component_buf_ != nil) {
-        std::memset([impl_->root_component_buf_ contents], 0, total_ray_num * sizeof(uint64_t));
-      }
       *static_cast<uint32_t*>([impl_->exit_comp_cnt_buf_ contents]) = 0u;
     }
 

--- a/test/parity-cross-backend/backend/test_cuda_component_mask_parity.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_component_mask_parity.cpp
@@ -12,10 +12,14 @@
 // produce branch has been retired (task-358.3).
 //
 // Why the parity is STRUCTURAL + STATISTICAL, not per-ray byte-exact
-//   CudaTraceBackend follows a single refract-priority path per ray while
-//   CpuTraceBackend fans out (reflect + refract) per hit and area-weight
-//   re-samples continuation entry — the two produce DIFFERENT ray populations.
-//   So per-ray mask equality is impossible; we compare weighted distributions +
+//   Both backends emit reflect + refract per hit (see CUDA trace kernel channel
+//   loop mirroring lumice_trace.metal:677 and CPU HitSurface at optics.cpp:18
+//   writing 2 branches per input); the difference is CONTINUATION:
+//   CudaTraceBackend advances only the refract branch (single-path
+//   continuation, refract-priority), while CpuTraceBackend keeps both reflect
+//   + refract branches as continuations (fan-out) and area-weight re-samples
+//   continuation entry — the two produce DIFFERENT ray populations. So per-ray
+//   mask equality is impossible; we compare weighted distributions +
 //   self-consistency invariants (mirrors the Metal harness rationale):
 //     - structural: no spurious bits, cross-layer joint bits present (proves the
 //       mask survives transit + shuffle + the Recombine handle swap end-to-end);
@@ -476,7 +480,8 @@ TEST(CudaComponentMaskParity, CpuMarginalBallpark) {
   fprintf(stderr, "[component-mask] CPU-vs-CUDA max |per-component frac| = %.4f\n", max_abs);
   // Same predicate-match + component-table logic on both backends → the per-
   // component marginals live in the same ballpark. LOOSE bound: the two
-  // backends trace DIFFERENT ray populations (single-path vs fan-out), so this
+  // backends trace DIFFERENT ray populations (CUDA continues one branch,
+  // CPU fans out reflect + refract as continuations — see header), so this
   // is a sanity anchor, not a tight numeric parity. Whole-crystal (None) bits
   // 0 and 2 are the tightest signal — they should be near 1.0 on both backends
   // (every emitted ray hit layer 0 / layer 1 respectively), while length-gated

--- a/test/parity-cross-backend/backend/test_metal_component_mask_parity.cpp
+++ b/test/parity-cross-backend/backend/test_metal_component_mask_parity.cpp
@@ -11,11 +11,15 @@
 //   has been retired (task-358.3).
 //
 // Why the parity is STRUCTURAL + STATISTICAL, not per-ray byte-exact
-//   MetalTraceBackend follows a single refract-priority path per ray while
-//   CpuTraceBackend fans out (reflect + refract) per hit and area-weight
-//   re-samples continuation entry — the two produce DIFFERENT ray populations
-//   (see test_metal_trace_parity.cpp header). So per-ray mask equality is
-//   impossible; we compare weighted distributions + self-consistency invariants:
+//   Both backends emit reflect + refract per hit (see lumice_trace.metal:677's
+//   `ch=0..2` loop and CPU HitSurface at optics.cpp:18 writing 2 branches per
+//   input); the difference is CONTINUATION: MetalTraceBackend advances only the
+//   refract branch (single-path continuation, `cont_face` refract-priority),
+//   while CpuTraceBackend keeps both reflect + refract branches as
+//   continuations (fan-out) and area-weight re-samples continuation entry — the
+//   two produce DIFFERENT ray populations (see test_metal_trace_parity.cpp
+//   header). So per-ray mask equality is impossible; we compare weighted
+//   distributions + self-consistency invariants:
 //     - structural: no spurious bits, cross-layer joint bits present (proves the
 //       mask survives transit + shuffle + the Recombine handle swap end-to-end);
 //     - energy: captured weight > 0 and stable;
@@ -451,7 +455,8 @@ TEST(MetalComponentMaskParity, CpuMarginalBallpark) {
   fprintf(stderr, "[component-mask] CPU-vs-Metal max |per-component frac| = %.4f\n", max_abs);
   // Same predicate-match + component-table logic on both backends → the per-
   // component marginals live in the same ballpark. LOOSE bound: the two
-  // backends trace DIFFERENT ray populations (single-path vs fan-out), so this
+  // backends trace DIFFERENT ray populations (Metal continues one branch,
+  // CPU fans out reflect + refract as continuations — see header), so this
   // is a sanity anchor, not a tight numeric parity. Whole-crystal (None) bits
   // 0 and 2 are the tightest signal — they should be near 1.0 on both backends
   // (every emitted ray hit layer 0 / layer 1 respectively), while length-gated

--- a/test/regression-sentinel/test_gpu_color_mask_batch_leak.py
+++ b/test/regression-sentinel/test_gpu_color_mask_batch_leak.py
@@ -1,0 +1,197 @@
+"""End-to-end regression test for the GPU per-raypath color-mask batch leak
+(fix/gpu-color-mask-batch-leak / explore-365).
+
+Bug (before fix)
+    Metal + CUDA gated the layer-0 `root_component` per-batch memset inside
+    the test-only `capture_ray_mask_` branch in TraceLayer. In production
+    (capture off), the layer-0 carried color-class mask buffer was never
+    reset while `transit_root_kernel` (layer ≥ 1) kept writing into it, so
+    batch N's layer-0 rays inherited batch N-1's carried color bits and
+    OR-merged them with their own crystal's color bit. The visible symptom
+    was cross-backend divergence on multi-crystal-L0 + multi-batch scenes:
+    per-class total CPU/Metal ratios of 7.03× (RED) and 3.09× (GREEN) on
+    `raypath_color_multi_layer.json`, with the dominant argmax winner
+    shifting between backends (CPU orange/magenta dominant, Metal green
+    dominant).
+
+Regression contract
+    On the multi-layer color config (5 L0 crystal entries + L1 crystal +
+    ray_num=4M >> dispatch grain), each color class's dominant-pixel-count
+    ratio between CPU and Metal must stay within a tight symmetric band
+    around 1.0. A resurrection of the batch-leak bug decorrelates the
+    per-class marginals across backends and drops the min/max ratio well
+    below the band (issue.md measured ~0.14–0.32 on broken code).
+
+Test protocol (issue-scenario contract, `feedback_test_must_use_issue_scenario`)
+    - Reuses the exact explore-365 fixture
+      (`test/e2e/configs/raypath_color_multi_layer.json`) — same knobs
+      that triggered the bug in prod.
+    - Runs a REAL server via `run_lumice` CLI (not a raw backend harness).
+      The bug only reproduces when the backend is reused across per-batch
+      BeginSession cycles, which the CLI does but the raw-backend +
+      fresh-backend-per-batch parity harness does not.
+    - `capture_ray_mask_` is off (CLI default).
+    - Compares CPU vs Metal dominant-pixel counts per color class in the
+      composite output.
+
+Slow marker
+    Marked `@pytest.mark.slow` because the fixture uses ray_num=4,000,000
+    to guarantee `ray_num > dispatch` across dispatch grains. Not part of
+    the fast CI suite; run before opening a PR that touches the GPU
+    backend or trace-layer color path.
+
+Darwin-only skip
+    Metal is only available on macOS. On Linux the CLI's `--backend metal`
+    silently falls back to CPU, which would degenerate this into a
+    CPU-vs-CPU tautology — skip instead.
+"""
+
+from __future__ import annotations
+
+import platform
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from test.e2e.image_utils import HAS_PILLOW
+from test.e2e.runner import find_lumice_binary, get_project_root, run_lumice
+
+if HAS_PILLOW:
+    from test.e2e.image_utils import classify_pixels_by_color_direction
+
+
+CONFIG_PATH = get_project_root() / "test" / "e2e" / "configs" / "raypath_color_multi_layer.json"
+
+
+# task-339.5 color-class list order (must match raypath_color_multi_layer.json).
+# Order is significant: the classifier maps returned per_class[i] to class i.
+CLASS_COLORS = [
+    (1.0, 0.0, 1.0),   # 0: MAGENTA — cross-layer AND {L0,C1}∧{L1,C2}
+    (1.0, 0.55, 0.0),  # 1: ORANGE  — L1 crystal 3 match-all
+    (1.0, 0.0, 0.0),   # 2: RED     — L0 C4 match-all
+    (0.0, 1.0, 0.0),   # 3: GREEN   — L0 C5 OR-union of two length predicates
+]
+
+CLASS_LABELS = ["MAGENTA", "ORANGE", "RED", "GREEN"]
+
+# Cosine tolerance for direction-based pixel classification. Matches
+# MULTI_LAYER_COS_TOL in test_raypath_color.py (0.90 tolerates JPEG chroma
+# bleed near halo boundaries).
+COS_TOL = 0.90
+
+# Per-class dominant-pixel min/max ratio floor. On the fix each class should
+# be ~1.0 up to MC noise; on the leaky code min/max collapses to ~0.14
+# (RED 7.03×) or ~0.32 (GREEN 3.09×) per issue.md. 0.65 leaves headroom for
+# statistical noise + JPEG quantization at 4M rays while still catching a
+# structural regression by a wide margin.
+PER_CLASS_MIN_RATIO = 0.65
+
+# Sanity floor: every class must have at least this many dominant pixels on
+# BOTH backends — the ratio contract is only meaningful when both backends
+# actually produce that class. If a class has zero pixels on one backend,
+# ratio is undefined; treat it as a hard failure separately.
+CLASS_MIN_PIXELS = 100
+
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Metal backend only available on macOS; CPU-vs-CPU is a tautology",
+)
+
+
+def _run_backend_composite(backend_args, out_dir: str) -> Path:
+    result = run_lumice(
+        ["-f", str(CONFIG_PATH), "-o", out_dir, *backend_args],
+    )
+    assert result.returncode == 0, (
+        f"Lumice failed (backend_args={backend_args}):\n"
+        f"stdout:\n{result.stdout}\n---\nstderr:\n{result.stderr}"
+    )
+    composite = Path(out_dir) / "img_01_components.jpg"
+    assert composite.exists() and composite.stat().st_size > 0, (
+        f"composite missing/empty (backend_args={backend_args}): {composite}"
+    )
+    return composite
+
+
+@pytest.mark.slow
+def test_multi_batch_per_class_ratio_cpu_vs_metal_within_band():
+    """CPU vs Metal per-class dominant-pixel counts stay within a tight band.
+
+    Guards against reintroduction of the layer-0 carried-mask cross-batch
+    leak. If the reset is misgated (or absent) again, batch N's rays inherit
+    prior batches' color bits on Metal but not CPU, decorrelating the
+    per-class marginals: min/max ratios plunge (measured ~0.14 for RED,
+    ~0.32 for GREEN in the bug state).
+    """
+    if not HAS_PILLOW:
+        pytest.skip("Pillow required for pixel classification")
+
+    try:
+        find_lumice_binary()
+    except FileNotFoundError as e:
+        pytest.skip(str(e))
+
+    assert CONFIG_PATH.exists(), f"missing fixture: {CONFIG_PATH}"
+
+    with tempfile.TemporaryDirectory(prefix="lumice_e2e_cpu_") as cpu_dir, \
+         tempfile.TemporaryDirectory(prefix="lumice_e2e_metal_") as metal_dir:
+        cpu_composite = _run_backend_composite([], cpu_dir)
+        metal_composite = _run_backend_composite(["--backend", "metal"], metal_dir)
+
+        cpu_result = classify_pixels_by_color_direction(
+            str(cpu_composite), CLASS_COLORS, cos_similarity_tol=COS_TOL,
+        )
+        metal_result = classify_pixels_by_color_direction(
+            str(metal_composite), CLASS_COLORS, cos_similarity_tol=COS_TOL,
+        )
+
+        cpu_counts = cpu_result["per_class"]
+        metal_counts = metal_result["per_class"]
+
+        # Diagnostic print — kept in the assert message on failure, but also
+        # emit here so `pytest -s` surfaces the numbers on green runs for
+        # trend-tracking.
+        print(
+            "\n[gpu-color-mask-batch-leak] per-class dominant pixels:\n"
+            + "\n".join(
+                f"  {CLASS_LABELS[i]:8s}: cpu={cpu_counts[i]:>6d} metal={metal_counts[i]:>6d} "
+                f"min/max={min(cpu_counts[i], metal_counts[i]) / max(cpu_counts[i], metal_counts[i], 1):.3f}"
+                for i in range(len(CLASS_LABELS))
+            )
+        )
+
+        # Both backends must produce every class above the sanity floor —
+        # a zero count would signal a different regression (class wiring
+        # broken) and make the ratio metric undefined.
+        for idx, label in enumerate(CLASS_LABELS):
+            assert cpu_counts[idx] >= CLASS_MIN_PIXELS, (
+                f"CPU produced only {cpu_counts[idx]} dominant pixels for "
+                f"class {label} (< sanity floor {CLASS_MIN_PIXELS}); "
+                f"per_class CPU={cpu_counts} metal={metal_counts}"
+            )
+            assert metal_counts[idx] >= CLASS_MIN_PIXELS, (
+                f"Metal produced only {metal_counts[idx]} dominant pixels "
+                f"for class {label} (< sanity floor {CLASS_MIN_PIXELS}); "
+                f"per_class CPU={cpu_counts} metal={metal_counts}"
+            )
+
+        # Symmetric ratio contract — the batch-leak bug pushed some classes
+        # to ~0.14–0.32 on Metal, well below the floor.
+        failures = []
+        for idx, label in enumerate(CLASS_LABELS):
+            hi = max(cpu_counts[idx], metal_counts[idx])
+            lo = min(cpu_counts[idx], metal_counts[idx])
+            ratio = lo / hi
+            if ratio < PER_CLASS_MIN_RATIO:
+                failures.append(
+                    f"  class {label}: cpu={cpu_counts[idx]} metal={metal_counts[idx]} "
+                    f"min/max={ratio:.3f} < floor={PER_CLASS_MIN_RATIO}"
+                )
+        assert not failures, (
+            "per-class dominant-pixel CPU/Metal ratio outside band — "
+            "possible reintroduction of the layer-0 carried-mask cross-batch "
+            "leak (explore-365):\n" + "\n".join(failures) +
+            f"\n  full: CPU={cpu_counts} Metal={metal_counts}"
+        )

--- a/test/regression-sentinel/test_gpu_color_mask_batch_leak.py
+++ b/test/regression-sentinel/test_gpu_color_mask_batch_leak.py
@@ -1,5 +1,4 @@
-"""End-to-end regression test for the GPU per-raypath color-mask batch leak
-(fix/gpu-color-mask-batch-leak / explore-365).
+"""End-to-end regression test for the GPU per-raypath color-mask batch leak.
 
 Bug (before fix)
     Metal + CUDA gated the layer-0 `root_component` per-batch memset inside
@@ -22,10 +21,9 @@ Regression contract
     per-class marginals across backends and drops the min/max ratio well
     below the band (issue.md measured ~0.14–0.32 on broken code).
 
-Test protocol (issue-scenario contract, `feedback_test_must_use_issue_scenario`)
-    - Reuses the exact explore-365 fixture
-      (`test/e2e/configs/raypath_color_multi_layer.json`) — same knobs
-      that triggered the bug in prod.
+Test protocol (issue-scenario contract)
+    - Reuses the exact fixture that reproduced the bug in prod
+      (`test/e2e/configs/raypath_color_multi_layer.json`).
     - Runs a REAL server via `run_lumice` CLI (not a raw backend harness).
       The bug only reproduces when the backend is reused across per-batch
       BeginSession cycles, which the CLI does but the raw-backend +
@@ -192,6 +190,6 @@ def test_multi_batch_per_class_ratio_cpu_vs_metal_within_band():
         assert not failures, (
             "per-class dominant-pixel CPU/Metal ratio outside band — "
             "possible reintroduction of the layer-0 carried-mask cross-batch "
-            "leak (explore-365):\n" + "\n".join(failures) +
+            "leak:\n" + "\n".join(failures) +
             f"\n  full: CPU={cpu_counts} Metal={metal_counts}"
         )


### PR DESCRIPTION
## 背景

GPU（Metal + CUDA）per-raypath 染色存在 **color-class mask 跨 batch 泄漏** correctness bug（explore-365 白盒定位，owner 三次驳回"非后端 bug"误判后深挖到底）。

**根因**：layer-0 carried color-class mask 缓冲（`root_component_buf_` / `d_root_component_`）的每-batch memset 被错误 gate 在 test-only `capture_ray_mask_` 标志之下。生产路径（CLI/GUI，capture 关闭）从不重置该缓冲，而 layer≥1 的 `transit_root_kernel` 持续写入。多 batch（`ray_num > dispatch`）+ 多 L0 crystal 场景下，batch N 的 layer-0 光线读到 batch N-1 遗留的陈旧 carried mask 并 OR 上本 crystal 色 bit → color-class mask 跨 batch 合并（实测 RED 7.03×、GREEN 3.09×），使 CPU/Metal 渲染出现确定性可见差异（CPU 橙/洋红主导 vs Metal 绿主导）。

**为何长期潜伏**：parity 测试 `SetCaptureRayMask(true)` 恰好启用被 gate 的 memset（走非生产分支）；且 harness 走 raw backend + fresh-backend-per-batch，从不复用缓冲。= explore-359 同款 "memset-on-alloc-not-per-batch" 姊妹 bug。

## 改动

- **修复（AC1）**：两后端 layer-0 `root_component` reset 移出 `capture_ray_mask_` gate，`first_ms` 无条件执行；与 capture-ring 专属分配/计数器 reset（纯 test-only）解耦。
- **回归测试（AC4）**：新增 `test/regression-sentinel/test_gpu_color_mask_batch_leak.py` —— 真 server（`run_lumice` CLI）+ capture off + 多 L0 crystal + transit + `ray_num=4M > dispatch`，跨后端 per-class dominant-pixel 比值一致性。填 parity harness 因 capture-mode + 单-batch 造成的双盲区。
- **注释纠正（AC5）**：修正 `test_{metal,cuda}_component_mask_parity.cpp` 误导性 "single refract-priority path" 表述（两后端均每 hit 出反+折两组、单支续传）。
- **反模式审计（AC6）**：`capture_ray_mask_` 全部命中逐处判定 + 同族关键词 grep，确认仅本次两处已解。

## 验证

- **AC4 红/绿双态**：revert 态稳定失败（4 类全越界，方向与 bug 一致：MAGENTA 0.027 / ORANGE 0.008 / RED 0.251 / GREEN 0.380），fix 态稳定通过（≥0.992，3 次非 flaky）；每态强制干净重建，dylib mtime 佐证跑的是不同二进制。
- **AC2 Metal**：全类 CPU/Metal 比值 →~1.00×（≥0.992），既有 PSNR 回归通过。
- **AC3 CUDA（dev49 RTX 4060Ti 亲验）**：per-class 比值 worst=0.992，CUDA parity battery 10/10 + gtest ComponentMask 7/7；rsync `--checksum` + build.log 佐证 `cuda_trace_backend.cu` 确实重编。
- **AC7 零回归**：`parity_test *ComponentMask*` 6/6、unit 4/4、GUI 5/5、fast/slow e2e 绿；唯一失败 `test_metal_gui_north_star`（GUI first_upload 计时）为 pre-existing、与本改动正交（该测试文件 diff 为空）。

## 行为/接口变化

无。只影响 GPU 后端内部缓冲重置时机，不改 C API / CLI / 配置格式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)