### PR TITLE
chore: harden reconciler include boundary + dedup wake path (scrum-353 T2 follow-up)

### DIFF
--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -231,6 +231,52 @@ def check_gui_api_boundary() -> list[Violation]:
     return out
 
 
+# reconciler-widget-include: gui_state_reconcile.cpp is the "single owner of effects" reconciler.
+# T1 (task-color-migration) landed one concrete-widget dependency in it — `#include "gui/
+# color_window.hpp"` to call PushDisplayState — which inverts the intended layering direction
+# (widget depends on reconciler abstraction, not the reverse). That is acceptable for a SINGLE
+# domain but must not accrete: the moment a second `need_X_push` display channel would add a
+# second widget-header include here, the author must instead introduce a push-handler registration/
+# dispatch abstraction (doc/gui-state-governance.md §4 支柱 2). The inline comment + doc were the
+# only guard, i.e. a soft constraint; this gate hardens it (决策公理 a09). Any `#include "gui/..."`
+# in this file outside the allowlist below fails — forcing exactly that evaluation.
+RECONCILE_CPP = SRC / "gui" / "gui_state_reconcile.cpp"
+RECONCILE_GUI_INCLUDE = re.compile(r'#\s*include\s*"(gui/[^"]+)"')
+# Grandfathered includes. `gui_state_reconcile.hpp` = own header; `gui_state.hpp` = pure data
+# struct (a tier below, not a widget); `color_window.hpp` = the single T1 reverse-include. Adding
+# a NEW widget-header entry here without introducing the abstraction is the thing to stop, so
+# extending this set is a deliberate reviewed act, not a silent edit.
+RECONCILE_ALLOWED_GUI_INCLUDES = frozenset(
+    {
+        "gui/gui_state_reconcile.hpp",
+        "gui/gui_state.hpp",
+        "gui/color_window.hpp",
+    }
+)
+
+
+def check_reconciler_widget_include() -> list[Violation]:
+    out: list[Violation] = []
+    if not RECONCILE_CPP.exists():
+        return out
+    for lineno, _orig, code in code_lines(RECONCILE_CPP):
+        m = RECONCILE_GUI_INCLUDE.search(code)
+        if m and m.group(1) not in RECONCILE_ALLOWED_GUI_INCLUDES:
+            out.append(
+                Violation(
+                    RECONCILE_CPP,
+                    lineno,
+                    "reconciler-widget-include",
+                    f'gui_state_reconcile.cpp must not add #include "{m.group(1)}": the '
+                    "reconciler is the single owner of effects and must not reverse-depend on a "
+                    "second widget domain. Introduce a push-handler registration/dispatch "
+                    "abstraction instead (doc/gui-state-governance.md §4 支柱 2), or if this is a "
+                    "pure data/utility header, add it to RECONCILE_ALLOWED_GUI_INCLUDES.",
+                )
+            )
+    return out
+
+
 def check_no_using_namespace() -> list[Violation]:
     out: list[Violation] = []
     for path in cxx_sources(SRC):
@@ -799,6 +845,7 @@ CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
     check_gui_api_boundary,
+    check_reconciler_widget_include,
     check_no_using_namespace,
     check_struct_layout_parity,
     check_no_config_by_value_copy,
@@ -825,7 +872,7 @@ def main() -> int:
         return 1
     print(
         "Policy check passed (env centralization, knob registration, GUI API boundary, "
-        "using-namespace, struct-layout parity, no-config-by-value-copy, "
+        "reconciler-widget-include, using-namespace, struct-layout parity, no-config-by-value-copy, "
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin)."
     )
     return 0

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -70,56 +70,55 @@ void ServerPoller::Stop() {
   GUI_LOG_DEBUG("[Poller] Stop: worker paused");
 }
 
-// task-color-migration M4: split from the former single `EnsureRunning` to give display-time
-// refresh callers a wake path that does NOT publish valid=false — see doc/gui-state-
-// governance.md §4 支柱 2 and the header contract on WakeForRefresh.
-void ServerPoller::WakeForRestart(LUMICE_Server* server) {
+// Shared kPaused → kRunning transition for both public wake entry points. The valid=false publish
+// is the ONLY behavioral difference between restart and refresh, so it is a single bool parameter —
+// see the header contract on TransitionToRunning / WakeForRestart / WakeForRefresh. Returns true iff
+// it actually resumed, so callers log their resume line only on a real transition (pre-refactor
+// behavior — no-op paths logged nothing).
+bool ServerPoller::TransitionToRunning(LUMICE_Server* server, bool publish_reset) {
   if (!server) {
-    return;
+    return false;
   }
   {
     std::lock_guard<std::mutex> lk(mutex_);
     if (state_.load() == State::kRunning) {
-      return;  // Already running — zero overhead
+      return false;  // Already running — zero overhead
     }
     if (state_.load() == State::kTerminating) {
-      return;
+      return false;
     }
     // kPaused → resume polling
     server_ = server;
     last_generation_ = 0;
     last_quality_pass_time_ = std::chrono::steady_clock::now();
-    PublishValidReset();
+    if (publish_reset) {
+      PublishValidReset();
+    }
     state_.store(State::kRunning);
   }
   cv_.notify_all();
-  GUI_LOG_DEBUG("[Poller] WakeForRestart: resumed from paused (valid=false published)");
+  return true;
+}
+
+// task-color-migration M4: split from the former single `EnsureRunning` to give display-time
+// refresh callers a wake path that does NOT publish valid=false — see doc/gui-state-
+// governance.md §4 支柱 2 and the header contract on WakeForRefresh.
+void ServerPoller::WakeForRestart(LUMICE_Server* server) {
+  // publish_reset=true: fresh sim generation — publish valid=false so consumers ignore stale
+  // stats/lifecycle until the worker republishes.
+  if (TransitionToRunning(server, /*publish_reset=*/true)) {
+    GUI_LOG_DEBUG("[Poller] WakeForRestart: resumed from paused (valid=false published)");
+  }
 }
 
 void ServerPoller::WakeForRefresh(LUMICE_Server* server) {
-  if (!server) {
-    return;
+  // publish_reset=false: display-time refresh — the current snapshot must stay `valid` across the
+  // wake edge so SyncFromPoller does not transiently observe an invalid snapshot (which would let
+  // ReconcileSimState pull a completed sim back into kSimulating — task-color-migration AC1
+  // activity bug root cause (a)).
+  if (TransitionToRunning(server, /*publish_reset=*/false)) {
+    GUI_LOG_DEBUG("[Poller] WakeForRefresh: resumed from paused (valid preserved)");
   }
-  {
-    std::lock_guard<std::mutex> lk(mutex_);
-    if (state_.load() == State::kRunning) {
-      return;  // Already running — zero overhead
-    }
-    if (state_.load() == State::kTerminating) {
-      return;
-    }
-    // kPaused → resume polling WITHOUT publishing valid=false. Display-time callers rely on
-    // the current snapshot staying `valid` across the wake edge so SyncFromPoller does not
-    // transiently observe an invalid snapshot (which would let ReconcileSimState pull a
-    // completed sim back into kSimulating — task-color-migration AC1 activity bug root
-    // cause (a)).
-    server_ = server;
-    last_generation_ = 0;
-    last_quality_pass_time_ = std::chrono::steady_clock::now();
-    state_.store(State::kRunning);
-  }
-  cv_.notify_all();
-  GUI_LOG_DEBUG("[Poller] WakeForRefresh: resumed from paused (valid preserved)");
 }
 
 // Publish a valid=false copy of the current snapshot, preserving the payload (carry-forward)

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -192,6 +192,20 @@ class ServerPoller {
   // Serializes under publish_mutex_. Called from Start()/WakeForRestart() on the main thread.
   void PublishValidReset();
 
+  // Shared body of WakeForRestart/WakeForRefresh: idempotently drive kPaused → kRunning with
+  // `server`, resetting the generation/quality-pass tracking under mutex_ and notifying the
+  // worker. The ONLY behavioral difference between the two public callers is whether a
+  // valid=false snapshot is published across the wake edge, so it is a single bool parameter:
+  //   publish_reset=true  (WakeForRestart) — fresh sim generation; consumers must ignore stale
+  //                        stats/lifecycle until the worker republishes.
+  //   publish_reset=false (WakeForRefresh) — display-time refresh; the current snapshot must
+  //                        stay `valid` across the wake so SyncFromPoller does not transiently
+  //                        observe an invalid snapshot (doc/gui-state-governance.md §4 支柱 2).
+  // Returns true iff it actually resumed (was kPaused); false on every no-op path (null server,
+  // already kRunning, kTerminating) so callers log their resume line only on a real transition,
+  // matching the pre-refactor behavior.
+  bool TransitionToRunning(LUMICE_Server* server, bool publish_reset);
+
   std::thread worker_;
   // state_ is atomic for lock-free reads in the poll loop; all writes are under mutex_.
   std::atomic<State> state_{ State::kPaused };


### PR DESCRIPTION
## 背景

清扫 `scratchpad/backlog.md`「scrum-353 T2 follow-up：reconciler 分层反转门禁化 + wake helper 抽取」两处非阻塞项（353.2 Minor / 353.5 Suggestion，2026-07-12 记入，趁稳定窗口处理）。

## 改动

**① reconciler 反向 include 门禁化（a09 软约束固化）**
`scripts/check_policies.py` 新增 `check_reconciler_widget_include`：`gui_state_reconcile.cpp`（single owner of effects reconciler）的 `#include "gui/..."` 限定到 grandfathered allowlist（`gui_state_reconcile.hpp` / `gui_state.hpp` / `color_window.hpp`）。T1 的 `color_window` 反向 include 单域可接受、但不得累积——第二个 `need_X_push` 显示通道若再加一个 widget 头 include 即 fail gate，逼作者改用 push-handler 注册/分派抽象（`doc/gui-state-governance.md §4 支柱 2`）。此前仅靠行内注释 + doc（软约束），本 gate 固化之。

**② wake helper 抽取（a05 减法优先）**
`server_poller.{hpp,cpp}` 抽私有 `TransitionToRunning(server, publish_reset)`，`WakeForRestart`/`WakeForRefresh` 共用之（`valid=false` publish 是二者唯一实质差异）。返回 `bool`，使调用方仅在真正 kPaused→kRunning 转换时打 resume 日志（保 pre-refactor 语义：no-op 路径不打日志）。

**刻意不做 ①(b) push-handler 注册抽象**：启动条件（第二个 `need_X_push` 域）未满足，现只染色一个域（a05 举证责任在增加方）。门禁 ① 落地后会在真出现第二域时自动逼出该评估。

## 验证

- `python3 scripts/check_policies.py` 绿（含新 check）；注入 `gui/panels.hpp` 负例命中 violation（exit 1）。
- `./scripts/format.sh --check` 绿。
- `./scripts/build.sh -gtj release` 编译通过 + gui_test 5/5。

🤖 Generated with [Claude Code](https://claude.com/claude-code)