### PR TITLE
docs(image_utils): 修正 classify_pixels_by_color_direction 过时 docstring

### DIFF
--- a/test/e2e/image_utils.py
+++ b/test/e2e/image_utils.py
@@ -58,17 +58,19 @@ def classify_pixels_by_color_direction(
     """Classify pixels of a composite image by their RGB direction.
 
     Contract (WHITE-BOX, keep in sync with compositor implementation):
-      This function assumes the composite image was produced by the
-      raypath-color compositor in `dominant` OR `painter` mode, where the
-      output pixel is `out = color_c * ey` for the winning class c (see
-      src/server/component_compositor.cpp CompositeDominantPixel /
-      CompositePainterPixel). Under that contract, a lit pixel's RGB
-      direction (after normalization) is EQUAL to the winning class's
-      `color_` direction, decoupled from the exposure scalar `ey`.
-      If the compositor's `additive` mode is used, this classifier is
-      NOT valid (linear class mix -> direction is a convex combination).
-      If the compositor's dominant/painter direction invariant changes,
-      this helper must be re-verified.
+      This function is valid ONLY for the compositor's `dominant` mode, where
+      the output pixel is `out = color_c * ey` for the single winning class c
+      (see src/server/component_compositor.cpp CompositeDominantPixel). Under
+      that contract, a lit pixel's RGB direction (after normalization) is
+      EQUAL to the winning class's `color_` direction, decoupled from the
+      exposure scalar `ey`.
+      It is NOT valid for `painter` mode: since the alpha-over redesign
+      (doc/gui-custom-spectrum-and-raypath-color.md §4.8) painter composites
+      `out = over(alpha_c * color_c)`, blending several classes, so a lit
+      pixel's direction is a convex combination rather than one class's color.
+      It is likewise NOT valid for `additive` mode (linear class mix ->
+      direction is a convex combination). If the compositor's `dominant`
+      direction invariant changes, this helper must be re-verified.
 
     Args:
       image_path: Path to a JPEG/PNG composite image.


### PR DESCRIPTION
## 背景

PR#199（doc §4.8）把 painter 合成从"二值单赢者"改为 Porter-Duff alpha-over blend。`test/e2e/image_utils.py::classify_pixels_by_color_direction` 的 "Contract" docstring 仍声称该分类器对 `dominant` **OR `painter`** 都有效（因为 `out = color_c * ey` 单赢者、像素方向 == 赢者 class 方向）——这对 painter 已不成立：alpha-over 下像素方向是多类的**凸组合**。

## 改动

纯 docstring：
- valid 收窄到**仅 `dominant`**。
- `painter` 移到 **NOT valid**，与 `additive` 并列，注明原因 = §4.8 alpha-over blend → 方向是凸组合。
- 去掉 `CompositePainterPixel` 引用与 "dominant/painter direction invariant" 措辞。

**不改函数逻辑、不改任何 caller。** 已核实全部现有 caller 都用 dominant-pinned config（`test_gpu_color_mask_batch_leak` / `test_raypath_color` → multi_layer/three_arcs 均 dominant；`test_image_utils_color_classify` → 合成图自检），docstring 修正不掩盖任何 latent 误用。

## 验证

- `ast.parse` OK；`pytest test_image_utils_color_classify.py` = 5 passed。

来源：task-368（PR#200）SUMMARY 登记的 follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)