### PR TITLE
feat: 放开 filter OR-clause 上限 8/16→4096(纯过滤,染色 mask 不动)

### DIFF
--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -436,6 +436,32 @@ for *why* a number is high or low.
 nsys profile --trace=cuda --stats=true -o /tmp/rep <Lumice ...>   # see TOOLCHAIN.md
 ```
 
+### Filter OR-summand scaling — no throughput cliff (scrum-filter-form-big-or de-risk, 2026-07-16)
+
+> **De-risk sanity result, NOT a canonical throughput point** (uses synthetic N-summand
+> filter configs, not the canonical scene set). Records why raising the device filter
+> OR-clause cap from 8 to 4096 is throughput-safe.
+
+Concern: a Complex filter with N OR-summands walks up to N `complex_sub_desc_buf` global
+reads per exit (device match). Would large N (256) cause a GPU memory-pressure cliff?
+
+Measured `--benchmark` (`mode:multi` rays_per_sec) across N=8/64/256 summands, filter-only
+(no color), per-backend baselines (Metal+CPU on Mac, CUDA+CPU on dev49 4060Ti):
+
+| backend | N=8 | N=64 | N=256 | 256/8 |
+|---|---|---|---|---|
+| CUDA (dev49 4060Ti) | 419.7M | 91.2M | **754.3M** | 1.80× |
+| Metal (Mac) | ~48.7M | 14.8M | **68.5M** | 1.41× |
+| CPU (Mac / dev49) | 5.0M / 10.0M | 3.2M / 6.6M | 5.6M / 10.2M | 1.1× / 1.0× |
+
+**No cliff.** On both GPUs N=256 is the throughput *peak* (256 never slower than 8). The
+curve is a non-monotonic N=64-trough U-shape on **all four backends including CPU** — since
+CPU has no GPU global-memory notion, the variation is raypath-geometry/survival-driven, not
+summand-count or GPU-memory. Cross-backend consistency decisively rules out a memory cliff.
+Confound (honest): summand count can't be isolated from raypath geometry (more summands ⇒ more
+distinct raypaths); the CPU cross-check is what disambiguates. Owner spot-verified CUDA N=8=425M
+/ N=256=772M independently. → OR-clause cap 8→4096 is throughput-safe.
+
 ### CI Automated Benchmark
 
 Every push triggers a CLI benchmark on all 4 CI platforms (Ubuntu x64/ARM, macOS ARM,

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -385,7 +385,20 @@ def check_struct_layout_parity() -> list[Violation]:
 # pointers (term_ids / term_counts) via LUMICE_CompositionSetClauses, so it
 # joins the ban list on the same "aliased owning pointer → double-free"
 # grounds as LUMICE_Config. Same 4 patterns run for each type.
+#
+# code-review-01 (round 1, Major) fix: the RHS of Patterns 1a/1b/1c originally
+# matched only a bare identifier (`\w+`), so the exact risk this task's own
+# issue.md/plan called out — `LUMICE_ComplexComposition rec = cfg.compositions[i];`
+# aliasing the owning term_ids/term_counts heap allocation — was invisible to the
+# gate. `_RHS_EXPR` below widens the RHS to also accept member (`.field`),
+# pointer-member (`->field`), and subscript (`[expr]`) chains so member/subscript
+# copy sources are caught too. The (still-open) function-call-RHS limitation
+# above is unrelated and unchanged.
 GUARDED_OWNING_TYPES = ["LUMICE_Config", "LUMICE_ComplexComposition"]
+
+# A bare identifier optionally followed by any number of `.field`, `->field`,
+# or `[expr]` accessors — e.g. `cfg`, `cfg.compositions[i]`, `arr[i]->comp`.
+_RHS_EXPR = r"\w+(?:\.\w+|->\w+|\[[^\[\]]+\])*"
 
 
 def _make_owning_type_patterns(type_name: str):
@@ -394,9 +407,9 @@ def _make_owning_type_patterns(type_name: str):
     compiled set — the four regexes are identical in shape but bound to the
     specific type token so error messages / self-assignment guards read
     naturally."""
-    copy_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*=\s*(\w+)\s*;")
-    direct_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\(\s*(\w+)\s*\)\s*;")
-    list_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\{\s*(\w+)\s*\}\s*;")
+    copy_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*=\s*(" + _RHS_EXPR + r")\s*;")
+    direct_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\(\s*(" + _RHS_EXPR + r")\s*\)\s*;")
+    list_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\{\s*(" + _RHS_EXPR + r")\s*\}\s*;")
     by_value_param = re.compile(r"\b" + type_name + r"\s+(\w+)\s*[,)]")
     decl = re.compile(r"\b" + type_name + r"(\s*[*&]?)\s*(\w+)")
     return copy_init, direct_init, list_init, by_value_param, decl

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -20,13 +20,15 @@ Checks:
      have identical ordered (type, name) field lists. Catches same-size field
      reorders that sizeof-based `static_assert`s do not detect (scrum-328.2
      Step 6).
-  6. no-config-by-value-copy — LUMICE_Config owns a heap allocation via its
-     raypath_color pointer (task-344, v4.8). Copying the struct by value
-     (copy-init, direct-init, list-init, by-value parameter, or later-line
-     assignment `y = x;`) aliases the same heap block and double-frees on
-     double Release. Route through pointer or `const LUMICE_Config&`, and
-     manage lifetime via LUMICE_ConfigCreateColorClasses / Release (or
-     lumice::ConfigColorGuard).
+  6. no-config-by-value-copy — LUMICE_Config owns heap allocations via its
+     raypath_color pointer (task-344, v4.8) AND each compositions[i]'s
+     term_ids/term_counts pointers (task-host-abi-cpu-caps, v4.9). The check
+     also covers LUMICE_ComplexComposition (each record is now an owning
+     type on its own). Copying either struct by value (copy-init, direct-
+     init, list-init, by-value parameter, or later-line assignment `y = x;`)
+     aliases the same heap blocks and double-frees on double Release. Route
+     through pointer or `const &`, and manage lifetime via the type's
+     Create/Set / Release C API (or lumice::ConfigOwningGuard).
   7. gui-state-field-tier-registration — every top-level field of
      `struct GuiState` (src/gui/gui_state.hpp) must be registered in EXACTLY
      one of the two tables in src/gui/gui_state_tiers.hpp: `kFieldTierTable`
@@ -379,32 +381,25 @@ def check_struct_layout_parity() -> list[Violation]:
 # specifically to sidestep it), but a future by-value-returning factory would
 # not be caught — extend Pattern 1a's RHS match to also accept `\w+\(...\)`
 # (excluding aggregate-init syntax) if this shape reappears.
-CONFIG_TYPE = "LUMICE_Config"
+# v4.9 (task-host-abi-cpu-caps): LUMICE_ComplexComposition now owns two heap
+# pointers (term_ids / term_counts) via LUMICE_CompositionSetClauses, so it
+# joins the ban list on the same "aliased owning pointer → double-free"
+# grounds as LUMICE_Config. Same 4 patterns run for each type.
+GUARDED_OWNING_TYPES = ["LUMICE_Config", "LUMICE_ComplexComposition"]
 
-# Pattern 1a: copy-init  `LUMICE_Config a = b;`
-CONFIG_COPY_INIT_RE = re.compile(
-    r"\b" + CONFIG_TYPE + r"\s+(\w+)\s*=\s*(\w+)\s*;"
-)
-# Pattern 1b: direct-init  `LUMICE_Config a(b);`
-CONFIG_DIRECT_INIT_RE = re.compile(
-    r"\b" + CONFIG_TYPE + r"\s+(\w+)\s*\(\s*(\w+)\s*\)\s*;"
-)
-# Pattern 1c: list-init  `LUMICE_Config a{b};`  (excludes `LUMICE_Config a{};`
-# and multi-field aggregate init `LUMICE_Config a{...,...}` — the initializer
-# must be a single bare identifier).
-CONFIG_LIST_INIT_RE = re.compile(
-    r"\b" + CONFIG_TYPE + r"\s+(\w+)\s*\{\s*(\w+)\s*\}\s*;"
-)
-# Pattern 2: by-value parameter  in a signature `... LUMICE_Config x, ...`
-# Excludes pointer/reference (`LUMICE_Config*` / `LUMICE_Config&`) and `const`
-# qualifiers via the "no `*`/`&` immediately before the name" clause. Anchors on
-# `,` or `)` following the identifier so we only match parameter positions.
-CONFIG_BY_VALUE_PARAM_RE = re.compile(
-    r"\b" + CONFIG_TYPE + r"\s+(\w+)\s*[,)]"
-)
-# Pattern 3: declaration collector  `LUMICE_Config name` (any suffix); the
-# alias-guard drops pointers/references separately.
-CONFIG_DECL_RE = re.compile(r"\b" + CONFIG_TYPE + r"(\s*[*&]?)\s*(\w+)")
+
+def _make_owning_type_patterns(type_name: str):
+    """Build the (copy_init, direct_init, list_init, by_value_param, decl) regex
+    tuple for one owning type. Kept as a factory so each type gets a fresh
+    compiled set — the four regexes are identical in shape but bound to the
+    specific type token so error messages / self-assignment guards read
+    naturally."""
+    copy_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*=\s*(\w+)\s*;")
+    direct_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\(\s*(\w+)\s*\)\s*;")
+    list_init = re.compile(r"\b" + type_name + r"\s+(\w+)\s*\{\s*(\w+)\s*\}\s*;")
+    by_value_param = re.compile(r"\b" + type_name + r"\s+(\w+)\s*[,)]")
+    decl = re.compile(r"\b" + type_name + r"(\s*[*&]?)\s*(\w+)")
+    return copy_init, direct_init, list_init, by_value_param, decl
 
 
 def _is_pointer_or_ref_decl(match: "re.Match[str]") -> bool:
@@ -413,24 +408,27 @@ def _is_pointer_or_ref_decl(match: "re.Match[str]") -> bool:
 
 def check_no_config_by_value_copy() -> list[Violation]:
     out: list[Violation] = []
-    for path in cxx_sources(SRC):
-        out.extend(_scan_config_copies(path))
-    test_root = REPO_ROOT / "test"
-    if test_root.exists():
-        for path in cxx_sources(test_root):
-            out.extend(_scan_config_copies(path))
+    for type_name in GUARDED_OWNING_TYPES:
+        patterns = _make_owning_type_patterns(type_name)
+        for path in cxx_sources(SRC):
+            out.extend(_scan_config_copies(path, type_name, patterns))
+        test_root = REPO_ROOT / "test"
+        if test_root.exists():
+            for path in cxx_sources(test_root):
+                out.extend(_scan_config_copies(path, type_name, patterns))
     return out
 
 
-def _scan_config_copies(path: Path) -> list[Violation]:
+def _scan_config_copies(path: Path, type_name: str, patterns) -> list[Violation]:
+    copy_init_re, direct_init_re, list_init_re, by_value_param_re, decl_re = patterns
     out: list[Violation] = []
-    # First pass: collect all `LUMICE_Config <name>` value declarations by name.
+    # First pass: collect all `<type_name> <name>` value declarations by name.
     # Excludes pointer/reference declarations. Used only for Pattern 3
     # (later-line bare assignment) to keep the check anchored on same-type
     # locals rather than any arbitrary `a = b`.
     value_decls: set[str] = set()
     for _lineno, _orig, code in code_lines(path):
-        for m in CONFIG_DECL_RE.finditer(code):
+        for m in decl_re.finditer(code):
             if _is_pointer_or_ref_decl(m):
                 continue
             value_decls.add(m.group(2))
@@ -440,7 +438,7 @@ def _scan_config_copies(path: Path) -> list[Violation]:
         # existing identifier. All three share the "RHS is one bare
         # identifier" judgement — aggregate init `{}`, `= {}`, `{a, b}`,
         # function call `foo()` are not matched.
-        for m in CONFIG_COPY_INIT_RE.finditer(code):
+        for m in copy_init_re.finditer(code):
             lhs, rhs = m.group(1), m.group(2)
             if lhs == rhs:
                 continue
@@ -449,11 +447,11 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                     path,
                     lineno,
                     "no-config-by-value-copy",
-                    f"copy-init `{CONFIG_TYPE} {lhs} = {rhs};` aliases the "
-                    "raypath_color heap allocation; use a pointer or reference.",
+                    f"copy-init `{type_name} {lhs} = {rhs};` aliases the "
+                    "owning heap allocation; use a pointer or reference.",
                 )
             )
-        for m in CONFIG_DIRECT_INIT_RE.finditer(code):
+        for m in direct_init_re.finditer(code):
             lhs, rhs = m.group(1), m.group(2)
             if lhs == rhs:
                 continue
@@ -462,11 +460,11 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                     path,
                     lineno,
                     "no-config-by-value-copy",
-                    f"direct-init `{CONFIG_TYPE} {lhs}({rhs});` aliases the "
-                    "raypath_color heap allocation; use a pointer or reference.",
+                    f"direct-init `{type_name} {lhs}({rhs});` aliases the "
+                    "owning heap allocation; use a pointer or reference.",
                 )
             )
-        for m in CONFIG_LIST_INIT_RE.finditer(code):
+        for m in list_init_re.finditer(code):
             lhs, rhs = m.group(1), m.group(2)
             if lhs == rhs:
                 continue
@@ -475,18 +473,18 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                     path,
                     lineno,
                     "no-config-by-value-copy",
-                    f"list-init `{CONFIG_TYPE} {lhs}{{{rhs}}};` aliases the "
-                    "raypath_color heap allocation; use a pointer or reference.",
+                    f"list-init `{type_name} {lhs}{{{rhs}}};` aliases the "
+                    "owning heap allocation; use a pointer or reference.",
                 )
             )
-        # Pattern 2: by-value function parameter. The `\s+` after LUMICE_Config
-        # already excludes `LUMICE_Config*name` / `LUMICE_Config&name`
+        # Pattern 2: by-value function parameter. The `\s+` after the type
+        # already excludes `<type>*name` / `<type>&name`
         # (adjacent `*`/`&` binds to the type token with no space). Explicit
-        # spaced variants like `LUMICE_Config * name` or `... & name` still
+        # spaced variants like `<type> * name` or `... & name` still
         # match Pattern 2 as a false positive — the plan accepts this because
         # the codebase uses adjacent `*`/`&` universally and the spaced form
         # would violate the local style anyway.
-        for m in CONFIG_BY_VALUE_PARAM_RE.finditer(code):
+        for m in by_value_param_re.finditer(code):
             # Guard against matching a value declaration inside a function
             # body (which Patterns 1a/1b/1c already own): parameter positions
             # are directly preceded by `(` or `,` (possibly with whitespace),
@@ -501,10 +499,10 @@ def _scan_config_copies(path: Path) -> list[Violation]:
             preceding = prefix[j] if j >= 0 else ""
             if preceding not in ("(", ","):
                 continue
-            # Skip trivial `LUMICE_Config x` where x is followed by `[` in
-            # e.g. `LUMICE_Config x[]` — that's an array parameter, not a
+            # Skip trivial `<type> x` where x is followed by `[` in
+            # e.g. `<type> x[]` — that's an array parameter, not a
             # by-value scalar. The regex ends on `[,)]` so an array param
-            # `LUMICE_Config x[]` would already not match (the `]` is not `,`
+            # `<type> x[]` would already not match (the `]` is not `,`
             # or `)`), no extra guard needed.
             name = m.group(1)
             out.append(
@@ -512,9 +510,9 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                     path,
                     lineno,
                     "no-config-by-value-copy",
-                    f"by-value parameter `{CONFIG_TYPE} {name}` aliases the "
-                    "raypath_color heap allocation; use "
-                    f"`const {CONFIG_TYPE}&` or `{CONFIG_TYPE}*`.",
+                    f"by-value parameter `{type_name} {name}` aliases the "
+                    "owning heap allocation; use "
+                    f"`const {type_name}&` or `{type_name}*`.",
                 )
             )
         # Pattern 3: `a = b;` where both `a` and `b` are same-type locals we
@@ -537,10 +535,10 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                     if assign_re.search(code):
                         # Filter out the declaration line itself (would double-
                         # count with Pattern 1a). Detected by checking that
-                        # `LUMICE_Config` does not immediately precede name_lhs
+                        # `<type>` does not immediately precede name_lhs
                         # on this line.
                         decl_here = re.compile(
-                            r"\b" + CONFIG_TYPE + r"\s+" + re.escape(name_lhs) + r"\b"
+                            r"\b" + type_name + r"\s+" + re.escape(name_lhs) + r"\b"
                         )
                         if decl_here.search(code):
                             continue
@@ -550,8 +548,8 @@ def _scan_config_copies(path: Path) -> list[Violation]:
                                 lineno,
                                 "no-config-by-value-copy",
                                 f"assignment `{name_lhs} = {name_rhs};` between two "
-                                f"{CONFIG_TYPE} locals aliases the raypath_color "
-                                "heap allocation; use a pointer/reference.",
+                                f"{type_name} locals aliases the owning heap "
+                                "allocation; use a pointer/reference.",
                             )
                         )
     return out

--- a/src/config/color_gate_table.cpp
+++ b/src/config/color_gate_table.cpp
@@ -102,6 +102,11 @@ ColorGateTable BuildColorGateTable(const RaypathColorConfig& color_cfg, const Sc
     LOG_WARNING("ColorGateTable: {} predicate(s) exceeded the {}-bit component budget and were assigned kNoBit",
                 overflow_count, ComponentTable::kMaxBits);
   }
+  // task-gui-feedback-affordances Step 5 (AC1): carry the drop count out for
+  // the GUI modal surfacing (ServerImpl::CommitConfig persists it, then
+  // LUMICE_GetColorOverflowInfo exposes it). Existing LOG_WARNING behavior
+  // unchanged — this counter is additive, not a replacement.
+  table.component_overflow_count_ = overflow_count;
   return table;
 }
 

--- a/src/config/color_gate_table.hpp
+++ b/src/config/color_gate_table.hpp
@@ -49,6 +49,14 @@ struct ColorGateEntry {
 
 struct ColorGateTable {
   std::vector<ColorGateEntry> entries_;
+  // task-gui-feedback-affordances Step 5 (AC1): number of predicates that hit
+  // `kNoBit` (component budget exhausted, `ComponentTable::kMaxBits=64`)
+  // during this build. Existing behavior (LOG_WARNING + assign kNoBit)
+  // preserved; this counter lets ServerImpl carry the count out of
+  // BuildColorGateTable so the GUI DoRun path can surface a user-visible
+  // "coloring degraded" modal (see server.cpp CommitConfig / c_api.cpp
+  // LUMICE_GetColorOverflowInfo).
+  size_t component_overflow_count_ = 0;
 };
 
 // Per-placement view for the CPU emit gate: predicates + parallel bit array

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -506,6 +506,7 @@ __device__ inline void EmitToDeviceXyz(float* __restrict__ d_xyz_buf,
 __device__ inline unsigned long long ApplyLayerColorBits(unsigned long long carried,
                                                           const DeviceFilterDesc* d_color_filter_desc,
                                                           const DeviceFilterDesc* d_complex_sub_desc,
+                                                          const uint8_t* d_and_term_counts,
                                                           const uint8_t* d_color_bit_map,
                                                           const uint8_t* path, uint32_t path_len,
                                                           const uint8_t* getfn_bytes,
@@ -517,8 +518,8 @@ __device__ inline unsigned long long ApplyLayerColorBits(unsigned long long carr
     const uint32_t color_slot_idx = gate_slot * static_cast<uint32_t>(kColorMaxGroupsPerSlot) + g;
     bool matched_c = false;
     const uint32_t c_smask = lm_filter::DeviceFilterSummandMask(
-        d_color_filter_desc[color_slot_idx], d_complex_sub_desc, path, path_len, getfn_bytes, getfn_offsets, gate_slot,
-        ray_dir, crystal_config_id, &matched_c);
+        d_color_filter_desc[color_slot_idx], d_complex_sub_desc, d_and_term_counts, path, path_len, getfn_bytes,
+        getfn_offsets, gate_slot, ray_dir, crystal_config_id, &matched_c);
     for (uint32_t k = 0u; k < kDeviceFilterMaxOrClauses; ++k) {
       if ((c_smask & (1u << k)) != 0u) {
         const uint8_t bit = d_color_bit_map[color_slot_idx * kDeviceFilterMaxOrClauses + k];
@@ -646,6 +647,12 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
                                        const uint32_t* __restrict__ d_getfn_offsets,
                                        const uint8_t* __restrict__ d_getfn_bytes,
                                        const DeviceFilterDesc* __restrict__ d_complex_sub_desc,
+                                       // task-device-flat-and-terms: parallel flat AND-term counts
+                                       // buffer, indexed via each Complex parent's `and_terms_start`.
+                                       // CUDA has no per-stage binding cap so this is an
+                                       // independent device pointer (Metal packs it into buffer 27
+                                       // via KernelParams.and_term_counts_base_offset instead).
+                                       const uint8_t* __restrict__ d_and_term_counts,
                                        uint32_t filter_desc_max_ci,
                                        uint32_t crystal_config_id,
                                        // S2 device-fused accumulation (ms_mode==0 final-layer emit).
@@ -855,8 +862,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
         const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                    static_cast<uint32_t>(crystal_id);
         const bool filter_pass = lm_filter::DeviceFilterCheck(
-            d_filter_desc[gate_slot], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot,
-            exit_world, crystal_config_id);
+            d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
+            d_getfn_offsets, gate_slot, exit_world, crystal_config_id);
         if (filter_pass) {
           // task-358.3: Fork-C physical-bit produce branch removed. `this_mask`
           // now starts from the carried mask and is OR-accumulated by ONLY the
@@ -867,9 +874,9 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           // color_params.has_color_groups so no raypath_color session → single
           // branch skip (AC4 zero-cost). Mirrors MSL lumice_trace.metal.
           if (color_params.has_color_groups != 0u) {
-            this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_color_bit_map,
-                                            path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot, exit_world,
-                                            crystal_config_id);
+            this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
+                                            d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
+                                            gate_slot, exit_world, crystal_config_id);
           }
           // Prob gate (prob-pass → continuation; prob-fail → mid-exit). The
           // gate_stream advances on each pcg_uniform draw so the per-bounce
@@ -923,8 +930,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
         const uint32_t gate_slot_e = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                      static_cast<uint32_t>(crystal_id);
         const bool filter_pass_e = lm_filter::DeviceFilterCheck(
-            d_filter_desc[gate_slot_e], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-            gate_slot_e, exit_world, crystal_config_id);
+            d_filter_desc[gate_slot_e], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
+            d_getfn_offsets, gate_slot_e, exit_world, crystal_config_id);
         if (filter_pass_e) {
           lm_pcg::PcgStream gate_f;
           gate_f.seed       = gate_final_mixed_seed;
@@ -946,9 +953,9 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
             // protect against.
             unsigned long long this_mask = carried_component;
             if (color_params.has_color_groups != 0u) {
-              this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_color_bit_map,
-                                              path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot_e, exit_world,
-                                              crystal_config_id);
+              this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
+                                              d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
+                                              gate_slot_e, exit_world, crystal_config_id);
             }
             EmitToDeviceXyz(d_xyz_buf, d_landed_weight, exit_world,
                             cmf_x, cmf_y, cmf_z, w_refl_e,
@@ -1072,17 +1079,17 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                    static_cast<uint32_t>(crystal_id);
           const bool filter_pass = lm_filter::DeviceFilterCheck(
-              d_filter_desc[gate_slot], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-              gate_slot, exit_world, crystal_config_id);
+              d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
+              d_getfn_offsets, gate_slot, exit_world, crystal_config_id);
           if (filter_pass) {
             // task-358.3: Fork-C produce branch retired; only Design-2 color
             // pass accumulates into this_mask (per-bounce mid-exit sibling of
             // the entry-face gate above).
             unsigned long long this_mask = carried_component;
             if (color_params.has_color_groups != 0u) {
-              this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_color_bit_map,
-                                              path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot, exit_world,
-                                              crystal_config_id);
+              this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
+                                              d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
+                                              gate_slot, exit_world, crystal_config_id);
             }
             bool do_continue = (lm_pcg::pcg_uniform(gate_stream) < ms_prob);
             if (do_continue) {
@@ -1123,8 +1130,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           const uint32_t gate_slot_r = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                        static_cast<uint32_t>(crystal_id);
           const bool filter_pass_r = lm_filter::DeviceFilterCheck(
-              d_filter_desc[gate_slot_r], d_complex_sub_desc, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-              gate_slot_r, exit_world, crystal_config_id);
+              d_filter_desc[gate_slot_r], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
+              d_getfn_offsets, gate_slot_r, exit_world, crystal_config_id);
           if (filter_pass_r) {
             lm_pcg::PcgStream gate_f;
             gate_f.seed       = gate_final_mixed_seed;
@@ -1141,9 +1148,9 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
               // two landmine-guard tests catch any silent asymmetry).
               unsigned long long this_mask = carried_component;
               if (color_params.has_color_groups != 0u) {
-                this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_color_bit_map,
-                                                path_rec, rec_len, d_getfn_bytes, d_getfn_offsets, gate_slot_r,
-                                                exit_world, crystal_config_id);
+                this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
+                                                d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
+                                                gate_slot_r, exit_world, crystal_config_id);
               }
               EmitToDeviceXyz(d_xyz_buf, d_landed_weight, exit_world,
                               cmf_x, cmf_y, cmf_z, w_refr,
@@ -1797,6 +1804,12 @@ struct CudaTraceBackend::Impl {
   uint32_t*         d_getfn_offsets_     = nullptr;  // (n_slot + 1) uint32 prefix-sum (or 1B dummy)
   uint8_t*          d_getfn_bytes_       = nullptr;  // flat GetFn byte stream (or 1B dummy)
   DeviceFilterDesc* d_complex_sub_desc_  = nullptr;  // flat Complex sub-descs (or 1B dummy)
+  // task-device-flat-and-terms: parallel flat buffer, one uint8 per OR-clause
+  // across all Complex descs (physical + color). CUDA uses an INDEPENDENT
+  // allocation (no Metal-style 30-buffer cap to worry about); mirrors the
+  // discipline of `d_color_bit_map_` / `d_getfn_bytes_`. 1-byte dummy in the
+  // no-Complex fallback so the kernel pointer stays bindable.
+  uint8_t*          d_and_term_counts_   = nullptr;
   uint32_t          filter_desc_max_ci_  = 0u;       // per-layer ci stride (MVP=1)
   uint32_t          filter_n_slot_       = 0u;       // total descriptor slots
   uint32_t          crystal_config_id_   = 0xFFFFu;  // for DeviceFilterMatchCrystal
@@ -2017,6 +2030,10 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     cudaFree(d_getfn_offsets_);    d_getfn_offsets_ = nullptr;
     cudaFree(d_getfn_bytes_);      d_getfn_bytes_ = nullptr;
     cudaFree(d_complex_sub_desc_); d_complex_sub_desc_ = nullptr;
+    // task-device-flat-and-terms: parallel flat buffer for AND-term counts;
+    // rebuilt alongside d_complex_sub_desc_ (including the color-rebuild
+    // re-upload — see EnsureFilterBuffers).
+    cudaFree(d_and_term_counts_);  d_and_term_counts_ = nullptr;
     // task-358.2 (cuda-color-parity): Design-2 color-region buffers persist with
     // the physical filter descriptors (built together in EnsureFilterBuffers);
     // free them together on full teardown.
@@ -2580,6 +2597,7 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   cudaFree(d_getfn_offsets_);     d_getfn_offsets_     = nullptr;
   cudaFree(d_getfn_bytes_);       d_getfn_bytes_       = nullptr;
   cudaFree(d_complex_sub_desc_);  d_complex_sub_desc_  = nullptr;
+  cudaFree(d_and_term_counts_);   d_and_term_counts_   = nullptr;
   // task-358.2: free any prior session's independent color-region buffers.
   cudaFree(d_color_filter_desc_);   d_color_filter_desc_ = nullptr;
   cudaFree(d_color_bit_map_);       d_color_bit_map_     = nullptr;
@@ -2612,6 +2630,9 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
        "cudaMemcpy d_getfn_offsets (dummy)");
     ck(cudaMalloc(&d_getfn_bytes_, 1u), "cudaMalloc d_getfn_bytes (dummy)");
     ck(cudaMalloc(&d_complex_sub_desc_, sizeof(DeviceFilterDesc)), "cudaMalloc d_complex_sub_desc (dummy)");
+    // task-device-flat-and-terms: 1-byte dummy so the kernel pointer stays
+    // bindable in no-Complex sessions (the Complex branch is never entered).
+    ck(cudaMalloc(&d_and_term_counts_, 1u), "cudaMalloc d_and_term_counts (dummy)");
     // task-358.2: independent color-region buffers — 1-byte dummies for the
     // no-scene fallback so the kernel color-pass pointers are always bindable
     // (the color pass is gated by color_params.has_color_groups; a no-scene
@@ -2660,6 +2681,9 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   std::vector<DeviceFilterDesc> descs(n_slot);
   std::vector<std::vector<uint8_t>> per_slot_bytes(n_slot);
   std::vector<DeviceFilterDesc> all_sub_descs;
+  // task-device-flat-and-terms: parallel flat buffer of per-OR-clause AND-term
+  // counts, indexed via `and_terms_start` on each Complex parent desc.
+  std::vector<uint8_t> and_term_counts_flat;
 
   for (size_t mi = 0; mi < n_layers; ++mi) {
     const auto& ms = spec.scene->ms_[mi];
@@ -2675,8 +2699,9 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
         // ComplexFilterParam; absence here is a programming error.
         assert(complex_p != nullptr && "Complex desc type without ComplexFilterParam variant");
         descs[slot].sub_desc_start = static_cast<uint32_t>(all_sub_descs.size());
+        descs[slot].and_terms_start = static_cast<uint32_t>(and_term_counts_flat.size());
         detail::BuildComplexSubDescs(*complex_p, proto, descs[slot].symmetry, descs[slot].sigma_a,
-                                     descs[slot].d_applicable != 0u, all_sub_descs);
+                                     descs[slot].d_applicable != 0u, all_sub_descs, and_term_counts_flat);
       }
     }
     // Trailing slots (ms.setting_.size() < max_ci) keep zero-init
@@ -2721,6 +2746,22 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   if (sub_desc_bytes > 0) {
     ck(cudaMemcpy(d_complex_sub_desc_, all_sub_descs.data(), sub_desc_bytes, cudaMemcpyHostToDevice),
        "cudaMemcpy d_complex_sub_desc");
+  }
+  // task-device-flat-and-terms: parallel flat AND-term counts buffer. 1-byte
+  // dummy fallback so the kernel pointer stays bindable when no Complex filter
+  // exists. This upload is REDONE in the color-rebuild step below when the
+  // color pass appends further Complex sub-descs; see the mirroring `if
+  // (any_color_group)` block. Missing that mirror is exactly the risk the plan
+  // §7 Risk 4 flagged (silent stale-data bug in color+big-OR configs).
+  {
+    const size_t and_term_bytes = and_term_counts_flat.size();
+    const size_t and_term_alloc = std::max<size_t>(and_term_bytes, 1u);
+    ck(cudaMalloc(&d_and_term_counts_, and_term_alloc), "cudaMalloc d_and_term_counts");
+    if (and_term_bytes > 0) {
+      ck(cudaMemcpy(d_and_term_counts_, and_term_counts_flat.data(), and_term_bytes,
+                    cudaMemcpyHostToDevice),
+         "cudaMemcpy d_and_term_counts");
+    }
   }
 
   // task-358.3: Fork-C `BuildComponentTable` upload retired. The independent
@@ -2834,8 +2875,9 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
           fc.param_ = FilterParam{ cfp };
           DeviceFilterDesc top = detail::BuildDeviceFilterDesc(fc, proto, setting.crystal_.axis_);
           top.sub_desc_start = static_cast<uint32_t>(all_sub_descs.size());
+          top.and_terms_start = static_cast<uint32_t>(and_term_counts_flat.size());
           detail::BuildComplexSubDescs(cfp, proto, top.symmetry, top.sigma_a,
-                                       top.d_applicable != 0u, all_sub_descs);
+                                       top.d_applicable != 0u, all_sub_descs, and_term_counts_flat);
           const size_t color_slot = gate_slot * kColorMaxGroupsPerSlot + gi;
           assert(color_slot < color_desc_region);
           color_descs[color_slot] = top;
@@ -2866,6 +2908,25 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
     if (sub_desc_bytes_v2 > 0) {
       ck(cudaMemcpy(d_complex_sub_desc_, all_sub_descs.data(), sub_desc_bytes_v2, cudaMemcpyHostToDevice),
          "cudaMemcpy d_complex_sub_desc (color rebuild)");
+    }
+    // task-device-flat-and-terms: MIRROR the sub-desc re-upload for the flat
+    // AND-term counts buffer. The color pass appends into
+    // `and_term_counts_flat` in lockstep with `all_sub_descs`, so skipping this
+    // rebuild would leave `d_and_term_counts_` pointing at the pre-color-pass
+    // snapshot → in color+big-OR configs the kernel would read stale/misaligned
+    // counts and silently miscount AND-terms. This mirror is plan §7 Risk 4's
+    // headline failure mode; the "big OR + color共存" CUDA e2e config (see the
+    // filter-parity test suite) exists specifically to lock the mirror in.
+    const size_t and_term_bytes_v2 = and_term_counts_flat.size();
+    const size_t and_term_alloc_v2 = std::max<size_t>(and_term_bytes_v2, 1u);
+    cudaFree(d_and_term_counts_);
+    d_and_term_counts_ = nullptr;
+    ck(cudaMalloc(&d_and_term_counts_, and_term_alloc_v2),
+       "cudaMalloc d_and_term_counts (color rebuild)");
+    if (and_term_bytes_v2 > 0) {
+      ck(cudaMemcpy(d_and_term_counts_, and_term_counts_flat.data(), and_term_bytes_v2,
+                    cudaMemcpyHostToDevice),
+         "cudaMemcpy d_and_term_counts (color rebuild)");
     }
   }
 
@@ -3585,6 +3646,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
         impl_->d_getfn_offsets_,
         impl_->d_getfn_bytes_,
         impl_->d_complex_sub_desc_,
+        impl_->d_and_term_counts_,
         impl_->filter_desc_max_ci_,
         ci_cfg_id,
         // S2 device-fused accumulation params.

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -186,6 +186,13 @@ struct KernelParams {
   uint32_t color_class_count;
   uint64_t color_class_bits[kMaxColorClassesDevice];
   uint8_t  color_class_combine[kMaxColorClassesDevice];
+  // task-device-flat-and-terms: byte offset (in bytes) inside the shared
+  // complex_sub_desc_buf_ where the flat `and_term_counts` region begins. The
+  // kernel derives `gate_and_term_counts = base + offset` via reinterpret_cast
+  // (both regions share buffer 27 to stay within Metal's 30-buffer per-stage
+  // cap). Zero when no Complex filter is present. Must match the MSL field of
+  // the same name in `KernelParams`.
+  uint32_t and_term_counts_base_offset;
 };
 // sizeof(ProjParams) == 76 (6 ints + 4 floats + float[9]); the 15 leading
 // 4-byte KernelParams scalars add 60, + proj 76 + capture_ray_mask 4 → 140
@@ -196,7 +203,11 @@ struct KernelParams {
 // task-358.3 renamed capture_component → capture_ray_mask (same 4B slot, no
 // layout change; the 304 assert below is unaffected).
 static_assert(sizeof(lm_proj::ProjParams) == 76u, "ProjParams layout drift — check projection_shared.h");
-static_assert(sizeof(KernelParams) == 304u,
+// task-device-flat-and-terms: appends a single uint32_t field
+// `and_term_counts_base_offset` (offset 304 → 308 bytes) but the struct's
+// alignment is 8 (uint64_t member `color_class_bits`), so the tail is rounded
+// up to 312.
+static_assert(sizeof(KernelParams) == 312u,
               "KernelParams size mismatch — update host struct to match Metal-side layout");
 
 // Device root-gen latitude path tags. Numeric wire encoding is single-sourced
@@ -942,6 +953,13 @@ struct MetalTraceBackend::Impl {
   size_t filter_desc_count_    = 0;  // total descs uploaded (flattened slots)
   size_t filter_desc_max_ci_   = 0;  // per-layer ci stride; flattened slot
                                      // (mi, ci) → mi * max_ci + ci
+  // task-device-flat-and-terms: byte offset inside `complex_sub_desc_buf_`
+  // where the flat AND-term counts region begins (packed AFTER the
+  // DeviceFilterDesc[] region in the SAME MTLBuffer allocation to stay under
+  // Metal's 30-buffer per-stage cap). Populated by EnsureFilterBuffers along
+  // with the desc/count layout; propagated to the kernel via
+  // `KernelParams::and_term_counts_base_offset`.
+  uint32_t and_term_counts_base_offset_ = 0u;
   // Layer dispatch helpers.
   void EnsureDevice();
   void EnsurePso();
@@ -1308,6 +1326,7 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
   getfn_offsets_buf_ = nil;
   getfn_bytes_buf_ = nil;
   complex_sub_desc_buf_ = nil;
+  and_term_counts_base_offset_ = 0u;
   // task-358.1: reset color state up-front; the descriptor append below turns
   // it back on when at least one placement produces groups.
   has_color_groups_  = false;
@@ -1376,6 +1395,12 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
   // Complex slot's `sub_desc_start` is recorded BEFORE pushing its sub-descs —
   // avoids needing a separate (slot, ComplexFilterParam) map for a second pass.
   std::vector<DeviceFilterDesc> all_sub_descs;
+  // task-device-flat-and-terms: flat AND-term counts buffer, one uint8 per
+  // OR-clause across all Complex filters, packed in OR-clause order under each
+  // parent desc. `and_terms_start` on the parent indexes here; two-region
+  // packing into `complex_sub_desc_buf_` keeps Metal's 30-buffer per-stage cap
+  // intact (single binding at atIndex:27; kernel reinterprets the tail).
+  std::vector<uint8_t> and_term_counts_flat;
   for (size_t mi = 0; mi < n_layers; ++mi) {
     const auto& ms = session_spec.scene->ms_[mi];
     for (size_t ci = 0; ci < ms.setting_.size(); ++ci) {
@@ -1391,9 +1416,10 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
         // get_if must succeed (defensive against future variant additions).
         assert(complex_p != nullptr && "Complex desc type without ComplexFilterParam variant");
         descs[slot].sub_desc_start = static_cast<uint32_t>(all_sub_descs.size());
+        descs[slot].and_terms_start = static_cast<uint32_t>(and_term_counts_flat.size());
         detail::BuildComplexSubDescs(*complex_p, proto, descs[slot].symmetry,
                                      descs[slot].sigma_a, descs[slot].d_applicable != 0u,
-                                     all_sub_descs);
+                                     all_sub_descs, and_term_counts_flat);
       }
     }
     // Empty trailing slots (ms.setting_.size() < max_ci) keep zero-init
@@ -1510,11 +1536,12 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
         fc.action_ = FilterConfig::kFilterIn;
         fc.param_ = FilterParam{ cfp };
         DeviceFilterDesc top = detail::BuildDeviceFilterDesc(fc, proto, setting.crystal_.axis_);
-        // sub_desc_start assigned BEFORE BuildComplexSubDescs appends (mirrors
-        // the physical-slot loop above).
+        // sub_desc_start / and_terms_start assigned BEFORE BuildComplexSubDescs
+        // appends (mirrors the physical-slot loop above).
         top.sub_desc_start = static_cast<uint32_t>(all_sub_descs.size());
+        top.and_terms_start = static_cast<uint32_t>(and_term_counts_flat.size());
         detail::BuildComplexSubDescs(cfp, proto, top.symmetry, top.sigma_a,
-                                     top.d_applicable != 0u, all_sub_descs);
+                                     top.d_applicable != 0u, all_sub_descs, and_term_counts_flat);
         // Place the descriptor at color_slot = gate_slot * K + gi (region-local
         // index; absolute filter_desc_buf_ index adds n_slot when we upload).
         size_t color_slot = gate_slot * kColorMaxGroupsPerSlot + gi;
@@ -1574,17 +1601,37 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
     }
   }
 
-  // Upload Complex sub-desc flat buffer (267.1b). Allocate a 1-byte dummy when
-  // there are no Complex filters so the kernel's buffer(11) binding is always
-  // valid (Metal disallows nil buffer binds).
+  // Upload Complex sub-desc flat buffer (267.1b) + flat AND-term counts
+  // (task-device-flat-and-terms) packed after it. Allocate a 1-byte dummy when
+  // both are empty so the kernel's buffer(27) binding is always valid (Metal
+  // disallows nil buffer binds). Kernel derives the counts pointer via
+  // `reinterpret_cast<device const uchar*>(sub_desc_buf) + and_term_counts_base_offset`.
+  //
+  // Layout audit: `sub_desc_bytes` is finalized BEFORE `and_term_counts_flat`
+  // is packed onto the tail (both vectors were populated in the same pass over
+  // Complex descriptors above), so `and_term_counts_base_offset_` cannot drift
+  // during the packing.
+  //
+  // Future extension: if a third distinct region ever needs to piggy-back on
+  // this buffer, replace the hand-tracked offsets with a small region table
+  // (offset + length per region) instead of adding another hand-computed
+  // constant — the "handful of offsets in KernelParams" pattern does not
+  // scale. See doc/gpu-porting-checklist.md for how to record shared-buffer
+  // regions when propagating to CUDA / future GPU backends.
   size_t sub_desc_bytes = all_sub_descs.size() * sizeof(DeviceFilterDesc);
-  size_t sub_alloc_bytes = std::max<size_t>(sub_desc_bytes, 1);
+  size_t and_term_bytes = and_term_counts_flat.size();
+  size_t sub_alloc_bytes = std::max<size_t>(sub_desc_bytes + and_term_bytes, 1);
   complex_sub_desc_buf_ = [device newBufferWithLength:sub_alloc_bytes
                                               options:MTLResourceStorageModeShared];
   assert(complex_sub_desc_buf_ != nil);
   if (sub_desc_bytes > 0) {
     std::memcpy([complex_sub_desc_buf_ contents], all_sub_descs.data(), sub_desc_bytes);
   }
+  if (and_term_bytes > 0) {
+    auto* base = static_cast<uint8_t*>([complex_sub_desc_buf_ contents]);
+    std::memcpy(base + sub_desc_bytes, and_term_counts_flat.data(), and_term_bytes);
+  }
+  and_term_counts_base_offset_ = static_cast<uint32_t>(sub_desc_bytes);
 
   // task-358.3: upload the Design-2 color-region bit map as the sole content of
   // gate_component_bits_buf_ (the leading Fork-C physical-bits region is gone;
@@ -2212,6 +2259,9 @@ void MetalTraceBackend::Impl::DispatchLayer(size_t num_rays,
   params.gate_seed = gen_seed_ ^
                      (ms_layer_idx * 65537u + crystal_id * 2654435761u);
   params.filter_desc_max_ci = static_cast<uint32_t>(filter_desc_max_ci_);
+  // task-device-flat-and-terms: kernel derives `gate_and_term_counts` from the
+  // shared `gate_sub_desc_buf` via this byte offset.
+  params.and_term_counts_base_offset = and_term_counts_base_offset_;
   // crystal_config_id is consumed only by DeviceFilterMatchCrystal; current
   // canonical configs leave it at kInvalidId (0xffff) so the filter rejects.
   uint16_t cfg_id = current_crystal.config_id_;
@@ -2458,6 +2508,7 @@ void MetalTraceBackend::Impl::Reset() {
   getfn_offsets_buf_ = nil;
   getfn_bytes_buf_ = nil;
   complex_sub_desc_buf_ = nil;
+  and_term_counts_base_offset_ = 0u;
   spec = SessionSpec{};
 }
 

--- a/src/core/device_filter_desc.cpp
+++ b/src/core/device_filter_desc.cpp
@@ -92,27 +92,19 @@ struct SimpleVisitor {
   void operator()(const CrystalFilterParam& p) const { FillCrystal(p, out); }
 };
 
-// Fill the Complex filter's top-level fields (type / or_clause_count /
-// and_term_counts[]). Does NOT touch sub_desc_start — that field is owned by
-// the caller (`EnsureFilterBuffers`) which assigns it before appending the
-// sub-descs via `BuildComplexSubDescs` (plan §3 D5).
+// Fill the Complex filter's top-level fields (type / or_clause_count). Does
+// NOT touch sub_desc_start / and_terms_start — those fields are owned by the
+// caller (`EnsureFilterBuffers`) which assigns them before appending the
+// sub-descs and AND-term counts via `BuildComplexSubDescs`.
+//
+// task-device-flat-and-terms: the former inline `and_term_counts[8]` array
+// has been removed; per-OR-clause AND-term counts now live in a separate
+// host-built flat buffer that `BuildComplexSubDescs` appends into.
 void FillComplexDescTop(const ComplexFilterParam& p, DeviceFilterDesc& out) {
-  // The OR-clause count is bounded by the struct-level `and_term_counts[]`
-  // array length (MSL has no dynamic allocation). Raising the limit requires
-  // updating `kDeviceFilterMaxOrClauses` + the C++/MSL array length together.
-  assert(p.filters_.size() <= kDeviceFilterMaxOrClauses &&
-         "Complex filter exceeds kDeviceFilterMaxOrClauses (8); raise constant + arrays together");
+  assert(p.filters_.size() <= kDeviceFilterOrClauseSanityCap &&
+         "Complex filter exceeds kDeviceFilterOrClauseSanityCap sanity bound; check host ABI clamp");
   out.type = kDeviceFilterTypeComplex;
-  out.or_clause_count = static_cast<uint8_t>(p.filters_.size());
-  // and_term_counts[] is zero-initialized by `DeviceFilterDesc desc{}` at the
-  // top of BuildDeviceFilterDesc; only set the slots we use.
-  for (size_t i = 0; i < p.filters_.size(); ++i) {
-    // and_term_counts[i] is uint8_t (0..255); AND-term count is far smaller in
-    // practice (the canonical ms3 config uses 1 per clause). The 255 ceiling
-    // is sufficient; raising would only require widening this field.
-    assert(p.filters_[i].size() <= 255u && "Complex AND-term count exceeds uint8_t (255)");
-    out.and_term_counts[i] = static_cast<uint8_t>(p.filters_[i].size());
-  }
+  out.or_clause_count = static_cast<uint16_t>(p.filters_.size());
 }
 
 struct TopVisitor {
@@ -150,13 +142,18 @@ DeviceFilterDesc BuildDeviceFilterDesc(const FilterConfig& config, const Crystal
 }
 
 void BuildComplexSubDescs(const ComplexFilterParam& p, const Crystal& crystal, uint8_t symmetry, int sigma_a,
-                          bool d_applicable, std::vector<DeviceFilterDesc>& out_sub_descs) {
-  assert(p.filters_.size() <= kDeviceFilterMaxOrClauses &&
-         "Complex filter exceeds kDeviceFilterMaxOrClauses (8); raise constant + arrays together");
+                          bool d_applicable, std::vector<DeviceFilterDesc>& out_sub_descs,
+                          std::vector<uint8_t>& out_and_term_counts) {
+  assert(p.filters_.size() <= kDeviceFilterOrClauseSanityCap &&
+         "Complex filter exceeds kDeviceFilterOrClauseSanityCap sanity bound; check host ABI clamp");
   for (const auto& or_clause : p.filters_) {
-    // Same uint8_t bound as FillComplexDescTop; kept here so an unsynced caller
-    // (e.g. tests bypassing FillComplexDescTop) still trips the check.
+    // Same uint8_t bound as before; kept here so an unsynced caller trips it
+    // even if the top-level desc builder is bypassed.
     assert(or_clause.size() <= 255u && "Complex AND-term count exceeds uint8_t (255)");
+    // task-device-flat-and-terms: same pass as sub-desc collection appends the
+    // per-OR-clause AND-term count into the parallel flat buffer, avoiding a
+    // second traversal.
+    out_and_term_counts.push_back(static_cast<uint8_t>(or_clause.size()));
     for (const auto& and_entry : or_clause) {
       // Mirror ComplexSpec ctor (filter_spec.cpp:316): sub-spec inherits the
       // parent Complex's symmetry / sigma_a / d_applicable. and_entry.first

--- a/src/core/device_filter_desc.hpp
+++ b/src/core/device_filter_desc.hpp
@@ -41,11 +41,41 @@ constexpr uint8_t kDeviceFilterTypeCrystal = 4;
 // (`complex_sub_desc_buf_`), one entry per AND-term, packed by OR-clause order.
 constexpr uint8_t kDeviceFilterTypeComplex = 5;
 
-// Struct-level upper bound on OR-clauses per Complex filter. The `and_term_counts`
-// array length is the hard limit (MSL has no dynamic allocation); raising it
-// requires updating this constant + the array length in `DeviceFilterDesc` and
-// the MSL mirror together.
+// task-device-flat-and-terms: filter/color decoupling.
+//
+// Since scrum-filter-form-big-or task-device-flat-and-terms, `kDeviceFilterMax
+// OrClauses = 8` is no longer the filter-side hard limit — it now solely
+// constrains the color path:
+//   1. `color_bit_map` stride (metal_trace_backend.mm / cuda_trace_backend.cu:
+//      `color_slot * kDeviceFilterMaxOrClauses + summand`).
+//   2. `DeviceFilterSummandMask`'s per-summand loop upper bound
+//      (filter_shared.h / lumice_trace.metal).
+//   3. The construction-time clamp on color-group OR-summands in
+//      `EnsureFilterBuffers`.
+//
+// Physical filter (non-color) Complex descriptors are governed by the flat
+// `and_term_counts` buffer (see `and_terms_start` in `DeviceFilterDesc`) and by
+// `kDeviceFilterOrClauseSanityCap` below, NOT by this 8. Do not conflate the
+// two.
 constexpr uint8_t kDeviceFilterMaxOrClauses = 8;
+
+// task-device-flat-and-terms: defensive sanity upper bound for physical-filter
+// OR-clauses. NOT an array length — `and_term_counts` is now a flat host-built
+// buffer whose length equals the OR-clause count at runtime — this constant
+// only backs the debug asserts in `BuildComplexSubDescs` / `FillComplexDescTop`
+// so a config that somehow slips a wildly out-of-range clause count past the
+// host ABI layer is flagged instead of silently overrunning the buffer.
+//
+// Value aligned with host `LUMICE_MAX_CONFIG_CLAUSES` (`src/include/lumice.h`);
+// the two are intentionally decoupled at include-time — we do not include the
+// public C API header from `src/core/` to preserve the existing one-way
+// dependency (core does not depend on the public API). The static_assert below
+// hard-fails if the sanity cap ever drops below the legacy color-path bound.
+constexpr uint16_t kDeviceFilterOrClauseSanityCap = 4096;
+static_assert(kDeviceFilterOrClauseSanityCap >= kDeviceFilterMaxOrClauses,
+              "filter sanity cap must not shrink below the legacy color-path bound");
+static_assert(kDeviceFilterOrClauseSanityCap >= 4096,
+              "keep in sync with host LUMICE_MAX_CONFIG_CLAUSES (see src/include/lumice.h)");
 
 // Plain-data descriptor uploaded to the Metal `filter_desc_buf_` (per filter).
 //
@@ -70,19 +100,32 @@ struct DeviceFilterDesc {
   uint8_t canonical_len;        // # significant bytes in canonical_bytes
   uint8_t has_entry;            // EntryExit only
   uint8_t has_exit;             // EntryExit only
-  uint8_t or_clause_count;      // Complex only: # OR-clauses (≤ kDeviceFilterMaxOrClauses);
-                                // non-Complex types leave this 0 (was `_pad0` in pre-267.1b layout)
+  uint8_t _pad_reserved;        // task-device-flat-and-terms: former or_clause_count uint8; kept
+                                // as a padding byte so the following uint32_t fields retain their
+                                // pre-change offsets. Widened or_clause_count moved to a uint16
+                                // slot below (paired with sub_desc_start).
   uint32_t min_len;             // EntryExit lower bound (≥1); Raypath uses canonical_len
   uint32_t max_len;             // EntryExit upper bound; 0 = no upper bound
   float dir[3];                 // Direction only (unit cartesian vector)
   float radii_c;                // Direction only: cos(radii_deg)
   uint32_t crystal_id;          // Crystal only
-  uint8_t and_term_counts[kDeviceFilterMaxOrClauses];  // Complex only: # AND-terms per OR-clause
-  uint32_t sub_desc_start;                             // Complex only: flat start index in complex_sub_desc_buf_
+  // task-device-flat-and-terms: `and_term_counts[]` inline array removed; the
+  // per-OR-clause AND-term counts live in a separate host-built flat buffer
+  // (`and_term_counts_buf`, one uint8 per OR-clause, packed by OR-clause order
+  // per parent desc). `and_terms_start` mirrors `sub_desc_start`'s role for
+  // that buffer. Widening: `or_clause_count` is now uint16_t (≤ 65535) to
+  // accommodate host `LUMICE_MAX_CONFIG_CLAUSES = 4096`.
+  uint32_t sub_desc_start;   // Complex only: flat start index in complex_sub_desc_buf_
+  uint32_t and_terms_start;  // Complex only: flat start index in and_term_counts_buf
+  uint16_t or_clause_count;  // Complex only: # OR-clauses (≤ kDeviceFilterOrClauseSanityCap);
+                             // non-Complex types leave this 0
+  uint16_t _pad_or_tail;     // padding so struct size stays a multiple of 4
 };
 
 static_assert(sizeof(DeviceFilterDesc) <= 256,
-              "DeviceFilterDesc must stay under 256 bytes — see plan §3.D2 (120B as of 267.1b)");
+              "DeviceFilterDesc must stay under 256 bytes — was 120B at 267.1b; task-device-flat-and-terms "
+              "drops and_term_counts[8] inline array and adds and_terms_start (uint32) + or_clause_count "
+              "widened to uint16, net delta is small (see Step 8 of the task plan)");
 
 namespace detail {
 
@@ -96,11 +139,13 @@ namespace detail {
 // memcmps verbatim when `fn_period < 0`.
 //
 // For Complex filters (`ComplexFilterParam`) the returned desc carries
-// `type = kDeviceFilterTypeComplex` + `or_clause_count` + `and_term_counts[]`
-// but **not** `sub_desc_start` — that field is assigned by the caller (e.g.
-// `EnsureFilterBuffers`) immediately before invoking `BuildComplexSubDescs`,
-// which appends the flat list of Simple sub-descs to the shared buffer (plan
-// §3 D5: two-function split keeps top-level desc construction state-free).
+// `type = kDeviceFilterTypeComplex` + `or_clause_count` but NOT
+// `sub_desc_start` or `and_terms_start` — those fields are assigned by the
+// caller (e.g. `EnsureFilterBuffers`) immediately before invoking
+// `BuildComplexSubDescs`, which appends the flat list of Simple sub-descs to
+// the shared buffer and the parallel flat list of per-OR-clause AND-term
+// counts (task-device-flat-and-terms). The two-function split keeps top-level
+// desc construction state-free.
 DeviceFilterDesc BuildDeviceFilterDesc(const FilterConfig& config, const Crystal& crystal,
                                        const AxisDistribution& axis_dist);
 
@@ -117,11 +162,16 @@ DeviceFilterDesc BuildDeviceFilterDesc(const FilterConfig& config, const Crystal
 // site. This mirrors host `ComplexSpec::Match`, which calls `and_f->Match`
 // (not `Check`) on sub-specs.
 //
-// Each OR-clause's AND-term count is asserted ≤ 255 (uint8_t domain). The
-// OR-clause count itself is checked at the parent desc level (≤
-// kDeviceFilterMaxOrClauses == 8).
+// Each OR-clause's AND-term count is asserted ≤ 255 (uint8_t domain) and
+// appended into `out_and_term_counts` in OR-clause order (task-device-flat-
+// and-terms: replaces the former inline `and_term_counts[8]` field on the
+// parent desc). The caller must record `start = out_and_term_counts.size()`
+// BEFORE this call and write it into the parent desc's `and_terms_start`
+// (mirrors `sub_desc_start` discipline). The OR-clause count itself is
+// checked against `kDeviceFilterOrClauseSanityCap`.
 void BuildComplexSubDescs(const ComplexFilterParam& p, const Crystal& crystal, uint8_t symmetry, int sigma_a,
-                          bool d_applicable, std::vector<DeviceFilterDesc>& out_sub_descs);
+                          bool d_applicable, std::vector<DeviceFilterDesc>& out_sub_descs,
+                          std::vector<uint8_t>& out_and_term_counts);
 
 // Build the per-crystal poly-index → face-number byte table consumed by the
 // device filter MATCH kernels (see `ApplyGetFn_dev` in `metal_filter_match_src

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -22,9 +22,10 @@ using namespace metal;
 using namespace lm_pcg;
 
 // --- DeviceFilterDesc mirror (must match src/core/device_filter_desc.hpp) ---
-// Field-by-field bit-exact alignment of host layout. sizeof must be 120 bytes
-// post-267.1b (Complex filter trailer added: or_clause_count reuses former
-// _pad0 byte; and_term_counts[8] + sub_desc_start appended). Verified by
+// Field-by-field bit-exact alignment of host layout. task-device-flat-and-terms:
+// `and_term_counts[8]` inline array removed (moved to a separate flat buffer
+// `and_term_counts_buf` indexed via `and_terms_start`); `or_clause_count`
+// widened to ushort so 4096-clause physical Complex filters fit. Verified by
 // host-side static_assert; MSL has no static_assert across strings, so the
 // parity harness uploads a single host-built desc and the kernel reads it
 // back — any layout drift surfaces as a mismatch.
@@ -39,14 +40,16 @@ struct DeviceFilterDesc {
   uchar  canonical_len;
   uchar  has_entry;
   uchar  has_exit;
-  uchar  or_clause_count;        // Complex only; 0 for non-Complex (was _pad0)
+  uchar  _pad_reserved;          // former or_clause_count uint8 slot; padding-only now
   uint   min_len;
   uint   max_len;
   float  dir[3];
   float  radii_c;
   uint   crystal_id;
-  uchar  and_term_counts[8];     // Complex only: # AND-terms per OR-clause
   uint   sub_desc_start;         // Complex only: flat start index in complex_sub_desc_buf
+  uint   and_terms_start;        // Complex only: flat start index in and_term_counts_buf
+  ushort or_clause_count;        // Complex only; 0 for non-Complex
+  ushort _pad_or_tail;           // trailing padding
 };
 
 // Device filter type tags. Mirror kDeviceFilterType* in device_filter_desc.hpp.
@@ -263,6 +266,7 @@ static inline bool DeviceFilterMatchSimple(device const DeviceFilterDesc& f,
 // silently disable any deferred-construction Complex filter.
 static inline bool DeviceFilterMatchComplex(device const DeviceFilterDesc& f,
                                             device const DeviceFilterDesc* complex_sub_desc_buf,
+                                            device const uchar* and_term_counts_buf,
                                             thread const uchar* path, uint path_len,
                                             device const uchar* getfn_bytes,
                                             device const uint*  getfn_offsets,
@@ -272,7 +276,7 @@ static inline bool DeviceFilterMatchComplex(device const DeviceFilterDesc& f,
   if (f.or_clause_count == 0) { return false; }  // see comment above
   uint sub_idx = f.sub_desc_start;
   for (uint or_i = 0; or_i < (uint)f.or_clause_count; or_i++) {
-    uint and_n = (uint)f.and_term_counts[or_i];
+    uint and_n = (uint)and_term_counts_buf[f.and_terms_start + or_i];
     bool and_ok = true;
     for (uint and_j = 0; and_j < and_n; and_j++) {
       if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx],
@@ -297,6 +301,7 @@ static inline bool DeviceFilterMatchComplex(device const DeviceFilterDesc& f,
 // here, so the MSL static call graph stays acyclic).
 static inline bool DeviceFilterMatch(device const DeviceFilterDesc& f,
                                      device const DeviceFilterDesc* complex_sub_desc_buf,
+                                     device const uchar* and_term_counts_buf,
                                      thread const uchar* path, uint path_len,
                                      device const uchar* getfn_bytes,
                                      device const uint*  getfn_offsets,
@@ -304,7 +309,7 @@ static inline bool DeviceFilterMatch(device const DeviceFilterDesc& f,
                                      thread const float* ray_dir,
                                      uint  ray_crystal_config_id) {
   if (f.type == kDevFilterTypeComplex) {
-    return DeviceFilterMatchComplex(f, complex_sub_desc_buf,
+    return DeviceFilterMatchComplex(f, complex_sub_desc_buf, and_term_counts_buf,
                                     path, path_len, getfn_bytes, getfn_offsets,
                                     crystal_slot, ray_dir, ray_crystal_config_id);
   }
@@ -316,13 +321,14 @@ static inline bool DeviceFilterMatch(device const DeviceFilterDesc& f,
 // filter_spec.hpp:42-45.
 static inline bool DeviceFilterCheck(device const DeviceFilterDesc& f,
                                      device const DeviceFilterDesc* complex_sub_desc_buf,
+                                     device const uchar* and_term_counts_buf,
                                      thread const uchar* path, uint path_len,
                                      device const uchar* getfn_bytes,
                                      device const uint*  getfn_offsets,
                                      uint  crystal_slot,
                                      thread const float* ray_dir,
                                      uint  ray_crystal_config_id) {
-  bool m = DeviceFilterMatch(f, complex_sub_desc_buf,
+  bool m = DeviceFilterMatch(f, complex_sub_desc_buf, and_term_counts_buf,
                              path, path_len, getfn_bytes, getfn_offsets,
                              crystal_slot, ray_dir, ray_crystal_config_id);
   return (f.action == 0u) ? m : !m;
@@ -348,6 +354,7 @@ constant uint kDevComponentStride = 8u;
 //   - other simple : 1 summand → bit 0 iff matched (mirrors non-None simple).
 static inline uint DeviceFilterSummandMask(device const DeviceFilterDesc& f,
                                            device const DeviceFilterDesc* complex_sub_desc_buf,
+                                           device const uchar* and_term_counts_buf,
                                            thread const uchar* path, uint path_len,
                                            device const uchar* getfn_bytes,
                                            device const uint*  getfn_offsets,
@@ -358,8 +365,11 @@ static inline uint DeviceFilterSummandMask(device const DeviceFilterDesc& f,
   if (f.type == kDevFilterTypeComplex) {
     uint mask = 0u;
     uint sub_idx = f.sub_desc_start;
+    // task-device-flat-and-terms: color-path helper, so `or_i <
+    // kDevComponentStride` stays as an explicit cap (color bit map + uint mask
+    // are still stride-limited to kDeviceFilterMaxOrClauses summands).
     for (uint or_i = 0u; or_i < (uint)f.or_clause_count && or_i < kDevComponentStride; or_i++) {
-      uint and_n = (uint)f.and_term_counts[or_i];
+      uint and_n = (uint)and_term_counts_buf[f.and_terms_start + or_i];
       bool and_ok = true;
       for (uint and_j = 0u; and_j < and_n; and_j++) {
         if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx],
@@ -499,6 +509,12 @@ struct KernelParams {
   uint  color_class_count;
   ulong color_class_bits[kMaxColorClassesDeviceMsl];
   uchar color_class_combine[kMaxColorClassesDeviceMsl];
+  // task-device-flat-and-terms: byte offset (in bytes) into the
+  // complex_sub_desc_buf allocation where the AND-term counts region begins.
+  // The kernel reinterprets `gate_sub_desc_buf + and_term_counts_base_offset`
+  // as a `device const uchar*` (both regions share buffer 27 to stay within
+  // Metal's 30-buffer per-stage cap). Zero when no Complex filter is present.
+  uint  and_term_counts_base_offset;
 };
 
 kernel void trace_layer_kernel(
@@ -586,6 +602,14 @@ kernel void trace_layer_kernel(
   // task-331.5: load the carried component mask once (constant for the whole
   // in-crystal path, exactly like the wl_idx lifetime tag below).
   ulong carried_component = root_component[tid];
+
+  // task-device-flat-and-terms: the AND-term counts region shares buffer 27
+  // with the Complex sub-desc region (Metal's per-stage 30-buffer cap left no
+  // room for a separate binding). Host `EnsureFilterBuffers` packs
+  // `[DeviceFilterDesc...][uint8 and_term_counts...]` into one allocation and
+  // supplies the byte offset via `KernelParams::and_term_counts_base_offset`.
+  device const uchar* gate_and_term_counts =
+      reinterpret_cast<device const uchar*>(gate_sub_desc_buf) + prm.and_term_counts_base_offset;
 
   float dx = root_d[tid * 3u + 0u];
   float dy = root_d[tid * 3u + 1u];
@@ -747,7 +771,7 @@ kernel void trace_layer_kernel(
           // prm.crystal_id" for the full derivation; multi-MS filter parity
           // proves this is the working form. Do NOT "fix" back to crystal_id.)
           bool filter_pass = DeviceFilterCheck(
-              gate_filter_desc[gate_slot], gate_sub_desc_buf,
+              gate_filter_desc[gate_slot], gate_sub_desc_buf, gate_and_term_counts,
               path_local, gate_len,
               gate_getfn_bytes, gate_getfn_offsets,
               gate_slot, ray_dir_w, prm.crystal_config_id);
@@ -775,7 +799,7 @@ kernel void trace_layer_kernel(
                 bool matched_col = false;
                 uint c_smask = DeviceFilterSummandMask(
                     gate_filter_desc[prm.color_desc_offset + color_slot_idx],
-                    gate_sub_desc_buf,
+                    gate_sub_desc_buf, gate_and_term_counts,
                     path_local, gate_len, gate_getfn_bytes, gate_getfn_offsets,
                     gate_slot, ray_dir_w, prm.crystal_config_id, &matched_col);
                 for (uint k = 0u; k < kDevComponentStride; k++) {
@@ -899,7 +923,7 @@ kernel void trace_layer_kernel(
           uint  gate_slot_f = prm.ms_layer_idx * prm.filter_desc_max_ci + prm.crystal_id;
           float ray_dir_w_f[3] = { wx, wy, wz };
           bool filter_pass_f = DeviceFilterCheck(
-              gate_filter_desc[gate_slot_f], gate_sub_desc_buf,
+              gate_filter_desc[gate_slot_f], gate_sub_desc_buf, gate_and_term_counts,
               path_local_f, gate_len_f,
               gate_getfn_bytes, gate_getfn_offsets,
               gate_slot_f, ray_dir_w_f, prm.crystal_config_id);
@@ -926,7 +950,7 @@ kernel void trace_layer_kernel(
                 bool matched_col_f = false;
                 uint c_smask_f = DeviceFilterSummandMask(
                     gate_filter_desc[prm.color_desc_offset + color_slot_idx_f],
-                    gate_sub_desc_buf,
+                    gate_sub_desc_buf, gate_and_term_counts,
                     path_local_f, gate_len_f, gate_getfn_bytes, gate_getfn_offsets,
                     gate_slot_f, ray_dir_w_f, prm.crystal_config_id, &matched_col_f);
                 for (uint k = 0u; k < kDevComponentStride; k++) {

--- a/src/core/shared/filter_shared.h
+++ b/src/core/shared/filter_shared.h
@@ -260,15 +260,15 @@ LM_FN bool DeviceFilterMatchSimple(const DeviceFilterDesc& f, const uint8_t* pat
 // filter_spec.cpp:274-288; DO NOT change to true — would silently disable
 // deferred-construction Complex filters).
 LM_FN bool DeviceFilterMatchComplex(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
-                                    const uint8_t* path, uint32_t path_len, const uint8_t* getfn_bytes,
-                                    const uint32_t* getfn_offsets, uint32_t crystal_slot, const float* ray_dir,
-                                    uint32_t ray_crystal_config_id) {
+                                    const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
+                                    const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
+                                    const float* ray_dir, uint32_t ray_crystal_config_id) {
   if (f.or_clause_count == 0u) {
     return false;
   }
   uint32_t sub_idx = f.sub_desc_start;
   for (uint32_t or_i = 0; or_i < static_cast<uint32_t>(f.or_clause_count); ++or_i) {
-    uint32_t and_n = static_cast<uint32_t>(f.and_term_counts[or_i]);
+    uint32_t and_n = static_cast<uint32_t>(and_term_counts_buf[f.and_terms_start + or_i]);
     bool and_ok = true;
     for (uint32_t and_j = 0; and_j < and_n; ++and_j) {
       if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, getfn_bytes, getfn_offsets,
@@ -292,12 +292,12 @@ LM_FN bool DeviceFilterMatchComplex(const DeviceFilterDesc& f, const DeviceFilte
 // Top-level dispatch — Complex → DeviceFilterMatchComplex; everything else →
 // DeviceFilterMatchSimple. Static call graph stays acyclic.
 LM_FN bool DeviceFilterMatch(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
-                             const uint8_t* path, uint32_t path_len, const uint8_t* getfn_bytes,
-                             const uint32_t* getfn_offsets, uint32_t crystal_slot, const float* ray_dir,
-                             uint32_t ray_crystal_config_id) {
+                             const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
+                             const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
+                             const float* ray_dir, uint32_t ray_crystal_config_id) {
   if (f.type == kDeviceFilterTypeComplex) {
-    return DeviceFilterMatchComplex(f, complex_sub_desc_buf, path, path_len, getfn_bytes, getfn_offsets, crystal_slot,
-                                    ray_dir, ray_crystal_config_id);
+    return DeviceFilterMatchComplex(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, getfn_bytes,
+                                    getfn_offsets, crystal_slot, ray_dir, ray_crystal_config_id);
   }
   return DeviceFilterMatchSimple(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot, ray_dir,
                                  ray_crystal_config_id);
@@ -306,11 +306,11 @@ LM_FN bool DeviceFilterMatch(const DeviceFilterDesc& f, const DeviceFilterDesc* 
 // Check = Match XOR (action == filter_out). Same algebra as
 // filter_spec.hpp:42-45.
 LM_FN bool DeviceFilterCheck(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
-                             const uint8_t* path, uint32_t path_len, const uint8_t* getfn_bytes,
-                             const uint32_t* getfn_offsets, uint32_t crystal_slot, const float* ray_dir,
-                             uint32_t ray_crystal_config_id) {
-  bool m = DeviceFilterMatch(f, complex_sub_desc_buf, path, path_len, getfn_bytes, getfn_offsets, crystal_slot, ray_dir,
-                             ray_crystal_config_id);
+                             const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
+                             const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
+                             const float* ray_dir, uint32_t ray_crystal_config_id) {
+  bool m = DeviceFilterMatch(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, getfn_bytes, getfn_offsets,
+                             crystal_slot, ray_dir, ray_crystal_config_id);
   return (f.action == 0u) ? m : !m;
 }
 
@@ -334,15 +334,21 @@ LM_FN bool DeviceFilterCheck(const DeviceFilterDesc& f, const DeviceFilterDesc* 
 // The result is capped at kDeviceFilterMaxOrClauses summands (== the Complex
 // or_clause_count upper bound); the component-bit table uses the same stride.
 LM_FN uint32_t DeviceFilterSummandMask(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
-                                       const uint8_t* path, uint32_t path_len, const uint8_t* getfn_bytes,
-                                       const uint32_t* getfn_offsets, uint32_t crystal_slot, const float* ray_dir,
-                                       uint32_t ray_crystal_config_id, bool* out_matched) {
+                                       const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
+                                       const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
+                                       const float* ray_dir, uint32_t ray_crystal_config_id, bool* out_matched) {
   if (f.type == kDeviceFilterTypeComplex) {
     uint32_t mask = 0u;
     uint32_t sub_idx = f.sub_desc_start;
+    // task-device-flat-and-terms: the `or_i < kDeviceFilterMaxOrClauses` cap
+    // is INTENTIONAL here — this function is a color-path helper (see the
+    // comment block above) and the color bit map / uint32 mask are still
+    // stride-limited to `kDeviceFilterMaxOrClauses` summands. Physical-filter
+    // Complex descriptors that carry more OR-clauses use `DeviceFilterCheck`,
+    // whose loop is bounded only by `f.or_clause_count` (no color-side cap).
     for (uint32_t or_i = 0u; or_i < static_cast<uint32_t>(f.or_clause_count) && or_i < kDeviceFilterMaxOrClauses;
          ++or_i) {
-      uint32_t and_n = static_cast<uint32_t>(f.and_term_counts[or_i]);
+      uint32_t and_n = static_cast<uint32_t>(and_term_counts_buf[f.and_terms_start + or_i]);
       bool and_ok = true;
       for (uint32_t and_j = 0u; and_j < and_n; ++and_j) {
         if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, getfn_bytes, getfn_offsets,

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -826,7 +826,7 @@ bool MaybeReconstructServerForBackend() {
   return true;
 }
 
-bool DoRun() {
+bool DoRun(bool user_initiated) {
   if (!g_server) {
     return true;
   }
@@ -948,6 +948,16 @@ bool DoRun() {
     if (PeekGuiWarning() != warning_msg) {
       GUI_LOG_WARNING("[GUI] DoRun: {} exceeds ABI limits ({}); keeping the previous configuration.",
                       color_overflow.class_index >= 0 ? "raypath color configuration" : "filter", log_locator);
+    }
+    // task-gui-feedback-affordances Step 2 (AC3): a user-clicked Run always
+    // opens the warning modal, even when the previous OK dismissed it and the
+    // overflow condition is unchanged. SetGuiWarning's identity-dedup would
+    // otherwise silently swallow the second Run. The auto-commit (70ms) path
+    // sets user_initiated=false so a stuck-overflow slider drag does not
+    // reopen the modal every tick and freeze the UI (app_panels.cpp:1315-1320
+    // records why "OK to clear" alone is wrong).
+    if (user_initiated) {
+      ClearGuiWarning();
     }
     SetGuiWarning(warning_msg);
     return true;

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -703,7 +703,7 @@ void CalibrateQualityThreshold() {
 
   // Use current default state to build a calibration config
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_color_guard(config);  // v4.8: release raypath_color on any early return
+  lumice::ConfigOwningGuard config_color_guard(config);  // v4.8: release raypath_color on any early return
   if (!FillLumiceConfig(g_state, &config)) {
     // Unlike DoRun (which pops SetGuiWarning), calibration degrades silently to the default
     // threshold: it does not touch the user's edited/committed config, so a log line is
@@ -914,7 +914,7 @@ bool DoRun() {
   // (graceful degradation) — poller untouched, buffer not torn — rather than commit a
   // truncated config.
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_color_guard(config);  // v4.8: release raypath_color on any early return
+  lumice::ConfigOwningGuard config_color_guard(config);  // v4.8: release raypath_color on any early return
   FilterOverflowInfo overflow;
   ColorClassOverflowInfo color_overflow;
   if (!FillLumiceConfig(g_state, &config, &overflow, &color_overflow)) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -973,9 +973,6 @@ bool DoRun(bool user_initiated) {
   int reused = 0;
   LUMICE_ErrorCode err = LUMICE_CommitConfigStruct(g_server, &config, &reused);
   if (err == LUMICE_OK) {
-    // A good commit clears any prior over-bounds warning so a later re-occurrence warns again.
-    ClearGuiWarning();
-
     // task-gui-feedback-affordances Step 7 (AC1): the ABI check above passed
     // (filter / raypath tracing / geometry all fit within their caps), but
     // the CORE may still have dropped color-classification predicates that
@@ -998,6 +995,9 @@ bool DoRun(bool user_initiated) {
     //     modal again.
     LUMICE_ColorOverflowInfo color_over{};
     LUMICE_GetColorOverflowInfo(g_server, &color_over);
+    // symmetry_group_overflow_count is currently hardcoded to 0 in c_api.cpp (the Metal/CUDA
+    // symmetry-group counter is not yet wired to a consumer — see backlog "symmetry_group
+    // overflow GUI surfacing"); the OR term is future-reserved dead code until that lands.
     if (color_over.component_overflow_count > 0 || color_over.symmetry_group_overflow_count > 0) {
       std::string degrade_msg =
           "This raypath color configuration exceeds its predicate/symmetry-group budget (" +
@@ -1007,10 +1007,23 @@ bool DoRun(bool user_initiated) {
           "Affected rays/crystals will render with missing or incomplete color. The underlying "
           "filtering/geometry is unaffected — only color assignment degrades.\n"
           "Simplify the color configuration (fewer distinct predicates per class / fewer symmetry variants) to fix.";
+      // Same user_initiated-gated-clear discipline as the FillLumiceConfig-failure branch
+      // above (AC3): only force-reopen on an explicit user Run. Do NOT unconditionally
+      // ClearGuiWarning() before this check (code-review-01 Critical 1) — that would zero
+      // g_gui_warning_current ahead of the comparison below, so SetGuiWarning's
+      // identity-dedup always sees an empty prior message and reopens the modal on every
+      // auto-commit tick (user_initiated=false) even when the SAME overflow persists,
+      // reproducing the "70ms slider drag freezes the UI" regression this task's Step 2
+      // fixed for the sibling branch.
       if (user_initiated) {
         ClearGuiWarning();
       }
       SetGuiWarning(degrade_msg);
+    } else {
+      // No color overflow: clear any prior over-bounds warning (the ABI-reject warning from
+      // the branch above, or a previous color-degrade warning that has now resolved) so a
+      // later re-occurrence of either warns again.
+      ClearGuiWarning();
     }
     g_state.last_committed_state = GuiState::ConfigSnapshot::From(g_state);
     // task-color-migration §4 M6 (repush discipline): a fresh commit invalidates every edge-

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -975,6 +975,43 @@ bool DoRun(bool user_initiated) {
   if (err == LUMICE_OK) {
     // A good commit clears any prior over-bounds warning so a later re-occurrence warns again.
     ClearGuiWarning();
+
+    // task-gui-feedback-affordances Step 7 (AC1): the ABI check above passed
+    // (filter / raypath tracing / geometry all fit within their caps), but
+    // the CORE may still have dropped color-classification predicates that
+    // overflowed the 64-bit component budget (BuildColorGateTable → kNoBit).
+    // Surface that as a modal so the user sees "coloring degraded" rather
+    // than staring at a partially-uncolored render with no explanation. The
+    // Log panel is collapsed by default, so a log-only warning is invisible
+    // to most users — this is the fix for the "core degrades silently" trap
+    // that was called out in this task's issue.md §A.
+    //
+    // Two mutually-exclusive branches feed SetGuiWarning inside DoRun:
+    //  1) FillLumiceConfig failure (above) → commit was REJECTED, previous
+    //     config kept. That branch already gated on `user_initiated` to force
+    //     a refire on explicit user Runs (Step 2 AC3).
+    //  2) This one → commit SUCCEEDED, coloring degrades gracefully. Uses a
+    //     different message string (SetGuiWarning's identity-dedup means two
+    //     different messages cannot swallow each other). Applies the same
+    //     `user_initiated` refire policy so a user who dismisses the modal
+    //     and re-Runs with the same still-oversized color config sees the
+    //     modal again.
+    LUMICE_ColorOverflowInfo color_over{};
+    LUMICE_GetColorOverflowInfo(g_server, &color_over);
+    if (color_over.component_overflow_count > 0 || color_over.symmetry_group_overflow_count > 0) {
+      std::string degrade_msg =
+          "This raypath color configuration exceeds its predicate/symmetry-group budget (" +
+          std::to_string(color_over.component_overflow_count) + " predicate(s) and/or " +
+          std::to_string(color_over.symmetry_group_overflow_count) +
+          " symmetry-group(s) dropped).\n"
+          "Affected rays/crystals will render with missing or incomplete color. The underlying "
+          "filtering/geometry is unaffected — only color assignment degrades.\n"
+          "Simplify the color configuration (fewer distinct predicates per class / fewer symmetry variants) to fix.";
+      if (user_initiated) {
+        ClearGuiWarning();
+      }
+      SetGuiWarning(degrade_msg);
+    }
     g_state.last_committed_state = GuiState::ConfigSnapshot::From(g_state);
     // task-color-migration §4 M6 (repush discipline): a fresh commit invalidates every edge-
     // trigger baseline so the next frame's reconciler unconditionally re-pushes the full

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1167,6 +1167,14 @@ bool ShouldDefaultEnableColorsOnOpen(bool raypath_color_empty) {
   return raypath_color_empty;
 }
 
+// task-gui-feedback-affordances Step 1 (AC2) — see app.hpp. Pure predicate,
+// intentionally trivial: the tint decision boundary is `raypath_color` is
+// non-empty, and pinning it in a testable function prevents the top-bar
+// rendering call site from drifting away from the same read.
+bool ShouldTintColorsButton(bool raypath_color_empty) {
+  return !raypath_color_empty;
+}
+
 // task-348.3 (⑤/⑥) shared writer — see app.hpp. Two-line function on purpose: the whole
 // point is that both write sites go through the same left-value assignment so future
 // code cannot introduce a third variant that reads/writes the wrong field.

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -171,7 +171,18 @@ void CalibrateQualityThreshold();
 // ~O(100ms)) and no current non-throttle caller is reachable during it; revisit
 // (add an explicit retry or assert) if a future UI path can trigger DoRun
 // mid-first-batch.
-bool DoRun();
+//
+// task-gui-feedback-affordances Step 2 (AC3) — `user_initiated` distinguishes
+// user-clicked Run (top-bar Run button, "Run first" in the Save-Modified
+// popup) from the main-loop 70ms auto-commit path. When true, DoRun calls
+// ClearGuiWarning() BEFORE any conditional SetGuiWarning so a persistent
+// overflow condition re-opens the warning modal on every explicit Run;
+// when false, SetGuiWarning's identity-dedup is preserved so a slider drag
+// producing a stuck-overflow commit each 70ms tick does not reopen the modal
+// (which would freeze the UI). No default value — every call site must make
+// this choice explicit so a future new caller cannot silently inherit the
+// wrong dedup semantics.
+bool DoRun(bool user_initiated);
 void DoStop();
 void DoRevert();
 void DoLoadBackground(GLFWwindow* window);
@@ -300,6 +311,21 @@ void RenderImportWarningPopup();
 void SetGuiWarning(const std::string& msg);
 void ClearGuiWarning();
 std::string PeekGuiWarning();  // test accessor: current in-flight message ("" if none)
+// task-gui-feedback-affordances Step 2 (AC3) test accessor: is a modal re-open
+// pending on the next RenderGuiWarningPopup? True between SetGuiWarning (fresh
+// or after ClearGuiWarning) and the frame that consumes it via OpenPopup. Lets
+// tests observe DoRun(user_initiated=true)'s "force-reopen on every explicit
+// Run" contract without spinning up a full ImGui frame.
+bool IsGuiWarningPending();
+
+namespace internal_test {
+// task-gui-feedback-affordances Step 2 (AC3) test helper: consume the pending
+// modal-open flag exactly as RenderGuiWarningPopup would on the next frame,
+// without touching the in-flight message. Lets AC3 tests exercise the
+// "OK dismissed the popup but the persistent overflow remains" state without
+// running a full ImGui frame that would fight the popup's input capture.
+void ConsumeGuiWarningPending();
+}  // namespace internal_test
 void RenderGuiWarningPopup();
 void RenderLogPanel(float window_width, float window_height);
 

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -263,6 +263,13 @@ bool ShouldFireCompositeUpload(const PreviewSnapshot& snap, unsigned long long l
 // false→true color_window_open transition (see RenderTopBar), not per-frame.
 bool ShouldDefaultEnableColorsOnOpen(bool raypath_color_empty);
 
+// task-gui-feedback-affordances Step 1 (AC2): decide whether the top-bar Colors
+// button should render with a distinct tint. True iff at least one color class
+// is configured (derived state; single source is `raypath_color.empty()` — no
+// new state source per scrum-353 GUI state governance). Pure predicate; the
+// caller in RenderTopBar wraps ImGui::Button with PushStyleColor when true.
+bool ShouldTintColorsButton(bool raypath_color_empty);
+
 // task-348.3 AC1/AC2 shared writer: toggle the user preference `show_composite_preview`.
 // Called from both the top-bar Colored checkbox (app_panels.cpp; icon-only Button in
 // 348.3, reverted to a plain-text Checkbox in 349.3 #4) and the in-window "Enable

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -275,6 +275,18 @@ void RenderTopBar(float window_width) {
   // New/Open/Save. Colors is the first occupant; future cross-cutting toggles
   // unrelated to file I/O or panel layout should land here rather than
   // competing for status-bar space.
+  //
+  // task-gui-feedback-affordances Step 1 (AC2): visually distinguish "has color
+  // classes" vs "no color classes" so the topbar signals whether coloring is
+  // configured before the window is opened. Derived state (empty check on
+  // raypath_color) — no new state source. Blue/purple tint avoids collision
+  // with Run (green) / Stop (red).
+  const bool tint_colors_button = ShouldTintColorsButton(g_state.raypath_color.empty());
+  if (tint_colors_button) {
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.30f, 0.35f, 0.65f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.40f, 0.45f, 0.75f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.25f, 0.28f, 0.55f, 1.0f));
+  }
   if (ImGui::Button(ICON_FA_PALETTE " Colors")) {
     // task-348.3 AC3 (⑦): apply the "default enable on open with no classes" rule
     // ONLY on the false→true transition of color_window_open. Doing it here (inside
@@ -287,6 +299,9 @@ void RenderTopBar(float window_width) {
     if (opening && ShouldDefaultEnableColorsOnOpen(g_state.raypath_color.empty())) {
       g_state.show_composite_preview = true;
     }
+  }
+  if (tint_colors_button) {
+    ImGui::PopStyleColor(3);
   }
 
   // task-colored-toggle-to-topbar (346.3): colored/full-spectrum display-time

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -171,7 +171,7 @@ void RenderTopBar(float window_width) {
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.55f, 0.2f, 1.0f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.35f, 0.1f, 1.0f));
     if (ImGui::Button(kRunLabel, ImVec2(run_stop_width, 0))) {
-      DoRun();
+      DoRun(/*user_initiated=*/true);
     }
     ImGui::PopStyleColor(3);
   }
@@ -1345,6 +1345,17 @@ std::string PeekGuiWarning() {
   return g_gui_warning_current;
 }
 
+// Test accessor: is a modal re-open pending on the next render? See app.hpp.
+bool IsGuiWarningPending() {
+  return g_gui_warning_trigger;
+}
+
+namespace internal_test {
+void ConsumeGuiWarningPending() {
+  g_gui_warning_trigger = false;
+}
+}  // namespace internal_test
+
 void RenderGuiWarningPopup() {
   if (g_gui_warning_trigger) {
     g_gui_warning_trigger = false;
@@ -1485,7 +1496,7 @@ void RenderSaveModifiedPopup(GLFWwindow* window) {
       ImGui::BeginDisabled();
     }
     if (ImGui::Button("Run first", ImVec2(100, 0))) {
-      DoRun();
+      DoRun(/*user_initiated=*/true);
       g_pending_save_kind = PendingSaveKind::kNone;
       // Abort any chained New/Open/Quit (see doc comment above) — Run doesn't
       // persist anything, so proceeding now would still discard the edit.

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -101,10 +101,20 @@ constexpr size_t kSummandRowBufSize = 256;
 // UI soft cap (kMaxSummandRows): prevents unbounded row growth from the "+ Add"
 // button before the real ABI-layer limits kick in. The authoritative overflow
 // gates live in file_io.cpp::FillLumiceConfig (ExpandSopToClauses → clauses vec
-// with LUMICE_kMaxComplexFilterClauses cap) and BuildExportJsonOrWarn; those
-// remain the last-word validators. 16 is the OR-summand row count and comfortably
-// fits typical multi-branch filters (a real config usually has ≤ 4 rows).
-constexpr size_t kMaxSummandRows = 16;
+// with LUMICE_MAX_CONFIG_CLAUSES cap) and BuildExportJsonOrWarn; those remain
+// the last-word validators. The ABI ceiling is now much higher (v4.9,
+// task-host-abi-cpu-caps: LUMICE_MAX_CONFIG_CLAUSES=4096), but this UI soft
+// cap sits below it — ImGui re-renders every row per frame without
+// virtualization, so several-thousand rows would tank the editor's frame rate.
+// 256 covers real "few-hundred OR summands" use cases with comfortable
+// headroom while staying inside the practical UI budget; a proper virtualized
+// / big-list mode is the task-369.4 D-item's job.
+constexpr size_t kMaxSummandRows = 256;
+// task-host-abi-cpu-caps AC4: compile-time sentinel — the whole point of v4.9 is to let
+// the GUI accept > 16 OR rows without the pre-v4.9 hard cap. If a future change accidentally
+// lowers this back to the historical 16, the intent is lost silently — the assert makes
+// that regression a build-time failure.
+static_assert(kMaxSummandRows > 16, "kMaxSummandRows must stay above the pre-v4.9 cap of 16");
 
 struct SummandRowBuf {
   uint64_t uid;

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -17,6 +17,7 @@
 #include "gui/crystal_renderer.hpp"
 #include "gui/destructive_style.hpp"
 #include "gui/face_number_overlay.hpp"
+#include "gui/file_io.hpp"  // SummarizeSopExpansion (Step 3 AC4 live preview)
 #include "gui/gui_constants.hpp"
 #include "gui/gui_state.hpp"
 #include "gui/panels.hpp"
@@ -852,6 +853,30 @@ static void RenderSummandRowList() {
     ImGui::PushTextWrapPos(0.0f);
     ImGui::TextUnformatted(FormatSopExpansionPreview(live_sop).c_str());
     ImGui::PopTextWrapPos();
+
+    // task-gui-feedback-affordances Step 3 (AC4): show the post-Cartesian
+    // expanded clause count against LUMICE_MAX_CONFIG_CLAUSES so the user
+    // learns early — before hitting OK / Run — that a ';'-heavy row will
+    // trip the ABI cap. Delegates to SummarizeSopExpansion, which shares
+    // ExpandSopToClauses with the commit path (file_io.hpp — single source).
+    // The commit path (DoRun's FillLumiceConfig branch) remains the ABI
+    // enforcement point; this preview is diagnostic-only (issue.md D "越界
+    // 有可见提示"; plan §2/§3 D "仅标红，不禁用 OK").
+    FilterConfig probe;  // throwaway wrapper — SummarizeSopExpansion only reads .param
+    probe.param = live_sop;
+    const SopExpansionSummary sop_summary = SummarizeSopExpansion(probe);
+    char clause_line[128] = { 0 };
+    std::snprintf(clause_line, sizeof(clause_line), "Clauses: %zu / %d", sop_summary.clause_count,
+                  LUMICE_MAX_CONFIG_CLAUSES);
+    if (sop_summary.overflow) {
+      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
+      ImGui::TextUnformatted(clause_line);
+      ImGui::SameLine();
+      ImGui::TextUnformatted("(exceeds limit — the previous config will be kept on OK)");
+      ImGui::PopStyleColor();
+    } else {
+      ImGui::TextDisabled("%s", clause_line);
+    }
   }
 }
 

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -528,6 +528,19 @@ static ExpandedFilter ExpandSopToClauses(const FilterConfig& f) {
   return ef;
 }
 
+// task-gui-feedback-affordances Step 3 (AC4) — see file_io.hpp. Cheap on-typing
+// summary that delegates to ExpandSopToClauses so the live preview and the
+// commit path share the same expansion arithmetic (no drift). Only the total
+// clause count + overflow flag are exposed; the callers do not need to see the
+// clause contents.
+SopExpansionSummary SummarizeSopExpansion(const FilterConfig& f) {
+  const ExpandedFilter ef = ExpandSopToClauses(f);
+  SopExpansionSummary summary;
+  summary.clause_count = ef.clauses.size();
+  summary.overflow = ef.overflow;
+  return summary;
+}
+
 // True when the expansion collapses to a single simple filter (1 clause, 1 term):
 // single raypath / single EE / single-factor single-alternative row. Such filters
 // emit ONE simple filter with no wrapping complex (byte-equivalent to pre-uplift).

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -898,7 +898,7 @@ bool BuildExportJsonOrWarn(const GuiState& state, std::string* out_json, std::st
   // a wrong config (code-review-02/03 Major). Pure — no dialog/filesystem — so this reject
   // path is directly unit-testable.
   LUMICE_Config probe{};
-  lumice::ConfigColorGuard probe_color_guard(probe);  // v4.8: release probe.raypath_color on scope exit
+  lumice::ConfigOwningGuard probe_color_guard(probe);  // v4.8: release probe.raypath_color on scope exit
   FilterOverflowInfo overflow;
   ColorClassOverflowInfo color_overflow;
   if (!FillLumiceConfig(state, &probe, &overflow, &color_overflow)) {
@@ -1299,23 +1299,45 @@ static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMI
     return false;
   }
 
-  int comp_idx = out->composition_count++;
-  LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
-  comp->clause_count = static_cast<int>(ef.clauses.size());
+  // v4.9 (task-host-abi-cpu-caps): compose the (term_counts, term_ids) triple on the stack
+  // first, then commit via LUMICE_CompositionSetClauses in one shot — mirrors the pattern
+  // used on the JsonToComplexComposition side. filter_idx / composition_count are advanced
+  // after Set succeeds; on Set failure (OOM) the caller sees "no partial write" (composition
+  // slot untouched, filters[] untouched, counters unchanged).
+  const int clause_n = static_cast<int>(ef.clauses.size());
+  std::vector<int> term_counts_vec;
+  std::vector<int> term_ids_vec;
+  term_counts_vec.reserve(static_cast<size_t>(clause_n));
+  term_ids_vec.reserve(static_cast<size_t>(total_terms));
+  int probe_filter_idx = *filter_idx;
   int running = 0;
   for (size_t cl = 0; cl < ef.clauses.size(); ++cl) {
     const auto& clause = ef.clauses[cl];
-    comp->term_counts[cl] = static_cast<int>(clause.size());
+    term_counts_vec.push_back(static_cast<int>(clause.size()));
     for (size_t tt = 0; tt < clause.size(); ++tt) {
-      int cid = next_filter_id + running++;
-      fill_term(&out->filters[(*filter_idx)++], cid, clause[tt]);
-      comp->clauses[cl][tt] = cid;
+      term_ids_vec.push_back(next_filter_id + running++);
     }
   }
-  int complex_id = next_filter_id + running;  // == next_filter_id + total_terms
-  LUMICE_FilterParam* cdst = &out->filters[(*filter_idx)++];
+  const int comp_idx = out->composition_count;
+  LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
+  if (LUMICE_CompositionSetClauses(comp, clause_n, term_counts_vec.data(), term_ids_vec.data()) != LUMICE_OK) {
+    return false;
+  }
+  // Set succeeded — now emit the per-term simple filters and the complex filter itself.
+  int emit_running = 0;
+  for (size_t cl = 0; cl < ef.clauses.size(); ++cl) {
+    const auto& clause = ef.clauses[cl];
+    for (size_t tt = 0; tt < clause.size(); ++tt) {
+      int cid = next_filter_id + emit_running++;
+      fill_term(&out->filters[probe_filter_idx++], cid, clause[tt]);
+    }
+  }
+  int complex_id = next_filter_id + emit_running;  // == next_filter_id + total_terms
+  LUMICE_FilterParam* cdst = &out->filters[probe_filter_idx++];
   set_common(cdst, complex_id, LUMICE_FILTER_TYPE_COMPLEX);
   cdst->composition_index = comp_idx;
+  *filter_idx = probe_filter_idx;
+  out->composition_count = comp_idx + 1;
   *out_main_id = complex_id;
   return true;
 }
@@ -1450,7 +1472,7 @@ static bool FillColorClasses(const GuiState& state, const std::map<int, int>& cr
   // `out`. Allocate on the caller's behalf via LUMICE_ConfigCreateColorClasses (implicit
   // allocation contract — the caller of FillLumiceConfig cannot know n_classes in
   // advance). Caller MUST release via LUMICE_ConfigReleaseColorClasses (see
-  // lumice::ConfigColorGuard in lumice_config_scope.hpp).
+  // lumice::ConfigOwningGuard in lumice_config_scope.hpp).
   LUMICE_ColorClass* dst_array = nullptr;
   if (n_classes > 0) {
     dst_array = LUMICE_ConfigCreateColorClasses(out, n_classes);
@@ -1493,6 +1515,9 @@ bool FillLumiceConfig(const GuiState& state, LUMICE_Config* out, FilterOverflowI
   // calls, memset would clobber the pointer without freeing it — release first so the
   // memset that follows sees a defensibly-null field. Release is null-safe / idempotent.
   LUMICE_ConfigReleaseColorClasses(out);
+  // v4.9 (task-host-abi-cpu-caps): compositions[i].term_ids/term_counts are also owning
+  // heap pointers — same memset-would-leak hazard as raypath_color; release first.
+  LUMICE_ConfigReleaseCompositions(out);
   std::memset(out, 0, sizeof(LUMICE_Config));
 
   // ID-pool model: walk entries, dedupe by pool id, emit one C crystal per reachable pool

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1309,7 +1309,7 @@ static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMI
   std::vector<int> term_ids_vec;
   term_counts_vec.reserve(static_cast<size_t>(clause_n));
   term_ids_vec.reserve(static_cast<size_t>(total_terms));
-  int probe_filter_idx = *filter_idx;
+  int pending_filter_idx = *filter_idx;
   int running = 0;
   for (size_t cl = 0; cl < ef.clauses.size(); ++cl) {
     const auto& clause = ef.clauses[cl];
@@ -1329,14 +1329,14 @@ static bool ExpandFilterToStruct(const FilterConfig& f, int next_filter_id, LUMI
     const auto& clause = ef.clauses[cl];
     for (size_t tt = 0; tt < clause.size(); ++tt) {
       int cid = next_filter_id + emit_running++;
-      fill_term(&out->filters[probe_filter_idx++], cid, clause[tt]);
+      fill_term(&out->filters[pending_filter_idx++], cid, clause[tt]);
     }
   }
   int complex_id = next_filter_id + emit_running;  // == next_filter_id + total_terms
-  LUMICE_FilterParam* cdst = &out->filters[probe_filter_idx++];
+  LUMICE_FilterParam* cdst = &out->filters[pending_filter_idx++];
   set_common(cdst, complex_id, LUMICE_FILTER_TYPE_COMPLEX);
   cdst->composition_index = comp_idx;
-  *filter_idx = probe_filter_idx;
+  *filter_idx = pending_filter_idx;
   out->composition_count = comp_idx + 1;
   *out_main_id = complex_id;
   return true;

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -11,6 +11,7 @@ namespace lumice::gui {
 
 struct GuiState;
 struct PreviewViewport;
+struct FilterConfig;
 class PreviewRenderer;
 
 // Identifies which filter reference triggered an ABI-bounds overflow inside FillLumiceConfig.
@@ -75,6 +76,18 @@ std::string SerializeCoreConfig(const GuiState& state);
 // returns false and fills *out_warning (with a FormatOverflowLocator-bearing message) on
 // overflow, leaving *out_json untouched. Either out-param may be null.
 bool BuildExportJsonOrWarn(const GuiState& state, std::string* out_json, std::string* out_warning);
+
+// task-gui-feedback-affordances Step 3 (AC4): summary of how many post-Cartesian
+// clauses a SoP would expand to and whether the ABI clause/term cap was hit.
+// Delegates to the same ExpandSopToClauses used by SerializeFilterForCore and
+// FillLumiceConfig, so the live preview cannot drift from the commit path
+// (issue.md hard constraint — no re-implementation on the GUI side). Meant
+// only for cheap on-typing preview: value bounded by LUMICE_MAX_CONFIG_CLAUSES.
+struct SopExpansionSummary {
+  size_t clause_count = 0;  // 1..LUMICE_MAX_CONFIG_CLAUSES; degenerate default is 1
+  bool overflow = false;    // true iff the expansion tripped the clause/term cap
+};
+SopExpansionSummary SummarizeSopExpansion(const FilterConfig& f);
 
 // Deserialize Core JSON string to GuiState, returns true on success
 bool DeserializeFromJson(const std::string& json_str, GuiState& state);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -303,7 +303,7 @@ int main(int argc, char** argv) {
             // test/gui/responsiveness/test_gui_perf.cpp (slider_drag scenario) copy this
             // same throttle+accounting block. Any change here MUST be mirrored there — the
             // gated-vs-committed distinction affects restart counting and rays accounting.
-            bool committed = gui::DoRun();
+            bool committed = gui::DoRun(/*user_initiated=*/false);
             if (committed) {
               gui::g_state.dirty = false;
             }

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -598,12 +598,25 @@ void LUMICE_ConfigReleaseColorClasses(LUMICE_Config* cfg);
 // triple. This is the ONLY supported writer for the composition storage — direct field writes
 // (previously legal against the old inline `clauses[16][8]`) are no longer defined.
 //
+// Unlike LUMICE_ConfigCreateColorClasses's two-phase allocate-then-fill-in-place pattern, this
+// API is a one-shot value write (Set): every production caller already holds the complete
+// (clause_count, term_counts, term_ids) triple on the stack before calling, so there is no
+// caller-visible "allocated but not yet populated" intermediate state to expose. Reach for this
+// same shape (Set over Create) for a future owning field only if callers likewise assemble the
+// full value before writing it in.
+//
 // Semantics:
 //   - `comp == nullptr` → returns LUMICE_ERR_NULL_ARG.
-//   - `clause_count < 0` → returns LUMICE_ERR_INVALID_CONFIG, `comp` left untouched.
-//   - `clause_count > 0 && (term_counts == nullptr || term_ids == nullptr)` → LUMICE_ERR_NULL_ARG.
-//   - Any `term_counts[i] < 0` → LUMICE_ERR_INVALID_CONFIG (full clause-count validation runs
-//     before any allocation; `comp` untouched on rejection).
+//   - `clause_count < 0` or `clause_count > LUMICE_MAX_CONFIG_CLAUSES` → returns
+//     LUMICE_ERR_INVALID_CONFIG, `comp` left untouched.
+//   - `clause_count > 0 && term_counts == nullptr` → LUMICE_ERR_NULL_ARG.
+//   - Any `term_counts[i] < 0` or `term_counts[i] > LUMICE_MAX_CONFIG_TERMS` →
+//     LUMICE_ERR_INVALID_CONFIG (full clause-count validation runs before any allocation;
+//     `comp` untouched on rejection).
+//   - `term_ids == nullptr` is only rejected (LUMICE_ERR_NULL_ARG) once `sum(term_counts[0..
+//     clause_count))` (total term count) is computed and found > 0 — i.e. `term_ids` may
+//     legitimately be null when every clause has 0 terms; see LUMICE_CompositionClauseTerms's
+//     doc comment for the resulting storage state.
 //   - `clause_count == 0` → release any existing allocation and land in the "OR of nothing"
 //     state (term_ids/term_counts nullptr, clause_count 0). term_counts/term_ids inputs
 //     are ignored in this branch.

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -178,10 +178,15 @@ LUMICE_ErrorCode LUMICE_CommitConfigFromFile(LUMICE_Server* server, const char* 
 // Discrete-spectrum entry cap. Mirrors core wl_pool.hpp::kWlPoolSizeMax (255).
 #define LUMICE_MAX_CONFIG_SPECTRUM_ENTRIES 255
 // Complex (sum-of-products) filter composition bounds. See LUMICE_ComplexComposition.
-// These are ABI ceilings baked into the struct layout; widen (breaking bump) if needed.
-#define LUMICE_MAX_CONFIG_COMPLEX 32  // max complex-filter composition records per config
-#define LUMICE_MAX_CONFIG_CLAUSES 16  // max OR clauses per complex filter
-#define LUMICE_MAX_CONFIG_TERMS 8     // max AND terms per clause
+// LUMICE_MAX_CONFIG_COMPLEX remains an ABI ceiling baked into the LUMICE_Config layout
+// (bounds the inline compositions[] array). LUMICE_MAX_CONFIG_CLAUSES / _TERMS are no
+// longer inline-array dimensions (v4.9, task-host-abi-cpu-caps): clause/term storage is
+// heap-allocated via LUMICE_CompositionSetClauses, and these two constants are pure
+// sanity ceilings that cap a single filter's OR/AND fan-out (defensive DoS bound against
+// malformed .lmc/JSON input). Widen (breaking bump) if needed.
+#define LUMICE_MAX_CONFIG_COMPLEX 32    // max complex-filter composition records per config
+#define LUMICE_MAX_CONFIG_CLAUSES 4096  // sanity ceiling: max OR clauses per complex filter
+#define LUMICE_MAX_CONFIG_TERMS 64      // sanity ceiling: max AND terms per clause
 // Raypath color-class (Design 2, task-342.2) ABI bounds. Same "widen (breaking bump)" rule as
 // LUMICE_MAX_CONFIG_COMPLEX / _CLAUSES / _TERMS. LUMICE_MAX_CONFIG_COLOR_CLASSES upper-aligns
 // with core ComponentTable::kMaxBits (64), the deduped predicate-atom budget of a scene.
@@ -289,15 +294,36 @@ typedef struct LUMICE_FilterParam_ {
 
 // Sum-of-products composition for a complex filter, referenced by
 // LUMICE_FilterParam.composition_index. The outer level is an OR over clauses; each clause
-// is an AND over its terms; each term (clauses[c][t]) is the ID of a SIMPLE filter in the
-// same config's filters[] pool (referenced by id — reorder-robust — not by array index;
-// a term may never reference another complex filter, matching core config semantics).
+// is an AND over its terms; each term is the ID of a SIMPLE filter in the same config's
+// filters[] pool (referenced by id — reorder-robust — not by array index; a term may never
+// reference another complex filter, matching core config semantics).
 // INVARIANT: compositions[] is rebuilt wholesale together with its host LUMICE_Config;
 // records are not individually reordered (composition_index is a pool index valid only
 // within one config snapshot). Consumers (e.g. GUI) must respect this whole-rebuild model.
+//
+// BREAKING (v4.9, task-host-abi-cpu-caps): storage layout changed from inline
+// `clauses[16][8]` / `term_counts[16]` to a pair of owned heap pointers with a
+// clause-major flat encoding. Rationale: at 16×8 inline the ceiling was too low for
+// real "OR of several hundred raypaths" use cases; naively widening the inline array
+// (e.g. to 4096×64) would push LUMICE_Config well past its 160 KB stack budget and
+// re-run the raypath_color[64] stack-overflow that task-344 already fixed on the
+// color path. Callers now populate one record via LUMICE_CompositionSetClauses and
+// must release via LUMICE_CompositionReleaseClauses (or via LUMICE_ConfigReleaseCompositions
+// / the C++ RAII guard lumice::ConfigOwningGuard). Do NOT copy this struct by value —
+// term_ids/term_counts are owning pointers; aliasing copies would double-free on double
+// Release (enforced by scripts/check_policies.py's `no-config-by-value-copy` gate).
+//
+// Fields:
+//   term_ids     — owned; flat array of simple-filter IDs, clause-major
+//                  (clause 0's terms, then clause 1's terms, …). Length = sum(term_counts[0..clause_count)).
+//   term_counts  — owned; term_counts[c] is the AND-term count of clause c. Length = clause_count.
+//   clause_count — number of OR clauses in this composition. 0 is a valid "OR of nothing" state
+//                  (both pointers nullptr); >0 requires both pointers non-null.
+//
+// Use LUMICE_CompositionClauseTerms to iterate a specific clause without recomputing the offset.
 typedef struct LUMICE_ComplexComposition_ {
-  int clauses[LUMICE_MAX_CONFIG_CLAUSES][LUMICE_MAX_CONFIG_TERMS];  // simple-filter IDs
-  int term_counts[LUMICE_MAX_CONFIG_CLAUSES];                       // number of terms in each clause
+  int* term_ids;     // owned; flat AND-term simple-filter IDs, clause-major (see block comment)
+  int* term_counts;  // owned; term_counts[c] = clause c's AND-term count; length == clause_count
   int clause_count;
 } LUMICE_ComplexComposition;
 
@@ -439,13 +465,23 @@ typedef struct LUMICE_RenderParam_ {
 // ~354 KB and pushed `LUMICE_Config` to 467 KB, which overflowed the ImGui test engine's
 // ~512 KB thread stack when two configs coexisted in one function. Callers now allocate via
 // `LUMICE_ConfigCreateColorClasses` and must release via `LUMICE_ConfigReleaseColorClasses`
-// (or via a C++ RAII guard such as `lumice::ConfigColorGuard`; see
+// (or via a C++ RAII guard such as `lumice::ConfigOwningGuard`; see
 // `src/include/lumice_config_scope.hpp`). Layout changed; callers must recompile.
+// BREAKING (v4.9, task-host-abi-cpu-caps): LUMICE_ComplexComposition's clause/term storage
+// moved off the inline layout onto a pair of owning heap pointers (term_ids / term_counts).
+// The outer `compositions[LUMICE_MAX_CONFIG_COMPLEX]` inline array is retained; only the
+// intra-record clause/term storage was heap-ified — which SHRINKS sizeof(LUMICE_Config)
+// (each record drops from ~580 B inline to ~24 B ptr+count). Callers populate a record via
+// LUMICE_CompositionSetClauses and release per-record via LUMICE_CompositionReleaseClauses
+// or config-wide via LUMICE_ConfigReleaseCompositions; the C++ RAII guard
+// `lumice::ConfigOwningGuard` releases both raypath_color AND compositions in one shot.
 //
 // Do not copy this struct by value (assignment, by-value parameter, or storing it in a
-// container) — `raypath_color` is an owning heap pointer; copies alias the same allocation
-// and cause double-free on double Release. Pass `LUMICE_Config*` or `const LUMICE_Config&`
-// instead. See LUMICE_ConfigCreateColorClasses / LUMICE_ConfigReleaseColorClasses.
+// container) — `raypath_color` AND each `compositions[i].term_ids/term_counts` are owning
+// heap pointers; copies alias the same allocations and cause double-free on double Release.
+// Pass `LUMICE_Config*` or `const LUMICE_Config&` instead. See
+// LUMICE_ConfigCreateColorClasses / LUMICE_ConfigReleaseColorClasses,
+// LUMICE_CompositionSetClauses / LUMICE_ConfigReleaseCompositions.
 typedef struct LUMICE_Config_ {
   // Crystals
   LUMICE_CrystalParam crystals[LUMICE_MAX_CONFIG_CRYSTALS];
@@ -507,6 +543,11 @@ typedef struct LUMICE_Config_ {
 // the inline layout onto the heap. Measured sizeof(LUMICE_Config) drops from 467 KB to
 // ~113 KB (plan §3 point 5); the 160 KB ceiling keeps ~40 % headroom for future fields
 // while still catching accidental re-inlining or unbounded array additions early.
+// v4.9 (task-host-abi-cpu-caps): LUMICE_ComplexComposition's inline `clauses[16][8]` /
+// `term_counts[16]` (~580 B/record × 32 records ≈ 18.6 KB) moved off inline onto per-record
+// heap pointers (24 B/record × 32 records = 768 B); measured sizeof(LUMICE_Config) drops from
+// ~113 KB to ~96 KB (~98 280 B on this platform), so the 160 KB ceiling still holds with even
+// more headroom than pre-v4.9.
 #if defined(__cplusplus)
 static_assert(sizeof(LUMICE_Config) <= 160u * 1024u,
               "LUMICE_Config exceeded its 160 KB ABI ceiling — either shrink a field or bump the ceiling deliberately");
@@ -541,8 +582,8 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
 // Ownership contract: whether the caller invokes Create directly OR indirectly triggers
 // allocation via LUMICE_ParseConfigString / LUMICE_ParseConfigFile (both allocate
 // implicitly based on the parsed JSON), the caller MUST call Release once done with
-// `cfg`. In C++ code, prefer the `lumice::ConfigColorGuard` RAII wrapper in
-// `src/include/lumice_config_scope.hpp`.
+// `cfg`. In C++ code, prefer the `lumice::ConfigOwningGuard` RAII wrapper in
+// `src/include/lumice_config_scope.hpp` (also releases compositions).
 LUMICE_ColorClass* LUMICE_ConfigCreateColorClasses(LUMICE_Config* cfg, int count);
 
 // Release the raypath_color allocation owned by `cfg`, if any. Idempotent and null-safe:
@@ -551,6 +592,63 @@ LUMICE_ColorClass* LUMICE_ConfigCreateColorClasses(LUMICE_Config* cfg, int count
 //   - Otherwise → free(cfg->raypath_color), then nullptr / count=0.
 // Safe to call multiple times; safe to call on a freshly zero-initialized LUMICE_Config.
 void LUMICE_ConfigReleaseColorClasses(LUMICE_Config* cfg);
+
+// =============== Complex-Composition storage lifecycle (task-host-abi-cpu-caps, BREAKING v4.9) ===============
+// Populate `comp` in one shot from an application-owned (clause_count, term_counts[], term_ids[])
+// triple. This is the ONLY supported writer for the composition storage — direct field writes
+// (previously legal against the old inline `clauses[16][8]`) are no longer defined.
+//
+// Semantics:
+//   - `comp == nullptr` → returns LUMICE_ERR_NULL_ARG.
+//   - `clause_count < 0` → returns LUMICE_ERR_INVALID_CONFIG, `comp` left untouched.
+//   - `clause_count > 0 && (term_counts == nullptr || term_ids == nullptr)` → LUMICE_ERR_NULL_ARG.
+//   - Any `term_counts[i] < 0` → LUMICE_ERR_INVALID_CONFIG (full clause-count validation runs
+//     before any allocation; `comp` untouched on rejection).
+//   - `clause_count == 0` → release any existing allocation and land in the "OR of nothing"
+//     state (term_ids/term_counts nullptr, clause_count 0). term_counts/term_ids inputs
+//     are ignored in this branch.
+//   - `clause_count > 0` → this call is CREATE-OR-REPLACE: if `comp` already held a prior
+//     allocation, it is released before the new one is allocated. On OOM, `comp` falls back
+//     to the "OR of nothing" state (fully-cleared, safe to Release again) and the function
+//     returns LUMICE_ERR_INVALID_CONFIG — mirrors LUMICE_ConfigCreateColorClasses's OOM policy.
+//   - `term_ids` must be a clause-major flat array of length `sum(term_counts[0..clause_count))`.
+//     Elements are simple-filter IDs; reference-integrity checks (each id resolves to an
+//     existing SIMPLE filter in the enclosing LUMICE_Config) are the CALLER's responsibility
+//     (the c_api / GUI writers already run this pre-check; see LUMICE_CommitConfigStruct).
+//   - Allocator is calloc/free; callers must eventually release via
+//     LUMICE_CompositionReleaseClauses (or its config-wide sibling / RAII guard).
+LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, int clause_count, const int* term_counts,
+                                              const int* term_ids);
+
+// Release the term_ids / term_counts allocations owned by `comp`, if any. Idempotent and null-safe:
+//   - `comp == nullptr` → no-op.
+//   - Otherwise → free both pointers (either may already be null), then leave `comp` in the
+//     "OR of nothing" state (both nullptr, clause_count=0).
+void LUMICE_CompositionReleaseClauses(LUMICE_ComplexComposition* comp);
+
+// Release the composition storage owned by every record in `cfg->compositions[0..composition_count)`.
+// Does NOT touch `composition_count` or the inline compositions[] array itself — those remain
+// part of the LUMICE_Config's own layout. Idempotent and null-safe:
+//   - `cfg == nullptr` → no-op.
+//   - Otherwise → iterates and calls LUMICE_CompositionReleaseClauses on each record.
+// Callers who reuse a `LUMICE_Config` across successive Parse / Fill invocations must call
+// this before the memset that clears the struct (otherwise the record pointers leak); the
+// C++ RAII guard `lumice::ConfigOwningGuard` calls it on scope exit alongside
+// LUMICE_ConfigReleaseColorClasses.
+void LUMICE_ConfigReleaseCompositions(LUMICE_Config* cfg);
+
+// Read-only convenience accessor: return a pointer to clause `clause_index`'s first AND-term
+// inside `comp->term_ids` (i.e. the address of `term_ids[prefix_sum(term_counts[0..clause_index))]`)
+// and write `term_counts[clause_index]` into `*out_term_count`. Encapsulates the prefix-sum
+// offset math so callers (ConfigToJson emit, tests, GUI diagnostics) don't recompute it.
+//
+// Semantics:
+//   - `comp == nullptr`                                       → returns nullptr, `*out_term_count` untouched.
+//   - `clause_index < 0` or `clause_index >= comp->clause_count` → returns nullptr, `*out_term_count`
+//                                                                 set to 0 if non-null.
+//   - Otherwise → returns the term-pointer and (if non-null) writes the per-clause term count.
+//     A 0-term clause returns a valid pointer to the (empty) slice and out_term_count = 0.
+const int* LUMICE_CompositionClauseTerms(const LUMICE_ComplexComposition* comp, int clause_index, int* out_term_count);
 
 // =============== Raypath Color Display-Time Setter (task-342.2) ===============
 // Display-time appearance of one color class (mutable without re-simulation): the RGB

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -91,7 +91,8 @@ typedef struct LUMICE_SimLifecycleResult_ {
 // (kColorMaxGroupsPerSlot=4) fires asynchronously on the worker thread's
 // first batch, so surfacing it requires poll infrastructure not yet wired.
 // Currently always 0; the field is kept in the ABI struct so future clients
-// do not need to re-widen it later.
+// do not need to re-widen it later. Tracked in backlog.md: "[GUI / 染色]
+// symmetry_group_overflow 的 GUI surfacing（poll infrastructure 待建）".
 typedef struct LUMICE_ColorOverflowInfo_ {
   int component_overflow_count;
   int symmetry_group_overflow_count;

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -643,11 +643,17 @@ void LUMICE_ConfigReleaseCompositions(LUMICE_Config* cfg);
 // offset math so callers (ConfigToJson emit, tests, GUI diagnostics) don't recompute it.
 //
 // Semantics:
-//   - `comp == nullptr`                                       → returns nullptr, `*out_term_count` untouched.
+//   - `comp == nullptr`                                       → returns nullptr, `*out_term_count`
+//                                                                 set to 0 if non-null.
 //   - `clause_index < 0` or `clause_index >= comp->clause_count` → returns nullptr, `*out_term_count`
 //                                                                 set to 0 if non-null.
-//   - Otherwise → returns the term-pointer and (if non-null) writes the per-clause term count.
-//     A 0-term clause returns a valid pointer to the (empty) slice and out_term_count = 0.
+//   - Otherwise → `*out_term_count` (if non-null) is always set to `term_counts[clause_index]`.
+//     The returned pointer is nullptr whenever `comp->term_ids` itself is null — which is the
+//     legitimate state when every clause in the composition has 0 terms (LUMICE_CompositionSetClauses
+//     skips that allocation entirely in that case); this applies even to a 0-term clause, so callers
+//     must not unconditionally dereference a non-null out_term_count as "safe to iterate".
+//     When `comp->term_ids` is non-null, the returned pointer (including for a 0-term clause) is a
+//     valid address into that buffer for the (possibly empty) slice.
 const int* LUMICE_CompositionClauseTerms(const LUMICE_ComplexComposition* comp, int clause_index, int* out_term_count);
 
 // =============== Raypath Color Display-Time Setter (task-342.2) ===============

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -78,6 +78,25 @@ typedef struct LUMICE_SimLifecycleResult_ {
   unsigned long long epoch;
 } LUMICE_SimLifecycleResult;
 
+// task-gui-feedback-affordances Step 7 (AC1): summary of how many color-
+// classification predicates / symmetry groups the CORE dropped during the
+// most recent commit. Used by the GUI DoRun path to surface a modal warning
+// that coloring will be truncated (the filter / geometry / raypath tracing
+// path is UNAFFECTED — only color assignment degrades).
+//
+// component_overflow_count is set SYNCHRONOUSLY inside CommitConfig (predicates
+// past the 64-bit ComponentTable budget were assigned kNoBit).
+// symmetry_group_overflow_count is RESERVED for a follow-up task — the CPU/
+// Metal/CUDA `EnsureFilterBuffers` per-slot symmetry-group cap
+// (kColorMaxGroupsPerSlot=4) fires asynchronously on the worker thread's
+// first batch, so surfacing it requires poll infrastructure not yet wired.
+// Currently always 0; the field is kept in the ABI struct so future clients
+// do not need to re-widen it later.
+typedef struct LUMICE_ColorOverflowInfo_ {
+  int component_overflow_count;
+  int symmetry_group_overflow_count;
+} LUMICE_ColorOverflowInfo;
+
 // =============== Ray Count Type ===============
 // 64-bit count type for ray / ray-segment / crystal totals. Must stay >= 64-bit:
 // `unsigned long` is only 32-bit on Windows (LLP64), which silently truncated
@@ -869,6 +888,14 @@ LUMICE_ErrorCode LUMICE_QueryServerState(LUMICE_Server* server, LUMICE_ServerSta
 // LUMICE_QueryServerState is a projection of this. After a synchronous commit,
 // call this to read back the just-minted epoch (no commit-signature change).
 LUMICE_ErrorCode LUMICE_GetSimLifecycle(LUMICE_Server* server, LUMICE_SimLifecycleResult* out);
+
+// task-gui-feedback-affordances Step 7 (AC1): synchronous readback of the
+// most recent commit's color-classification overflow counters (see the
+// LUMICE_ColorOverflowInfo doc block above). The GUI DoRun path calls this
+// after CommitConfigStruct returns OK; a non-zero component_overflow_count
+// triggers a modal "coloring degraded" prompt. LUMICE_OK on success;
+// LUMICE_ERR_NULL_ARG if server or out is null.
+LUMICE_ErrorCode LUMICE_GetColorOverflowInfo(LUMICE_Server* server, LUMICE_ColorOverflowInfo* out);
 
 void LUMICE_StopServer(LUMICE_Server* server);
 

--- a/src/include/lumice_config_scope.hpp
+++ b/src/include/lumice_config_scope.hpp
@@ -1,14 +1,22 @@
 // C++ RAII helpers for LUMICE_Config lifetime management. Header-only; sits next to
 // lumice.h and only calls the public C API. GUI / tests should include this instead of
-// hand-writing LUMICE_ConfigReleaseColorClasses cleanup on every early return.
+// hand-writing per-owning-field cleanup on every early return.
 //
 // Design (task-344, BREAKING v4.8): `LUMICE_Config::raypath_color` is a heap-allocated
 // LUMICE_ColorClass* owned by the struct. Anything that populates the array
 // (LUMICE_ConfigCreateColorClasses, LUMICE_ParseConfigString / _File, GUI's
 // FillLumiceConfig) leaves the caller holding a config that must Release before scope
 // exit — otherwise the allocation leaks. ImGui-style IM_CHECK / gtest EXPECT_EQ /
-// early-return code paths make manual cleanup easy to skip; ConfigColorGuard makes it
+// early-return code paths make manual cleanup easy to skip; the guard makes it
 // automatic.
+//
+// Extended (task-host-abi-cpu-caps, BREAKING v4.9): every
+// `LUMICE_Config::compositions[i]` record now owns two heap pointers (term_ids /
+// term_counts) via LUMICE_CompositionSetClauses; the guard also invokes
+// LUMICE_ConfigReleaseCompositions on scope exit so callers don't need a second guard.
+// The class was renamed `ConfigColorGuard` → `ConfigOwningGuard` to make the extended
+// responsibility explicit (a "Color"-scoped name would be misleading for the
+// composition release).
 
 #ifndef LUMICE_LUMICE_CONFIG_SCOPE_HPP_
 #define LUMICE_LUMICE_CONFIG_SCOPE_HPP_
@@ -17,27 +25,32 @@
 
 namespace lumice {
 
-// Non-owning of the LUMICE_Config struct itself; owns only the lifetime of its
-// raypath_color allocation. Attach it to a stack-local config immediately after
-// declaration, BEFORE any call that may populate raypath_color[]:
+// Non-owning of the LUMICE_Config struct itself; owns only the lifetime of its heap-
+// backed owning fields (raypath_color allocation + each compositions[i].term_ids /
+// term_counts allocation). Attach it to a stack-local config immediately after
+// declaration, BEFORE any call that may populate those fields:
 //
 //     LUMICE_Config cfg{};
-//     lumice::ConfigColorGuard color_guard(cfg);
-//     LUMICE_ParseConfigString(json_str, &cfg);   // may allocate raypath_color
+//     lumice::ConfigOwningGuard cfg_guard(cfg);
+//     LUMICE_ParseConfigString(json_str, &cfg);   // may allocate raypath_color and compositions
 //     // ... use cfg ...
-//     // color_guard destructor calls LUMICE_ConfigReleaseColorClasses on scope exit,
-//     // regardless of IM_CHECK / EXPECT_EQ / exception early return.
+//     // cfg_guard destructor calls LUMICE_ConfigReleaseColorClasses AND
+//     // LUMICE_ConfigReleaseCompositions on scope exit, regardless of IM_CHECK /
+//     // EXPECT_EQ / exception early return.
 //
 // Non-copyable and non-movable to avoid two guards ever pointing at the same config
-// (which would double-Release).
-class ConfigColorGuard {
+// (which would double-Release both owning fields).
+class ConfigOwningGuard {
  public:
-  explicit ConfigColorGuard(LUMICE_Config& cfg) noexcept : cfg_(&cfg) {}
-  ~ConfigColorGuard() { LUMICE_ConfigReleaseColorClasses(cfg_); }
-  ConfigColorGuard(const ConfigColorGuard&) = delete;
-  ConfigColorGuard& operator=(const ConfigColorGuard&) = delete;
-  ConfigColorGuard(ConfigColorGuard&&) = delete;
-  ConfigColorGuard& operator=(ConfigColorGuard&&) = delete;
+  explicit ConfigOwningGuard(LUMICE_Config& cfg) noexcept : cfg_(&cfg) {}
+  ~ConfigOwningGuard() {
+    LUMICE_ConfigReleaseColorClasses(cfg_);
+    LUMICE_ConfigReleaseCompositions(cfg_);
+  }
+  ConfigOwningGuard(const ConfigOwningGuard&) = delete;
+  ConfigOwningGuard& operator=(const ConfigOwningGuard&) = delete;
+  ConfigOwningGuard(ConfigOwningGuard&&) = delete;
+  ConfigOwningGuard& operator=(ConfigOwningGuard&&) = delete;
 
  private:
   LUMICE_Config* cfg_;

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -709,7 +709,7 @@ LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, i
   if (!comp) {
     return LUMICE_ERR_NULL_ARG;
   }
-  if (clause_count < 0) {
+  if (clause_count < 0 || clause_count > LUMICE_MAX_CONFIG_CLAUSES) {
     return LUMICE_ERR_INVALID_CONFIG;
   }
   if (clause_count > 0 && (term_counts == nullptr || term_ids == nullptr)) {
@@ -717,9 +717,12 @@ LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, i
   }
   // Full validation BEFORE any allocation so an invalid input leaves `comp` untouched
   // (mirrors the "no partial writes on rejection" contract other Set-style API here follow).
+  // Upper bounds are enforced here (not just by callers) because this is documented as
+  // the ONLY supported writer, including non-C++ bindings that cannot be trusted to
+  // pre-check LUMICE_MAX_CONFIG_CLAUSES/_TERMS themselves (code-review round 1, Major).
   size_t total_terms = 0;
   for (int cl = 0; cl < clause_count; cl++) {
-    if (term_counts[cl] < 0) {
+    if (term_counts[cl] < 0 || term_counts[cl] > LUMICE_MAX_CONFIG_TERMS) {
       return LUMICE_ERR_INVALID_CONFIG;
     }
     total_terms += static_cast<size_t>(term_counts[cl]);
@@ -861,13 +864,24 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
     if (comp.clause_count < 0 || comp.clause_count > LUMICE_MAX_CONFIG_CLAUSES) {
       return LUMICE_ERR_INVALID_CONFIG;
     }
-    if (comp.clause_count > 0 && (comp.term_ids == nullptr || comp.term_counts == nullptr)) {
+    // term_counts is always required once clause_count > 0 (LUMICE_CompositionSetClauses
+    // always allocates it in that case). term_ids, however, legitimately stays nullptr
+    // when every clause has 0 terms (total_terms == 0) — SetClauses skips that allocation
+    // on purpose. Conflating the two here would reject a state SetClauses itself produces
+    // (code-review round 1, Major; e.g. JSON `"composition": [[]]` round-tripped through
+    // Parse then CommitConfigStruct).
+    if (comp.clause_count > 0 && comp.term_counts == nullptr) {
       return LUMICE_ERR_INVALID_CONFIG;
     }
+    size_t comp_total_terms = 0;
     for (int cl = 0; cl < comp.clause_count; cl++) {
       if (comp.term_counts[cl] < 0 || comp.term_counts[cl] > LUMICE_MAX_CONFIG_TERMS) {
         return LUMICE_ERR_INVALID_CONFIG;
       }
+      comp_total_terms += static_cast<size_t>(comp.term_counts[cl]);
+    }
+    if (comp_total_terms > 0 && comp.term_ids == nullptr) {
+      return LUMICE_ERR_INVALID_CONFIG;
     }
   }
 

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -1864,6 +1864,21 @@ LUMICE_ErrorCode LUMICE_GetSimLifecycle(LUMICE_Server* server, LUMICE_SimLifecyc
 }
 
 
+// task-gui-feedback-affordances Step 7 (AC1): synchronous readback of the
+// component-bit overflow counter written inside CommitConfig.
+// symmetry_group_overflow_count is reserved (currently always 0) — the async
+// polling path is scheduled for a follow-up task (see progress.md Step 4
+// DECISION 2026-07-15 23:00).
+LUMICE_ErrorCode LUMICE_GetColorOverflowInfo(LUMICE_Server* server, LUMICE_ColorOverflowInfo* out) {
+  if (!server || !out) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  out->component_overflow_count = static_cast<int>(server->server_->GetLastColorComponentOverflowCount());
+  out->symmetry_group_overflow_count = 0;  // reserved — see follow-up backlog
+  return LUMICE_OK;
+}
+
+
 void LUMICE_StopServer(LUMICE_Server* server) {
   if (!server) {
     return;

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -400,12 +400,14 @@ nlohmann::json ConfigToJson(const LUMICE_Config& c) {
         json composition = json::array();
         for (int cl = 0; cl < comp.clause_count; cl++) {
           // Mirror core to_json: a 1-term clause emits a bare id; a multi-term clause an array.
-          if (comp.term_counts[cl] == 1) {
-            composition.push_back(comp.clauses[cl][0]);
+          int term_n = 0;
+          const int* terms_p = LUMICE_CompositionClauseTerms(&comp, cl, &term_n);
+          if (term_n == 1 && terms_p != nullptr) {
+            composition.push_back(terms_p[0]);
           } else {
             json terms = json::array();
-            for (int t = 0; t < comp.term_counts[cl]; t++) {
-              terms.push_back(comp.clauses[cl][t]);
+            for (int t = 0; t < term_n; t++) {
+              terms.push_back(terms_p[t]);
             }
             composition.push_back(terms);
           }
@@ -696,6 +698,133 @@ void LUMICE_ConfigReleaseColorClasses(LUMICE_Config* cfg) {
 }
 
 
+// =============== Complex-Composition storage lifecycle (task-host-abi-cpu-caps, BREAKING v4.9) ===============
+// Same C-ABI-boundary rationale for calloc/free as LUMICE_ConfigCreateColorClasses above:
+// LUMICE_Config crosses the C ABI, and non-C++ bindings must be able to release the
+// composition storage without a C++ runtime — a documented exception to the "no raw
+// new/delete" project rule (AGENTS.md).
+
+LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, int clause_count, const int* term_counts,
+                                              const int* term_ids) {
+  if (!comp) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  if (clause_count < 0) {
+    return LUMICE_ERR_INVALID_CONFIG;
+  }
+  if (clause_count > 0 && (term_counts == nullptr || term_ids == nullptr)) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  // Full validation BEFORE any allocation so an invalid input leaves `comp` untouched
+  // (mirrors the "no partial writes on rejection" contract other Set-style API here follow).
+  size_t total_terms = 0;
+  for (int cl = 0; cl < clause_count; cl++) {
+    if (term_counts[cl] < 0) {
+      return LUMICE_ERR_INVALID_CONFIG;
+    }
+    total_terms += static_cast<size_t>(term_counts[cl]);
+  }
+
+  // Create-or-replace: release any prior allocation before overwriting the pointers,
+  // guarding "consecutive Set with different clause_count" from leaking the previous
+  // allocation. Pairs with the memset-before-Release fix in JsonToConfig / FillLumiceConfig.
+  LUMICE_CompositionReleaseClauses(comp);
+
+  if (clause_count == 0) {
+    // "OR of nothing" state — no allocation, both pointers stay nullptr.
+    return LUMICE_OK;
+  }
+
+  auto* counts_buf =
+      static_cast<int*>(std::calloc(  // NOLINT(cppcoreguidelines-no-malloc): C ABI boundary; see block comment above.
+          static_cast<size_t>(clause_count), sizeof(int)));
+  if (!counts_buf) {
+    // OOM: fall back to "OR of nothing" (already released above); mirror ColorClasses OOM policy.
+    return LUMICE_ERR_INVALID_CONFIG;
+  }
+  int* ids_buf = nullptr;
+  if (total_terms > 0) {
+    ids_buf =
+        static_cast<int*>(std::calloc(  // NOLINT(cppcoreguidelines-no-malloc): C ABI boundary; see block comment above.
+            total_terms, sizeof(int)));
+    if (!ids_buf) {
+      std::free(counts_buf);  // NOLINT(cppcoreguidelines-no-malloc): C ABI boundary.
+      return LUMICE_ERR_INVALID_CONFIG;
+    }
+  }
+  // Both allocations succeeded — commit.
+  for (int cl = 0; cl < clause_count; cl++) {
+    counts_buf[cl] = term_counts[cl];
+  }
+  for (size_t i = 0; i < total_terms; i++) {
+    ids_buf[i] = term_ids[i];
+  }
+  comp->term_counts = counts_buf;
+  comp->term_ids = ids_buf;
+  comp->clause_count = clause_count;
+  return LUMICE_OK;
+}
+
+void LUMICE_CompositionReleaseClauses(LUMICE_ComplexComposition* comp) {
+  if (!comp) {
+    return;
+  }
+  if (comp->term_counts) {
+    std::free(comp->term_counts);  // NOLINT(cppcoreguidelines-no-malloc): C ABI boundary; see block comment above.
+    comp->term_counts = nullptr;
+  }
+  if (comp->term_ids) {
+    std::free(comp->term_ids);  // NOLINT(cppcoreguidelines-no-malloc): C ABI boundary; see block comment above.
+    comp->term_ids = nullptr;
+  }
+  comp->clause_count = 0;
+}
+
+void LUMICE_ConfigReleaseCompositions(LUMICE_Config* cfg) {
+  if (!cfg) {
+    return;
+  }
+  // Composition_count is a plain int written by callers; iterate up to whatever they set,
+  // but never past the ABI ceiling (defends against a garbage / uninitialized count value).
+  int n = cfg->composition_count;
+  if (n < 0) {
+    n = 0;
+  }
+  if (n > LUMICE_MAX_CONFIG_COMPLEX) {
+    n = LUMICE_MAX_CONFIG_COMPLEX;
+  }
+  for (int i = 0; i < n; i++) {
+    LUMICE_CompositionReleaseClauses(&cfg->compositions[i]);
+  }
+  // Leave composition_count alone — this Release only frees the intra-record heap storage;
+  // the inline compositions[] array itself is part of LUMICE_Config's own layout.
+}
+
+const int* LUMICE_CompositionClauseTerms(const LUMICE_ComplexComposition* comp, int clause_index, int* out_term_count) {
+  if (!comp) {
+    if (out_term_count) {
+      *out_term_count = 0;
+    }
+    return nullptr;
+  }
+  if (clause_index < 0 || clause_index >= comp->clause_count) {
+    if (out_term_count) {
+      *out_term_count = 0;
+    }
+    return nullptr;
+  }
+  // Prefix-sum offset into the flat term_ids buffer.
+  size_t offset = 0;
+  for (int cl = 0; cl < clause_index; cl++) {
+    offset += static_cast<size_t>(comp->term_counts[cl]);
+  }
+  if (out_term_count) {
+    *out_term_count = comp->term_counts[clause_index];
+  }
+  return (comp->term_ids != nullptr) ? (comp->term_ids + offset) : nullptr;
+}
+
+
 // Struct->JSON path: see doc/capi-lifecycle-architecture.md §6.2.
 LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_Config* config, int* out_reused) {
   if (!server || !config) {
@@ -718,6 +847,27 @@ LUMICE_ErrorCode LUMICE_CommitConfigStruct(LUMICE_Server* server, const LUMICE_C
     if (config->raypath_color[i].match_count < 0 ||
         config->raypath_color[i].match_count > LUMICE_MAX_CONFIG_COLOR_REFS) {
       return LUMICE_ERR_INVALID_CONFIG;
+    }
+  }
+  // v4.9 (task-host-abi-cpu-caps): compositions[i].term_ids/term_counts are heap pointers;
+  // mirror the raypath_color null-pointer defense above and enforce the ABI sanity
+  // ceilings (clause/term storage moved off inline layout, but the CLAUSES/TERMS constants
+  // are retained as DoS-guard caps against malformed input).
+  if (config->composition_count < 0 || config->composition_count > LUMICE_MAX_CONFIG_COMPLEX) {
+    return LUMICE_ERR_INVALID_CONFIG;
+  }
+  for (int i = 0; i < config->composition_count; i++) {
+    const auto& comp = config->compositions[i];
+    if (comp.clause_count < 0 || comp.clause_count > LUMICE_MAX_CONFIG_CLAUSES) {
+      return LUMICE_ERR_INVALID_CONFIG;
+    }
+    if (comp.clause_count > 0 && (comp.term_ids == nullptr || comp.term_counts == nullptr)) {
+      return LUMICE_ERR_INVALID_CONFIG;
+    }
+    for (int cl = 0; cl < comp.clause_count; cl++) {
+      if (comp.term_counts[cl] < 0 || comp.term_counts[cl] > LUMICE_MAX_CONFIG_TERMS) {
+        return LUMICE_ERR_INVALID_CONFIG;
+      }
     }
   }
 
@@ -1269,47 +1419,58 @@ static LUMICE_ErrorCode JsonToComplexComposition(const nlohmann::json& fj, LUMIC
     return LUMICE_ERR_MISSING_FIELD;
   }
   const auto& cmp = fj.at("composition");
-  // Bounds are checked before writing into the pool slot so a rejected input never leaves a
-  // clause_count inconsistent with the ABI ceiling. An empty composition ([]) is accepted as
-  // a degenerate "OR of nothing" (clause_count == 0), mirroring core (no non-empty requirement).
-  if (out->composition_count >= LUMICE_MAX_CONFIG_COMPLEX || static_cast<int>(cmp.size()) > LUMICE_MAX_CONFIG_CLAUSES) {
+  // v4.9 (task-host-abi-cpu-caps): build the full (term_counts, term_ids) triple on the
+  // stack first, then commit atomically via LUMICE_CompositionSetClauses AFTER all
+  // validation succeeds. This also removes the pre-v4.9 "composition_count++ before
+  // per-clause validation" partial-write hazard (§3.5 in the plan).
+  const int clause_count = static_cast<int>(cmp.size());
+  if (out->composition_count >= LUMICE_MAX_CONFIG_COMPLEX || clause_count > LUMICE_MAX_CONFIG_CLAUSES) {
     return LUMICE_ERR_INVALID_CONFIG;
   }
-  int comp_idx = out->composition_count++;
-  LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
-  comp->clause_count = static_cast<int>(cmp.size());
-  for (int cl = 0; cl < comp->clause_count; cl++) {
+  std::vector<int> term_counts_vec;
+  std::vector<int> term_ids_vec;
+  term_counts_vec.reserve(static_cast<size_t>(clause_count));
+  for (int cl = 0; cl < clause_count; cl++) {
     const auto& clause = cmp[cl];
     // A clause is either a bare id (1-term) or an array of ids (matches core to_json).
     if (clause.is_array()) {
-      comp->term_counts[cl] = static_cast<int>(clause.size());
-      if (comp->term_counts[cl] > LUMICE_MAX_CONFIG_TERMS) {
+      const int tn = static_cast<int>(clause.size());
+      if (tn > LUMICE_MAX_CONFIG_TERMS) {
         return LUMICE_ERR_INVALID_CONFIG;
       }
-      for (int t = 0; t < comp->term_counts[cl]; t++) {
-        comp->clauses[cl][t] = clause[t].get<int>();
+      term_counts_vec.push_back(tn);
+      for (int t = 0; t < tn; t++) {
+        term_ids_vec.push_back(clause[t].get<int>());
       }
     } else {
-      comp->term_counts[cl] = 1;
-      comp->clauses[cl][0] = clause.get<int>();
-    }
-    // Reference integrity: each term must name an existing SIMPLE filter (dangling ids and
-    // references to a complex filter are rejected — the latter matches core semantics, which
-    // only allow SimpleFilterParam in a composition, so cycles are impossible by construction).
-    for (int t = 0; t < comp->term_counts[cl]; t++) {
-      int ref_id = comp->clauses[cl][t];
-      bool found_simple = false;
-      for (int k = 0; k < out->filter_count; k++) {
-        if (out->filters[k].id == ref_id && out->filters[k].type != LUMICE_FILTER_TYPE_COMPLEX) {
-          found_simple = true;
-          break;
-        }
-      }
-      if (!found_simple) {
-        return LUMICE_ERR_INVALID_CONFIG;
-      }
+      term_counts_vec.push_back(1);
+      term_ids_vec.push_back(clause.get<int>());
     }
   }
+  // Reference integrity: each term must name an existing SIMPLE filter (dangling ids and
+  // references to a complex filter are rejected — the latter matches core semantics, which
+  // only allow SimpleFilterParam in a composition, so cycles are impossible by construction).
+  for (int ref_id : term_ids_vec) {
+    bool found_simple = false;
+    for (int k = 0; k < out->filter_count; k++) {
+      if (out->filters[k].id == ref_id && out->filters[k].type != LUMICE_FILTER_TYPE_COMPLEX) {
+        found_simple = true;
+        break;
+      }
+    }
+    if (!found_simple) {
+      return LUMICE_ERR_INVALID_CONFIG;
+    }
+  }
+  const int comp_idx = out->composition_count;
+  LUMICE_ComplexComposition* comp = &out->compositions[comp_idx];
+  auto err = LUMICE_CompositionSetClauses(comp, clause_count, term_counts_vec.data(), term_ids_vec.data());
+  if (err != LUMICE_OK) {
+    return err;
+  }
+  // Publish the composition to the config only after Set succeeds — matches the "advance
+  // count last" pattern already used elsewhere in this file (e.g. spectrum_entries).
+  out->composition_count = comp_idx + 1;
   f->composition_index = comp_idx;
   return LUMICE_OK;
 }
@@ -1319,6 +1480,9 @@ static LUMICE_ErrorCode JsonToConfig(const nlohmann::json& root, LUMICE_Config* 
   // calls, memset would clobber the pointer without freeing it — release first so the
   // memset that follows sees a defensibly-null field. Release is null-safe / idempotent.
   LUMICE_ConfigReleaseColorClasses(out);
+  // v4.9 (task-host-abi-cpu-caps): compositions[i].term_ids/term_counts are also owning
+  // heap pointers — same memset-would-leak hazard as raypath_color; release first.
+  LUMICE_ConfigReleaseCompositions(out);
   std::memset(out, 0, sizeof(LUMICE_Config));
   out->spectrum = "D65";  // Safe default (memset leaves nullptr)
 

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -712,7 +712,17 @@ LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, i
   if (clause_count < 0 || clause_count > LUMICE_MAX_CONFIG_CLAUSES) {
     return LUMICE_ERR_INVALID_CONFIG;
   }
-  if (clause_count > 0 && (term_counts == nullptr || term_ids == nullptr)) {
+  // term_counts is required whenever clause_count > 0 (every clause needs its own count).
+  // term_ids, however, must NOT be required upfront: a composition where every clause has 0
+  // terms (total_terms == 0) is legitimate (LUMICE_CompositionClauseTerms's doc comment and
+  // LUMICE_CommitConfigStruct's validation both already treat it as such), and a caller with
+  // total_terms == 0 may reasonably pass term_ids == nullptr for that empty flat buffer — e.g.
+  // JsonToComplexComposition's std::vector<int> term_ids_vec, whose .data() is nullptr when
+  // never push_back'd into. Requiring non-null unconditionally rejected exactly that legitimate
+  // shape at the ONLY writer, before CommitConfigStruct ever saw it (code-review round 2,
+  // Major — round 1's fix only patched CommitConfigStruct's read-side check, not this entry
+  // point). So the term_ids null-check is deferred until total_terms is known.
+  if (clause_count > 0 && term_counts == nullptr) {
     return LUMICE_ERR_NULL_ARG;
   }
   // Full validation BEFORE any allocation so an invalid input leaves `comp` untouched
@@ -726,6 +736,9 @@ LUMICE_ErrorCode LUMICE_CompositionSetClauses(LUMICE_ComplexComposition* comp, i
       return LUMICE_ERR_INVALID_CONFIG;
     }
     total_terms += static_cast<size_t>(term_counts[cl]);
+  }
+  if (total_terms > 0 && term_ids == nullptr) {
+    return LUMICE_ERR_NULL_ARG;
   }
 
   // Create-or-replace: release any prior allocation before overwriting the pointers,

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -112,6 +112,12 @@ class ServerImpl {
   // otherwise. class_count must equal the active color-class count.
   Error GetColorClassSignals(uint8_t* out_flags, int class_count);
 
+  // task-gui-feedback-affordances Step 5 (AC1): synchronous accessor for the
+  // component-bit overflow count captured in the most recent CommitConfig.
+  size_t GetLastColorComponentOverflowCount() const {
+    return last_color_component_overflow_count_.load(std::memory_order_acquire);
+  }
+
  private:
   // task-268.7: single-engine orchestration — server now runs exactly one
   // Simulator. The legacy kDefaultSimulatorCnt = PhysicalCoreCount() was removed
@@ -169,6 +175,14 @@ class ServerImpl {
   // default; no raypath_color → color class table is empty → composite gate
   // skips the compositor anyway).
   CompositeMode active_composite_mode_ = CompositeMode::kDominant;
+
+  // task-gui-feedback-affordances Step 5 (AC1): number of color predicates
+  // that hit `kNoBit` in the most recent BuildColorGateTable call. Carried
+  // out synchronously in CommitConfig (see server.cpp:506 nearby). Exposed
+  // via LUMICE_GetColorOverflowInfo so DoRun's post-commit surface can pop a
+  // "coloring degraded" modal. Written under status_mutex_ (single writer =
+  // CommitConfig, atomic read by the C API path is safe).
+  std::atomic<size_t> last_color_component_overflow_count_{ 0 };
 
   // task-345.3: display-time EV for the composite path only. Zero (default) →
   // 2^0 = 1.0 → composite behavior is bit-for-bit pre-345.3 (structural AC4
@@ -504,6 +518,13 @@ Error ServerImpl::CommitConfig(const nlohmann::json& config_json, bool* out_reus
     // (per-class Y-lane accumulation) and into the compositor
     // (CompositeColorClassesLinear); no legacy per-bit adapter layer.
     ColorGateTable color_gate_table = BuildColorGateTable(new_config.raypath_color_, new_config.scene_);
+    // task-gui-feedback-affordances Step 5 (AC1): carry the component-bit
+    // overflow count (predicates that hit `kNoBit`) out so the GUI DoRun path
+    // can surface a "coloring degraded" modal via LUMICE_GetColorOverflowInfo.
+    // Written on the successful (non-throwing) branch — a parse/config error
+    // above leaves the prior counter untouched, matching the "keep prior
+    // committed state" semantics of the surrounding try/catch.
+    last_color_component_overflow_count_.store(color_gate_table.component_overflow_count_, std::memory_order_release);
     class_table = BuildColorClassTable(new_config.raypath_color_, new_config.scene_, color_gate_table);
     composite_mode = ParseCompositeMode(new_config.raypath_color_.mode_);
   } catch (const nlohmann::json::out_of_range& e) {
@@ -1648,6 +1669,13 @@ uint64_t Server::CommittedEpoch() const {
 
 bool Server::IsIdle() const {
   return GetStatus() == ServerStatus::kIdle;
+}
+
+size_t Server::GetLastColorComponentOverflowCount() const {
+  if (!impl_) {
+    return 0;
+  }
+  return impl_->GetLastColorComponentOverflowCount();
 }
 
 Error Server::SetRaypathColors(const ColorClassDisplay* classes, int class_count, const int* z_order,

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -427,6 +427,17 @@ class Server {
   Error GetColorClassSignals(uint8_t* out_flags, int class_count);
 
   /**
+   * @brief task-gui-feedback-affordances Step 5 (AC1): number of color predicates
+   *        that hit `kNoBit` in the most recent BuildColorGateTable call
+   *        (component-bit budget, kMaxBits=64, exhausted). Written synchronously
+   *        inside CommitConfig; read by LUMICE_GetColorOverflowInfo so the GUI
+   *        DoRun path can pop a "coloring degraded" modal without waiting for
+   *        the first backend batch to land.
+   * @return 0 iff no predicate was dropped; else the drop count.
+   */
+  size_t GetLastColorComponentOverflowCount() const;
+
+  /**
    * @brief task-345.3: display-time EV multiplier for the composite path only.
    * @param ev_total Total EV (manual + auto) to apply as 2^ev_total inside DoSnapshot Phase 2.
    * @return Error::Success. Mono path is untouched — only the composite result carries the

--- a/test/e2e/configs/parity_big_or_with_color.json
+++ b/test/e2e/configs/parity_big_or_with_color.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "task-device-flat-and-terms plan §7 Risk 4 强制交付物: physical filter has a >8 OR-clause Complex filter AND the scene has raypath_color enabled. Exercises CUDA's color-rebuild二次上传mirror for and_term_counts (test_cuda_filter_parity.py suspect: if the second upload of d_and_term_counts is skipped, kernel reads stale/misaligned counts only in color+big-OR configs — undetectable in the plain 20-clause fixture).",
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": { "height": 1.2 },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 90, "std": 360 },
+        "azimuth": { "type": "uniform", "mean": 0,  "std": 360 }
+      }
+    }
+  ],
+  "filter": [
+    { "id":  1, "type": "raypath", "raypath": [3, 5], "symmetry": "PBD" },
+    { "id":  2, "type": "raypath", "raypath": [3, 6], "symmetry": "PBD" },
+    { "id":  3, "type": "raypath", "raypath": [3, 7], "symmetry": "PBD" },
+    { "id":  4, "type": "raypath", "raypath": [3, 8], "symmetry": "PBD" },
+    { "id":  5, "type": "raypath", "raypath": [4, 5], "symmetry": "PBD" },
+    { "id":  6, "type": "raypath", "raypath": [4, 6], "symmetry": "PBD" },
+    { "id":  7, "type": "raypath", "raypath": [4, 7], "symmetry": "PBD" },
+    { "id":  8, "type": "raypath", "raypath": [4, 8], "symmetry": "PBD" },
+    { "id":  9, "type": "raypath", "raypath": [5, 3], "symmetry": "PBD" },
+    { "id": 10, "type": "raypath", "raypath": [5, 4], "symmetry": "PBD" },
+    { "id": 11, "type": "raypath", "raypath": [5, 6], "symmetry": "PBD" },
+    { "id": 12, "type": "raypath", "raypath": [5, 7], "symmetry": "PBD" },
+    {
+      "id": 20,
+      "type": "complex",
+      "composition": [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12]],
+      "symmetry": "PBD",
+      "action": "filter_in"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "spectrum": "D65"
+    },
+    "ray_num": 1000000,
+    "max_hits": 7,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          { "crystal": 1, "proportion": 10, "filter": 20 }
+        ]
+      }
+    ]
+  },
+  "raypath_color": {
+    "mode": "dominant",
+    "classes": [
+      { "color": [1.0, 0.0, 0.0], "match": [ { "layer": 0, "crystal": 1, "type": "entry_exit", "min_len": 1, "max_len": 1 } ] },
+      { "color": [0.0, 1.0, 0.0], "match": [ { "layer": 0, "crystal": 1, "type": "entry_exit", "min_len": 2, "max_len": 2 } ] },
+      { "color": [0.0, 0.0, 1.0], "match": [ { "layer": 0, "crystal": 1, "type": "entry_exit", "min_len": 3 } ] }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": { "type": "dual_fisheye_equal_area", "fov": 180 },
+      "resolution": [512, 256],
+      "view": { "elevation": 0 },
+      "visible": "full"
+    }
+  ]
+}

--- a/test/gui/functional/test_gui_color_window.cpp
+++ b/test/gui/functional/test_gui_color_window.cpp
@@ -23,7 +23,7 @@
 #include "gui/file_io.hpp"  // FillLumiceConfig — pipeline assertion for AC4 default flow-through.
 #include "gui/gui_state.hpp"
 #include "gui/raypath_segments.hpp"
-#include "include/lumice_config_scope.hpp"  // ConfigColorGuard — auto-releases raypath_color for AC4 test.
+#include "include/lumice_config_scope.hpp"  // ConfigOwningGuard — auto-releases raypath_color for AC4 test.
 #include "test_gui_shared.hpp"
 
 namespace {
@@ -1285,7 +1285,7 @@ void RegisterColorWindowTests(ImGuiTestEngine* engine) {
       // the new default reaches the scrum-356 per-ref symmetry pipeline
       // without any renderer-side changes.
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color[0].match[0].predicate.symmetry, 7);
 

--- a/test/gui/functional/test_gui_color_window.cpp
+++ b/test/gui/functional/test_gui_color_window.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 
 #include "IconsFontAwesome6.h"  // ICON_FA_* selectors for locating icon-prefixed buttons.
+#include "gui/app.hpp"          // ShouldTintColorsButton — Step 1 predicate for AC2.
 #include "gui/color_window.hpp"
 #include "gui/file_io.hpp"  // FillLumiceConfig — pipeline assertion for AC4 default flow-through.
 #include "gui/gui_state.hpp"
@@ -1526,6 +1527,60 @@ void RegisterColorWindowTests(ImGuiTestEngine* engine) {
       IM_CHECK(ctx->ItemExists("**/$$1/" ICON_FA_EYE));
       IM_CHECK(!ctx->ItemExists("**/$$1/" ICON_FA_EYE_SLASH));
       ctx->SetRef("");
+
+      gui::g_state.color_window_open = false;
+      ctx->Yield(2);
+    };
+  }
+
+  // task-gui-feedback-affordances Step 1 (AC2): the topbar Colors button must
+  // render with a distinct tint when at least one color class is configured.
+  // The tint decision is pinned in the pure predicate ShouldTintColorsButton
+  // so this test locks the decision boundary directly (raypath_color empty →
+  // no tint; non-empty → tint), without depending on ImGuiTestEngine's ability
+  // to read pushed style colors (which its ItemInfo API does not expose).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "color_window", "topbar_colors_button_tint_predicate");
+    t->TestFunc = [](ImGuiTestContext*) {
+      ResetTestState();
+      IM_CHECK(!gui::ShouldTintColorsButton(true));  // empty → no tint
+      IM_CHECK(gui::ShouldTintColorsButton(false));  // has classes → tint
+    };
+  }
+
+  // task-gui-feedback-affordances Step 1 (AC2): end-to-end wire — after
+  // clicking + Add Class the raypath_color vector grows, the predicate flips
+  // true, and the Colors button remains rendered/clickable in the tinted
+  // state. This exercises the real ImGui frame path (top-bar renders the
+  // button, PushStyleColor stack balances, layout intact), which is the
+  // "GUI test 实际验证" leg of AC5.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "color_window", "topbar_colors_button_renders_in_both_states");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      // Empty state: predicate false, button exists.
+      IM_CHECK(gui::g_state.raypath_color.empty());
+      IM_CHECK(!gui::ShouldTintColorsButton(gui::g_state.raypath_color.empty()));
+      IM_CHECK(ctx->ItemExists("##TopBar/" ICON_FA_PALETTE " Colors"));
+
+      // Populate raypath_color via the Colors window (real UI path).
+      gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+      gui::g_state.run_intent = gui::RunIntent::kLoaded;
+      gui::g_state.sim_state = gui::GuiState::SimState::kDone;
+      gui::g_state.committed_epoch = 5;
+      gui::g_state.display_epoch_floor = 0;
+      gui::g_state.dirty = false;
+      gui::g_state.color_window_open = true;
+      ctx->Yield(4);
+      ctx->ItemClick("**/" ICON_FA_PLUS " Add Class");
+      ctx->Yield(2);
+
+      // Non-empty state: predicate true, button still exists and remains
+      // clickable (PushStyleColor stack balanced ⇒ no ImGui assertion).
+      IM_CHECK(!gui::g_state.raypath_color.empty());
+      IM_CHECK(gui::ShouldTintColorsButton(gui::g_state.raypath_color.empty()));
+      IM_CHECK(ctx->ItemExists("##TopBar/" ICON_FA_PALETTE " Colors"));
 
       gui::g_state.color_window_open = false;
       ctx->Yield(2);

--- a/test/gui/functional/test_gui_composite_preview.cpp
+++ b/test/gui/functional/test_gui_composite_preview.cpp
@@ -1689,7 +1689,7 @@ void RegisterCompositePreviewTests(ImGuiTestEngine* engine) {
     gui::g_state.raypath_color_mode = LUMICE_COLOR_MODE_PAINTER;
 
     auto RunToDoneAndCheckIntent = [&]() {
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
       IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(gui::RunIntent::kRunning));
       auto start = std::chrono::steady_clock::now();
       while (gui::g_state.sim_state != gui::GuiState::SimState::kDone ||
@@ -1803,7 +1803,7 @@ void RegisterCompositePreviewTests(ImGuiTestEngine* engine) {
     gui::g_state.raypath_color.push_back(cls);
     gui::g_state.raypath_color_mode = LUMICE_COLOR_MODE_DOMINANT;
 
-    gui::DoRun();
+    gui::DoRun(/*user_initiated=*/true);
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(gui::RunIntent::kRunning));
     auto start = std::chrono::steady_clock::now();
     while (gui::g_state.sim_state != gui::GuiState::SimState::kDone ||

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -5,7 +5,7 @@
 #include "IconsFontAwesome6.h"
 #include "gui/export_fbo_renderer.hpp"      // RenderExportToRgba for GL pixel-level assertions
 #include "gui/raypath_segments.hpp"         // ParseSummandText / SumOfProducts (SoP round-trip tests)
-#include "include/lumice_config_scope.hpp"  // lumice::ConfigColorGuard for LUMICE_Config RAII
+#include "include/lumice_config_scope.hpp"  // lumice::ConfigOwningGuard for LUMICE_Config RAII
 #include "test_gui_shared.hpp"
 
 // task-349.4 wait-until-condition helper — bounded polling that yields to the main render
@@ -198,7 +198,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       // full end-to-end chain: file JSON -> deserialize -> loaded -> C struct
       // -> core (code-review r2 Minor-1).
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       gui::FillLumiceConfig(loaded, &cfg);
       IM_CHECK_EQ(cfg.scatter_count, 2);
       IM_CHECK_EQ(cfg.scattering[0].probability, 0.3f);
@@ -406,7 +406,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       // (4) FillLumiceConfig populates spectrum_entries[]/spectrum_count.
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       gui::FillLumiceConfig(gui::g_state, &cfg);
       IM_CHECK_EQ(cfg.spectrum_count, 3);
       IM_CHECK_EQ(cfg.spectrum_entries[0].wavelength, 450.0f);
@@ -1909,11 +1909,11 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
         LUMICE_Config from_struct{};
 
-        lumice::ConfigColorGuard from_struct_guard(from_struct);
+        lumice::ConfigOwningGuard from_struct_guard(from_struct);
         IM_CHECK(gui::FillLumiceConfig(gui::g_state, &from_struct));  // struct path (ExpandFilterToStruct)
         std::string json = gui::SerializeCoreConfig(gui::g_state);    // JSON path (SerializeFilterForCore)
         LUMICE_Config from_json{};
-        lumice::ConfigColorGuard from_json_guard(from_json);
+        lumice::ConfigOwningGuard from_json_guard(from_json);
         IM_CHECK_EQ(LUMICE_ParseConfigString(json.c_str(), &from_json), LUMICE_OK);
 
         IM_CHECK_EQ(from_struct.filter_count, from_json.filter_count);
@@ -1940,9 +1940,13 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
             const LUMICE_ComplexComposition& cb = from_json.compositions[b.composition_index];
             IM_CHECK_EQ(ca.clause_count, cb.clause_count);
             for (int cl = 0; cl < ca.clause_count; cl++) {
-              IM_CHECK_EQ(ca.term_counts[cl], cb.term_counts[cl]);
-              for (int tt = 0; tt < ca.term_counts[cl]; tt++) {
-                IM_CHECK_EQ(ca.clauses[cl][tt], cb.clauses[cl][tt]);
+              int a_n = 0;
+              int b_n = 0;
+              const int* a_terms = LUMICE_CompositionClauseTerms(&ca, cl, &a_n);
+              const int* b_terms = LUMICE_CompositionClauseTerms(&cb, cl, &b_n);
+              IM_CHECK_EQ(a_n, b_n);
+              for (int tt = 0; tt < a_n; tt++) {
+                IM_CHECK_EQ(a_terms[tt], b_terms[tt]);
               }
             }
           }
@@ -2050,7 +2054,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         layer.entries.push_back(e);
         gui::g_state.layers.push_back(layer);
         LUMICE_Config over{};
-        lumice::ConfigColorGuard over_guard(over);
+        lumice::ConfigOwningGuard over_guard(over);
         gui::FilterOverflowInfo overflow;
         IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over, &overflow));  // over ABI bounds -> false
         // "no partial writes on overflow" contract (ExpandFilterToStruct doc): the overflowing
@@ -2103,7 +2107,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         layer.entries.push_back(e);
         gui::g_state.layers.push_back(layer);
         LUMICE_Config over{};
-        lumice::ConfigColorGuard over_guard(over);
+        lumice::ConfigOwningGuard over_guard(over);
         IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over));  // term count > 8 -> false
         IM_CHECK_EQ(over.filter_count, 0);
         IM_CHECK_EQ(over.composition_count, 0);
@@ -2125,16 +2129,19 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
           c.face_distance[i] = 1.0f;
         }
         gui::g_state.crystals.push_back(c);
-        // Three raypath factors ANDed, each carrying 4 ';'-OR alternatives:
-        // 4 * 4 * 4 = 64 would-be clauses >> LUMICE_MAX_CONFIG_CLAUSES(16), but only
-        // 3 factors (<= term cap) — so this exercises the clause-product path, not
-        // the term-count path.
+        // Four raypath factors ANDed, each carrying 9 ';'-OR alternatives:
+        // 9 * 9 * 9 * 9 = 6561 would-be clauses > LUMICE_MAX_CONFIG_CLAUSES(4096), still under
+        // the per-clause factor cap (4 factors <= LUMICE_MAX_CONFIG_TERMS=64) — so this
+        // exercises the clause-product path, not the term-count path. Detection triggers on
+        // the 4th expansion attempt (acc.size() 729 * 9 = 6561 > kMaxClauses), so only ~729
+        // intermediate 3-element vectors materialize (cheap).
         gui::SummandText row;
-        row.text = "1;2;3;4 & 1;2;3;4 & 1;2;3;4";
+        row.text = "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4";
         row.factors = {
-          gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
-          gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
-          gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
+          gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+          gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+          gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+          gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
         };
         gui::FilterConfig f;
         f.param = gui::SumOfProducts{ row };
@@ -2148,8 +2155,8 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         layer.entries.push_back(e);
         gui::g_state.layers.push_back(layer);
         LUMICE_Config over{};
-        lumice::ConfigColorGuard over_guard(over);
-        IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over));  // Cartesian > 16 clauses -> false
+        lumice::ConfigOwningGuard over_guard(over);
+        IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &over));  // Cartesian > 4096 clauses -> false
         IM_CHECK_EQ(over.filter_count, 0);
         IM_CHECK_EQ(over.composition_count, 0);
 
@@ -2161,7 +2168,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         std::string core_json = gui::SerializeCoreConfig(gui::g_state);
         IM_CHECK(!core_json.empty());
         LUMICE_Config from_json{};
-        lumice::ConfigColorGuard from_json_guard(from_json);
+        lumice::ConfigOwningGuard from_json_guard(from_json);
         IM_CHECK_EQ(LUMICE_ParseConfigString(core_json.c_str(), &from_json), LUMICE_OK);
         IM_CHECK_EQ(from_json.filter_count, 1);       // bounded match-all stand-in, not 64 clauses
         IM_CHECK_EQ(from_json.composition_count, 0);  // no complex emitted for the stand-in
@@ -2188,13 +2195,14 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         c.face_distance[i] = 1.0f;
       }
       gui::g_state.crystals.push_back(c);
-      // 3 raypath factors x 4 alternatives = 64 clauses >> LUMICE_MAX_CONFIG_CLAUSES.
+      // 4 raypath factors x 9 alternatives = 6561 clauses > LUMICE_MAX_CONFIG_CLAUSES(4096).
       gui::SummandText row;
-      row.text = "1;2;3;4 & 1;2;3;4 & 1;2;3;4";
+      row.text = "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4";
       row.factors = {
-        gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
-        gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
-        gui::Factor{ gui::RaypathParams{ "1;2;3;4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
       };
       gui::FilterConfig f;
       f.name = "BigFilter";
@@ -2307,7 +2315,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     t->TestFunc = [](ImGuiTestContext*) {
       ResetTestState();
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 0);
       // doc §4.8: GUI default is now painter.
@@ -2335,7 +2343,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       const auto& c = cfg.raypath_color[0];
@@ -2369,7 +2377,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].match_count, 1);
@@ -2390,7 +2398,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].match[0].predicate.type, LUMICE_FILTER_TYPE_UNSET);
@@ -2410,7 +2418,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       const auto& p = cfg.raypath_color[0].match[0].predicate;
@@ -2448,7 +2456,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].combine, LUMICE_COLOR_COMBINE_ALL);
@@ -2473,7 +2481,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color[0].visible, 0);
       IM_CHECK_EQ(cfg.raypath_color[0].solo, 1);
@@ -2503,7 +2511,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].match_count, 1);  // orphan dropped
@@ -2528,7 +2536,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].match_count, 1);
@@ -2549,7 +2557,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       IM_CHECK_EQ(cfg.raypath_color_count, 1);
       IM_CHECK_EQ(cfg.raypath_color[0].match_count, 0);
@@ -2568,7 +2576,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         gui::g_state.raypath_color.push_back(cls);
       }
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       gui::ColorClassOverflowInfo color_overflow;
       IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &cfg, nullptr, &color_overflow));
       IM_CHECK(color_overflow.class_over_cap);
@@ -2588,7 +2596,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       }
       gui::g_state.raypath_color.push_back(cls);
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       gui::ColorClassOverflowInfo color_overflow;
       IM_CHECK(!gui::FillLumiceConfig(gui::g_state, &cfg, nullptr, &color_overflow));
       IM_CHECK(!color_overflow.class_over_cap);
@@ -2678,7 +2686,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       // Struct emit carries the bitmask.
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       const auto& sp = cfg.raypath_color[0].match[0].predicate;
       IM_CHECK_EQ(sp.symmetry, 5);  // P|D
@@ -2711,7 +2719,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       // Struct emit.
       LUMICE_Config cfg{};
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       const auto& sp = cfg.raypath_color[0].match[0].predicate;
 
@@ -2755,7 +2763,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
 
       LUMICE_Config cfg{};
 
-      lumice::ConfigColorGuard cfg_guard(cfg);
+      lumice::ConfigOwningGuard cfg_guard(cfg);
       IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
       auto j = nlohmann::json::parse(gui::SerializeCoreConfig(gui::g_state));
       const auto& jrefs = j["raypath_color"]["classes"][0]["match"];
@@ -3029,7 +3037,7 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
         gui::g_state.renderer.exposure_offset = offset;
 
         LUMICE_Config cfg{};
-        lumice::ConfigColorGuard cfg_guard(cfg);
+        lumice::ConfigOwningGuard cfg_guard(cfg);
         IM_CHECK(gui::FillLumiceConfig(gui::g_state, &cfg));
         IM_CHECK_EQ(cfg.renderer_count, 1);
         // The GUI Run path must NEVER bake exposure_offset here. Manual + auto EV both

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -2235,6 +2235,47 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // task-gui-feedback-affordances Step 3 (AC4): SummarizeSopExpansion delegates
+  // to the same ExpandSopToClauses as the commit path so the live preview and
+  // the ABI enforcement point share the exact same arithmetic (no drift).
+  // Single-row default (blank) collapses to 1 clause, non-overflow; a 6561-
+  // would-be-clause row (4 × 9-alt) trips the LUMICE_MAX_CONFIG_CLAUSES=4096
+  // cap and reports overflow with the bounded degenerate stand-in.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "summarize_sop_expansion_delegates_to_commit_path");
+    t->TestFunc = [](ImGuiTestContext*) {
+      gui::FilterConfig f_ok;
+      f_ok.SetRaypath(gui::RaypathParams{ "3-5" });
+      const auto s_ok = gui::SummarizeSopExpansion(f_ok);
+      IM_CHECK(!s_ok.overflow);
+      IM_CHECK_EQ(s_ok.clause_count, static_cast<size_t>(1));
+
+      // Multi-alternative single-row: `;`-OR expands but stays well below cap.
+      gui::FilterConfig f_multi;
+      f_multi.SetRaypath(gui::RaypathParams{ "3-5;1-2" });
+      const auto s_multi = gui::SummarizeSopExpansion(f_multi);
+      IM_CHECK(!s_multi.overflow);
+      IM_CHECK_EQ(s_multi.clause_count, static_cast<size_t>(2));
+
+      // Overflow: 4 × 9-alt = 6561 > LUMICE_MAX_CONFIG_CLAUSES(4096).
+      gui::SummandText row;
+      row.text = "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4";
+      row.factors = {
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+      };
+      gui::FilterConfig f_over;
+      f_over.param = gui::SumOfProducts{ row };
+      const auto s_over = gui::SummarizeSopExpansion(f_over);
+      IM_CHECK(s_over.overflow);
+      // ExpandSopToClauses replaces the huge tree with a bounded degenerate
+      // stand-in (1 clause) on overflow — the summary reflects that.
+      IM_CHECK_EQ(s_over.clause_count, static_cast<size_t>(1));
+    };
+  }
+
   // FormatOverflowLocator format contract (pure function, no GUI): the unnamed form drops the
   // filter clause and keeps 1-based Layer/Entry, and the indices are presented as +1.
   {

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -5426,6 +5426,93 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       IM_CHECK(warning.find("This raypath color configuration exceeds its predicate") != std::string::npos);
       IM_CHECK(warning.find("Simplify the color configuration") != std::string::npos);
 
+      // Precise count lock (code-review-01 Suggestion): 66 unique predicates - kMaxBits(64) = 2
+      // dropped. Ties the end-to-end GUI test to the same exact number the Step 5/7 unit tests
+      // assert, rather than only the message substring.
+      LUMICE_ColorOverflowInfo color_over{};
+      IM_CHECK(LUMICE_GetColorOverflowInfo(gui::g_server, &color_over) == LUMICE_OK);
+      IM_CHECK(color_over.component_overflow_count == 2);
+
+      // Cleanup.
+      gui::ClearGuiWarning();
+      gui::g_state.raypath_color.clear();
+      gui::g_server_poller.Stop();
+      LUMICE_StopServer(gui::g_server);
+      LUMICE_DestroyServer(gui::g_server);
+      gui::g_server = nullptr;
+      gui::g_state.run_intent = gui::RunIntent::kNone;
+      gui::g_state.committed_epoch = 0;
+      gui::g_state.dirty = false;
+    };
+  }
+
+  // task-gui-feedback-affordances code-review-01 Critical 1 regression anchor: a persistent
+  // color-overflow condition (unlike the FillLumiceConfig-REJECT branch covered by the sibling
+  // `overflow_auto_commit_dedup` test) goes through the commit-SUCCEEDED branch of DoRun. That
+  // branch used to call ClearGuiWarning() unconditionally before checking for a color overflow,
+  // which zeroed the identity-dedup state ahead of the comparison and made every auto-commit
+  // tick (user_initiated=false) reopen the modal even though the SAME overflow persisted —
+  // reproducing the "70ms slider drag freezes the UI" regression Step 2 fixed for the ABI-reject
+  // branch. This test drives two auto-commit ticks against the same 66-predicate overflow setup
+  // as `big_or_filter_with_color_overflow_surfaces_warning` and asserts the second tick does NOT
+  // respawn the modal.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "color_overflow_auto_commit_dedup");
+    t->TestFunc = [](ImGuiTestContext*) {
+      ResetTestState();
+      gui::ClearGuiWarning();
+      gui::g_server = LUMICE_CreateServer();
+      IM_CHECK(gui::g_server != nullptr);
+
+      gui::g_state.raypath_color.clear();
+      constexpr int kNumClasses = 3;
+      constexpr int kRefsPerClass = 22;
+      static_assert(kNumClasses * kRefsPerClass > 64, "must exceed ComponentTable::kMaxBits");
+      int uid = 0;
+      for (int c = 0; c < kNumClasses; ++c) {
+        gui::ColorClassConfig cls;
+        cls.color[0] = 1.0f - c * 0.2f;
+        cls.color[1] = 0.5f;
+        cls.color[2] = 0.0f + c * 0.2f;
+        cls.combine = 0;
+        cls.visible = true;
+        cls.solo = false;
+        for (int k = 0; k < kRefsPerClass; ++k, ++uid) {
+          gui::ColorClassRefConfig ref;
+          ref.layer_idx = 0;
+          ref.crystal_pool_id = 0;
+          ref.match_all = false;
+          if (uid < 64) {
+            const int f1 = 1 + (uid % 8);
+            const int f2 = 1 + (uid / 8);
+            ref.predicate_text = std::to_string(f1) + "-" + std::to_string(f2);
+          } else {
+            const int tail = uid - 63;
+            ref.predicate_text = "1-1-" + std::to_string(tail);
+          }
+          cls.match.push_back(ref);
+        }
+        gui::g_state.raypath_color.push_back(cls);
+      }
+
+      gui::g_state.sim.infinite = false;
+      gui::g_state.sim.ray_num_millions = 0.001f;
+
+      // First auto-commit tick: overflow persists → commit succeeds, color-degrade warning set.
+      gui::DoRun(/*user_initiated=*/false);
+      IM_CHECK(!gui::PeekGuiWarning().empty());
+      IM_CHECK(gui::IsGuiWarningPending());
+      const std::string first_msg = gui::PeekGuiWarning();
+
+      // Frame consumes OpenPopup; trigger cleared, message retained.
+      gui::internal_test::ConsumeGuiWarningPending();
+      IM_CHECK(!gui::IsGuiWarningPending());
+
+      // Second auto-commit tick with the SAME overflow: dedup MUST hold (no modal respawn).
+      gui::DoRun(/*user_initiated=*/false);
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), first_msg.c_str());
+      IM_CHECK(!gui::IsGuiWarningPending());
+
       // Cleanup.
       gui::ClearGuiWarning();
       gui::g_state.raypath_color.clear();

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -5352,6 +5352,44 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // task-gui-feedback-affordances Step 3 (AC4): the filter Edit modal live
+  // preview must render its "Clauses: N / <limit>" line for both the normal
+  // case and the overflow case (red-styled). This test opens the Edit modal,
+  // types an over-cap row (4 × 9-alt = 6561 clauses > 4096), yields frames so
+  // the immediate-mode preview runs — exercising the new PushStyleColor /
+  // PopStyleColor branch — then Cancels out. The primary assertion is that no
+  // ImGui style-stack assertion fires (branch balance is correct) and that
+  // the modal remains navigable. The precise clause-count value is locked by
+  // the sibling summarize_sop_expansion_delegates_to_commit_path unit test.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "live_preview_clause_count_overflow_no_crash");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+
+      // Non-overflow first: a simple row keeps the preview in the disabled-text
+      // branch. Yield extra frames so ImGui commits at least one full render
+      // pass through the preview code.
+      ctx->ItemInputValue("**/##row_text_0", "3-5");
+      ctx->Yield(3);
+
+      // Now push into overflow territory: 4 factors × 9 alternatives each →
+      // 6561 clauses, well above LUMICE_MAX_CONFIG_CLAUSES = 4096.
+      ctx->ItemInputValue("**/##row_text_0",
+                          "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4");
+      ctx->Yield(3);
+
+      // The Edit modal is still open and its Cancel item is still clickable —
+      // proving the preview render did not throw an ImGui assertion (which
+      // would tear down the modal / test).
+      IM_CHECK(ctx->ItemExists("**/" ICON_FA_XMARK " Cancel##edit_modal"));
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
   // task-gui-feedback-affordances Step 2 (AC3): a user-clicked Run always
   // re-opens the warning modal when the overflow condition persists, even
   // after the user dismissed the previous popup with OK. DoRun(true) calls

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -5352,6 +5352,93 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // task-gui-feedback-affordances Step 7 (AC1): the end-to-end degrade-warning
+  // wire. Big-OR filter (host-side ABI-legal) + a color config with > 64
+  // distinct predicates on one placement — the ABI check passes (commit is
+  // NOT rejected), the CORE drops the excess predicates (kNoBit), and DoRun
+  // surfaces the "coloring degraded" modal via SetGuiWarning with a message
+  // string DIFFERENT from the ABI-overflow message (identity-dedup safety).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "big_or_filter_with_color_overflow_surfaces_warning");
+    t->TestFunc = [](ImGuiTestContext*) {
+      ResetTestState();
+      gui::ClearGuiWarning();
+      gui::g_server = LUMICE_CreateServer();
+      IM_CHECK(gui::g_server != nullptr);
+
+      // Populate raypath_color across 3 classes × 22 refs = 66 unique
+      // raypath predicates on the (layer 0, crystal 1) placement. Each ref
+      // uses a distinct 2-face raypath text ("f1-f2") so structural dedup
+      // does not collapse them across classes; face numbers stay in the
+      // valid prism range 1..8 (kMaxHits is 64, well above our lengths).
+      // ABI caps allow 32 refs/class and 64 classes; splitting across
+      // classes is the only way to get > 64 predicates through the ABI to
+      // the CORE, where BuildColorGateTable dedupes across classes and hits
+      // ComponentTable::kMaxBits=64 → 66-64 = 2 predicates dropped.
+      gui::g_state.raypath_color.clear();
+      constexpr int kNumClasses = 3;
+      constexpr int kRefsPerClass = 22;
+      static_assert(kNumClasses * kRefsPerClass > 64, "must exceed ComponentTable::kMaxBits");
+      int uid = 0;  // index into a 64-combo (f1,f2) grid; overflow refs (>=64) use 3-face raypaths
+      for (int c = 0; c < kNumClasses; ++c) {
+        gui::ColorClassConfig cls;
+        cls.color[0] = 1.0f - c * 0.2f;
+        cls.color[1] = 0.5f;
+        cls.color[2] = 0.0f + c * 0.2f;
+        cls.combine = 0;
+        cls.visible = true;
+        cls.solo = false;
+        for (int k = 0; k < kRefsPerClass; ++k, ++uid) {
+          gui::ColorClassRefConfig ref;
+          ref.layer_idx = 0;
+          ref.crystal_pool_id = 0;  // maps to CrystalConfig::id_ = 1 in ResetTestState()
+          ref.match_all = false;
+          if (uid < 64) {
+            const int f1 = 1 + (uid % 8);
+            const int f2 = 1 + (uid / 8);
+            ref.predicate_text = std::to_string(f1) + "-" + std::to_string(f2);
+          } else {
+            // Two extra 3-face raypaths past the 64-combo grid — structurally
+            // distinct from all length-2 predicates above so total unique
+            // predicates = 66 → 2 overflow past kMaxBits.
+            const int tail = uid - 63;  // 1, 2
+            ref.predicate_text = "1-1-" + std::to_string(tail);
+          }
+          cls.match.push_back(ref);
+        }
+        gui::g_state.raypath_color.push_back(cls);
+      }
+
+      // Sim ray count small so the run finishes quickly if it starts.
+      gui::g_state.sim.infinite = false;
+      gui::g_state.sim.ray_num_millions = 0.001f;
+
+      gui::DoRun(/*user_initiated=*/true);
+
+      // Commit MUST succeed (ABI accepts the config); the drop is a
+      // display-layer degradation only.
+      const std::string warning = gui::PeekGuiWarning();
+      IM_CHECK(!warning.empty());
+      IM_CHECK(warning.find("color") != std::string::npos || warning.find("Color") != std::string::npos);
+      // The message MUST be distinct from the two existing ABI-overflow msgs
+      // (filter cap / color-class cap), else SetGuiWarning's identity-dedup
+      // would silently collapse them (regression anchor per plan §7 risk 3).
+      IM_CHECK(warning.find("This raypath color configuration exceeds its predicate") != std::string::npos);
+      IM_CHECK(warning.find("Simplify the color configuration") != std::string::npos);
+
+      // Cleanup.
+      gui::ClearGuiWarning();
+      gui::g_state.raypath_color.clear();
+      gui::g_server_poller.Stop();
+      LUMICE_StopServer(gui::g_server);
+      LUMICE_DestroyServer(gui::g_server);
+      gui::g_server = nullptr;
+      gui::g_state.run_intent = gui::RunIntent::kNone;
+      gui::g_state.committed_epoch = 0;
+      gui::g_state.dirty = false;
+    };
+  }
+
   // task-gui-feedback-affordances Step 3 (AC4): the filter Edit modal live
   // preview must render its "Clauses: N / <limit>" line for both the normal
   // case and the overflow case (red-styled). This test opens the Edit modal,

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4794,6 +4794,41 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // T6b — AC4 (scrum-369.1 host-abi-cpu-caps): the "+ Add OR row" soft cap was
+  // raised from 16 to kMaxSummandRows=256, so the button must stay ENABLED past
+  // the old 16-row limit. Click it up to 20 rows and assert (a) the button never
+  // reports Disabled below the cap and (b) row uid 16 (the 17th row) exists —
+  // proving growth past 16. First-hand runtime verification of AC4 via the real
+  // GUI widget path (owner decision 2026-07-15, in lieu of a manual click).
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "add_rows_past_16_enabled");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Edit##fi");
+      ctx->Yield(4);
+
+      // Fresh modal starts with one blank row (uid 0). Add 19 more → uids 0..19.
+      for (int i = 0; i < 19; ++i) {
+        auto info_add = ctx->ItemInfo("**/+ Add OR row##summand_add");
+        IM_CHECK((info_add.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+        ctx->ItemClick("**/+ Add OR row##summand_add");
+        ctx->Yield(2);
+      }
+
+      // Row uid 16 = the 17th row: the button admitted growth well past 16.
+      IM_CHECK(ctx->ItemExists("**/##row_text_16"));
+      IM_CHECK(ctx->ItemExists("**/##row_text_19"));
+      // Still below kMaxSummandRows=256, so the button remains enabled.
+      auto info_add_final = ctx->ItemInfo("**/+ Add OR row##summand_add");
+      IM_CHECK((info_add_final.ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
   // T7 — Multi-row commit + per-row edit isolation (subsumes the pre-H5
   // per-type buffer isolation contract). Add three rows with distinct
   // grammar shapes (pure raypath / EE / AND mix), OK, verify the SoP has

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -2523,7 +2523,7 @@ void RegisterP1SliderBoundaryTests(ImGuiTestEngine* engine) {
       IM_CHECK(gui::g_server != nullptr);
       gui::g_state.sim.infinite = false;
       gui::g_state.sim.ray_num_millions = 0.5f;
-      gui::DoRun();  // real Run path: synchronous commit populates last_committed_state.
+      gui::DoRun(/*user_initiated=*/true);  // real Run path: synchronous commit populates last_committed_state.
       IM_CHECK(gui::g_state.last_committed_state.has_value());
       gui::g_state.dirty = false;  // DoRun doesn't touch dirty; pin a known pre-edit baseline.
       ctx->Yield(2);
@@ -3441,7 +3441,7 @@ void RegisterP1RunningTests(ImGuiTestEngine* engine) {
       // Act: change a crystal parameter, mark dirty, commit on test thread
       gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height = 2.5f;
       gui::g_state.dirty = true;
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
 
       // Assert: a new texture upload happens within timeout
       bool ok = WaitForSimRestartAtLeast(ctx, baseline, 1500);
@@ -3493,7 +3493,7 @@ void RegisterP1RunningTests(ImGuiTestEngine* engine) {
       // Act: change filter raypath, mark filter dirty, commit
       gui::g_state.filters[*gui::g_state.layers[0].entries[0].filter_id].MutableRaypathText() = "3-1-5-7";
       gui::g_state.MarkStructHardDirty();
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
 
       // Filter changes may take slightly longer (epoch-floor fence until re-commit); use 2000ms
       bool ok = WaitForSimRestartAtLeast(ctx, baseline, 2000);
@@ -3541,7 +3541,7 @@ void RegisterP1RunningTests(ImGuiTestEngine* engine) {
       gui::g_state.sim.infinite = false;
       gui::g_state.sim.ray_num_millions = 0.5f;  // small enough that the run can finish
       gui::g_state.dirty = true;
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
 
       bool ok = WaitForSimRestartAtLeast(ctx, baseline, 2000);
 
@@ -5349,6 +5349,118 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, 0, std::nullopt), 1);
       // Pair (0, 0) is unique to entry 1.
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, 0, std::optional<int>{ 0 }), 1);
+    };
+  }
+
+  // task-gui-feedback-affordances Step 2 (AC3): a user-clicked Run always
+  // re-opens the warning modal when the overflow condition persists, even
+  // after the user dismissed the previous popup with OK. DoRun(true) calls
+  // ClearGuiWarning() before SetGuiWarning() so the identity-dedup does NOT
+  // swallow the second Run. Uses the same 4-factor × 9-alt raypath (6561
+  // would-be clauses > LUMICE_MAX_CONFIG_CLAUSES=4096) as the export_json
+  // overflow tests so the overflow trigger stays a single source of truth.
+  //
+  // We assert via IsGuiWarningPending() — the internal "OpenPopup pending"
+  // flag — rather than driving a full frame + clicking "OK", because:
+  //   1) The dedup semantics live entirely in SetGuiWarning/ClearGuiWarning
+  //      and their observable is precisely that flag transition.
+  //   2) Running frames while a modal is open makes the harness fight the
+  //      popup's input capture, obscuring the invariant this test is here
+  //      to lock.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "overflow_user_initiated_run_refires");
+    t->TestFunc = [](ImGuiTestContext*) {
+      ResetTestState();
+      gui::ClearGuiWarning();
+      gui::g_server = LUMICE_CreateServer();
+      IM_CHECK(gui::g_server != nullptr);
+
+      // Same over-cap recipe as import_export/export_json_rejects_overflow_filter:
+      // 4 raypath factors × 9 alternatives = 6561 clauses > 4096.
+      gui::SummandText row;
+      row.text = "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4";
+      row.factors = {
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+      };
+      gui::FilterConfig f;
+      f.name = "OverflowFilter";
+      f.param = gui::SumOfProducts{ row };
+      gui::g_state.filters.push_back(f);
+      gui::SetFilter(gui::g_state, gui::g_state.layers[0].entries[0], gui::g_state.filters.back());
+
+      // First user Run: overflow → warning set + trigger set.
+      gui::DoRun(/*user_initiated=*/true);
+      IM_CHECK(!gui::PeekGuiWarning().empty());
+      IM_CHECK(gui::IsGuiWarningPending());
+      const std::string first_msg = gui::PeekGuiWarning();
+
+      // Simulate the frame that consumes OpenPopup (RenderGuiWarningPopup
+      // clears the trigger after calling OpenPopup) without touching the
+      // in-flight message — matches what happens after a real frame renders.
+      gui::internal_test::ConsumeGuiWarningPending();
+      IM_CHECK(!gui::PeekGuiWarning().empty());
+      IM_CHECK(!gui::IsGuiWarningPending());
+
+      // Second user Run with the same overflow: MUST re-open the modal.
+      gui::DoRun(/*user_initiated=*/true);
+      IM_CHECK_STR_EQ(gui::PeekGuiWarning().c_str(), first_msg.c_str());
+      IM_CHECK(gui::IsGuiWarningPending());
+
+      // Cleanup.
+      gui::ClearGuiWarning();
+      LUMICE_StopServer(gui::g_server);
+      LUMICE_DestroyServer(gui::g_server);
+      gui::g_server = nullptr;
+    };
+  }
+
+  // task-gui-feedback-affordances Step 2 (AC3): main-loop auto-commit
+  // (DoRun(user_initiated=false)) MUST preserve dedup so a persistent
+  // overflow condition re-detected every 70ms tick does not respawn the
+  // modal (which would freeze user interaction the moment a slider drag
+  // pushes them into overflow). Same overflow setup as the sibling test.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_filter_type", "overflow_auto_commit_dedup");
+    t->TestFunc = [](ImGuiTestContext*) {
+      ResetTestState();
+      gui::ClearGuiWarning();
+      gui::g_server = LUMICE_CreateServer();
+      IM_CHECK(gui::g_server != nullptr);
+
+      gui::SummandText row;
+      row.text = "1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4 & 1;2;3;4;5;6;7;8;3-4";
+      row.factors = {
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+        gui::Factor{ gui::RaypathParams{ "1;2;3;4;5;6;7;8;3-4" } },
+      };
+      gui::FilterConfig f;
+      f.name = "OverflowFilter";
+      f.param = gui::SumOfProducts{ row };
+      gui::g_state.filters.push_back(f);
+      gui::SetFilter(gui::g_state, gui::g_state.layers[0].entries[0], gui::g_state.filters.back());
+
+      // First auto-commit tick: overflow → warning set + trigger set.
+      gui::DoRun(/*user_initiated=*/false);
+      IM_CHECK(!gui::PeekGuiWarning().empty());
+      IM_CHECK(gui::IsGuiWarningPending());
+
+      // Frame consumes OpenPopup; trigger cleared, message retained.
+      gui::internal_test::ConsumeGuiWarningPending();
+      IM_CHECK(!gui::IsGuiWarningPending());
+
+      // Second auto-commit tick with the SAME overflow: dedup MUST hold.
+      gui::DoRun(/*user_initiated=*/false);
+      IM_CHECK(!gui::IsGuiWarningPending());  // no modal respawn
+
+      gui::ClearGuiWarning();
+      LUMICE_StopServer(gui::g_server);
+      LUMICE_DestroyServer(gui::g_server);
+      gui::g_server = nullptr;
     };
   }
 }

--- a/test/gui/functional/test_gui_lifecycle.cpp
+++ b/test/gui/functional/test_gui_lifecycle.cpp
@@ -236,7 +236,7 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state.use_gpu_backend = true;  // -> Metal single engine via MaybeReconstructServerForBackend
 #endif
 
-    gui::DoRun();  // real product Run path: sets run_intent=kRunning + commits + starts poller.
+    gui::DoRun(/*user_initiated=*/true);  // real product Run path: sets run_intent=kRunning + commits + starts poller.
     // DoRun no longer writes sim_state (it is reconcile-derived), so assert the INTENT it set.
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(RunIntent::kRunning));
 
@@ -508,7 +508,7 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state = gui::InitDefaultState();
     gui::g_state.sim.infinite = true;
 
-    gui::DoRun();  // real Run path: run_intent=kRunning, commit, start poller.
+    gui::DoRun(/*user_initiated=*/true);  // real Run path: run_intent=kRunning, commit, start poller.
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(RunIntent::kRunning));
 
     // Drive frames until the display reflects the running backend (kSimulating).
@@ -662,7 +662,7 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state.use_gpu_backend = true;
 #endif
 
-    gui::DoRun();
+    gui::DoRun(/*user_initiated=*/true);
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(RunIntent::kRunning));
 
     // Drive SyncFromPoller until the reconcile settles on kDone (natural completion).
@@ -816,7 +816,7 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state.raypath_color.push_back(c0);
     gui::g_state.raypath_color.push_back(c1);
 
-    gui::DoRun();
+    gui::DoRun(/*user_initiated=*/true);
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(RunIntent::kRunning));
 
     // Drive until sim_state == kDone AND intent has latched to kRunCompleted (Mealy edge in
@@ -933,7 +933,7 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state.raypath_color.push_back(c0);
     gui::g_state.raypath_color.push_back(c1);
 
-    gui::DoRun();
+    gui::DoRun(/*user_initiated=*/true);
     IM_CHECK_EQ(static_cast<int>(gui::g_state.run_intent), static_cast<int>(RunIntent::kRunning));
     auto start = std::chrono::steady_clock::now();
     while (gui::g_state.sim_state != SimState::kDone || gui::g_state.run_intent != RunIntent::kRunCompleted) {

--- a/test/gui/responsiveness/test_gui_perf.cpp
+++ b/test/gui/responsiveness/test_gui_perf.cpp
@@ -86,7 +86,7 @@ void StartPerfSimulation() {
 #if defined(__APPLE__)
         gui::g_state.use_gpu_backend = want_metal;  // set AFTER deserialize (it resets g_state)
 #endif
-        gui::DoRun();
+        gui::DoRun(/*user_initiated=*/true);
         return;
       }
     }
@@ -112,7 +112,7 @@ void StartPerfSimulation() {
 #if defined(__APPLE__)
   gui::g_state.use_gpu_backend = want_metal;
 #endif
-  gui::DoRun();
+  gui::DoRun(/*user_initiated=*/true);
 }
 
 void StopPerfSimulation() {
@@ -302,7 +302,7 @@ void RegisterPerfTests(ImGuiTestEngine* engine) {
             // the NEXT successful commit's snapshot (no double-count). `last_commit` always
             // advances so the 70ms cadence check is unchanged.
             auto rays_this_cycle = read_server_rays();
-            bool committed = gui::DoRun();
+            bool committed = gui::DoRun(/*user_initiated=*/false);
             if (committed) {
               per_restart_rays.push_back(rays_this_cycle);
               cumulative_rays += rays_this_cycle;

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -400,7 +400,7 @@ int main(int argc, char** argv) {
             LUMICE_GetStatsResults(gui::g_server, stats, 1);
             unsigned long snapshot_rays = stats[0].sim_ray_num;
 
-            bool committed = gui::DoRun();
+            bool committed = gui::DoRun(/*user_initiated=*/false);
             if (committed) {
               g_main_loop_cumulative_rays += snapshot_rays;
               g_main_loop_restart_count++;

--- a/test/gui/visual/test_gui_auto_ev.cpp
+++ b/test/gui/visual/test_gui_auto_ev.cpp
@@ -155,7 +155,7 @@ void RegisterAutoEvRegressionTests(ImGuiTestEngine* engine) {
       // 4. DoRun → triggers SerializeCoreConfig (dual-fisheye override) → starts poller.
       // DoRun sets the intent (run_intent=kRunning); sim_state is reconcile-derived on the next
       // frame, so assert the intent here (the wait loop below drives frames to kSimulating/data).
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
       IM_CHECK_EQ((int)gui::g_state.run_intent, (int)gui::RunIntent::kRunning);
 
       // 5. Reset counter so the wait loop below starts from 0

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -620,7 +620,7 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
         r.visible = 2;
         r.exposure_offset = 0.0f;
       }
-      gui::DoRun();
+      gui::DoRun(/*user_initiated=*/true);
 
       // Wait for first texture upload (up to 10s)
       auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);

--- a/test/parity-cross-backend/backend/metal_filter_match_test_src.mm
+++ b/test/parity-cross-backend/backend/metal_filter_match_test_src.mm
@@ -37,6 +37,13 @@ struct FilterMatchTestParams {
 //   9  out_match_buf         : uchar[n]
 //   10 params                : FilterMatchTestParams
 //   11 complex_sub_desc_buf  : DeviceFilterDesc[] (Complex sub-specs, flat)
+//   12 and_term_counts_buf   : uchar[] (task-device-flat-and-terms — parallel
+//                              flat AND-term counts, one uint8 per OR-clause
+//                              across every Complex parent; indexed via
+//                              `and_terms_start`). Independent MTLBuffer here
+//                              (test kernel has plenty of free bindings —
+//                              production Metal packs it into buffer 27 via
+//                              KernelParams.and_term_counts_base_offset).
 kernel void filter_match_test_kernel(
     device const DeviceFilterDesc* filter_desc        [[buffer(0)]],
     device const uint*             getfn_offsets      [[buffer(1)]],
@@ -50,6 +57,7 @@ kernel void filter_match_test_kernel(
     device uchar*                  out_match          [[buffer(9)]],
     constant FilterMatchTestParams& prm               [[buffer(10)]],
     device const DeviceFilterDesc* complex_sub_desc   [[buffer(11)]],
+    device const uchar*            and_term_counts    [[buffer(12)]],
     uint tid [[thread_position_in_grid]]) {
   if (tid >= prm.n) { return; }
   uint len = (uint)ray_path_len[tid];
@@ -67,10 +75,10 @@ kernel void filter_match_test_kernel(
   device const DeviceFilterDesc& f = filter_desc[fi];
   bool result;
   if (prm.check_mode == 0u) {
-    result = DeviceFilterMatch(f, complex_sub_desc, path_local, len, getfn_bytes, getfn_offsets,
+    result = DeviceFilterMatch(f, complex_sub_desc, and_term_counts, path_local, len, getfn_bytes, getfn_offsets,
                                (uint)ray_cslot[tid], dir_local, (uint)ray_cid[tid]);
   } else {
-    result = DeviceFilterCheck(f, complex_sub_desc, path_local, len, getfn_bytes, getfn_offsets,
+    result = DeviceFilterCheck(f, complex_sub_desc, and_term_counts, path_local, len, getfn_bytes, getfn_offsets,
                                (uint)ray_cslot[tid], dir_local, (uint)ray_cid[tid]);
   }
   out_match[tid] = result ? 1u : 0u;

--- a/test/parity-cross-backend/backend/test_cuda_filter_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_filter_parity.py
@@ -264,3 +264,56 @@ def test_cuda_multi_ms_filter_cross_seed_self_consistency():
         "verify (transit_seed, transit_ray_count + tid) tuple stays disjoint "
         "across seed-{42, 7} runs."
     )
+
+
+# --------------------------------------------------------------------------- #
+# task-device-flat-and-terms AC1/AC4 — big OR-clause Complex + color coexist.
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.slow
+def test_cuda_big_or_complex_with_color_parity_vs_legacy():
+    """Task-device-flat-and-terms plan §7 Risk 4: physical filter is a 12-clause
+    OR Complex filter (>8, exercises the new flat AND-term counts buffer) AND
+    ``raypath_color`` is enabled → the color pass appends further sub-descs
+    into ``all_sub_descs`` and ``and_term_counts_flat`` after the physical loop.
+
+    The CUDA-side ``EnsureFilterBuffers`` rebuilds ``d_complex_sub_desc_`` under
+    ``if (any_color_group)``; task-device-flat-and-terms MUST mirror that
+    rebuild for ``d_and_term_counts_`` — otherwise, in color+big-OR configs the
+    kernel reads stale/misaligned AND-term counts and mis-evaluates the
+    physical filter (silently invisible to configs without color, since the
+    v1 upload matches the v1 vector).
+
+    Failure mode = "big-OR OK on its own, color OK on its own, but combining
+    them scrambles the physical filter". Pure device-side bug — invisible on
+    the CPU-shared logic test.
+    """
+    cfg = "parity_big_or_with_color"
+    legacy = _run(cfg, "legacy", seed=_SEED)
+    cuda = _run(cfg, "cuda", seed=_SEED)
+
+    _assert_routed(legacy, "legacy", cfg)
+    _assert_routed(cuda, "cuda", cfg)
+
+    corr = _raw_corr_ds(cuda, legacy)
+    cuda_Y = float(cuda.flt_buf[..., 1].sum())
+    legacy_Y = float(legacy.flt_buf[..., 1].sum())
+    assert legacy_Y > 0.0, f"{cfg}: legacy total Y == 0; cannot form energy ratio"
+    energy_ratio = cuda_Y / legacy_Y
+
+    print(
+        f"[parity] {cfg}: cuda ds_corr={corr:.4f} "
+        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+    )
+
+    assert corr >= _T_RAW_CORR_DS, (
+        f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Suspect the CUDA "
+        "color-rebuild path skipping d_and_term_counts_ re-upload (see "
+        "cuda_trace_backend.cu color rebuild block) — physical filter reads "
+        "the pre-color-pass counts snapshot in color+big-OR configs."
+    )
+    assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
+        f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
+        f"[1 ± {_T_ENERGY_TOL}]. Same suspects as above; a mis-indexed "
+        "and_term_counts read can turn AND-terms into no-ops or double-count."
+    )

--- a/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
+++ b/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
@@ -79,8 +79,14 @@ using metal_test::ShouldSkipMetalTests;
 // Layout sanity — guards future struct edits (parity harness reuploads bytes
 // verbatim so any host-side reshape that changes sizeof must be intentional).
 TEST(DeviceFilterDescLayout, SizeFitsBudget) {
-  // Post-267.1b: 108B → 120B (or_clause_count reuses former _pad0;
-  // and_term_counts[8] + sub_desc_start appended for Complex filter support).
+  // task-device-flat-and-terms: `and_term_counts[8]` inline array retired
+  // (moved to a separate host-built flat buffer indexed by `and_terms_start`).
+  // `or_clause_count` was a uint8 (1B); it is now uint16 (2B) plus a trailing
+  // uint16 padding. Former `or_clause_count` position now holds a 1-byte
+  // `_pad_reserved`. Net swap: -8B (inline array) +4B (and_terms_start) +2B
+  // (or_clause_count widen) +2B (trailing pad) = 0B. Total stays 120B; assert
+  // the exact number so any host layout drift is caught early. The <256 belt
+  // is the coarser budget.
   EXPECT_EQ(sizeof(DeviceFilterDesc), static_cast<size_t>(120));
   EXPECT_LE(sizeof(DeviceFilterDesc), static_cast<size_t>(256));
 }
@@ -262,7 +268,7 @@ size_t DispatchParity(MetalHarness& h,
                       id<MTLBuffer> ray_cslot, id<MTLBuffer> ray_cid,
                       id<MTLBuffer> ray_dir, id<MTLBuffer> ray_filter,
                       id<MTLBuffer> out_match, const FilterMatchTestParams& prm,
-                      id<MTLBuffer> complex_sub_desc) {
+                      id<MTLBuffer> complex_sub_desc, id<MTLBuffer> and_term_counts) {
   @autoreleasepool {
     id<MTLBuffer> prm_buf = [h.device newBufferWithLength:sizeof(FilterMatchTestParams)
                                                   options:MTLResourceStorageModeShared];
@@ -282,6 +288,8 @@ size_t DispatchParity(MetalHarness& h,
     [enc setBuffer:out_match        offset:0 atIndex:9];
     [enc setBuffer:prm_buf          offset:0 atIndex:10];
     [enc setBuffer:complex_sub_desc offset:0 atIndex:11];
+    // task-device-flat-and-terms: parallel flat AND-term counts buffer.
+    [enc setBuffer:and_term_counts  offset:0 atIndex:12];
     NSUInteger tg = std::min<NSUInteger>(256, h.pso.maxTotalThreadsPerThreadgroup);
     [enc dispatchThreads:MTLSizeMake(prm.n, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
     [enc endEncoding];
@@ -325,6 +333,9 @@ struct ParityFixture {
   // Flat Complex sub-spec descs. Each Complex slot in `descs` carries
   // sub_desc_start indexing here; non-Complex slots leave the field at 0.
   std::vector<DeviceFilterDesc> complex_sub_descs;
+  // task-device-flat-and-terms: parallel flat AND-term counts buffer indexed
+  // via each Complex parent's `and_terms_start`.
+  std::vector<uint8_t> and_term_counts;
   std::vector<std::unique_ptr<FilterSpec>> host_specs;
   std::vector<FilterConfig> filter_configs;  // kept alive for FilterSpec::Create
   AxisDistribution axis;
@@ -515,6 +526,29 @@ ParityFixture BuildFixture(bool d_applicable_axis) {
         FilterConfig::kFilterIn,
         { { SimpleFilterParam{ a }, SimpleFilterParam{ c } } }));
   }
+  // Complex-E — task-device-flat-and-terms: 20 OR-clauses × 1 AND, direct
+  // >8-clause coverage on the real Metal GPU (AC1's second evidence line
+  // alongside the host-shared-logic test). Face pairs are the same 20 real hex
+  // combinations the host-side test uses so any parity failure surfaces on the
+  // exact same fixture that the CPU-shared matcher already validates.
+  {
+    std::vector<std::vector<SimpleFilterParam>> or_clauses;
+    or_clauses.reserve(20);
+    static constexpr std::pair<IdType, IdType> kFacePairs[20] = {
+        {3, 5}, {3, 6}, {3, 7}, {3, 8}, {4, 5}, {4, 6}, {4, 7}, {4, 8},
+        {5, 3}, {5, 4}, {5, 6}, {5, 7}, {6, 3}, {6, 4}, {6, 5}, {6, 7},
+        {7, 3}, {7, 4}, {7, 5}, {8, 3},
+    };
+    for (const auto& fp : kFacePairs) {
+      RaypathFilterParam p;
+      p.raypath_ = std::vector<IdType>{ fp.first, fp.second };
+      or_clauses.push_back({ SimpleFilterParam{ p } });
+    }
+    push(MakeComplexConfig(
+        static_cast<uint8_t>(FilterConfig::kSymP | FilterConfig::kSymB | FilterConfig::kSymD),
+        FilterConfig::kFilterIn,
+        std::move(or_clauses)));
+  }
 
   fx.descs.reserve(fx.filter_configs.size());
   fx.host_specs.reserve(fx.filter_configs.size());
@@ -523,14 +557,16 @@ ParityFixture BuildFixture(bool d_applicable_axis) {
     DeviceFilterDesc desc = detail::BuildDeviceFilterDesc(cfg, fx.crystal, fx.axis);
     // Inline Complex sub-desc collection — mirrors EnsureFilterBuffers in
     // metal_trace_backend.mm so the fixture exercises the same layout
-    // production uploads.
+    // production uploads. task-device-flat-and-terms: `and_terms_start` +
+    // `and_term_counts` flat buffer added as a fifth argument.
     if (desc.type == kDeviceFilterTypeComplex) {
       const auto* cp = std::get_if<ComplexFilterParam>(&cfg.param_);
       assert(cp != nullptr && "Complex desc type without ComplexFilterParam variant");
       desc.sub_desc_start = static_cast<uint32_t>(fx.complex_sub_descs.size());
+      desc.and_terms_start = static_cast<uint32_t>(fx.and_term_counts.size());
       detail::BuildComplexSubDescs(*cp, fx.crystal, desc.symmetry,
                                    desc.sigma_a, desc.d_applicable != 0u,
-                                   fx.complex_sub_descs);
+                                   fx.complex_sub_descs, fx.and_term_counts);
     }
     fx.descs.push_back(desc);
     fx.host_specs.push_back(FilterSpec::Create(cfg, fx.crystal, fx.axis));
@@ -663,6 +699,12 @@ void RunSweep(MetalHarness& h, const ParityFixture& fx, std::mt19937& rng,
   // dispatch which only triggers on Complex filter slots.
   id<MTLBuffer> complex_sub_buf = MakeShared(h.device, fx.complex_sub_descs.data(),
                                              fx.complex_sub_descs.size() * sizeof(DeviceFilterDesc));
+  // task-device-flat-and-terms: parallel flat AND-term counts (buffer 12).
+  // Test harness uses an independent binding — there are plenty of free slots
+  // (production Metal packs it into buffer 27 via
+  // KernelParams.and_term_counts_base_offset to stay under the 30-buffer cap).
+  id<MTLBuffer> and_term_buf = MakeShared(h.device, fx.and_term_counts.data(),
+                                          fx.and_term_counts.size());
   auto rb = UploadRays(h.device, rays, fx.face_seq_cap);
 
   FilterMatchTestParams prm{};
@@ -671,7 +713,7 @@ void RunSweep(MetalHarness& h, const ParityFixture& fx, std::mt19937& rng,
   prm.check_mode = check_mode;
   DispatchParity(h, filter_desc_buf, offsets_buf, getfn_buf,
                  rb.path, rb.path_len, rb.cslot, rb.cid, rb.dir, rb.filter,
-                 rb.out_match, prm, complex_sub_buf);
+                 rb.out_match, prm, complex_sub_buf, and_term_buf);
 
   const uint8_t* dev_out = static_cast<const uint8_t*>([rb.out_match contents]);
   size_t mism = 0;
@@ -722,9 +764,11 @@ TEST(MetalFilterMatchParity, RandomSequencesAcrossAxisAndCheckMode) {
   size_t total = 0, mism = 0;
   for (int axis_d_app : { 0, 1 }) {
     ParityFixture fx = BuildFixture(axis_d_app != 0);
-    // 10 Simple + 4 Complex (A/B/C/D). When this count changes, update both
-    // BuildFixture and this constant.
-    constexpr size_t kFilterCnt = 14;
+    // 10 Simple + 5 Complex (A/B/C/D/E). When this count changes, update both
+    // BuildFixture and this constant. task-device-flat-and-terms added
+    // Complex-E (20 OR-clauses × 1 AND) so the sweep exercises >8 OR-clauses on
+    // the real GPU.
+    constexpr size_t kFilterCnt = 15;
     ASSERT_EQ(fx.descs.size(), kFilterCnt);
     // Guard against the "double pass-through" trap: if all Complex descs had
     // or_clause_count==0, both host (empty Complex → false) and device (early

--- a/test/unit-correctness/config/test_color_gate_table.cpp
+++ b/test/unit-correctness/config/test_color_gate_table.cpp
@@ -232,6 +232,30 @@ TEST(BuildColorGateTable, PredicatesBeyondBudgetGetKNoBit) {
   auto table = lumice::BuildColorGateTable(cfg, scene);
   ASSERT_EQ(table.entries_.size(), ComponentTable::kMaxBits + 1);
   EXPECT_EQ(table.entries_[ComponentTable::kMaxBits].bit_, ComponentTable::kNoBit);
+  // task-gui-feedback-affordances Step 5 (AC1): the drop count is carried out
+  // on the same table so ServerImpl::CommitConfig can persist it for the GUI
+  // modal surfacing. 65 predicates - 64 bits = 1 dropped.
+  EXPECT_EQ(table.component_overflow_count_, static_cast<size_t>(1));
+}
+
+// task-gui-feedback-affordances Step 5 (AC1): the additive component_overflow_
+// count_ field on ColorGateTable is 0 whenever no predicate overflowed —
+// existing (non-overflow) fixtures must not regress into false positives on
+// the new counter.
+TEST(BuildColorGateTable, ComponentOverflowCountZeroBelowBudget) {
+  SceneConfig scene = MakeScene({ { 1 } });
+  RaypathColorConfig cfg;
+  ColorClassConfig cls;
+  cls.color_[0] = 1.0f;
+  // 3 unique predicates on the same placement — well below the 64-bit cap.
+  for (size_t k = 0; k < 3; ++k) {
+    EntryExitFilterParam ee{};
+    ee.min_len_ = static_cast<size_t>(k + 1);
+    cls.match_.push_back(MakeRef(0, 1, SimpleFilterParam{ ee }));
+  }
+  cfg.classes_.push_back(std::move(cls));
+  auto table = lumice::BuildColorGateTable(cfg, scene);
+  EXPECT_EQ(table.component_overflow_count_, static_cast<size_t>(0));
 }
 
 // ---- pure-function idempotence ----

--- a/test/unit-correctness/core/test_device_filter_check_host.cpp
+++ b/test/unit-correctness/core/test_device_filter_check_host.cpp
@@ -87,6 +87,9 @@ struct Fixture {
   std::vector<uint8_t> getfn;
   uint32_t getfn_offsets[2] = { 0u, 0u };
   std::vector<DeviceFilterDesc> complex_subs;
+  // task-device-flat-and-terms: parallel flat AND-term counts buffer,
+  // indexed via each Complex parent's `and_terms_start`.
+  std::vector<uint8_t> and_term_counts;
   std::vector<FilterConfig> filter_configs;
   std::vector<std::unique_ptr<FilterSpec>> host_specs;
 };
@@ -190,6 +193,26 @@ Fixture BuildFixture(bool d_applicable_axis) {
     push(MakeComplexConfig(static_cast<uint8_t>(FilterConfig::kSymP | FilterConfig::kSymB | FilterConfig::kSymD),
                            FilterConfig::kFilterIn, { { SimpleFilterParam{ a }, SimpleFilterParam{ c } } }));
   }
+  // 9: task-device-flat-and-terms — big-OR Complex, 20 OR-clauses × 1 AND
+  // (raypath), sweeping realistic hex face pairs. Directly exercises the flat
+  // `and_term_counts_buf` path (host-inline array is gone) with a clause count
+  // well above the legacy 8-cap. AC1's primary evidence: >8-clause Complex on
+  // the shared device matcher must match FilterSpec::Check byte-for-byte.
+  {
+    std::vector<std::vector<SimpleFilterParam>> or_clauses;
+    or_clauses.reserve(20);
+    static constexpr std::pair<IdType, IdType> kFacePairs[20] = {
+      { 3, 5 }, { 3, 6 }, { 3, 7 }, { 3, 8 }, { 4, 5 }, { 4, 6 }, { 4, 7 }, { 4, 8 }, { 5, 3 }, { 5, 4 },
+      { 5, 6 }, { 5, 7 }, { 6, 3 }, { 6, 4 }, { 6, 5 }, { 6, 7 }, { 7, 3 }, { 7, 4 }, { 7, 5 }, { 8, 3 },
+    };
+    for (const auto& fp : kFacePairs) {
+      RaypathFilterParam p;
+      p.raypath_ = std::vector<IdType>{ fp.first, fp.second };
+      or_clauses.push_back({ SimpleFilterParam{ p } });
+    }
+    push(MakeComplexConfig(static_cast<uint8_t>(FilterConfig::kSymP | FilterConfig::kSymB | FilterConfig::kSymD),
+                           FilterConfig::kFilterIn, std::move(or_clauses)));
+  }
 
   fx.descs.reserve(fx.filter_configs.size());
   fx.host_specs.reserve(fx.filter_configs.size());
@@ -198,8 +221,9 @@ Fixture BuildFixture(bool d_applicable_axis) {
     if (desc.type == kDeviceFilterTypeComplex) {
       const auto* cp = std::get_if<ComplexFilterParam>(&cfg.param_);
       desc.sub_desc_start = static_cast<uint32_t>(fx.complex_subs.size());
+      desc.and_terms_start = static_cast<uint32_t>(fx.and_term_counts.size());
       detail::BuildComplexSubDescs(*cp, fx.crystal, desc.symmetry, desc.sigma_a, desc.d_applicable != 0u,
-                                   fx.complex_subs);
+                                   fx.complex_subs, fx.and_term_counts);
     }
     fx.descs.push_back(desc);
     fx.host_specs.push_back(FilterSpec::Create(cfg, fx.crystal, fx.axis));
@@ -213,6 +237,9 @@ Fixture BuildFixture(bool d_applicable_axis) {
   // always carries Complex entries).
   if (fx.complex_subs.empty()) {
     fx.complex_subs.push_back(DeviceFilterDesc{});
+  }
+  if (fx.and_term_counts.empty()) {
+    fx.and_term_counts.push_back(0u);
   }
   return fx;
 }
@@ -281,8 +308,8 @@ bool HostCheck(const Fixture& fx, const Ray& r) {
 }
 
 bool DeviceCheck(const Fixture& fx, const Ray& r) {
-  return lm_filter::DeviceFilterCheck(fx.descs[r.filter_idx], fx.complex_subs.data(), r.raw_poly.data(), r.path_len,
-                                      fx.getfn.data(), fx.getfn_offsets,
+  return lm_filter::DeviceFilterCheck(fx.descs[r.filter_idx], fx.complex_subs.data(), fx.and_term_counts.data(),
+                                      r.raw_poly.data(), r.path_len, fx.getfn.data(), fx.getfn_offsets,
                                       /*crystal_slot=*/0u, r.dir, static_cast<uint32_t>(r.crystal_config_id));
 }
 

--- a/test/unit-correctness/core/test_filter_spec.cpp
+++ b/test/unit-correctness/core/test_filter_spec.cpp
@@ -790,5 +790,43 @@ TEST(EntryExitSpec_Match, PBD_OrbitInvariant) {
   }
 }
 
+// =============== task-host-abi-cpu-caps AC2: CPU runtime honors > 16 OR clauses ===============
+
+// The core FilterSpec CPU runtime uses `std::vector<std::vector<unique_ptr>>` internally
+// (filter_spec.cpp:325), so its OR-clause capacity was never actually bounded by the ABI
+// LUMICE_MAX_CONFIG_CLAUSES=16 — the cap only lived in the ABI layout. This test proves
+// that CPU-side Match() semantics work correctly on a ComplexSpec built with N > 16 real
+// OR-clauses (only one of which corresponds to the raypath being probed), i.e. the CPU
+// path was ready for widening all along and the plan §2 "widen ABI to unlock runtime"
+// framing holds.
+TEST(FilterSpec_ManyOrClauses, MatchOnlyMatchingClause) {
+  Crystal crystal = Crystal::CreatePrism(1.0f);
+  constexpr uint8_t kSym = FilterConfig::kSymNone;
+  // Build 30 distinct real raypaths (> the pre-v4.9 ABI cap of 16), varying face numbers over
+  // valid prism range [1, 8]. Then Match against the single raypath at index 24 — only its
+  // matching clause should be satisfied; every other clause must reject it (proving that
+  // ComplexSpec-OR does not spuriously match beyond the intended clause).
+  std::vector<std::vector<IdType>> seeds;
+  for (int i = 0; i < 30; i++) {
+    IdType f0 = static_cast<IdType>(1 + (i % 8));
+    IdType f1 = static_cast<IdType>(1 + ((i + 3) % 8));
+    seeds.push_back({ f0, f1 });
+  }
+  auto spec = MakeComplexSpec(crystal, seeds, kSym, kSigmaARollDeg[0]);
+  ASSERT_NE(spec, nullptr);
+
+  // Probe against each seed: MUST match (its own clause is in the OR).
+  for (size_t i = 0; i < seeds.size(); i++) {
+    SCOPED_TRACE("seed[" + std::to_string(i) + "]=" + FormatRaypath(seeds[i]));
+    EXPECT_TRUE(SpecMatch(spec.get(), seeds[i])) << "OR clause " << i << " (>16) not matched by its own seed";
+  }
+
+  // Probe against a raypath that does NOT appear in any of the 30 clauses: MUST reject.
+  // Use a 3-hop raypath that cannot be produced by any 2-hop seed.
+  std::vector<IdType> non_member = { 3, 5, 7 };
+  EXPECT_FALSE(SpecMatch(spec.get(), non_member))
+      << "ComplexSpec spuriously matched a raypath outside all " << seeds.size() << " OR clauses";
+}
+
 }  // namespace
 }  // namespace lumice

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -2320,39 +2320,48 @@ TEST(StructFilterComplex, EmptyCompositionAccepted) {
 }
 
 TEST(StructFilterComplex, EmptyClauseWithinCompositionCommitEndToEnd) {
-  // Regression (code-review-01, round 1, Major): LUMICE_CompositionSetClauses only allocates
-  // term_ids when total_terms > 0, so a composition where every clause has 0 terms
+  // Regression (code-review-01/02, round 1+2, Major): LUMICE_CompositionSetClauses only
+  // allocates term_ids when total_terms > 0, so a composition where every clause has 0 terms
   // (clause_count > 0, total_terms == 0) legitimately ends up with term_ids == nullptr while
-  // term_counts stays allocated (non-null). Before the fix, LUMICE_CommitConfigStruct's
-  // composition validation conflated term_ids == nullptr with term_counts == nullptr and
-  // rejected this state with LUMICE_ERR_INVALID_CONFIG.
-  //
-  // NOTE: this exact state is NOT reachable via the JSON `"composition": [[]]` path today —
-  // JsonToComplexComposition builds term_ids via std::vector<int>::push_back, so a 0-term
-  // clause leaves that vector empty, and its `.data()` is nullptr, which independently trips
-  // LUMICE_CompositionSetClauses's own "term_ids == nullptr" *argument* check (verified: Parse
-  // returns LUMICE_ERR_NULL_ARG for that JSON shape, never reaching Commit). This test instead
-  // constructs the composition directly through the public C API — any caller (including a
-  // future non-C++ binding) can reach this state by passing a non-null-but-unused term_ids
-  // buffer alongside all-zero term_counts — which is the state LUMICE_CommitConfigStruct must
-  // defensively accept.
+  // term_counts stays allocated (non-null). Round 1 fixed LUMICE_CommitConfigStruct's read-side
+  // check but left SetClauses's own entry-point null-check requiring term_ids unconditionally
+  // non-null whenever clause_count > 0 — which rejected exactly this legitimate shape earlier,
+  // at LUMICE_ParseConfigString time, for the two real production callers (JsonToComplexComposition
+  // / ExpandFilterToStruct) whose std::vector<int> term_ids accumulator is left empty (and thus
+  // .data() == nullptr) when total_terms == 0. Round 2 fixes SetClauses itself to only require
+  // term_ids non-null once total_terms is known to be > 0, restoring pre-v4.9 JSON round-trip
+  // behavior for this shape end-to-end (Parse -> Commit), covering both `[[]]` (one empty
+  // clause) and `[[],[]]` (two empty clauses) per round 1's original ask.
+  nlohmann::json filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 },
+        { "action", "filter_in" },
+        { "type", "complex" },
+        { "composition", nlohmann::json::array({ nlohmann::json::array() }) } },  // [[]]
+      { { "id", 3 },
+        { "action", "filter_in" },
+        { "type", "complex" },
+        { "composition", nlohmann::json::array({ nlohmann::json::array(), nlohmann::json::array() }) } },  // [[],[]]
+  });
   LUMICE_Config cfg{};
   lumice::ConfigOwningGuard cfg_guard(cfg);
-  ASSERT_EQ(LUMICE_ParseConfigString(MakeFullConfigJson().c_str(), &cfg), LUMICE_OK);
-  ASSERT_EQ(cfg.filter_count, 1);  // MakeFullConfigJson's single raypath filter, id 1
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
+  ASSERT_GE(cfg.filter_count, 3);
+  EXPECT_EQ(cfg.filters[1].type, LUMICE_FILTER_TYPE_COMPLEX);
+  EXPECT_EQ(cfg.filters[2].type, LUMICE_FILTER_TYPE_COMPLEX);
 
-  cfg.filters[1].id = 2;
-  cfg.filters[1].type = LUMICE_FILTER_TYPE_COMPLEX;
-  cfg.filters[1].composition_index = 0;
-  cfg.filter_count = 2;
-  cfg.composition_count = 1;
+  const auto& comp1 = cfg.compositions[cfg.filters[1].composition_index];
+  EXPECT_EQ(comp1.clause_count, 1);
+  EXPECT_NE(comp1.term_counts, nullptr);
+  EXPECT_EQ(comp1.term_counts[0], 0);
+  EXPECT_EQ(comp1.term_ids, nullptr);
 
-  int zero_term_counts[1] = { 0 };
-  int dummy_term_ids[1] = { 0 };  // never dereferenced (total_terms == 0); must be non-null
-  ASSERT_EQ(LUMICE_CompositionSetClauses(&cfg.compositions[0], 1, zero_term_counts, dummy_term_ids), LUMICE_OK);
-  EXPECT_EQ(cfg.compositions[0].clause_count, 1);
-  EXPECT_NE(cfg.compositions[0].term_counts, nullptr);
-  EXPECT_EQ(cfg.compositions[0].term_ids, nullptr);
+  const auto& comp2 = cfg.compositions[cfg.filters[2].composition_index];
+  EXPECT_EQ(comp2.clause_count, 2);
+  EXPECT_NE(comp2.term_counts, nullptr);
+  EXPECT_EQ(comp2.term_counts[0], 0);
+  EXPECT_EQ(comp2.term_counts[1], 0);
+  EXPECT_EQ(comp2.term_ids, nullptr);
 
   cfg.infinite = 0;
   cfg.ray_num = 100;

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -19,7 +19,7 @@
 #include "core/crystal.hpp"
 #include "core/def.hpp"
 #include "include/lumice.h"
-#include "include/lumice_config_scope.hpp"  // lumice::ConfigColorGuard RAII for raypath_color
+#include "include/lumice_config_scope.hpp"  // lumice::ConfigOwningGuard RAII for raypath_color
 #include "server/c_api_internal.hpp"        // ConfigToJson (test-only exposure) for emit-shape assertions
 
 // Regression guard (task-fix-stats-ray-count-u32-overflow): ray-count fields must be
@@ -495,7 +495,7 @@ static std::string MakeFullConfigJson() {
 TEST(ParseConfigApi, MinimalPrismConfig) {
   auto json = MakeMinimalConfigJson();
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &config), LUMICE_OK);
 
   EXPECT_EQ(config.crystal_count, 1);
@@ -538,7 +538,7 @@ TEST(ParseConfigApi, RayNumAbove32BitNotTruncated) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_OK);
   EXPECT_EQ(config.infinite, 0);
   // Pre-fix on Windows this truncated to 705'032'704; post-fix it holds the full value.
@@ -549,7 +549,7 @@ TEST(ParseConfigApi, RayNumAbove32BitNotTruncated) {
 TEST(ParseConfigApi, FullConfigWithPyramidAndFilter) {
   auto json = MakeFullConfigJson();
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &config), LUMICE_OK);
 
   // Two crystals
@@ -593,7 +593,7 @@ TEST(ParseConfigApi, FullConfigWithPyramidAndFilter) {
 TEST(ParseConfigApi, ParseModifyCommit) {
   auto json = MakeMinimalConfigJson();
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   ASSERT_EQ(LUMICE_ParseConfigString(json.c_str(), &config), LUMICE_OK);
 
   // Modify ray_num
@@ -625,7 +625,7 @@ TEST(ParseConfigApi, ParseConfigFile) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigFile(tmp_path.u8string().c_str(), &config), LUMICE_OK);
   EXPECT_EQ(config.crystal_count, 1);
   EXPECT_FLOAT_EQ(config.crystals[0].height, 1.5f);
@@ -636,7 +636,7 @@ TEST(ParseConfigApi, ParseConfigFile) {
 
 TEST(ParseConfigApi, NullArgs) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(nullptr, &config), LUMICE_ERR_NULL_ARG);
   EXPECT_EQ(LUMICE_ParseConfigString("{}", nullptr), LUMICE_ERR_NULL_ARG);
   EXPECT_EQ(LUMICE_ParseConfigFile(nullptr, &config), LUMICE_ERR_NULL_ARG);
@@ -646,7 +646,7 @@ TEST(ParseConfigApi, NullArgs) {
 
 TEST(ParseConfigApi, InvalidJson) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString("not json at all", &config), LUMICE_ERR_INVALID_JSON);
   EXPECT_EQ(LUMICE_ParseConfigString("{invalid", &config), LUMICE_ERR_INVALID_JSON);
 }
@@ -654,7 +654,7 @@ TEST(ParseConfigApi, InvalidJson) {
 
 TEST(ParseConfigApi, MissingCrystalSection) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   // Valid JSON but missing "crystal" key
   EXPECT_EQ(LUMICE_ParseConfigString(R"({"scene": {}})", &config), LUMICE_ERR_MISSING_FIELD);
 }
@@ -662,7 +662,7 @@ TEST(ParseConfigApi, MissingCrystalSection) {
 
 TEST(ParseConfigApi, FileNotFound) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigFile("/tmp/nonexistent_lumice_config_12345.json", &config), LUMICE_ERR_FILE_NOT_FOUND);
 }
 
@@ -675,7 +675,7 @@ TEST(ParseConfigApi, UnsupportedFilterType) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_ERR_INVALID_VALUE);
 }
 
@@ -696,7 +696,7 @@ TEST(ParseConfigApi, ArraySpectrumParsed) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   ASSERT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_OK);
   EXPECT_EQ(config.spectrum_count, 2);
   EXPECT_FLOAT_EQ(config.spectrum_entries[0].wavelength, 450.0f);
@@ -712,7 +712,7 @@ TEST(ParseConfigApi, StructSpectrumRoundTrip) {
   // the array shape core light_config expects (mirrors GUI struct→commit path).
   auto json = MakeMinimalConfigJson();
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   ASSERT_EQ(LUMICE_ParseConfigString(json.c_str(), &config), LUMICE_OK);
 
   config.spectrum_count = 3;
@@ -742,7 +742,7 @@ TEST(ParseConfigApi, ArraySpectrumOverCap) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -756,7 +756,7 @@ TEST(ParseConfigApi, SpectrumEnumerations) {
 
     LUMICE_Config config{};
 
-    lumice::ConfigColorGuard config_guard(config);
+    lumice::ConfigOwningGuard config_guard(config);
     ASSERT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_OK) << "Failed for spectrum: " << sp;
     EXPECT_STREQ(config.spectrum, sp);
     EXPECT_EQ(config.spectrum_count, 0);
@@ -769,7 +769,7 @@ TEST(ParseConfigApi, SpectrumEnumerations) {
 
   LUMICE_Config config{};
 
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   EXPECT_EQ(LUMICE_ParseConfigString(root.dump().c_str(), &config), LUMICE_ERR_INVALID_VALUE);
 }
 
@@ -1393,7 +1393,7 @@ namespace {
 // is enough to inspect the emitted filter shape without a server.
 // task-344: caller-owned out-param (LUMICE_Config is now non-copyable — raypath_color owns
 // a heap allocation; returning by value would leave two aliased copies). Caller must attach
-// a lumice::ConfigColorGuard to `out` before calling.
+// a lumice::ConfigOwningGuard to `out` before calling.
 void FillOneFilterConfig(LUMICE_Config* out, const LUMICE_FilterParam& f) {
   out->filter_count = 1;
   out->filters[0] = f;
@@ -1417,7 +1417,7 @@ TEST(StructFilterEmit, None) {
   f.action = 0;  // filter_in
   f.type = LUMICE_FILTER_TYPE_NONE;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1439,7 +1439,7 @@ TEST(StructFilterEmit, Raypath) {
   f.raypath[2] = 5;
   f.symmetry = 1 | 2;  // P | B
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1462,7 +1462,7 @@ TEST(StructFilterEmit, EntryExitAllFields) {
   f.ee_min_len = 2;
   f.ee_max_len = 8;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1485,7 +1485,7 @@ TEST(StructFilterEmit, EntryExitWildcardsOmitted) {
   f.ee_min_len = 1;
   f.ee_max_len = -1;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1505,7 +1505,7 @@ TEST(StructFilterEmit, Direction) {
   f.dir_el = -15.0f;
   f.dir_radii = 2.5f;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1522,7 +1522,7 @@ TEST(StructFilterEmit, Crystal) {
   f.type = LUMICE_FILTER_TYPE_CRYSTAL;
   f.crystal_id = 2;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   auto root = ConfigToJson(config);
   const auto& jf = root.at("filter").at(0);
@@ -1536,7 +1536,7 @@ TEST(StructFilterEmit, UnsetTypeThrows) {
   LUMICE_FilterParam f{};  // type defaults to 0 == UNSET
   f.id = 1;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   EXPECT_THROW(ConfigToJson(config), std::invalid_argument);
 }
@@ -1546,7 +1546,7 @@ TEST(StructFilterEmit, OutOfRangeTypeThrows) {
   f.id = 1;
   f.type = 99;  // out of range
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, f);
   EXPECT_THROW(ConfigToJson(config), std::invalid_argument);
 }
@@ -1561,7 +1561,7 @@ namespace {
 void ExpectEmitMatchesCore(const LUMICE_FilterParam& lf, const lumice::FilterConfig& fc) {
   nlohmann::json core_j = fc;  // ADL -> lumice::to_json(json&, const FilterConfig&)
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneFilterConfig(&config, lf);
   auto my_j = ConfigToJson(config).at("filter").at(0);
   EXPECT_EQ(my_j, core_j) << "C-API emit:\n" << my_j.dump(2) << "\ncore to_json:\n" << core_j.dump(2);
@@ -1689,7 +1689,7 @@ namespace {
 // filter (keeping its id, so the scattering reference stays valid) with `f` and shrink to
 // a fast finite sim. Returns the config ready for LUMICE_CommitConfigStruct.
 // task-344: caller-owned out-param. Populates `out` via LUMICE_ParseConfigString then
-// overrides filter[0] and finiteness. Caller must attach ConfigColorGuard first.
+// overrides filter[0] and finiteness. Caller must attach ConfigOwningGuard first.
 void FillCommitConfigWithFilter(LUMICE_Config* out, const LUMICE_FilterParam& f) {
   EXPECT_EQ(LUMICE_ParseConfigString(MakeFullConfigJson().c_str(), out), LUMICE_OK);
   EXPECT_GE(out->filter_count, 1);
@@ -1702,7 +1702,7 @@ void FillCommitConfigWithFilter(LUMICE_Config* out, const LUMICE_FilterParam& f)
 
 int CommitFilter(const LUMICE_FilterParam& f) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillCommitConfigWithFilter(&config, f);
   auto* server = LUMICE_CreateServer();
   EXPECT_NE(server, nullptr);
@@ -1773,7 +1773,7 @@ namespace {
 // the round-tripped filters[0]. Exercises both new 327.1 pieces end to end.
 LUMICE_FilterParam RoundTripFilter(const LUMICE_FilterParam& in) {
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   FillOneFilterConfig(&cfg, in);
   // Zero-init so that if LUMICE_ConfigToJson unexpectedly fails, the subsequent
   // LUMICE_ParseConfigString sees a valid empty C-string (loud parse error) rather than
@@ -1784,7 +1784,7 @@ LUMICE_FilterParam RoundTripFilter(const LUMICE_FilterParam& in) {
   EXPECT_EQ(LUMICE_ConfigToJson(&cfg, buf, sizeof(buf), &len), LUMICE_OK);
   EXPECT_LT(len, sizeof(buf));  // these small configs never truncate
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   EXPECT_EQ(LUMICE_ParseConfigString(buf, &out), LUMICE_OK);
   EXPECT_EQ(out.filter_count, 1);
   return out.filters[0];
@@ -1889,7 +1889,7 @@ TEST(StructFilterParse, NonRaypathTypesNoLongerRejected) {
   auto json = FullConfigWithFilterJson(
       { { "id", 1 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 }, { "exit", 5 } });
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_OK);
   ASSERT_GE(out.filter_count, 1);
   EXPECT_EQ(out.filters[0].type, LUMICE_FILTER_TYPE_ENTRY_EXIT);
@@ -1904,7 +1904,7 @@ TEST(StructFilterParse, ComplexWithoutCompositionRejected) {
   // filter missing its required "composition" array is rejected with MISSING_FIELD.
   auto json = FullConfigWithFilterJson({ { "id", 1 }, { "action", "filter_in" }, { "type", "complex" } });
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_MISSING_FIELD);
 }
 
@@ -1912,7 +1912,7 @@ TEST(StructFilterParse, UnknownTypeRejected) {
   // The default branch also covers arbitrary unknown type strings (not just "complex").
   auto json = FullConfigWithFilterJson({ { "id", 1 }, { "action", "filter_in" }, { "type", "bogus" } });
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_ERR_INVALID_VALUE);
 }
 
@@ -1924,7 +1924,7 @@ TEST(StructFilterParse, IllegalEntryExitValuePassesThroughLikeCore) {
   auto json = FullConfigWithFilterJson(
       { { "id", 1 }, { "action", "filter_in" }, { "type", "entry_exit" }, { "entry", 3 }, { "min_len", 0 } });
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   EXPECT_EQ(LUMICE_ParseConfigString(json.c_str(), &out), LUMICE_OK);
   ASSERT_GE(out.filter_count, 1);
   EXPECT_EQ(out.filters[0].ee_min_len, 0);  // stored verbatim, not normalized/rejected here
@@ -1941,7 +1941,7 @@ void ExpectParseMatchesCore(const nlohmann::json& jf) {
   nlohmann::json core_out = fc;
   // my path: ParseConfigString -> struct -> LUMICE_ConfigToJson -> filter[0]
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFilterJson(jf).c_str(), &cfg), LUMICE_OK);
   char buf[8192];
   size_t len = 0;
@@ -1998,7 +1998,7 @@ TEST(StructFilterParse, ConfigToJsonBufferTruncationContract) {
   f.raypath[0] = 3;
   f.raypath[1] = 5;
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   FillOneFilterConfig(&cfg, f);
 
   // NULL config -> NULL_ARG.
@@ -2078,12 +2078,16 @@ void ExpectComplexMatchesCore(const nlohmann::json& filter_array, int complex_id
 
   LUMICE_Config cfg{};
 
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filter_array).c_str(), &cfg), LUMICE_OK);
-  char buf[16384];
+  // Query full length first, then allocate a right-sized buffer — the pre-v4.9 fixed 16KB
+  // buffer overflowed once compositions with N > ~100 OR-clauses became possible.
+  size_t needed = 0;
+  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, nullptr, 0, &needed), LUMICE_OK);
+  std::vector<char> buf(needed + 1, '\0');
   size_t len = 0;
-  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, buf, sizeof(buf), &len), LUMICE_OK);
-  auto my_root = nlohmann::json::parse(std::string(buf, len));
+  ASSERT_EQ(LUMICE_ConfigToJson(&cfg, buf.data(), buf.size(), &len), LUMICE_OK);
+  auto my_root = nlohmann::json::parse(std::string(buf.data(), len));
   nlohmann::json my_j;
   for (const auto& jf : my_root.at("filter")) {
     if (jf.at("id").get<int>() == complex_id) {
@@ -2129,7 +2133,7 @@ TEST(StructFilterComplex, StructRoundTrip) {
   // Build a complex config struct directly, round-trip through the public serialize+parse
   // APIs, and assert the composition survives (clause/term/id fidelity).
   LUMICE_Config in{};
-  lumice::ConfigColorGuard in_guard(in);
+  lumice::ConfigOwningGuard in_guard(in);
   in.filter_count = 3;
   in.filters[0].id = 1;
   in.filters[0].type = LUMICE_FILTER_TYPE_RAYPATH;
@@ -2146,29 +2150,35 @@ TEST(StructFilterComplex, StructRoundTrip) {
   in.filters[2].type = LUMICE_FILTER_TYPE_COMPLEX;
   in.filters[2].composition_index = 0;
   in.composition_count = 1;
-  in.compositions[0].clause_count = 2;
-  in.compositions[0].term_counts[0] = 2;  // AND(1,2)
-  in.compositions[0].clauses[0][0] = 1;
-  in.compositions[0].clauses[0][1] = 2;
-  in.compositions[0].term_counts[1] = 1;  // bare 1
-  in.compositions[0].clauses[1][0] = 1;
+  // v4.9: compositions[i] owns heap ptrs; populate via LUMICE_CompositionSetClauses
+  // rather than direct field writes. `clauses = OR(AND(1,2), 1)` in clause-major flat form:
+  //   term_counts = [2, 1], term_ids = [1, 2,   1]
+  int rt_term_counts[2] = { 2, 1 };
+  int rt_term_ids[3] = { 1, 2, 1 };
+  ASSERT_EQ(LUMICE_CompositionSetClauses(&in.compositions[0], 2, rt_term_counts, rt_term_ids), LUMICE_OK);
 
   char buf[16384];
   size_t len = 0;
   ASSERT_EQ(LUMICE_ConfigToJson(&in, buf, sizeof(buf), &len), LUMICE_OK);
   LUMICE_Config out{};
-  lumice::ConfigColorGuard out_guard(out);
+  lumice::ConfigOwningGuard out_guard(out);
   ASSERT_EQ(LUMICE_ParseConfigString(buf, &out), LUMICE_OK);
 
   ASSERT_EQ(out.filter_count, 3);
   ASSERT_EQ(out.filters[2].type, LUMICE_FILTER_TYPE_COMPLEX);
   const auto& oc = out.compositions[out.filters[2].composition_index];
   EXPECT_EQ(oc.clause_count, 2);
-  EXPECT_EQ(oc.term_counts[0], 2);
-  EXPECT_EQ(oc.clauses[0][0], 1);
-  EXPECT_EQ(oc.clauses[0][1], 2);
-  EXPECT_EQ(oc.term_counts[1], 1);
-  EXPECT_EQ(oc.clauses[1][0], 1);
+  int c0_n = 0;
+  const int* c0_terms = LUMICE_CompositionClauseTerms(&oc, 0, &c0_n);
+  ASSERT_NE(c0_terms, nullptr);
+  EXPECT_EQ(c0_n, 2);
+  EXPECT_EQ(c0_terms[0], 1);
+  EXPECT_EQ(c0_terms[1], 2);
+  int c1_n = 0;
+  const int* c1_terms = LUMICE_CompositionClauseTerms(&oc, 1, &c1_n);
+  ASSERT_NE(c1_terms, nullptr);
+  EXPECT_EQ(c1_n, 1);
+  EXPECT_EQ(c1_terms[0], 1);
 }
 
 TEST(StructFilterComplex, CommitStructEndToEnd) {
@@ -2179,7 +2189,7 @@ TEST(StructFilterComplex, CommitStructEndToEnd) {
       { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
   cfg.infinite = 0;
   cfg.ray_num = 100;
@@ -2205,7 +2215,7 @@ TEST(StructFilterComplex, ComplexFilterCommitReusesOnNonRendererChange) {
       { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2 } } },
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
   cfg.infinite = 0;
   cfg.ray_num = 100;
@@ -2232,7 +2242,7 @@ TEST(StructFilterComplex, DanglingReferenceRejected) {
       { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 99 } } },  // 99 not defined
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2244,7 +2254,7 @@ TEST(StructFilterComplex, ReferenceToComplexRejected) {
       { { "id", 3 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 2 } } },  // refs complex 2
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2262,7 +2272,7 @@ TEST(StructFilterComplex, TooManyTermsRejected) {
                       { "type", "complex" },
                       { "composition", nlohmann::json::array({ big_clause }) } });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2277,7 +2287,7 @@ TEST(StructFilterComplex, TooManyClausesRejected) {
       { { "id", 2 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", comp } },
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2291,7 +2301,7 @@ TEST(StructFilterComplex, TooManyCompositionsRejected) {
         { { "id", 100 + i }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1 } } });
   }
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2302,11 +2312,115 @@ TEST(StructFilterComplex, EmptyCompositionAccepted) {
       { { "id", 2 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", nlohmann::json::array() } },
   });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
   ASSERT_GE(cfg.filter_count, 2);
   EXPECT_EQ(cfg.filters[1].type, LUMICE_FILTER_TYPE_COMPLEX);
   EXPECT_EQ(cfg.compositions[cfg.filters[1].composition_index].clause_count, 0);
+}
+
+// task-host-abi-cpu-caps AC1 (§4 Step 8): a `complex` filter that OR's N > 16 real raypath
+// simple filters (well past the pre-v4.9 LUMICE_MAX_CONFIG_CLAUSES=16 cap) survives the full
+// C-API round-trip (JSON parse ↔ ConfigToJson emit ↔ core to_json cross-check). Uses the same
+// ExpectComplexMatchesCore helper as OrOfRaypathsMatchesCore, so failure would flag any
+// difference between the new pointer-storage emit and core's to_json output byte for byte.
+TEST(StructFilterComplex, ManyOrClausesMatchesCore) {
+  constexpr int kN = 200;  // >> old cap 16, well under new cap 4096
+  nlohmann::json filters = nlohmann::json::array();
+  nlohmann::json comp = nlohmann::json::array();
+  for (int i = 1; i <= kN; i++) {
+    // Distinct real raypaths — a mix of 1-face and 2-face patterns; face numbers cycle
+    // over the valid prism range [1, 8] so each generated raypath is a legal simple filter.
+    int f0 = 1 + ((i - 1) % 8);
+    int f1 = 1 + (i % 8);
+    filters.push_back({ { "id", i }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { f0, f1 } } });
+    comp.push_back(i);
+  }
+  const int complex_id = kN + 1;
+  filters.push_back(
+      { { "id", complex_id }, { "action", "filter_in" }, { "type", "complex" }, { "composition", comp } });
+  // Cross-check: core's own to_json vs C-API round-trip must agree even at 200 OR clauses.
+  ExpectComplexMatchesCore(filters, complex_id);
+}
+
+// task-host-abi-cpu-caps AC1 end-to-end (§4 Step 8): the same N > 16 OR-clauses complex filter
+// commits successfully to a real server through the struct path (Config → C ABI →
+// core ConfigManager). If the pre-v4.9 clause-count-16 cap silently truncated, the composition
+// would round-trip with fewer clauses and either LUMICE_ERR_INVALID_CONFIG or an incorrect
+// commit would surface here.
+TEST(StructFilterComplex, ManyOrClausesCommitStructEndToEnd) {
+  constexpr int kN = 200;
+  nlohmann::json filters = nlohmann::json::array();
+  nlohmann::json comp = nlohmann::json::array();
+  for (int i = 1; i <= kN; i++) {
+    int f0 = 1 + ((i - 1) % 8);
+    int f1 = 1 + (i % 8);
+    filters.push_back({ { "id", i }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { f0, f1 } } });
+    comp.push_back(i);
+  }
+  const int complex_id = kN + 1;
+  filters.push_back(
+      { { "id", complex_id }, { "action", "filter_in" }, { "type", "complex" }, { "composition", comp } });
+  LUMICE_Config cfg{};
+  lumice::ConfigOwningGuard cfg_guard(cfg);
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(filters).c_str(), &cfg), LUMICE_OK);
+  ASSERT_EQ(cfg.compositions[cfg.filters[kN].composition_index].clause_count, kN);
+  cfg.infinite = 0;
+  cfg.ray_num = 100;
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+  int reused = -1;
+  EXPECT_EQ(LUMICE_CommitConfigStruct(server, &cfg, &reused), LUMICE_OK);
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
+// task-host-abi-cpu-caps §7 risk 2 regression (§4 Step 8): parse two different compositions
+// into the SAME LUMICE_Config in sequence; the second parse must fully replace the first
+// (correct clause_count, correct term ids, no residual state from the first). This is the
+// direct regression witness for the double-free / leak hazard introduced by making
+// LUMICE_ComplexComposition an owning type — the create-or-replace contract in
+// LUMICE_CompositionSetClauses + release-before-memset in JsonToConfig together ensure the
+// first parse's heap allocations are released before the second parse overwrites the pointers.
+// Value-semantics only (mirrors ConsecutiveParseIntoSameConfigOverridesCorrectly);
+// leak detection itself lives outside this test (valgrind / asan, plan §7 risk 2).
+TEST(StructFilterComplex, ConsecutiveParseIntoSameCompositionOverridesCorrectly) {
+  LUMICE_Config cfg{};
+  lumice::ConfigOwningGuard cfg_guard(cfg);
+
+  // First parse: a 3-clause OR of raypaths.
+  nlohmann::json first_filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 1, 4 } } },
+      { { "id", 3 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 6, 7 } } },
+      { { "id", 10 }, { "action", "filter_in" }, { "type", "complex" }, { "composition", { 1, 2, 3 } } },
+  });
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(first_filters).c_str(), &cfg), LUMICE_OK);
+  ASSERT_EQ(cfg.composition_count, 1);
+  ASSERT_EQ(cfg.compositions[0].clause_count, 3);
+  ASSERT_NE(cfg.compositions[0].term_ids, nullptr);
+  ASSERT_NE(cfg.compositions[0].term_counts, nullptr);
+
+  // Second parse into the SAME cfg: a single-clause AND (different clause_count AND different
+  // term shape). Verifies the CREATE-OR-REPLACE contract on both LUMICE_Config-level Release
+  // (via JsonToConfig) and per-record LUMICE_CompositionSetClauses (via JsonToComplexComposition).
+  nlohmann::json second_filters = nlohmann::json::array({
+      { { "id", 1 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 3, 5 } } },
+      { { "id", 2 }, { "action", "filter_in" }, { "type", "raypath" }, { "raypath", { 1, 4 } } },
+      { { "id", 20 },
+        { "action", "filter_in" },
+        { "type", "complex" },
+        { "composition", nlohmann::json::array({ nlohmann::json::array({ 1, 2 }) }) } },
+  });
+  ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithFiltersJson(second_filters).c_str(), &cfg), LUMICE_OK);
+  ASSERT_EQ(cfg.composition_count, 1);
+  EXPECT_EQ(cfg.compositions[0].clause_count, 1);
+  int c0_n = 0;
+  const int* c0_terms = LUMICE_CompositionClauseTerms(&cfg.compositions[0], 0, &c0_n);
+  ASSERT_NE(c0_terms, nullptr);
+  EXPECT_EQ(c0_n, 2);
+  EXPECT_EQ(c0_terms[0], 1);
+  EXPECT_EQ(c0_terms[1], 2);
 }
 
 // =====================================================================================
@@ -2320,7 +2434,7 @@ namespace {
 
 // Minimal LUMICE_Config carrying exactly one color class, for ConfigToJson emit assertions.
 // task-344: `out` must be a caller-owned LUMICE_Config with a lifetime-bound
-// lumice::ConfigColorGuard already attached. This function allocates raypath_color via
+// lumice::ConfigOwningGuard already attached. This function allocates raypath_color via
 // LUMICE_ConfigCreateColorClasses on `out` — the guard's destructor releases it.
 void FillOneColorClassConfig(LUMICE_Config* out, const LUMICE_ColorClass& cls, int mode = LUMICE_COLOR_MODE_DOMINANT) {
   LUMICE_ColorClass* classes = LUMICE_ConfigCreateColorClasses(out, 1);
@@ -2413,7 +2527,7 @@ std::string MakeColorSimConfigWithSymmetryJson() {
 
 TEST(StructColorClassEmit, MatchAllDefaultOmitsPredicateType) {
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, MakeWholeCrystalClass());
   auto root = ConfigToJson(config);
   ASSERT_TRUE(root.contains("raypath_color"));
@@ -2435,7 +2549,7 @@ TEST(StructColorClassEmit, RaypathPredicate) {
   cls.match[0].predicate.raypath[0] = 3;
   cls.match[0].predicate.raypath[1] = 5;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2454,7 +2568,7 @@ TEST(StructColorClassEmit, EntryExitPredicateAllFields) {
   cls.match[0].predicate.ee_min_len = 2;
   cls.match[0].predicate.ee_max_len = 8;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2475,7 +2589,7 @@ TEST(StructColorClassEmit, EntryExitWildcardsOmitted) {
   cls.match[0].predicate.ee_min_len = 1;
   cls.match[0].predicate.ee_max_len = -1;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2490,7 +2604,7 @@ TEST(StructColorClassEmit, DirectionPredicate) {
   cls.match[0].predicate.dir_el = -15.0f;
   cls.match[0].predicate.dir_radii = 2.5f;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2506,7 +2620,7 @@ TEST(StructColorClassEmit, CrystalPredicate) {
   cls.match[0].predicate.type = LUMICE_FILTER_TYPE_CRYSTAL;
   cls.match[0].predicate.crystal_id = 7;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2521,7 +2635,7 @@ TEST(StructColorClassEmit, CombineAllVisibleFalseSoloTrueEmitted) {
   cls.visible = 0;  // A4: zero-init default would also be 0 (invisible)
   cls.solo = 1;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& jc = EmitFirstColorClass(root);
@@ -2537,7 +2651,7 @@ TEST(StructColorClassEmit, ZeroInitClassIsInvisible) {
   cls.match_count = 1;
   cls.match[0].crystal = 1;
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& jc = EmitFirstColorClass(root);
@@ -2548,7 +2662,7 @@ TEST(StructColorClassEmit, ZeroInitClassIsInvisible) {
 TEST(StructColorClassEmit, ZeroCountOmitsKey) {
   // AC4: no color classes => no "raypath_color" key => JSON byte-shape identical to pre-v4.7.
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   config.raypath_color_count = 0;
   auto root = ConfigToJson(config);
   EXPECT_FALSE(root.contains("raypath_color"));
@@ -2557,14 +2671,14 @@ TEST(StructColorClassEmit, ZeroCountOmitsKey) {
 TEST(StructColorClassEmit, ModeAdditiveAndPainterEmitted) {
   {
     LUMICE_Config config{};
-    lumice::ConfigColorGuard config_guard(config);
+    lumice::ConfigOwningGuard config_guard(config);
     FillOneColorClassConfig(&config, MakeWholeCrystalClass(), LUMICE_COLOR_MODE_ADDITIVE);
     auto add = ConfigToJson(config);
     EXPECT_EQ(add.at("raypath_color").at("mode").get<std::string>(), "additive");
   }
   {
     LUMICE_Config config{};
-    lumice::ConfigColorGuard config_guard(config);
+    lumice::ConfigOwningGuard config_guard(config);
     FillOneColorClassConfig(&config, MakeWholeCrystalClass(), LUMICE_COLOR_MODE_PAINTER);
     auto pnt = ConfigToJson(config);
     EXPECT_EQ(pnt.at("raypath_color").at("mode").get<std::string>(), "painter");
@@ -2579,7 +2693,7 @@ TEST(StructColorClassEmit, SymmetrySingleBitEmitted) {
   cls.match[0].predicate.raypath[0] = 3;
   cls.match[0].predicate.symmetry = 1;  // P
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2593,7 +2707,7 @@ TEST(StructColorClassEmit, SymmetryCombinedBitsEmitted) {
   cls.match[0].predicate.crystal_id = 1;
   cls.match[0].predicate.symmetry = 1 | 2 | 4;  // PBD
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2608,7 +2722,7 @@ TEST(StructColorClassEmit, SymmetryWithMatchAll) {
   cls.match[0].predicate.type = LUMICE_FILTER_TYPE_UNSET;
   cls.match[0].predicate.symmetry = 2;  // B
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2626,7 +2740,7 @@ TEST(StructColorClassEmit, SymmetryOmittedWhenDefaultOnTypedArm) {
   cls.match[0].predicate.raypath[0] = 3;
   // cls.match[0].predicate.symmetry left at 0 (zero-init).
   LUMICE_Config config{};
-  lumice::ConfigColorGuard config_guard(config);
+  lumice::ConfigOwningGuard config_guard(config);
   FillOneColorClassConfig(&config, cls);
   auto root = ConfigToJson(config);
   const auto& ref = EmitFirstColorClass(root).at("match").at(0);
@@ -2663,7 +2777,7 @@ TEST(StructColorClassEmitIsomorphism, RoundTripThroughCore) {
 
   LUMICE_Config cfg{};
 
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color_count, 2);
   ASSERT_EQ(cfg.raypath_color_mode, LUMICE_COLOR_MODE_ADDITIVE);
@@ -2680,7 +2794,7 @@ TEST(ParseConfigApi, RaypathColorArrayFormParsed) {
   nlohmann::json rc =
       nlohmann::json::array({ ColorClassJson({ 1.0f, 0.0f, 0.0f }, nlohmann::json::array({ ColorRefJson(0, 1) })) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   EXPECT_EQ(cfg.raypath_color_count, 1);
   // doc §4.8: bare-array wire form now
@@ -2702,7 +2816,7 @@ TEST(ParseConfigApi, RaypathColorObjectFormParsed) {
   c0["solo"] = true;
   rc["classes"] = nlohmann::json::array({ c0 });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   EXPECT_EQ(cfg.raypath_color_count, 1);
   EXPECT_EQ(cfg.raypath_color_mode, LUMICE_COLOR_MODE_PAINTER);
@@ -2727,7 +2841,7 @@ TEST(ParseConfigApi, RaypathColorPredicateArms) {
   cry["crystal_id"] = 9;
   nlohmann::json rc = nlohmann::json::array({ ColorClassJson({ 1, 0, 0 }, nlohmann::json::array({ ee, dir, cry })) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color_count, 1);
   ASSERT_EQ(cfg.raypath_color[0].match_count, 3);
@@ -2769,7 +2883,7 @@ TEST(ParseConfigApi, RaypathColorPredicateSymmetryParsed) {
   nlohmann::json rc =
       nlohmann::json::array({ ColorClassJson({ 1, 0, 0 }, nlohmann::json::array({ rp, ee, dir, cry, ma })) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color_count, 1);
   ASSERT_EQ(cfg.raypath_color[0].match_count, 5);
@@ -2796,7 +2910,7 @@ TEST(ParseConfigApi, RaypathColorPredicateSymmetryOmittedDefaultsToZero) {
   nlohmann::json ma = ColorRefJson(0, 1);
   nlohmann::json rc = nlohmann::json::array({ ColorClassJson({ 1, 0, 0 }, nlohmann::json::array({ rp, ma })) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color[0].match_count, 2);
   EXPECT_EQ(cfg.raypath_color[0].match[0].predicate.symmetry, 0);
@@ -2808,7 +2922,7 @@ TEST(ParseConfigApi, RaypathColorComplexPredicateRejected) {
   bad["type"] = "complex";
   nlohmann::json rc = nlohmann::json::array({ ColorClassJson({ 1, 0, 0 }, nlohmann::json::array({ bad })) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_ERR_INVALID_VALUE);
 }
 
@@ -2820,7 +2934,7 @@ TEST(ParseConfigApi, RaypathColorClassesOverCapRejected) {
   nlohmann::json rc;
   rc["classes"] = classes;
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2831,7 +2945,7 @@ TEST(ParseConfigApi, RaypathColorRefsOverCapRejected) {
   }
   nlohmann::json rc = nlohmann::json::array({ ColorClassJson({ 1, 0, 0 }, match) });
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   EXPECT_EQ(LUMICE_ParseConfigString(FullConfigWithRaypathColorJson(rc).c_str(), &cfg), LUMICE_ERR_INVALID_CONFIG);
 }
 
@@ -2870,7 +2984,7 @@ TEST(RaypathColorApi, JsonAndStructCommitPixelEquivalent) {
   LUMICE_Server* b = LUMICE_CreateServerEx(&sc);
   ASSERT_NE(b, nullptr);
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(json.c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color_count, 2);
   ASSERT_EQ(LUMICE_CommitConfigStruct(b, &cfg, nullptr), LUMICE_OK);
@@ -2925,7 +3039,7 @@ TEST(RaypathColorApi, JsonAndStructCommitPixelEquivalentWithSymmetry) {
   LUMICE_Server* b = LUMICE_CreateServerEx(&sc);
   ASSERT_NE(b, nullptr);
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   ASSERT_EQ(LUMICE_ParseConfigString(json.c_str(), &cfg), LUMICE_OK);
   ASSERT_EQ(cfg.raypath_color_count, 2);
   // Direct assertion that the struct path carries the symmetry bit (redundant with the
@@ -3359,7 +3473,7 @@ TEST(RaypathColorApi, CommitConfigStructOverCapRejected) {
   // branch fires before any dereference (this test never intended to allocate an
   // out-of-cap array, and Create would reject the count anyway).
   LUMICE_Config over_classes{};
-  lumice::ConfigColorGuard over_classes_guard(over_classes);
+  lumice::ConfigOwningGuard over_classes_guard(over_classes);
   over_classes.raypath_color_count = LUMICE_MAX_CONFIG_COLOR_CLASSES + 1;
   EXPECT_EQ(LUMICE_CommitConfigStruct(s, &over_classes, nullptr), LUMICE_ERR_INVALID_CONFIG);
 
@@ -3368,7 +3482,7 @@ TEST(RaypathColorApi, CommitConfigStructOverCapRejected) {
   // previous inline-array pattern (`over_refs.raypath_color[0].match_count = ...`) would
   // deref a nullptr under the new ABI.
   LUMICE_Config over_refs{};
-  lumice::ConfigColorGuard over_refs_guard(over_refs);
+  lumice::ConfigOwningGuard over_refs_guard(over_refs);
   LUMICE_ColorClass* classes = LUMICE_ConfigCreateColorClasses(&over_refs, 1);
   ASSERT_NE(classes, nullptr);
   classes[0].match_count = LUMICE_MAX_CONFIG_COLOR_REFS + 1;
@@ -3388,7 +3502,7 @@ TEST(RaypathColorApi, CommitConfigStructRejectsNullArrayWithNonzeroCount) {
   ASSERT_NE(s, nullptr);
 
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
   cfg.raypath_color_count = 1;  // > 0
   cfg.raypath_color = nullptr;  // but no allocation
   EXPECT_EQ(LUMICE_CommitConfigStruct(s, &cfg, nullptr), LUMICE_ERR_INVALID_CONFIG);
@@ -3405,7 +3519,7 @@ TEST(RaypathColorApi, CommitConfigStructRejectsNullArrayWithNonzeroCount) {
 // task's plan §6 valgrind cross-check, not here.
 TEST(RaypathColorApi, ConsecutiveParseIntoSameConfigOverridesCorrectly) {
   LUMICE_Config cfg{};
-  lumice::ConfigColorGuard cfg_guard(cfg);
+  lumice::ConfigOwningGuard cfg_guard(cfg);
 
   // First parse: 2 classes.
   nlohmann::json c0 = ColorClassJson({ 1.0f, 0.0f, 0.0f }, nlohmann::json::array({ ColorRefJson(0, 1) }));

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -2319,6 +2319,51 @@ TEST(StructFilterComplex, EmptyCompositionAccepted) {
   EXPECT_EQ(cfg.compositions[cfg.filters[1].composition_index].clause_count, 0);
 }
 
+TEST(StructFilterComplex, EmptyClauseWithinCompositionCommitEndToEnd) {
+  // Regression (code-review-01, round 1, Major): LUMICE_CompositionSetClauses only allocates
+  // term_ids when total_terms > 0, so a composition where every clause has 0 terms
+  // (clause_count > 0, total_terms == 0) legitimately ends up with term_ids == nullptr while
+  // term_counts stays allocated (non-null). Before the fix, LUMICE_CommitConfigStruct's
+  // composition validation conflated term_ids == nullptr with term_counts == nullptr and
+  // rejected this state with LUMICE_ERR_INVALID_CONFIG.
+  //
+  // NOTE: this exact state is NOT reachable via the JSON `"composition": [[]]` path today —
+  // JsonToComplexComposition builds term_ids via std::vector<int>::push_back, so a 0-term
+  // clause leaves that vector empty, and its `.data()` is nullptr, which independently trips
+  // LUMICE_CompositionSetClauses's own "term_ids == nullptr" *argument* check (verified: Parse
+  // returns LUMICE_ERR_NULL_ARG for that JSON shape, never reaching Commit). This test instead
+  // constructs the composition directly through the public C API — any caller (including a
+  // future non-C++ binding) can reach this state by passing a non-null-but-unused term_ids
+  // buffer alongside all-zero term_counts — which is the state LUMICE_CommitConfigStruct must
+  // defensively accept.
+  LUMICE_Config cfg{};
+  lumice::ConfigOwningGuard cfg_guard(cfg);
+  ASSERT_EQ(LUMICE_ParseConfigString(MakeFullConfigJson().c_str(), &cfg), LUMICE_OK);
+  ASSERT_EQ(cfg.filter_count, 1);  // MakeFullConfigJson's single raypath filter, id 1
+
+  cfg.filters[1].id = 2;
+  cfg.filters[1].type = LUMICE_FILTER_TYPE_COMPLEX;
+  cfg.filters[1].composition_index = 0;
+  cfg.filter_count = 2;
+  cfg.composition_count = 1;
+
+  int zero_term_counts[1] = { 0 };
+  int dummy_term_ids[1] = { 0 };  // never dereferenced (total_terms == 0); must be non-null
+  ASSERT_EQ(LUMICE_CompositionSetClauses(&cfg.compositions[0], 1, zero_term_counts, dummy_term_ids), LUMICE_OK);
+  EXPECT_EQ(cfg.compositions[0].clause_count, 1);
+  EXPECT_NE(cfg.compositions[0].term_counts, nullptr);
+  EXPECT_EQ(cfg.compositions[0].term_ids, nullptr);
+
+  cfg.infinite = 0;
+  cfg.ray_num = 100;
+  auto* server = LUMICE_CreateServer();
+  ASSERT_NE(server, nullptr);
+  int reused = -1;
+  EXPECT_EQ(LUMICE_CommitConfigStruct(server, &cfg, &reused), LUMICE_OK);
+  LUMICE_StopServer(server);
+  LUMICE_DestroyServer(server);
+}
+
 // task-host-abi-cpu-caps AC1 (§4 Step 8): a `complex` filter that OR's N > 16 real raypath
 // simple filters (well past the pre-v4.9 LUMICE_MAX_CONFIG_CLAUSES=16 cap) survives the full
 // C-API round-trip (JSON parse ↔ ConfigToJson emit ↔ core to_json cross-check). Uses the same

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -952,6 +952,60 @@ TEST_F(ServerLifecycleApi, GetSimLifecycleNullArgs) {
   EXPECT_EQ(LUMICE_GetSimLifecycle(server_, nullptr), LUMICE_ERR_NULL_ARG);
 }
 
+// task-gui-feedback-affordances Step 7 (AC1): LUMICE_GetColorOverflowInfo
+// exposes the component-bit overflow count captured synchronously during
+// CommitConfig. A well-formed color config (no overflow) reads 0; a config
+// with > 64 distinct predicates on one placement reads the number dropped.
+TEST_F(ServerLifecycleApi, GetColorOverflowInfoZeroWhenNoOverflow) {
+  auto json = MakeSmallSimConfigJson();
+  ASSERT_EQ(LUMICE_CommitConfig(server_, json.c_str()), LUMICE_OK);
+  LUMICE_ColorOverflowInfo info{};
+  ASSERT_EQ(LUMICE_GetColorOverflowInfo(server_, &info), LUMICE_OK);
+  EXPECT_EQ(info.component_overflow_count, 0);
+  EXPECT_EQ(info.symmetry_group_overflow_count, 0);  // reserved field always 0 in this task
+}
+
+TEST_F(ServerLifecycleApi, GetColorOverflowInfoReportsPredicateDrops) {
+  // Build a config where the color config has 65 unique predicates on the
+  // single placement (layer 0, crystal 1). 65 - 64 (ComponentTable::kMaxBits)
+  // = 1 predicate must be dropped to kNoBit.
+  auto base = nlohmann::json::parse(MakeSmallSimConfigJson());
+  nlohmann::json classes = nlohmann::json::array();
+  nlohmann::json cls;
+  cls["color"] = { 1.0, 0.0, 0.0 };
+  nlohmann::json matches = nlohmann::json::array();
+  for (int k = 0; k < 65; ++k) {
+    // Each ref carries a structurally-unique EE predicate (distinct min_len),
+    // so dedup does NOT collapse them; every ref consumes one component bit.
+    // Fields sit at the ref's top level (Design-2 RaypathColorRef inline
+    // predicate schema — see raypath_color_config.cpp from_json).
+    nlohmann::json ref;
+    ref["layer"] = 0;
+    ref["crystal"] = 1;
+    ref["type"] = "entry_exit";
+    ref["entry"] = 1;
+    ref["exit"] = 1;
+    ref["min_len"] = k + 1;
+    matches.push_back(ref);
+  }
+  cls["match"] = matches;
+  classes.push_back(cls);
+  base["raypath_color"]["classes"] = classes;
+  const std::string json = base.dump();
+
+  ASSERT_EQ(LUMICE_CommitConfig(server_, json.c_str()), LUMICE_OK);
+  LUMICE_ColorOverflowInfo info{};
+  ASSERT_EQ(LUMICE_GetColorOverflowInfo(server_, &info), LUMICE_OK);
+  EXPECT_EQ(info.component_overflow_count, 1);  // 65 - 64 = 1 predicate dropped
+  EXPECT_EQ(info.symmetry_group_overflow_count, 0);
+}
+
+TEST_F(ServerLifecycleApi, GetColorOverflowInfoNullArgs) {
+  LUMICE_ColorOverflowInfo info{};
+  EXPECT_EQ(LUMICE_GetColorOverflowInfo(nullptr, &info), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_GetColorOverflowInfo(server_, nullptr), LUMICE_ERR_NULL_ARG);
+}
+
 
 TEST_F(ServerLifecycleApi, GetRenderResults) {
   CommitAndWaitForIdle();


### PR DESCRIPTION
## 目标

放开**纯过滤(不染色)**场景下 filter 谓词单元(OR summand / AND term)的数量上限:OR clause 从 host ABI 的 16 / device 的 8 统一放开到 **4096**,让用户在只关注整体光晕形态时可放入大量 OR 光路。**染色路径的 64-bit component mask 完全不动**(加宽 mask 是 always-on 全民成本、>64 可区分色非真需求——owner 决策明确排除)。

## 改动(4 个子任务,scrum-filter-form-big-or)

- **host / ABI / CPU / GUI**:`LUMICE_ComplexComposition` 改 **pointer+count**(照 v4.8 `raypath_color` 指针化先例:`Create/Release` C API + `ConfigOwningGuard` RAII + `no-config-by-value-copy` 门禁;避免大固定数组重演 `LUMICE_Config` 爆栈,Config 体积反降至 ~96KB);`LUMICE_MAX_CONFIG_CLAUSES` 16→4096 / `_TERMS` 8→64;GUI `kMaxSummandRows` 16→256。
- **device (Metal + CUDA)**:`DeviceFilterDesc::and_term_counts[8]` inline 数组 → 并行 flat 缓冲(复刻既有 `complex_sub_desc_buf` 模式);`or_clause_count` uint8→uint16;**解耦** `kDeviceFilterMaxOrClauses`——filter 侧新增 `kDeviceFilterOrClauseSanityCap=4096`,color 侧维持 8-bounded(stride / SummandMask / clamp 不变)。Metal 打包上传 + CUDA 独立 buffer(含色组 rebuild 二次上传)+ MSL 镜像 + `static_assert(sizeof)`。
- **GUI 反馈**:Colors 按钮"有/无染色类"态色;`DoRun(bool user_initiated)` 修复 overflow warning 二次 Run 不复现的 dedup bug(显式 Run 强制重开、自动提交保留 dedup);编辑期 live preview "Clauses: N/cap" 越界标红;染色降级 core→GUI 可见提示(component_overflow 半条)。
- **染色 ABI 常量 `_COLOR_CLASSES=64` / `_COLOR_REFS=32` 零改动。**

## 验证

- **host**:4 轮 code-review APPROVE;GUI 一手用例 `add_rows_past_16_enabled`(真机驱动 +Add 过 16 行);`build.sh -tgj` + `pytest` 全绿。
- **device CUDA(dev49 RTX 4060Ti)**:CUDA parity battery **11 passed**,含风险 4 专属路径 `test_cuda_big_or_complex_with_color_parity_vs_legacy`(色组 rebuild 二次上传,host/Metal 覆盖不到)**PASSED**。
- **device CUDA(win-builder GTX 1070Ti)**:sm_61 交叉编译通过。
- **Metal(Mac)**:`test_metal_filter_match_parity` Complex-E 20-clause 绿。
- **perf de-risk(无 cliff)**:8/64/256 summand `--benchmark` 三后端——**N=256 是两个 GPU 的吞吐峰值**(CUDA 754M / Metal 68.5M > N=8),U 形(N=64 谷底)跨 CPU 复现=raypath 几何驱动非 GPU 内存;owner 独立 spot-verify CUDA N=256=772M>N=8=425M。结论入 `doc/performance-testing.md`。
- **GUI**:`gui_test` 454 绿(+7 新测);code-review 抓到并修掉 1 Critical 回归(染色降级误触 70ms 弹窗刷屏)。

## 遗留(已入 backlog)

- `symmetry_group_overflow`(对称组丢弃计数)的 GUI surfacing 需 poll infra,本 PR 只落地 component_overflow 半条(a05);degrade_msg 中该计数恒 0 的文案随之一并修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
