### PR TITLE
fix(test): ASCII-ize parity test messages for GBK-locale Windows

### DIFF
--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -122,10 +122,16 @@
   set LUMICE_CUDA_ENABLED=1
   set LUMICE_LIB=C:\lumice-src\build\Release\bin\lumice.dll
   set PATH=C:\lumice-src\build\Release\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin;%PATH%
+  set PYTHONUTF8=1
   cd /d C:\lumice-src
   C:\lumice-test\py311\python.exe -m pytest -v test\parity-cross-backend\backend\test_cuda_exit_seam_parity.py test\parity-cross-backend\backend\test_cuda_filter_parity.py test\parity-cross-backend\backend\test_cuda_multi_ms_parity.py
   ```
   耗时 ~7min，1070Ti/sm_61 走 compute_61 PTX JIT。
+  - ⚠️ **`set PYTHONUTF8=1` 必带**：中文 Windows 控制台默认 GBK codec，parity 测试的
+    docstring/traceback 若含非 ASCII 字符（数学符号、破折号），pytest 输出时会
+    `UnicodeEncodeError` 崩在渲染上 → parity 计算已完成但断言未执行 = 假失败遮蔽真结果。
+    `PYTHONUTF8=1` 强制 Python UTF-8 I/O，与 locale 无关，是这个坑的环境兜底。
+    测试消息串本身已改 ASCII（治本），此为第二道保险。
 - **PS over ssh 通用坑**：默认 shell 是 PowerShell，内联引号 + 中文 locale 易乱码/解析错 →
   **一律写 .ps1/.bat 文件 scp 过去，再 `powershell -NoProfile -ExecutionPolicy Bypass -File`
   或 `cmd /c`**。用完清理 `C:\lumice-test` 下的临时脚本（共享机卫生）。

--- a/test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_exit_seam_parity.py
@@ -138,19 +138,19 @@ def test_cuda_single_ms_no_filter_parity():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} psnr={psnr:.2f}dB "
-        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+        f"energy_ratio={energy_ratio:.4f} (tol +/-{_T_ENERGY_TOL})"
     )
 
     # G1
     assert corr >= _T_RAW_CORR_DS, (
         f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS} (G1 floor). "
         "Suspect frame invariant 6 (rot_c2w missing), from_face guard bug, "
-        "or Möller-Trumbore precision issue."
+        "or Moller-Trumbore precision issue."
     )
     # G2
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]. Suspect Fresnel sampling drift / exit-cap "
+        f"[1 +/- {_T_ENERGY_TOL}]. Suspect Fresnel sampling drift / exit-cap "
         "overflow / TIR mishandling."
     )
 
@@ -186,6 +186,6 @@ def test_cuda_cross_seed_self_consistency():
     )
     assert corr_cuda >= corr_legacy - _T_SELF_MARGIN, (
         f"{cfg}: cuda cross-seed self-consistency {corr_cuda:.4f} < "
-        f"legacy_self {corr_legacy:.4f} − {_T_SELF_MARGIN}. Suspect PCG seed "
+        f"legacy_self {corr_legacy:.4f} - {_T_SELF_MARGIN}. Suspect PCG seed "
         "collapse / per-thread stream reuse in trace_single_ms_kernel."
     )

--- a/test/parity-cross-backend/backend/test_cuda_filter_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_filter_parity.py
@@ -125,7 +125,7 @@ def test_cuda_impossible_filter_produces_zero_intensity():
     )
     assert not result.fell_back, "impossible filter test: CUDA backend fell back to legacy"
     assert result.snapshot_intensity == pytest.approx(0.0, abs=1e-6), (
-        f"CUDA filter gate did NOT terminate filter-fail rays — Design A violation: "
+        f"CUDA filter gate did NOT terminate filter-fail rays - Design A violation: "
         f"snapshot_intensity={result.snapshot_intensity:.6f} (expected ~0). "
         "Suspect kernel emit gate skipping DeviceFilterCheck, or the dummy desc "
         "fallback being used when a real filter desc was needed."
@@ -163,17 +163,17 @@ def test_cuda_single_ms_filter_image_parity_vs_legacy():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} psnr={psnr:.2f}dB "
-        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+        f"energy_ratio={energy_ratio:.4f} (tol +/-{_T_ENERGY_TOL})"
     )
 
     assert corr >= _T_RAW_CORR_DS, (
         f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Suspect DrainExits "
-        "GetFn remap or FilterSpec::Check argument shape — the CPU unit test "
+        "GetFn remap or FilterSpec::Check argument shape - the CPU unit test "
         "test_device_filter_check_host.cpp already validated the device matcher."
     )
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]. Suspect final_ms_prob_ wired wrong or drain_rng_ "
+        f"[1 +/- {_T_ENERGY_TOL}]. Suspect final_ms_prob_ wired wrong or drain_rng_ "
         "seeded with the device-gate counter (would oversubtract)."
     )
 
@@ -212,18 +212,18 @@ def test_cuda_multi_ms_filter_image_parity_vs_legacy():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} psnr={psnr:.2f}dB "
-        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+        f"energy_ratio={energy_ratio:.4f} (tol +/-{_T_ENERGY_TOL})"
     )
 
     assert corr >= _T_RAW_CORR_DS, (
         f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Cross-check filter "
         "desc upload (EnsureFilterBuffers per-slot index) + path_rec content "
         "at the emit gate (Metal+CPU mid-layer exits write poly-index path "
-        "verbatim — CUDA must mirror)."
+        "verbatim - CUDA must mirror)."
     )
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]. Audit mid-exit routing (filter-fail must drop, "
+        f"[1 +/- {_T_ENERGY_TOL}]. Audit mid-exit routing (filter-fail must drop, "
         "filter-pass + prob-fail must mid-exit) and DrainExits' branch on "
         "final_ms_layer_idx_."
     )
@@ -259,7 +259,7 @@ def test_cuda_multi_ms_filter_cross_seed_self_consistency():
     )
     assert corr_cuda >= corr_legacy - _T_SELF_MARGIN, (
         f"{cfg}: cuda cross-seed self-consistency {corr_cuda:.4f} < "
-        f"legacy_self {corr_legacy:.4f} − {_T_SELF_MARGIN}. Suspect drain_rng_ "
+        f"legacy_self {corr_legacy:.4f} - {_T_SELF_MARGIN}. Suspect drain_rng_ "
         "or transit_ray_count_ collapse under the filter-drop survival rate; "
         "verify (transit_seed, transit_ray_count + tid) tuple stays disjoint "
         "across seed-{42, 7} runs."
@@ -303,17 +303,17 @@ def test_cuda_big_or_complex_with_color_parity_vs_legacy():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} "
-        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+        f"energy_ratio={energy_ratio:.4f} (tol +/-{_T_ENERGY_TOL})"
     )
 
     assert corr >= _T_RAW_CORR_DS, (
         f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Suspect the CUDA "
         "color-rebuild path skipping d_and_term_counts_ re-upload (see "
-        "cuda_trace_backend.cu color rebuild block) — physical filter reads "
+        "cuda_trace_backend.cu color rebuild block) - physical filter reads "
         "the pre-color-pass counts snapshot in color+big-OR configs."
     )
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]. Same suspects as above; a mis-indexed "
+        f"[1 +/- {_T_ENERGY_TOL}]. Same suspects as above; a mis-indexed "
         "and_term_counts read can turn AND-terms into no-ops or double-count."
     )

--- a/test/parity-cross-backend/backend/test_cuda_multi_ms_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_multi_ms_parity.py
@@ -141,7 +141,7 @@ def test_cuda_multi_ms_image_parity_vs_legacy():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} psnr={psnr:.2f}dB "
-        f"energy_ratio={energy_ratio:.4f} (tol ±{_T_ENERGY_TOL})"
+        f"energy_ratio={energy_ratio:.4f} (tol +/-{_T_ENERGY_TOL})"
     )
 
     # AC2a
@@ -153,7 +153,7 @@ def test_cuda_multi_ms_image_parity_vs_legacy():
     # AC2c
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]. Suspect prob_fail dropped (should be mid-exit), "
+        f"[1 +/- {_T_ENERGY_TOL}]. Suspect prob_fail dropped (should be mid-exit), "
         "cont buffer overflow (warn log), or transit kernel zeroing rays via "
         "tri_to_poly kInvalidId fallback."
     )
@@ -194,7 +194,7 @@ def test_cuda_high_continuation_no_exit_overflow_corruption():
 
     print(
         f"[parity] {cfg}: cuda ds_corr={corr:.4f} energy_ratio={energy_ratio:.4f} "
-        f"(floors corr≥{_T_RAW_CORR_DS}, |energy−1|≤{_T_ENERGY_TOL})"
+        f"(floors corr>={_T_RAW_CORR_DS}, |energy-1|<={_T_ENERGY_TOL})"
     )
 
     # ds_corr is the discriminating metric: the dropped-tail damage is spatial,
@@ -206,7 +206,7 @@ def test_cuda_high_continuation_no_exit_overflow_corruption():
     )
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
         f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {_T_ENERGY_TOL}]."
+        f"[1 +/- {_T_ENERGY_TOL}]."
     )
 
 
@@ -252,7 +252,7 @@ def test_cuda_three_layer_multi_ci_parity_vs_legacy():
 
     print(
         f"[parity] {cfg}(300K): cuda ds_corr={corr:.4f} energy_ratio={energy_ratio:.4f} "
-        f"(floors corr≥{_T_RAW_CORR_DS}, |energy−1|≤{_T_ENERGY_TOL})"
+        f"(floors corr>={_T_RAW_CORR_DS}, |energy-1|<={_T_ENERGY_TOL})"
     )
     assert corr >= _T_RAW_CORR_DS, (
         f"{cfg}: ds_corr {corr:.4f} < {_T_RAW_CORR_DS}. Multi-CI path broken on a "
@@ -260,7 +260,7 @@ def test_cuda_three_layer_multi_ci_parity_vs_legacy():
         "layer crystal_id-indexed DrainExits)."
     )
     assert abs(energy_ratio - 1.0) <= _T_ENERGY_TOL, (
-        f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside [1 ± {_T_ENERGY_TOL}]."
+        f"{cfg}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside [1 +/- {_T_ENERGY_TOL}]."
     )
 
 
@@ -298,7 +298,7 @@ def test_cuda_multi_ms_cross_seed_self_consistency():
     )
     assert corr_cuda >= corr_legacy - _T_SELF_MARGIN, (
         f"{cfg}: cuda cross-seed self-consistency {corr_cuda:.4f} < "
-        f"legacy_self {corr_legacy:.4f} − {_T_SELF_MARGIN}. Suspect PCG seed "
+        f"legacy_self {corr_legacy:.4f} - {_T_SELF_MARGIN}. Suspect PCG seed "
         "collapse in transit_multi_ms_kernel (transit_seed_ / transit_ray_count_ "
-        "not advancing per dispatch) — this is the scrum-267.3 failure mode."
+        "not advancing per dispatch) - this is the scrum-267.3 failure mode."
     )

--- a/test/parity-cross-backend/backend/test_cuda_projection_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_projection_parity.py
@@ -93,7 +93,7 @@ def _assert_routed_cuda(r: BufferedSimResult, lens_type: str) -> None:
         f"log did not emit the CudaTraceBackend routing line. log tail: {r.log_lines[-5:]}"
     )
     assert not r.fell_back, (
-        f"{lens_type}: CUDA was requested but fell back to legacy CPU — the "
+        f"{lens_type}: CUDA was requested but fell back to legacy CPU - the "
         f"projection is NOT actually accelerated. log tail: {r.log_lines[-5:]}"
     )
 
@@ -113,7 +113,7 @@ def test_cuda_projection_parity(lens_type: str, _proj_configs):
 
     assert legacy_a.routed_backend == "legacy" and not legacy_a.fell_back, (
         f"{lens_type}: legacy oracle routed={legacy_a.routed_backend!r} "
-        f"fell_back={legacy_a.fell_back} — env pollution suspected."
+        f"fell_back={legacy_a.fell_back} - env pollution suspected."
     )
     _assert_routed_cuda(cuda_a, lens_type)
 
@@ -122,7 +122,7 @@ def test_cuda_projection_parity(lens_type: str, _proj_configs):
 
     cuda_y = float(cuda_a.flt_buf[..., 1].sum())
     legacy_y = float(legacy_a.flt_buf[..., 1].sum())
-    assert legacy_y > 0.0, f"{lens_type}: legacy total Y == 0 — scene carries no signal"
+    assert legacy_y > 0.0, f"{lens_type}: legacy total Y == 0 - scene carries no signal"
     energy_ratio = cuda_y / legacy_y
 
     cuda_b = _run(cfg, "cuda", seed=_SEED_B)
@@ -144,11 +144,11 @@ def test_cuda_projection_parity(lens_type: str, _proj_configs):
     assert psnr >= T_PSNR_DB, f"{lens_type}: render PSNR {psnr:.2f} dB < {T_PSNR_DB}"
     assert abs(energy_ratio - 1.0) <= T_ENERGY_TOL, (
         f"{lens_type}: cuda/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {T_ENERGY_TOL}] — global energy imbalance in the exit/emit path."
+        f"[1 +/- {T_ENERGY_TOL}] - global energy imbalance in the exit/emit path."
     )
     assert cuda_self >= legacy_self - T_SELF_MARGIN, (
         f"{lens_type}: cuda cross-seed self-consistency {cuda_self:.4f} < "
-        f"legacy_self {legacy_self:.4f} − {T_SELF_MARGIN} — suspect PCG stream "
+        f"legacy_self {legacy_self:.4f} - {T_SELF_MARGIN} - suspect PCG stream "
         f"collapse / orientation undersampling in the CUDA path for this projection."
     )
 

--- a/test/parity-cross-backend/backend/test_device_gen_default_path.py
+++ b/test/parity-cross-backend/backend/test_device_gen_default_path.py
@@ -127,7 +127,7 @@ def test_default_path_device_gen_vs_host_gen_single_ms():
     )
     assert ds >= _DS_CORR_FLOOR, (
         f"dual_fisheye_ref default path: device-gen ON vs OFF ds_corr={ds:.4f} "
-        f"< {_DS_CORR_FLOOR} — systematic divergence between device-gen and "
+        f"< {_DS_CORR_FLOOR} - systematic divergence between device-gen and "
         f"host-gen on the default render path."
     )
 
@@ -203,7 +203,7 @@ def test_device_gen_activation_proof_fixed_seed():
     )
     assert rel_err > _ACTIVATION_RELERR_FLOOR, (
         f"dual_fisheye_ref sim_seed=42: device-gen ON vs OFF rel_err={rel_err:.3e} "
-        f"<= {_ACTIVATION_RELERR_FLOOR:.0e} — GPU PCG and host mt19937 produced "
+        f"<= {_ACTIVATION_RELERR_FLOOR:.0e} - GPU PCG and host mt19937 produced "
         f"near-identical output at the same seed. device-gen likely fell back "
         f"to host-gen; the default-path coverage in this file is then assert-may-pass."
     )

--- a/test/parity-cross-backend/backend/test_metal_batch_invariance.py
+++ b/test/parity-cross-backend/backend/test_metal_batch_invariance.py
@@ -132,7 +132,7 @@ def _spawn_run(config_name: str, batch: int):
     status["batches"] = int(m.group(1)) if m else -1
     assert status["batches"] > 0, (
         f"{config_name} batch={batch}: could not read effective batch count "
-        f"(Consume profile line missing) — cannot confirm batch took effect."
+        f"(Consume profile line missing) - cannot confirm batch took effect."
     )
     arr = np.load(out.name)
     os.unlink(out.name)
@@ -162,7 +162,7 @@ def test_metal_batch_invariance(config_name):
     assert s_large["batches"] * 4 < s_small["batches"], (
         f"{config_name}: batch grain did not actually differ "
         f"(b{_SMALL_BATCH}={s_small['batches']} batches, b{_LARGE_BATCH}={s_large['batches']}); "
-        f"suspect a frozen LUMICE_BATCH_RAY_NUM static — the comparison would be vacuous."
+        f"suspect a frozen LUMICE_BATCH_RAY_NUM static - the comparison would be vacuous."
     )
 
     cross = _corr(small, large)
@@ -180,13 +180,13 @@ def test_metal_batch_invariance(config_name):
     # severity. Does NOT enforce full invariance — the residual (gap≈0.013 today)
     # is an explore-3 / geometry-pool decision (concern #5).
     assert cross >= _CATASTROPHE_CORR, (
-        f"{config_name}: SEVERE batch dependence — cross-batch corr={cross:.4f} < "
+        f"{config_name}: SEVERE batch dependence - cross-batch corr={cross:.4f} < "
         f"{_CATASTROPHE_CORR}. Scrum 2's rewrite re-coupled the GPU dispatch batch to "
         f"the statistical result at gross severity."
     )
     assert abs(energy_ratio - 1.0) <= _CATASTROPHE_ENERGY_TOL, (
-        f"{config_name}: SEVERE batch energy dependence — energy_ratio={energy_ratio:.4f} "
-        f"outside [1±{_CATASTROPHE_ENERGY_TOL}]."
+        f"{config_name}: SEVERE batch energy dependence - energy_ratio={energy_ratio:.4f} "
+        f"outside [1+/-{_CATASTROPHE_ENERGY_TOL}]."
     )
 
 
@@ -241,7 +241,7 @@ def test_metal_exit_conservation_heavy():
     overflowed = bool(_RE_OVERFLOW.search(log))
     print(f"[exit-cons] ms3_mixed_pyramid_heavy: exit_overflow={overflowed} (gate: no overflow)")
     assert not overflowed, (
-        "ms3_mixed_pyramid_heavy overflowed exit_cap=12288 — Scrum-268.4's "
+        "ms3_mixed_pyramid_heavy overflowed exit_cap=12288 - Scrum-268.4's "
         "incremental drain regressed. Re-introduce clamp-side observability "
         "(see commit fb722c20 for the drain design) before relaxing this gate."
     )

--- a/test/parity-cross-backend/backend/test_metal_exit_seam_parity.py
+++ b/test/parity-cross-backend/backend/test_metal_exit_seam_parity.py
@@ -153,7 +153,7 @@ def _assert_routed(r: BufferedSimResult, expected_backend: str, config_name: str
     assert r.routed_backend == expected_backend, (
         f"{config_name}/{expected_backend}: routed={r.routed_backend!r} "
         f"(expected {expected_backend!r}); core log did not emit the expected "
-        f"routing line — see log_lines for the actual path."
+        f"routing line - see log_lines for the actual path."
     )
     assert not r.fell_back, (
         f"{config_name}/{expected_backend}: fell back to legacy (lens/view "
@@ -332,8 +332,8 @@ def _assert_metal_self_consistency(
     )
     assert metal_self >= legacy_self - _SELF_MARGIN, (
         f"{config_name}: metal cross-seed self-consistency {metal_self:.4f} < "
-        f"legacy_self {legacy_self:.4f} − {_SELF_MARGIN}. Suspect transit/gen "
-        f"PCG stream collapse — metal orientations are less self-similar across "
+        f"legacy_self {legacy_self:.4f} - {_SELF_MARGIN}. Suspect transit/gen "
+        f"PCG stream collapse - metal orientations are less self-similar across "
         f"seeds than legacy, signalling under-sampling."
     )
 
@@ -356,11 +356,11 @@ def _assert_energy_conservation(
     ratio = metal_Y / legacy_Y
     print(
         f"[energy] {config_name}: metal/legacy Y ratio={ratio:.4f} "
-        f"tol=±{_ENERGY_TOL}"
+        f"tol=+/-{_ENERGY_TOL}"
     )
     assert abs(ratio - 1.0) <= _ENERGY_TOL, (
         f"{config_name}: metal/legacy total-Y ratio {ratio:.4f} outside "
-        f"[1 ± {_ENERGY_TOL}]. Suspect global energy imbalance in continuation/"
+        f"[1 +/- {_ENERGY_TOL}]. Suspect global energy imbalance in continuation/"
         f"emit-gate path (cf. fused-emit-gate +16% regression class)."
     )
 

--- a/test/parity-cross-backend/backend/test_metal_projection_parity.py
+++ b/test/parity-cross-backend/backend/test_metal_projection_parity.py
@@ -95,7 +95,7 @@ def _assert_routed_metal(r: BufferedSimResult, lens_type: str) -> None:
         f"log did not emit the MetalTraceBackend routing line. log tail: {r.log_lines[-5:]}"
     )
     assert not r.fell_back, (
-        f"{lens_type}: Metal was requested but fell back to legacy CPU — the "
+        f"{lens_type}: Metal was requested but fell back to legacy CPU - the "
         f"projection is NOT actually accelerated. log tail: {r.log_lines[-5:]}"
     )
 
@@ -117,7 +117,7 @@ def test_metal_projection_parity(lens_type: str, _proj_configs):
     # as requested (legacy assertion also catches leaked env pollution).
     assert legacy_a.routed_backend == "legacy" and not legacy_a.fell_back, (
         f"{lens_type}: legacy oracle routed={legacy_a.routed_backend!r} "
-        f"fell_back={legacy_a.fell_back} — env pollution suspected."
+        f"fell_back={legacy_a.fell_back} - env pollution suspected."
     )
     _assert_routed_metal(metal_a, lens_type)
 
@@ -128,7 +128,7 @@ def test_metal_projection_parity(lens_type: str, _proj_configs):
     # (a) Parity metric 2: total-Y energy conservation.
     metal_y = float(metal_a.flt_buf[..., 1].sum())
     legacy_y = float(legacy_a.flt_buf[..., 1].sum())
-    assert legacy_y > 0.0, f"{lens_type}: legacy total Y == 0 — scene carries no signal"
+    assert legacy_y > 0.0, f"{lens_type}: legacy total Y == 0 - scene carries no signal"
     energy_ratio = metal_y / legacy_y
 
     # (a) Parity metric 3: cross-seed self-consistency (corr-blind undersampling).
@@ -151,11 +151,11 @@ def test_metal_projection_parity(lens_type: str, _proj_configs):
     assert psnr >= T_PSNR_DB, f"{lens_type}: render PSNR {psnr:.2f} dB < {T_PSNR_DB}"
     assert abs(energy_ratio - 1.0) <= T_ENERGY_TOL, (
         f"{lens_type}: metal/legacy total-Y ratio {energy_ratio:.4f} outside "
-        f"[1 ± {T_ENERGY_TOL}] — global energy imbalance in the exit/emit path."
+        f"[1 +/- {T_ENERGY_TOL}] - global energy imbalance in the exit/emit path."
     )
     assert metal_self >= legacy_self - T_SELF_MARGIN, (
         f"{lens_type}: metal cross-seed self-consistency {metal_self:.4f} < "
-        f"legacy_self {legacy_self:.4f} − {T_SELF_MARGIN} — suspect orientation "
+        f"legacy_self {legacy_self:.4f} - {T_SELF_MARGIN} - suspect orientation "
         f"undersampling (corr-blind) in the Metal path for this projection."
     )
 


### PR DESCRIPTION
## 问题

CUDA/Metal parity 测试的 `print()` / `assert` 失败消息 f-string 含非 ASCII 数学符号
(`−` U+2212、`≥`、`≤`、`±`、em-dash 等)。在中文 Windows 控制台(GBK codec)上,pytest
输出这些字符时 GBK 无法编码 → `UnicodeEncodeError` 崩在渲染上。**parity 计算已完成,
但断言/print 崩溃 → 真结果被假失败遮蔽**。task-381 (#209) 在 win-builder 验证
`test_cuda_multi_ms_parity.py` 时命中(其 AC1 body 是一条无条件执行的多行 `print()`)。

影响面:绊倒每个在 win-builder 上跑 pytest 的 CUDA 改动(含后续几何随机化性能工作)+ CI windows job。

## 修法(治本 + 兜底)

- **治本**:AST 定位的替换器只改 `assert`-msg / `print` / `pytest.fail` / `raise` 参数里的非
  ASCII 数学符号 → ASCII(`−`→`-` / `±`→`+/-` / `≥`→`>=` / `≤`→`<=` / em-dash→`-` /
  `ö`→`o` 等),**8 文件 54 glyph**。
- **兜底**:`doc/gpu-remote-cuda-build-testing.md` 的 win-builder parity recipe 加 `set PYTHONUTF8=1`
  (强制 Python UTF-8 I/O,与 locale 无关,覆盖 traceback 渲染任何残留非 ASCII)。

## 为什么不动注释/docstring

注释/docstring 非控制台输出路径,且**携带 pre-existing 工作笔记引用**(如 `scrum-...plan.md`、
`task-268.4`)——重排这些行会让 `check_new_refs.py` 把 pre-existing 引用当新增行拦掉。故用 AST
精确锁定 message 串规避该 landmine;docstring 里的非 ASCII 由 `PYTHONUTF8=1` belt 覆盖。

## 验证

- message 行非 ASCII 残留 = **0**(AST 复扫)。
- Mac `pytest -q -m "not slow"`(CI 同款 fast e2e):**79 passed, 1 skipped**。
- `check_new_refs --staged` 绿;pre-commit policy + new-refs 全绿;py_compile 9 文件 OK。
- win-builder 上不再 `UnicodeEncodeError` = 交后续远程 CUDA 验证顺带确认(本地无 win-builder)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
