### PR TITLE
fix(core): pyramid + random face_distance Metal SIGSEGV (count/stride decouple)

### DIFF
--- a/scripts/verify_pyramid_crash_sentinel_detection_power.sh
+++ b/scripts/verify_pyramid_crash_sentinel_detection_power.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# verify_pyramid_crash_sentinel_detection_power.sh — two-arm A/B verification of
+# the pyramid+random-face_distance SIGSEGV regression sentinel
+# (test/regression-sentinel/test_pyramid_geometry_crash.py).
+#
+# Purpose:
+#   Confirm the sentinel detects the crash it is written to catch — i.e. that
+#   reverting the fix commit + rebuilding clean + rerunning the sentinel
+#   reliably turns it red on hardware that reproduces the SIGSEGV. Guards
+#   against the "build reported exit 0 but was up-to-date and never rebuilt"
+#   trap that has silently voided past two-arm verifications.
+#
+# Discipline:
+#   - Runs both arms in independent `git worktree`s (never touches the caller's
+#     working tree). No `git revert` on the checked-out branch.
+#   - Forces a clean rebuild (`rm -rf build/`) on each arm — never trust an
+#     incremental "up-to-date" report as evidence a rebuild happened.
+#   - Records md5 of both arm binaries and refuses to proceed if they match.
+#   - Reports the reverted arm's signal-death count.
+#
+# NOT a CI gate. Manual invocation only, when a suspicion arises that the
+# sentinel may have lost detection power (e.g. after a refactor touching the
+# fix commit, or after a session-level environment change).
+#
+# Usage: from the repo root
+#   ./scripts/verify_pyramid_crash_sentinel_detection_power.sh
+#
+# Options via env:
+#   SENTINEL_REVERT_BASE  — commit to check out for the reverted arm (default
+#                          =  the parent of HEAD, i.e. the state before the fix
+#                          commit landed). Set to override if the fix has been
+#                          rebased onto a different base.
+#   SENTINEL_N            — sentinel run count per arm (default 15). At the
+#                          calibrated fixture the shrink branch fires ~6 times
+#                          per run, so N=15 samples ~90 shrink events — enough
+#                          for a reasonable Bernoulli signal at the observed
+#                          Mac-native crash rate (which may be zero: the
+#                          historical 4/4 signal deaths were reported on
+#                          different hardware; the sentinel is still valuable
+#                          on Mac because the anti-vacuous WARN assertion
+#                          keeps it honest).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Default REVERT_BASE = parent of HEAD (assumes HEAD is on the fix commit or
+# a merged-in fix PR). Override with SENTINEL_REVERT_BASE if the tree layout
+# differs.
+REVERT_BASE="${SENTINEL_REVERT_BASE:-$(git rev-parse HEAD~1)}"
+N_RUNS="${SENTINEL_N:-15}"
+
+FIXED_HEAD="$(git rev-parse HEAD)"
+
+# Refuse to run if the caller has uncommitted tracked-file changes.
+if ! git diff --quiet HEAD --; then
+  echo "ERROR: working tree has uncommitted tracked-file changes. Commit or stash first." >&2
+  exit 1
+fi
+
+WORK_PARENT="$(mktemp -d "${TMPDIR:-/tmp}/lumice_pyramid_sentinel_verify_XXXXXX")"
+FIXED_WORKTREE="$WORK_PARENT/fixed"
+REVERTED_WORKTREE="$WORK_PARENT/reverted"
+
+cleanup() {
+  local exit_code="$1"
+  echo "--- cleanup: removing worktrees ---"
+  git worktree remove --force "$FIXED_WORKTREE" 2>/dev/null || true
+  if [ "$exit_code" -eq 2 ] || [ "$exit_code" -eq 4 ]; then
+    git worktree prune
+    echo "cleanup: exit $exit_code — retaining reverted arm worktree for inspection:" >&2
+    echo "  $REVERTED_WORKTREE" >&2
+    echo "  (remove manually with: git worktree remove --force '$REVERTED_WORKTREE' && rm -rf '$WORK_PARENT')" >&2
+    return
+  fi
+  git worktree remove --force "$REVERTED_WORKTREE" 2>/dev/null || true
+  rm -rf "$WORK_PARENT"
+  git worktree prune
+  echo "cleanup done. Main worktree at $REPO_ROOT was never modified."
+}
+trap 'cleanup $?' EXIT
+
+echo "=== fixed arm (HEAD=$FIXED_HEAD) ==="
+git worktree add --detach "$FIXED_WORKTREE" "$FIXED_HEAD"
+(
+  cd "$FIXED_WORKTREE"
+  rm -rf build
+  ./scripts/build.sh -sj release >/dev/null
+)
+FIXED_BIN="$FIXED_WORKTREE/build/cmake_install/Lumice"
+FIXED_MD5="$(md5 -q "$FIXED_BIN" 2>/dev/null || md5sum "$FIXED_BIN" | awk '{print $1}')"
+echo "fixed arm binary: $FIXED_BIN"
+echo "fixed arm md5:    $FIXED_MD5"
+
+echo "=== reverted arm (base=$REVERT_BASE) ==="
+git worktree add --detach "$REVERTED_WORKTREE" "$REVERT_BASE"
+(
+  cd "$REVERTED_WORKTREE"
+  rm -rf build
+  ./scripts/build.sh -sj release >/dev/null
+)
+REVERTED_BIN="$REVERTED_WORKTREE/build/cmake_install/Lumice"
+REVERTED_MD5="$(md5 -q "$REVERTED_BIN" 2>/dev/null || md5sum "$REVERTED_BIN" | awk '{print $1}')"
+echo "reverted arm binary: $REVERTED_BIN"
+echo "reverted arm md5:    $REVERTED_MD5"
+
+if [ "$FIXED_MD5" = "$REVERTED_MD5" ]; then
+  echo "ERROR: fixed and reverted arm binaries have IDENTICAL md5 — one of the arms" >&2
+  echo "was not actually rebuilt. This is the 'up-to-date' trap the two-arm" >&2
+  echo "protocol exists to catch. Refusing to draw any conclusion about detection" >&2
+  echo "power." >&2
+  exit 1
+fi
+
+echo "=== reverted arm: sentinel run (N=$N_RUNS) ==="
+# Run the current-HEAD sentinel against the reverted-arm binary — the sentinel
+# code has the signal-vs-clean-exit classification the script's grep relies on,
+# and reverting the fixture along with the fix would defeat the point of the
+# A/B test. Pytest picks up the current-HEAD sentinel from the caller's repo.
+set +e
+SENTINEL_N="$N_RUNS" LUMICE_BIN="$REVERTED_BIN" \
+  pytest -v "test/regression-sentinel/test_pyramid_geometry_crash.py" \
+  --tb=short 2>&1 | tee "$WORK_PARENT/reverted_arm.log"
+SENTINEL_EXIT=${PIPESTATUS[0]}
+set -e
+
+if grep -q "Lumice binary infrastructure check failed" "$WORK_PARENT/reverted_arm.log"; then
+  echo "" >&2
+  echo "INFRASTRUCTURE ERROR: reverted arm's module-scope smoke check failed —" >&2
+  echo "the reverted-arm binary could not even run a known-good config. The" >&2
+  echo "parametrized sentinel loop never executed. Inspect" >&2
+  echo "  $REVERTED_WORKTREE/build/" >&2
+  echo "before drawing any conclusion." >&2
+  exit 4
+fi
+
+SIGNAL_DEATH_COUNT=$(grep -c "signal-death" "$WORK_PARENT/reverted_arm.log" || true)
+CLEAN_NONZERO_COUNT=$(grep -c "clean non-zero exit" "$WORK_PARENT/reverted_arm.log" || true)
+
+echo ""
+echo "=== summary ==="
+echo "fixed arm md5:      $FIXED_MD5"
+echo "reverted arm md5:   $REVERTED_MD5"
+echo "reverted arm N:     $N_RUNS"
+echo "signal deaths:      $SIGNAL_DEATH_COUNT"
+echo "clean non-zero:     $CLEAN_NONZERO_COUNT"
+echo "pytest exit:        $SENTINEL_EXIT"
+
+if [ "$SIGNAL_DEATH_COUNT" -ge 1 ]; then
+  echo "PASS: reverted arm exhibits signal death — sentinel detection power confirmed."
+  exit 0
+fi
+
+if [ "$CLEAN_NONZERO_COUNT" -ge 1 ] && [ "$SIGNAL_DEATH_COUNT" -eq 0 ]; then
+  echo "INCONCLUSIVE: reverted arm exited non-zero but not from a signal —" >&2
+  echo "this looks like an infrastructure failure (binary won't run), not the" >&2
+  echo "SIGSEGV the sentinel is written to catch. Investigate the reverted-arm" >&2
+  echo "build output at $REVERTED_WORKTREE/build/ before drawing conclusions" >&2
+  echo "about sentinel detection power." >&2
+  exit 2
+fi
+
+# The pre-fix crash rate is hardware-dependent — the historical 4/4 SIGSEGV was
+# observed at a different site and Metal driver combination; on some hardware
+# the wild read stays within the mapped allocation and the process completes
+# cleanly (still delivering silent-wrong output on CPU, and possibly wild
+# centroid data on Metal that the shader tolerates). 0/N signal deaths on such
+# hardware is expected — but that does NOT mean the sentinel is worthless: it
+# still catches (a) any hardware/driver combo that DOES reproduce the crash,
+# and (b) any regression that removes the fixture's shrink-branch coverage
+# (via the anti-vacuous WARN assertion in the sentinel itself).
+echo "AMBIGUOUS: 0/$N_RUNS signal deaths on the reverted arm." >&2
+echo "This does NOT necessarily mean the sentinel is broken — pre-fix crashes" >&2
+echo "were hardware-dependent. Rerun with SENTINEL_N=$((N_RUNS * 4)) on hardware" >&2
+echo "known to reproduce the SIGSEGV before concluding the sentinel has lost" >&2
+echo "detection power. On hardware that never reproduces, the sentinel's" >&2
+echo "anti-vacuous WARN assertion (in the sentinel itself, not this script)" >&2
+echo "still provides meaningful coverage of the fixed code path." >&2
+exit 3

--- a/scripts/verify_pyramid_crash_sentinel_detection_power.sh
+++ b/scripts/verify_pyramid_crash_sentinel_detection_power.sh
@@ -46,10 +46,23 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Default REVERT_BASE = parent of HEAD (assumes HEAD is on the fix commit or
-# a merged-in fix PR). Override with SENTINEL_REVERT_BASE if the tree layout
-# differs.
-REVERT_BASE="${SENTINEL_REVERT_BASE:-$(git rev-parse HEAD~1)}"
+# Default REVERT_BASE = the pre-fix tree state = this branch's merge-base with
+# origin/main. Do NOT use HEAD~1: the crystal.cpp fix is the FIRST commit on
+# this branch while the test/config/this-script land in LATER commits, so HEAD~1
+# still contains the fix and the "reverted" arm would silently compile fixed
+# code (false detection power — the exact HEAD~N off-by-one this task's plan
+# forbade). Override with SENTINEL_REVERT_BASE for other tree layouts (e.g. a
+# rebased/merged fix).
+if [ -n "${SENTINEL_REVERT_BASE:-}" ]; then
+  REVERT_BASE="$SENTINEL_REVERT_BASE"
+else
+  REVERT_BASE="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+  if [ -z "$REVERT_BASE" ]; then
+    echo "ERROR: could not derive REVERT_BASE (git merge-base HEAD origin/main failed)." >&2
+    echo "Pass SENTINEL_REVERT_BASE=<pre-fix commit> explicitly." >&2
+    exit 1
+  fi
+fi
 N_RUNS="${SENTINEL_N:-15}"
 
 FIXED_HEAD="$(git rev-parse HEAD)"

--- a/scripts/verify_pyramid_crash_sentinel_detection_power.sh
+++ b/scripts/verify_pyramid_crash_sentinel_detection_power.sh
@@ -26,10 +26,14 @@
 #   ./scripts/verify_pyramid_crash_sentinel_detection_power.sh
 #
 # Options via env:
-#   SENTINEL_REVERT_BASE  — commit to check out for the reverted arm (default
-#                          =  the parent of HEAD, i.e. the state before the fix
-#                          commit landed). Set to override if the fix has been
-#                          rebased onto a different base.
+#   SENTINEL_REVERT_BASE  — commit to check out for the reverted arm (default =
+#                          this branch's merge-base with origin/main, i.e. the
+#                          pre-fix tree state, assuming the fix commit is the
+#                          first commit on this branch; hard-errors if origin/main
+#                          is unavailable). Set to override if the fix has been
+#                          rebased/merged onto a different base. Do NOT assume
+#                          "parent of HEAD" — the fix + its tests span several
+#                          commits, so HEAD~1 would still contain the fix.
 #   SENTINEL_N            — sentinel run count per arm (default 15). At the
 #                          calibrated fixture the shrink branch fires ~6 times
 #                          per run, so N=15 samples ~90 shrink events — enough

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1669,11 +1669,39 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
 
   // Centroid per polygon face (mean of the polygon-triangle vertices) — same
   // formula as the explore spike (metal_full.mm / metal_ms.mm).
+  //
+  // Depth-of-defense bound check: symmetric to CPU Crystal::GetFn(IdType) at
+  // crystal.cpp:437-441. The root cause of the pyramid+random-face_distance
+  // Metal SIGSEGV was a stride/count mismatch inside BuildPolygonFaceData
+  // (fixed in the same task); after that fix poly_tri[f] is guaranteed to be
+  // a valid triangle index, so this guard is not what makes the code correct.
+  // It exists so any future upstream count/stride drift surfaces as a
+  // detectable "centroid stuck at origin + one WARN per UploadCrystal call"
+  // symptom rather than a wild read into tvtx. EnsurePolyBuffers only grows
+  // centroid_buf, so on shrink we must NOT leave the slot untouched — it would
+  // hold the previous crystal's stale centroid; write zeros explicitly.
+  size_t tri_cnt = crystal.TotalTriangles();
   const int* poly_tri = crystal.GetPolygonFaceTriId();
   const float* tvtx   = crystal.GetTriangleVtx();
   auto* centroid_ptr  = static_cast<float*>([centroid_buf contents]);
+  bool centroid_bound_warned = false;
   for (size_t f = 0; f < poly_cnt; f++) {
-    const float* v = tvtx + static_cast<size_t>(poly_tri[f]) * 9;
+    int t = poly_tri[f];
+    if (t < 0 || static_cast<size_t>(t) >= tri_cnt) {
+      centroid_ptr[f * 3 + 0] = 0.0f;
+      centroid_ptr[f * 3 + 1] = 0.0f;
+      centroid_ptr[f * 3 + 2] = 0.0f;
+      if (!centroid_bound_warned) {
+        ILOG_WARN(EffectiveLogger(logger_),
+                  "UploadCrystal: polygon face {} has out-of-range tri_id={} (tri_cnt={}); "
+                  "wrote zero centroid. This is depth-of-defense — root cause should be in "
+                  "BuildPolygonFaceData count/stride invariants.",
+                  f, t, tri_cnt);
+        centroid_bound_warned = true;
+      }
+      continue;
+    }
+    const float* v = tvtx + static_cast<size_t>(t) * 9;
     for (int k = 0; k < 3; k++) {
       centroid_ptr[f * 3 + k] = (v[0 * 3 + k] + v[1 * 3 + k] + v[2 * 3 + k]) / 3.0f;
     }
@@ -1688,7 +1716,6 @@ void MetalTraceBackend::Impl::UploadCrystal(const Crystal& crystal) {
   // on extreme-wedge (~≥87.4°) crystals (dot ≈ 0.9994).
   // NOTE: kFaceCoplanarFloor must match the value in crystal.cpp::BuildPolygonFaceData
   // and simulator.cpp::detail::PolygonFaceOfTri.
-  size_t tri_cnt = crystal.TotalTriangles();
   EnsureTriBuffers(tri_cnt);
   std::memcpy([tri_vtx_buf_ contents], crystal.GetTriangleVtx(),
               tri_cnt * 9 * sizeof(float));

--- a/src/core/crystal.cpp
+++ b/src/core/crystal.cpp
@@ -707,7 +707,7 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
       }
     }
     if (tri_best_plane < 0 || tri_best_dot < 1.0f - kFaceCoplanarFloor) {
-      LOG_WARNING("BuildPolygonFaceData: triangle %zu has no coplanar plane (best_dot=%.4f)", t,
+      LOG_WARNING("BuildPolygonFaceData: triangle {} has no coplanar plane (best_dot={:.4f})", t,
                   static_cast<double>(tri_best_dot));
       continue;
     }
@@ -717,16 +717,52 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
     }
   }
 
-  // Count planes that won at least one triangle.
-  size_t valid_cnt = 0;
-  for (size_t p = 0; p < plane_cnt; p++) {
-    if (plane_best_tri[p] >= 0) {
-      valid_cnt++;
-    }
+  // Degenerate-face safety net: reject planes whose representative triangle has
+  // near-zero area relative to the largest triangle. This signals an upstream
+  // geometry-gen artifact (a polygon plane survived without a real surface); in
+  // current pipeline Triangulate already skips faces with <3 vertices, so this
+  // gate is belt-and-suspenders for future configs (asymmetric d[6], near-degenerate
+  // apex collapse, etc.). max_tri_area only depends on face_area_ which is populated
+  // by ComputeCacheData before this function runs, so we can compute it up-front —
+  // it does not depend on the accept/reject decision.
+  float max_tri_area = 0.0f;
+  for (size_t t = 0; t < tri_cnt; t++) {
+    max_tri_area = std::max(max_tri_area, face_area_[t]);
   }
 
-  poly_face_cnt_ = valid_cnt;
-  if (valid_cnt == 0) {
+  // Single-pass acceptance: collect surviving (plane_idx, rep_tri) pairs. The
+  // acceptance predicate — "plane won a triangle" AND "representative triangle
+  // is not degenerate" — is evaluated exactly once here. A previous two-phase
+  // form evaluated only the first half to size the allocation, then re-applied
+  // the second half in the fill loop and rewrote poly_face_cnt_ to the final
+  // written count; that left the allocated memory laid out at the larger
+  // stride while poly_face_cnt_ shrank, so copy/move ctors of Crystal
+  // re-derived the pointer offsets from the shrunk count and read
+  // poly_face_d_ / poly_face_tri_id_ from wrong regions of poly_face_data_,
+  // causing Metal SIGSEGV and CPU silent-wrong-fn on pyramid+random
+  // face_distance configs. Now poly_face_cnt_ ≡ accepted.size() and equals
+  // the actual allocated stride from first assignment onward.
+  struct AcceptedFace {
+    size_t plane_idx;
+    int rep_tri;
+  };
+  std::vector<AcceptedFace> accepted;
+  accepted.reserve(plane_cnt);
+  for (size_t p = 0; p < plane_cnt; p++) {
+    if (plane_best_tri[p] < 0) {
+      continue;
+    }
+    int rep_tri = plane_best_tri[p];
+    if (max_tri_area > 0.0f && face_area_[rep_tri] < 1e-6f * max_tri_area) {
+      LOG_WARNING("BuildPolygonFaceData: plane {} has degenerate rep triangle {} (area={:.4e}, max={:.4e})", p, rep_tri,
+                  static_cast<double>(face_area_[rep_tri]), static_cast<double>(max_tri_area));
+      continue;
+    }
+    accepted.push_back({ p, rep_tri });
+  }
+
+  poly_face_cnt_ = accepted.size();
+  if (poly_face_cnt_ == 0) {
     poly_face_data_.reset();
     poly_face_n_ = nullptr;
     poly_face_d_ = nullptr;
@@ -734,42 +770,22 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
     return;
   }
 
-  // Allocate: normals(3*cnt) + dist(cnt) + tri_id as int(cnt) = 5*cnt floats
-  poly_face_data_ = std::make_unique<float[]>(valid_cnt * 5);
+  // Allocate: normals(3*cnt) + dist(cnt) + tri_id as int(cnt) = 5*cnt floats.
+  // stride is fixed by poly_face_cnt_ (= accepted.size()) and never re-derived
+  // from a shrunk count elsewhere.
+  poly_face_data_ = std::make_unique<float[]>(poly_face_cnt_ * 5);
   poly_face_n_ = poly_face_data_.get();
-  poly_face_d_ = poly_face_data_.get() + valid_cnt * 3;
-  poly_face_tri_id_ = reinterpret_cast<int*>(poly_face_data_.get() + valid_cnt * 4);
+  poly_face_d_ = poly_face_data_.get() + poly_face_cnt_ * 3;
+  poly_face_tri_id_ = reinterpret_cast<int*>(poly_face_data_.get() + poly_face_cnt_ * 4);
 
-  // Degenerate-face safety net (Step 3): warn if the representative triangle of any
-  // accepted polygon face has near-zero area relative to the largest triangle. This
-  // signals an upstream geometry-gen issue (a polygon plane survived without a real
-  // surface); in current pipeline the upstream Triangulate already skips faces with
-  // <3 vertices, so this gate is belt-and-suspenders for future configs (asymmetric
-  // d[6], near-degenerate apex collapse, etc.).
-  float max_tri_area = 0.0f;
-  for (size_t t = 0; t < tri_cnt; t++) {
-    max_tri_area = std::max(max_tri_area, face_area_[t]);
+  for (size_t i = 0; i < poly_face_cnt_; i++) {
+    const auto& a = accepted[i];
+    poly_face_n_[i * 3 + 0] = plane_n[a.plane_idx * 3 + 0];
+    poly_face_n_[i * 3 + 1] = plane_n[a.plane_idx * 3 + 1];
+    poly_face_n_[i * 3 + 2] = plane_n[a.plane_idx * 3 + 2];
+    poly_face_d_[i] = plane_d[a.plane_idx];
+    poly_face_tri_id_[i] = a.rep_tri;
   }
-
-  size_t idx = 0;
-  for (size_t p = 0; p < plane_cnt; p++) {
-    if (plane_best_tri[p] < 0) {
-      continue;
-    }
-    int rep_tri = plane_best_tri[p];
-    if (max_tri_area > 0.0f && face_area_[rep_tri] < 1e-6f * max_tri_area) {
-      LOG_WARNING("BuildPolygonFaceData: plane %zu has degenerate rep triangle %d (area=%.4e, max=%.4e)", p, rep_tri,
-                  static_cast<double>(face_area_[rep_tri]), static_cast<double>(max_tri_area));
-      continue;
-    }
-    poly_face_n_[idx * 3 + 0] = plane_n[p * 3 + 0];
-    poly_face_n_[idx * 3 + 1] = plane_n[p * 3 + 1];
-    poly_face_n_[idx * 3 + 2] = plane_n[p * 3 + 2];
-    poly_face_d_[idx] = plane_d[p];
-    poly_face_tri_id_[idx] = plane_best_tri[p];
-    idx++;
-  }
-  poly_face_cnt_ = idx;  // Re-count after degenerate filtering.
 }
 
 float Crystal::GetRefractiveIndex(float wl) const {

--- a/src/core/crystal.cpp
+++ b/src/core/crystal.cpp
@@ -1,9 +1,11 @@
 #include "core/crystal.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <utility>
@@ -17,6 +19,21 @@
 #include "util/logger.hpp"
 
 namespace lumice {
+
+namespace {
+// Process-global count of degenerate polygon faces dropped by
+// BuildPolygonFaceData (the count/stride "shrink" path). Test observability
+// only; see Crystal::DegenerateShrinkCount().
+std::atomic<uint64_t> g_degenerate_shrink_count{ 0 };
+}  // namespace
+
+uint64_t Crystal::DegenerateShrinkCount() {
+  return g_degenerate_shrink_count.load(std::memory_order_relaxed);
+}
+
+void Crystal::ResetDegenerateShrinkCount() {
+  g_degenerate_shrink_count.store(0, std::memory_order_relaxed);
+}
 
 // Legal face-number sets mirror FillHexFnMap below:
 //   basal:         1, 2
@@ -756,6 +773,7 @@ void Crystal::BuildPolygonFaceData(const float* plane_coef, size_t plane_cnt) {
     if (max_tri_area > 0.0f && face_area_[rep_tri] < 1e-6f * max_tri_area) {
       LOG_WARNING("BuildPolygonFaceData: plane {} has degenerate rep triangle {} (area={:.4e}, max={:.4e})", p, rep_tri,
                   static_cast<double>(face_area_[rep_tri]), static_cast<double>(max_tri_area));
+      g_degenerate_shrink_count.fetch_add(1, std::memory_order_relaxed);
       continue;
     }
     accepted.push_back({ p, rep_tri });

--- a/src/core/crystal.hpp
+++ b/src/core/crystal.hpp
@@ -2,6 +2,7 @@
 #define SRC_CORE_CRYSTAL_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -301,6 +302,14 @@ class Crystal {
   const float* GetPolygonFaceNormal() const;
   const float* GetPolygonFaceDist() const;
   const int* GetPolygonFaceTriId() const;
+
+  // Test observability: process-global count of degenerate polygon faces
+  // dropped by BuildPolygonFaceData (the count/stride "shrink" path that used
+  // to corrupt copy/move). Lets regression tests assert they actually
+  // exercised the shrink branch instead of passing vacuously. Thread-safe;
+  // reset before a measured sweep, read after.
+  static uint64_t DegenerateShrinkCount();
+  static void ResetDegenerateShrinkCount();
 
   IdType config_id_ = kInvalidId;
 

--- a/test/e2e/configs/repro_crash_pyramid_face_distance.json
+++ b/test/e2e/configs/repro_crash_pyramid_face_distance.json
@@ -1,0 +1,123 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "pyramid",
+      "shape": {
+        "prism_h": 1.2,
+        "upper_h": 0.05,
+        "lower_h": 0.05,
+        "upper_indices": [
+          1,
+          0,
+          1
+        ],
+        "lower_indices": [
+          1,
+          0,
+          1
+        ],
+        "face_distance": [
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.5
+          }
+        ]
+      },
+      "axis": {
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 0.8
+        }
+      }
+    }
+  ],
+  "filter": [],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 550,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 2000000,
+    "max_hits": 8,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 1
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "linear",
+        "fov": 55
+      },
+      "resolution": [
+        400,
+        300
+      ],
+      "ray_color": [
+        1,
+        1,
+        1
+      ],
+      "background_color": [
+        0,
+        0,
+        0
+      ]
+    }
+  ]
+}

--- a/test/regression-sentinel/test_pyramid_geometry_crash.py
+++ b/test/regression-sentinel/test_pyramid_geometry_crash.py
@@ -1,0 +1,191 @@
+"""Regression guard: pyramid + random face_distance must not SIGSEGV on Metal.
+
+Fix commit: 3c3bc3fb (fix(core): decouple polygon-face count/stride in
+Crystal::BuildPolygonFaceData)
+
+Root cause: BuildPolygonFaceData used a two-phase sizing where the initial
+poly_face_cnt_ came from valid_cnt (planes that won at least one triangle) and
+the allocation was laid out at stride=valid_cnt. The fill loop then applied a
+second filter (representative-triangle area < 1e-6 * max) and rewrote
+poly_face_cnt_ = idx to the final written count. The allocated buffer stayed
+laid out at the larger stride while poly_face_cnt_ shrank. Crystal's copy/move
+ctors re-derived the poly_face_d_ / poly_face_tri_id_ offsets from the shrunk
+count and pointed them at the wrong regions of poly_face_data_:
+
+  - CPU: GetFn(IdType)'s inner bound-check turned the wild tri_id read into a
+    silent kInvalidId return; polygon-face numbers went missing, downstream
+    raypath/filter behavior degraded silently.
+  - Metal: UploadCrystal's centroid loop dereferenced the wild tri_id into
+    the triangle-vertex buffer, walking past the mapped allocation on some
+    inputs → SIGSEGV in the Simulator hot path.
+
+The trigger requires a mesh that (a) passes the RejectMalformed factory
+Euler-check gate at the boundary, yet (b) still has at least one polygon plane
+whose argmax-representative triangle has near-zero area (below 1e-6 * max_area).
+Thin-wedge pyramid + gauss(1, 0.5) face_distance surfaces this shrink path
+reliably: this fixture hits ~6 "degenerate rep triangle" branches per 2M-ray
+run on the current calibrated configuration.
+
+The fix rewrites BuildPolygonFaceData to collect the surviving planes first and
+then size the allocation off `accepted.size()`, so poly_face_cnt_ equals the
+actual allocation stride from first assignment onward. Copy/move ctors then
+re-derive correct offsets; UploadCrystal's centroid read stays in bounds.
+
+Layered defenses (belt-and-suspenders, all in the same commit — the guards
+below only turn any future upstream stride drift into a detectable "no fn" /
+"zero centroid + WARN" symptom rather than a wild read):
+  - CPU: Crystal::GetFn(IdType)'s inner tri bound-check (pre-existing).
+  - Metal: MetalTraceBackend::Impl::UploadCrystal's centroid tri_id bound-check
+    (added symmetrically in the same fix commit).
+
+Assertions:
+  1. `returncode == 0` — the primary signal the SIGSEGV is caught.
+  2. stderr contains the "degenerate rep triangle" WARN at least once per run —
+     the anti-vacuous guard. If a future upstream change (e.g. a stronger
+     factory gate) stopped surfacing the shrink path here, `returncode == 0`
+     would silently keep passing while the sentinel had lost the coverage it
+     was written for. Requiring the warning means the fixture is still driving
+     traffic through the fixed path; the day it stops, this sentinel fails
+     loudly and asks for a fixture retune, not a silent green.
+
+Runs fast (~2s per iteration × N=15 ≈ 30s) so it stays in the default `pytest
+-v` PR gate (no @pytest.mark.slow). The two-arm detection-power verification
+(scripts/verify_pyramid_crash_sentinel_detection_power.sh) uses the same
+fixture with a longer N, run manually when the sentinel's coverage is in
+doubt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from test.e2e.runner import find_lumice_binary, get_project_root
+
+
+_CONFIG_PATH = get_project_root() / "test" / "e2e" / "configs" / "repro_crash_pyramid_face_distance.json"
+
+# A trivially-runnable config used only by the module-level smoke check. The
+# ms_filter_leak_impossible fixture is a good pick: it uses a stable prism
+# geometry (no random face_distance), always exits cleanly, and lives beside
+# the reproducer fixture so it fails for the same infrastructure reasons.
+_SMOKE_CONFIG_PATH = get_project_root() / "test" / "e2e" / "configs" / "ms_filter_leak_impossible.json"
+
+
+def _run_config(config_path: Path, timeout: float = 60.0) -> subprocess.CompletedProcess:
+    binary = find_lumice_binary()
+    cfg = json.loads(config_path.read_text())
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(cfg, f)
+        cfg_path = f.name
+    env = os.environ.copy()
+    # Bias the fixture toward per-crystal shrink-path traffic within a short
+    # wallclock: smaller dispatch batches → more resample points at the same
+    # ray_num. LUMICE_DISPATCH_RAY_NUM is a documented A-class experimental
+    # knob (see doc/env-var-policy.md); it never bypasses any user-facing
+    # switch — it only changes dispatch granularity, so setting it here is
+    # equivalent to what a manual invocation would pass through the CLI.
+    env.setdefault("LUMICE_DISPATCH_RAY_NUM", "1024")
+    try:
+        return subprocess.run(
+            [str(binary), "-f", cfg_path],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    finally:
+        Path(cfg_path).unlink(missing_ok=True)
+
+
+def _run_once() -> subprocess.CompletedProcess:
+    return _run_config(_CONFIG_PATH, timeout=60.0)
+
+
+def _smoke_check_binary() -> None:
+    """Fail fast before N runs if the binary can't even start on a stable config."""
+    result = _run_config(_SMOKE_CONFIG_PATH, timeout=30.0)
+    assert result.returncode == 0, (
+        f"Lumice binary infrastructure check failed (returncode={result.returncode}) — "
+        f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
+        f"config. Check LUMICE_BIN, the shared-library build (`./scripts/build.sh -j "
+        f"release`), or the linker. This sentinel will now skip the parametrized "
+        f"runs to avoid misattributing infrastructure failure to the pyramid+random "
+        f"face_distance crash it is written to catch.\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _binary_smoke_check() -> None:
+    _smoke_check_binary()
+
+
+# 15 runs matches the sister prism-face_distance sentinel (~30s wallclock at
+# ~2s/run). Overridable via SENTINEL_N so
+# scripts/verify_pyramid_crash_sentinel_detection_power.sh can raise N when
+# hunting for signal deaths without editing this file.
+_N_RUNS = int(os.environ.get("SENTINEL_N", "15"))
+
+
+def _classify_exit(returncode: int) -> str:
+    """Distinguish POSIX signal death from a clean non-zero exit for reporting.
+
+    Anchor: scripts/verify_pyramid_crash_sentinel_detection_power.sh greps
+    this function's output for "signal-death" and "clean non-zero exit" to
+    classify the reverted-arm run. Changing either literal here without
+    updating the script's grep patterns will silently make it report
+    AMBIGUOUS/0-detections regardless of what actually happened.
+    """
+    if returncode < 0:
+        try:
+            name = signal.Signals(-returncode).name
+        except ValueError:
+            name = f"SIG{-returncode}"
+        return f"signal-death ({name}) — SIGSEGV-class regression"
+    if returncode > 0:
+        return f"clean non-zero exit (returncode={returncode}) — NOT a signal death; likely config rejection, infrastructure, or API issue"
+    return "clean exit (returncode=0)"
+
+
+# Substring — deliberately not the full message — the AC6 refresh reformatted
+# the placeholder syntax (printf → spdlog), and this substring survives both
+# forms unchanged. Bound to Crystal::BuildPolygonFaceData's degenerate-branch
+# warning; if that log is ever removed or reworded, this sentinel is expected
+# to fail loudly so the fixture can be retuned to a new observable that still
+# proves the fixed code path is being exercised.
+_DEGENERATE_WARN_SUBSTR = "degenerate rep triangle"
+
+
+@pytest.mark.parametrize("run_idx", list(range(_N_RUNS)))
+def test_pyramid_random_face_distance_no_crash(run_idx: int) -> None:
+    """Pyramid + gauss(1, 0.5) face_distance must exit 0 AND exercise the fixed
+    BuildPolygonFaceData degenerate-branch path (proved via WARN emission)."""
+    result = _run_once()
+    assert result.returncode == 0, (
+        f"Lumice exited: {_classify_exit(result.returncode)}\n"
+        f"run_idx={run_idx}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    # Anti-vacuous guard: the fixture must still drive the degenerate branch
+    # this sentinel is written to cover. If this fires, retune the fixture
+    # (e.g. widen face_distance std, thin the wedge further) rather than
+    # deleting the assertion. The Lumice CLI routes spdlog to stdout by
+    # default, so we check both streams — either match counts.
+    combined = result.stdout + result.stderr
+    assert _DEGENERATE_WARN_SUBSTR in combined, (
+        f"Sentinel fixture no longer exercises the degenerate-representative-triangle "
+        f"branch of BuildPolygonFaceData — `returncode==0` is meaningless coverage "
+        f"unless the fixed path is actually being hit. Retune the fixture "
+        f"({_CONFIG_PATH.name}) so at least one WARN containing "
+        f"'{_DEGENERATE_WARN_SUBSTR}' is emitted per run.\n"
+        f"run_idx={run_idx}\n"
+        f"stdout tail:\n{result.stdout[-2000:]}\n"
+        f"stderr tail:\n{result.stderr[-2000:]}"
+    )

--- a/test/regression-sentinel/test_pyramid_geometry_crash.py
+++ b/test/regression-sentinel/test_pyramid_geometry_crash.py
@@ -62,12 +62,26 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from test.e2e.runner import find_lumice_binary, get_project_root
+
+
+# The SIGSEGV this sentinel guards lives in the Metal backend
+# (UploadCrystal's centroid loop dereferencing a wild tri_id). On the CPU
+# backend the same corrupted crystal is caught by Crystal::GetFn's bound-check
+# (PR #206), so a CPU run neither crashes pre-fix NOR post-fix — running the
+# sentinel on CPU has ZERO crash-detection power (it would pass a reverted,
+# still-broken binary). We therefore force Metal below and skip entirely where
+# Metal does not exist.
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="pyramid UploadCrystal SIGSEGV is Metal-specific; no Metal backend off macOS",
+)
 
 
 _CONFIG_PATH = get_project_root() / "test" / "e2e" / "configs" / "repro_crash_pyramid_face_distance.json"
@@ -93,6 +107,12 @@ def _run_config(config_path: Path, timeout: float = 60.0) -> subprocess.Complete
     # switch — it only changes dispatch granularity, so setting it here is
     # equivalent to what a manual invocation would pass through the CLI.
     env.setdefault("LUMICE_DISPATCH_RAY_NUM", "1024")
+    # Force the Metal backend: the guarded crash is Metal-only, and the CLI's
+    # default backend is CPU on this platform, which would make every run pass
+    # regardless of the fix (see module-level note). Verified in the smoke check
+    # that Metal actually engaged (gpu_route=true) rather than silently falling
+    # back to CPU.
+    env.setdefault("LUMICE_TRACE_BACKEND", "metal")
     try:
         return subprocess.run(
             [str(binary), "-f", cfg_path],
@@ -121,6 +141,16 @@ def _smoke_check_binary() -> None:
         f"face_distance crash it is written to catch.\n"
         f"stderr:\n{result.stderr}"
     )
+    # The crash is Metal-only. If the forced backend did not actually engage
+    # (e.g. Metal unavailable → CPU fallback), the parametrized runs would pass
+    # vacuously on a still-broken binary. Skip rather than give false assurance.
+    combined = result.stdout + result.stderr
+    if "gpu_route=true" not in combined:
+        pytest.skip(
+            "Metal backend did not engage (no 'gpu_route=true' in output) — the "
+            "pyramid crash is Metal-specific and a CPU run has no crash-detection "
+            "power, so this sentinel is skipped rather than passing vacuously."
+        )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/test/regression-sentinel/test_pyramid_geometry_crash.py
+++ b/test/regression-sentinel/test_pyramid_geometry_crash.py
@@ -40,8 +40,9 @@ below only turn any future upstream stride drift into a detectable "no fn" /
 
 Assertions:
   1. `returncode == 0` — the primary signal the SIGSEGV is caught.
-  2. stderr contains the "degenerate rep triangle" WARN at least once per run —
-     the anti-vacuous guard. If a future upstream change (e.g. a stronger
+  2. stdout+stderr (combined) contains the "degenerate rep triangle" WARN at
+     least once per run — the anti-vacuous guard (the Lumice CLI routes spdlog
+     to stdout, so the assertion checks both streams). If a future upstream change (e.g. a stronger
      factory gate) stopped surfacing the shrink path here, `returncode == 0`
      would silently keep passing while the sentinel had lost the coverage it
      was written for. Requiring the warning means the fixture is still driving

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -1040,4 +1040,84 @@ TEST_F(V3TestCrystal, GetFnPolyIdxOutOfRangeReturnsInvalidId) {
   }
 }
 
+TEST_F(V3TestCrystal, PyramidRandomFaceDistanceMoveGetFnLegal) {
+  // Regression guard for the polygon-face count/stride mismatch previously
+  // living in BuildPolygonFaceData: when the degenerate-representative-triangle
+  // branch fires it shrank poly_face_cnt_ below the actual allocation stride;
+  // Crystal's copy/move ctors then re-derived poly_face_d_ / poly_face_tri_id_
+  // offsets from the shrunk count and read from wrong regions of
+  // poly_face_data_. Symptoms: CPU GetFn(IdType) either returned kInvalidId
+  // (bound-checked garbage tri) or, when the garbage happened to land in
+  // fn_map_ range, silently wrong face numbers; Metal UploadCrystal wild-read
+  // → SIGSEGV. After the fix poly_face_cnt_ ≡ actual allocation stride so
+  // copy/move are structurally safe.
+  //
+  // Detection strategy: fixed-seed random sweep over pyramid + gauss(1, 0.3)
+  // face_distance samples; for each surviving crystal exercise both move-ctor
+  // and move-assignment (the real production paths — MakeCrystal returns by
+  // value which forces move, and metal_trace_backend re-assigns current_crystal
+  // each dispatch batch), then require every polygon face's GetFn to (a) not be
+  // kInvalidId and (b) resolve to a legal pyramid face number. Pre-fix, at
+  // least one of the swept crystals lands on the shrink path and one of these
+  // two assertions fires; post-fix, both stay bit-for-bit intact regardless.
+  //
+  // Fixed seed makes the "random" sweep deterministic — no CI flake. 200
+  // iterations empirically covers ~30 shrink events, well above 1/reliably
+  // triggered.
+  std::mt19937 gen(42);
+  std::normal_distribution<float> dist_gen(1.0f, 0.5f);
+  // Multiple h regimes — the SHRINK case requires an upstream-passable
+  // mesh that still has a near-zero-area representative triangle for at
+  // least one polygon plane; that condition is sensitive to the pyramid
+  // wedge geometry as well as face_distance.
+  struct HTuple {
+    float h1, h2, h3;
+  };
+  const HTuple h_regimes[] = {
+    { 0.3f, 1.0f, 0.3f },    // moderate wedge, close to production defaults
+    { 0.1f, 1.2f, 0.5f },    // very thin upper wedge
+    { 0.8f, 0.3f, 0.8f },    // wedge-heavy
+    { 0.05f, 1.5f, 0.05f },  // extremely thin wedges
+  };
+  size_t swept = 0;
+  for (int iter = 0; iter < 500; iter++) {
+    float dist[6];
+    for (int i = 0; i < 6; i++) {
+      dist[i] = dist_gen(gen);
+    }
+    const auto& h = h_regimes[iter % 4];
+    Crystal c = Crystal::CreatePyramid(1, 1, 1, 1, h.h1, h.h2, h.h3, dist);
+    // Upstream rejects severely degenerate meshes (non-manifold Euler check)
+    // by returning a zero-triangle Crystal — skip; the count/stride path never
+    // runs there.
+    if (c.PolygonFaceCount() == 0) {
+      continue;
+    }
+    // Exercise both move-ctor (mirrors `MakeCrystal(...)` by-value return) and
+    // move-assignment (mirrors `current_crystal = MakeCrystal(...)` in
+    // metal_trace_backend.mm — the exact production call point the pre-fix
+    // crash was observed at).
+    const size_t face_cnt_before = c.PolygonFaceCount();
+    Crystal moved(std::move(c));
+    ASSERT_EQ(moved.PolygonFaceCount(), face_cnt_before) << "iter=" << iter << " (move-ctor count drift)";
+    Crystal assigned;
+    assigned = std::move(moved);
+    ASSERT_EQ(assigned.PolygonFaceCount(), face_cnt_before) << "iter=" << iter << " (move-assign count drift)";
+    for (size_t p = 0; p < assigned.PolygonFaceCount(); p++) {
+      IdType fn = assigned.GetFn(static_cast<IdType>(p));
+      ASSERT_NE(fn, kInvalidId) << "iter=" << iter << " poly_idx=" << p
+                                << " — GetFn returned kInvalidId, indicating polygon face tri_id "
+                                << "landed in a wrong region of poly_face_data_ (count/stride mismatch)";
+      ASSERT_TRUE(IsLegalFace(CrystalKind::kPyramid, static_cast<int>(fn)))
+          << "iter=" << iter << " poly_idx=" << p << " fn=" << fn
+          << " — GetFn resolved to an out-of-range face number, indicating polygon face tri_id "
+          << "landed in a plausible-but-wrong region of fn_map_";
+    }
+    swept++;
+  }
+  // Sanity: the fixed seed must have exercised at least a few surviving
+  // crystals, otherwise the guard is vacuous.
+  ASSERT_GT(swept, 20u) << "fixed-seed sweep produced too few surviving crystals; guard is vacuous";
+}
+
 }  // namespace

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -1052,7 +1052,7 @@ TEST_F(V3TestCrystal, PyramidRandomFaceDistanceMoveGetFnLegal) {
   // → SIGSEGV. After the fix poly_face_cnt_ ≡ actual allocation stride so
   // copy/move are structurally safe.
   //
-  // Detection strategy: fixed-seed random sweep over pyramid + gauss(1, 0.3)
+  // Detection strategy: fixed-seed deterministic sweep over pyramid +
   // face_distance samples; for each surviving crystal exercise both move-ctor
   // and move-assignment (the real production paths — MakeCrystal returns by
   // value which forces move, and metal_trace_backend re-assigns current_crystal
@@ -1061,11 +1061,29 @@ TEST_F(V3TestCrystal, PyramidRandomFaceDistanceMoveGetFnLegal) {
   // least one of the swept crystals lands on the shrink path and one of these
   // two assertions fires; post-fix, both stay bit-for-bit intact regardless.
   //
-  // Fixed seed makes the "random" sweep deterministic — no CI flake. 200
-  // iterations empirically covers ~30 shrink events, well above 1/reliably
-  // triggered.
+  // PORTABILITY: the face_distance samples are drawn by mapping raw mt19937
+  // output through a hand-written uniform transform — NOT std::normal_/
+  // uniform_real_distribution, whose bit-exact output sequences are unspecified
+  // and differ across libstdc++ (dev49/Linux) and libc++ (macOS). mt19937's
+  // uint32 stream plus this manual mapping is identical on every stdlib, so the
+  // fixed seed constructs the *same* crystals — and therefore hits the *same*
+  // shrink events — everywhere. That is what makes the anti-vacuous assertion
+  // below trustworthy cross-platform (see project learning on distribution
+  // non-portability).
+  //
+  // ANTI-VACUOUS: the GetFn assertions only have detection power on crystals
+  // that actually took the degenerate-shrink path. We reset the process-global
+  // shrink counter, run the sweep, and assert it fired — otherwise a future
+  // sampling/geometry drift could make this guard pass while testing nothing.
+  Crystal::ResetDegenerateShrinkCount();
   std::mt19937 gen(42);
-  std::normal_distribution<float> dist_gen(1.0f, 0.5f);
+  // Map a fresh mt19937 draw to face_distance in [0.3, 1.7) — spread wide
+  // enough to produce near-zero-area representative triangles (the shrink
+  // trigger) while staying upstream-constructible.
+  auto next_dist = [&gen]() {
+    const float u = static_cast<float>(gen() >> 8) * (1.0f / 16777216.0f);  // [0,1)
+    return 0.3f + u * 1.4f;
+  };
   // Multiple h regimes — the SHRINK case requires an upstream-passable
   // mesh that still has a near-zero-area representative triangle for at
   // least one polygon plane; that condition is sensitive to the pyramid
@@ -1083,7 +1101,7 @@ TEST_F(V3TestCrystal, PyramidRandomFaceDistanceMoveGetFnLegal) {
   for (int iter = 0; iter < 500; iter++) {
     float dist[6];
     for (int i = 0; i < 6; i++) {
-      dist[i] = dist_gen(gen);
+      dist[i] = next_dist();
     }
     const auto& h = h_regimes[iter % 4];
     Crystal c = Crystal::CreatePyramid(1, 1, 1, 1, h.h1, h.h2, h.h3, dist);
@@ -1118,6 +1136,14 @@ TEST_F(V3TestCrystal, PyramidRandomFaceDistanceMoveGetFnLegal) {
   // Sanity: the fixed seed must have exercised at least a few surviving
   // crystals, otherwise the guard is vacuous.
   ASSERT_GT(swept, 20u) << "fixed-seed sweep produced too few surviving crystals; guard is vacuous";
+  // Anti-vacuous: the GetFn assertions above only have detection power on
+  // crystals that took the degenerate-shrink path. Require the sweep to have
+  // actually fired it — a future sampling/geometry drift that stops hitting the
+  // shrink branch must fail loudly here, not pass while testing nothing.
+  ASSERT_GT(Crystal::DegenerateShrinkCount(), 0u)
+      << "fixed-seed sweep never exercised the degenerate-shrink path (poly-face count/stride shrink); "
+      << "the move/GetFn assertions above were vacuous. If geometry sampling changed, re-calibrate the "
+      << "face_distance range in next_dist() so the sweep hits the shrink branch again.";
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

`pyramid` crystal + random `face_distance` (both documented config syntax) → Metal `EXC_BAD_ACCESS`/SIGSEGV. Default backend, zero knobs, valid config — a shipping crash (a03). Existing bug on stock `main` (reproduced 3/3 pre-fix on Metal). PR #206 only fixed the prism path.

## Root cause (white-box)

`Crystal::BuildPolygonFaceData` decided `poly_face_cnt_` in two stages: it allocated `poly_face_data_` at stride `valid_cnt`, then the degenerate-rep-triangle filter could accept fewer faces and re-count `poly_face_cnt_ = idx` **without re-laying-out the buffer**. The object stayed self-consistent, but `Crystal`'s copy/move ctors re-derive `poly_face_d_`/`poly_face_tri_id_` offsets *from the shrunk count* → they land in the wrong region of `poly_face_data_`. `MakeCrystal` returns by value → every degenerate-filtered crystal is corrupted on move. On CPU the wild `tri_id` is caught by `GetFn`'s bound-check (PR #206) → silent-wrong face numbers; on Metal `UploadCrystal` reads it raw → SIGSEGV.

## Fix

- **Collect-then-size** rewrite: the accept predicate is evaluated once into a small vector; `poly_face_cnt_ = accepted.size()` equals the allocation stride from the first assignment. `valid_cnt`/`idx` intermediates gone → stride ≡ count always, copy/move re-derivation is structurally correct. One root-cause fix heals the Metal crash **and** the CPU silent-wrong path.
- Symmetric bound-check + stale-centroid zeroing in Metal `UploadCrystal`.
- Two `printf`→spdlog format-string fixes in the same function (`:761`, `:710`).

## Tests / evidence (first-hand)

- **AC2 baseline**: reverted (pre-fix) arm on Metal **3/3 SIGSEGV** → fixed arm on Metal **5/5 clean** + sentinel **15/15 green**.
- New unit test (`PyramidRandomFaceDistanceMoveGetFnLegal`): move-ctor/move-assign + `GetFn` legality over a portable (mt19937 + manual uniform, stdlib-independent) sweep, with an **anti-vacuous** assertion that the shrink branch actually fired (verified hits 4×).
- New Metal-forced crash sentinel + two-arm detection-power script. **Note:** the initial sentinel ran the default CPU backend (guarded) → zero crash-detection power; fixed to force `LUMICE_TRACE_BACKEND=metal` (skips off-macOS / on CPU fallback). Red/green verified: fixed 15/15 green, reverted 15/15 red.
- prism ring-1 sentinel (PR #206) 15/15 not regressed; unit + parity suites green; format/policy gates green.

## Follow-ups (noted, not blocking)

- slow e2e (`-sj` + `pytest -m slow`) before merge if desired.
- CUDA/dev49 hardware parity: dev49 unavailable today; white-box confirms all three backends read the same host accessor, so fixing host fixes all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)