### PR TITLE
feat(cuda): degenerate K-shape pool parity + crystal-count assertion (scrum-392)

### DIFF
--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1345,13 +1345,25 @@ __global__ void transit_multi_ms_kernel(
 
   // 4. Uniform sample inside the chosen triangle → entry point p.
   float p[3];
-  lm_pcg::sample_triangle(stream, d_tri_vtx_ray + tri_id * 9u, p);
 
   // 5. tri_to_poly. kInvalidId (uint16_t 0xffff) signals "triangle has no
   //    polygon backing under the coplanar-floor predicate" — mirror Metal's
   //    InitRay_p_fid zero-weight fallback so downstream trace dispatches see
   //    a benign drop (w=0 short-circuits the entry-face emit and main loop).
-  uint16_t to_face_u16 = d_tri_to_poly_ray[tri_id];
+  //    K-shape degenerate-slot guard (mirrors gen_root_kernel): shape_tri_cnt
+  //    == 0 → shape_tri_off aliases the next slot's triangles / pool tail, so
+  //    skip both reads and route into the kInvalidId zero-weight drop.
+  //    Non-degenerate rays are unaffected (AC2 bit-exact path unchanged).
+  uint16_t to_face_u16;
+  if (shape_tri_cnt == 0u) {
+    p[0] = 0.0f;
+    p[1] = 0.0f;
+    p[2] = 0.0f;
+    to_face_u16 = kInvalidIdU16;
+  } else {
+    lm_pcg::sample_triangle(stream, d_tri_vtx_ray + tri_id * 9u, p);
+    to_face_u16 = d_tri_to_poly_ray[tri_id];
+  }
   float w = d_cont_w_in[tid];
   uint32_t to_face_u32;
   if (to_face_u16 == kInvalidIdU16) {
@@ -1551,10 +1563,26 @@ __global__ void gen_root_kernel(float* __restrict__ d_root_d,           // 3 × 
   float u_cat = lm_pcg::pcg_uniform(stream);
   uint32_t tri_id = lm_pcg::categorical_sample(proj_prob, n_tri, u_cat);
   float p[3];
-  lm_pcg::sample_triangle(stream, d_tri_vtx_ray + tri_id * 9u, p);
 
   // 4. tri_to_poly. kInvalidId → zero-weight drop (InitRay_p_fid fallback).
-  uint16_t to_face_u16 = d_tri_to_poly_ray[tri_id];
+  //    K-shape degenerate-slot guard: when shape_tri_cnt == 0 (ring0-legal
+  //    zero-triangle Crystal that "contributes nothing"), shape_tri_off aliases
+  //    the NEXT pool slot's packed triangles (or runs past the pool tail on the
+  //    last slot), so sampling tri_id 0 here would silently read a neighbor
+  //    shape's vtx / tri_to_poly. Skip both reads and route into the existing
+  //    kInvalidId zero-weight drop below — same sentinel, no new mechanism.
+  //    Non-degenerate rays never take this branch, so the K==0 / AC2 bit-exact
+  //    path is numerically unchanged.
+  uint16_t to_face_u16;
+  if (shape_tri_cnt == 0u) {
+    p[0] = 0.0f;
+    p[1] = 0.0f;
+    p[2] = 0.0f;
+    to_face_u16 = kInvalidIdU16;
+  } else {
+    lm_pcg::sample_triangle(stream, d_tri_vtx_ray + tri_id * 9u, p);
+    to_face_u16 = d_tri_to_poly_ray[tri_id];
+  }
   float weight = d_wl_pool[wl_idx].spd_weight;
   uint32_t to_face_u32;
   if (to_face_u16 == kInvalidIdU16) {
@@ -2635,7 +2663,26 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
         size_t poly_cnt = crystal.PolygonFaceCount();
         size_t tri_cnt  = crystal.TotalTriangles();
         if (poly_cnt == 0 || tri_cnt == 0) {
-          throw BackendUnavailableError("CudaTraceBackend::BuildGeomPool: degenerate crystal geometry");
+          // Ring0-legal degenerate slot: a zero-triangle Crystal is a valid
+          // "contributes nothing" product (Crystal::MakePrismClosedForm returns
+          // Mesh(0,0) when the closed-form validity gate fails). Tolerate it
+          // exactly like Metal's UploadCrystalPool — record a {poly_off, 0,
+          // tri_off, 0} shape row with no geometry bytes and DO NOT advance
+          // poly_acc/tri_acc. The per-ray shape pick in gen_root_kernel /
+          // transit_multi_ms_kernel drops any ray that lands on a tri_cnt==0
+          // slot (zero weight, kInvalidId face). Throwing here was the root
+          // cause of the CPU-fallback + PolygonFaceOfTri log-storm: one
+          // degenerate slot in a 512-shape K-pool must not fail the whole
+          // backend. `continue` skips the geometry getters (safe on Mesh(0,0)).
+          // The kMaxTriPerKernel throw below is a distinct kernel-stack bound,
+          // unrelated to ring0 degeneracy, and stays fatal.
+          pool_poly_off_.push_back(poly_acc);
+          pool_poly_cnt_.push_back(0u);
+          pool_tri_off_.push_back(tri_acc);
+          pool_tri_cnt_.push_back(0u);
+          pool_crystals_.push_back(std::move(crystal));
+          ++pool_shape_count_this_batch_;
+          continue;
         }
         if (tri_cnt > static_cast<size_t>(lm_pcg::kMaxTriPerKernel)) {
           throw BackendUnavailableError(

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -1275,8 +1275,21 @@ kernel void gen_root_kernel(
   uint local_tri = categorical_sample(proj_prob, n_tri, u_cat);
   uint tri_id = tri_off + local_tri;
   float p[3];
-  sample_triangle(stream, tri_vtx + tri_id * 9u, p);
-  uint to_face = tri_to_poly[tri_id];
+  // K-shape degenerate-slot guard: tri_cnt == 0 (ring0-legal zero-triangle
+  // Crystal) → tri_off aliases the NEXT slot's triangles (or the pool tail), so
+  // tri_vtx / tri_to_poly[tri_id] would read a neighbor shape. Skip both reads
+  // and route into the kInvalidId zero-weight drop below. Non-degenerate rays
+  // never take this branch → AC2 bit-exact single-shape path unchanged.
+  uint to_face;
+  if (tri_cnt == 0u) {
+    p[0] = 0.0f;
+    p[1] = 0.0f;
+    p[2] = 0.0f;
+    to_face = kInvalidId;
+  } else {
+    sample_triangle(stream, tri_vtx + tri_id * 9u, p);
+    to_face = tri_to_poly[tri_id];
+  }
   float weight = wl_pool[wl_idx].spd_weight;  // scrum-268.8 per-ray spd weight
   if (to_face == kInvalidId) {
     // Mirrors InitRay_p_fid fallback (simulator.cpp:92-94): zero weight when
@@ -1413,8 +1426,20 @@ kernel void transit_root_kernel(
   uint local_tri = categorical_sample(proj_prob, n_tri, u_cat);
   uint tri_id = tri_off + local_tri;
   float p[3];
-  sample_triangle(stream, tri_vtx + tri_id * 9u, p);
-  uint to_face = tri_to_poly[tri_id];
+  // K-shape degenerate-slot guard (mirrors gen_root_kernel): tri_cnt == 0 →
+  // tri_off aliases the next slot's triangles / pool tail, so skip both reads
+  // and route into the kInvalidId zero-weight drop. Non-degenerate rays
+  // unaffected (AC2 bit-exact path unchanged).
+  uint to_face;
+  if (tri_cnt == 0u) {
+    p[0] = 0.0f;
+    p[1] = 0.0f;
+    p[2] = 0.0f;
+    to_face = kInvalidId;
+  } else {
+    sample_triangle(stream, tri_vtx + tri_id * 9u, p);
+    to_face = tri_to_poly[tri_id];
+  }
 
   // 4. Carry continuation weight; mirror InitRay_p_fid fallback (zero weight
   //    when a triangle has no polygon backing).

--- a/test/e2e/configs/repro_cuda_geom_pool_degenerate.json
+++ b/test/e2e/configs/repro_cuda_geom_pool_degenerate.json
@@ -1,0 +1,15 @@
+{
+  "crystal": [{ "id": 1, "type": "prism",
+    "shape": { "height": 1.2, "face_distance": [{"type":"gauss","mean":1.0,"std":0.50}, {"type":"gauss","mean":1.0,"std":0.50}, {"type":"gauss","mean":1.0,"std":0.50}, {"type":"gauss","mean":1.0,"std":0.50}, {"type":"gauss","mean":1.0,"std":0.50}, {"type":"gauss","mean":1.0,"std":0.50}] },
+    "axis": { "azimuth": {"type":"uniform","mean":0.0,"std":360.0},
+              "roll": {"type":"uniform","mean":0.0,"std":360.0},
+              "zenith": {"type":"gauss","mean":90.0,"std":0.8} } }],
+  "filter": [{ "id": 1, "type": "entry_exit", "entry": 3, "exit": 5, "action": "filter_in" }],
+  "scene": { "light_source": { "type": "sun", "altitude": 20.0, "azimuth": 0, "diameter": 0.5,
+               "spectrum": [{"wavelength": 550, "weight": 1.0}] },
+    "ray_num": 400000, "max_hits": 8, "geom_clock": 64,
+    "scattering": [{ "prob": 0.0, "entries": [{"crystal": 1, "proportion": 1, "filter": 1}] }] },
+  "render": [{ "id": 1, "lens": { "type": "dual_fisheye_equal_area", "fov": 360 },
+               "resolution": [512, 256], "visible": "full",
+               "ray_color": [1,1,1], "background_color": [0,0,0] }]
+}

--- a/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
@@ -189,12 +189,13 @@ TEST(CudaRichExit, ExitFaceIsValid) {
 }
 
 // =============================================================================
-// task-exit-seam-crystal-count: CUDA backend reports final-layer setting count.
-// Semantics: return value is the LAST MS layer's setting count (mirrors
-// Impl::final_layer_crystals_ populated during BeginSession), not a cross-layer
-// sum. Locks plan §2 default assumption 2.
+// K-shape geometry pool: GetLastBatchCrystalCount reports the CROSS-LAYER sum
+// of distinct pool shapes built during the batch (Σ layers Σ ci P_ci). At the
+// default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so the
+// return value equals Σ layers Σ ci 1 = the cross-layer setting count. Same
+// semantic as Metal (see MetalTraceBackend.GetLastBatchCrystalCountSumsPoolShapesAcrossLayers).
 // =============================================================================
-TEST(CudaBackendCrystalCount, ReturnsFinalLayerSettings) {
+TEST(CudaBackendCrystalCount, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers) {
   if (!CudaDeviceAvailable()) {
     GTEST_SKIP() << "No CUDA device available on this host.";
   }
@@ -216,7 +217,8 @@ TEST(CudaBackendCrystalCount, ReturnsFinalLayerSettings) {
   }
 
   // Case 2 — multi MS scene with 3 settings on the FINAL layer, 1 on the
-  // first. Return value MUST be 3, not 4 (cross-layer sum).
+  // first. Return value MUST be the cross-layer sum 1 + 3 = 4, not the
+  // final-layer-only count (3).
   {
     auto scene = MakePrismScene(/*max_hits=*/4);
     // Convert single-MS scene to 2-MS: original layer becomes the first
@@ -246,7 +248,9 @@ TEST(CudaBackendCrystalCount, ReturnsFinalLayerSettings) {
 
     CudaTraceBackend backend;
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 3u) << "Final-layer settings count, not cross-layer sum (would be 4)";
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u)
+        << "Cross-layer pool-shape sum at K=0: 1 (layer 0) + 3 (layer 1). "
+           "Pre-K-pool semantic was final-layer settings only (3).";
     backend.EndSession();
   }
 }

--- a/test/regression-sentinel/test_cuda_degenerate_geometry_parity.py
+++ b/test/regression-sentinel/test_cuda_degenerate_geometry_parity.py
@@ -1,0 +1,137 @@
+"""Regression guard: CUDA must stay isomorphic with CPU/Metal on degenerate
+K-shape pool geometry (no backend fallback, no per-ray log storm, no frame loss).
+
+Root cause (the defect this guards against):
+  With the per-ray K-shape geometry pool active (SceneConfig geom_clock > 0) and a
+  face_distance distribution wide enough to occasionally produce a zero-triangle
+  Crystal (a ring0-legal "contributes nothing" product of the closed-form validity
+  gate), the CUDA BuildGeomPool used to throw BackendUnavailableError on the FIRST
+  degenerate slot of a ~512-shape pool. That aborted the whole GPU backend for the
+  rest of the Run() (the CPU-fallback path), and the legacy CPU InitRayFirstMs then
+  emitted one unthrottled PolygonFaceOfTri WARNING per ray of every degenerate ci —
+  the observed log storm. Metal's UploadCrystalPool already tolerated degenerate
+  slots, so CUDA was the sole backend violating the contract. Additionally, all four
+  root-gen/transit kernels (both GPU backends) shared a latent neighbor-aliasing read:
+  a tri_cnt==0 pool slot's tri_off points at the NEXT slot's triangles (or the pool
+  tail), so sampling it silently pulled a neighbor shape's geometry.
+
+Fix: BuildGeomPool records a zero-length pool slot and continues instead of throwing;
+all four kernels route a tri_cnt==0 pick into the existing kInvalidId zero-weight drop.
+
+Reproduction config (test/e2e/configs/repro_cuda_geom_pool_degenerate.json): prism with
+6 gauss(1.0, 0.50) face_distance draws + geom_clock=64. At std=0.50 the closed-form
+gate rejects ~0.8% of shapes; with 512 shapes/batch that is ~98% of batches carrying
+at least one degenerate slot, so the pre-fix throw fired on essentially every batch.
+Baseline (pre-fix) on dev49: 1 fallback + ~3100 PolygonFaceOfTri warnings, crystals
+count jumps from 6250 (GPU K-pool) to 12500 (CPU legacy) as the drop settles. Fixed:
+0 fallback, 0 storm, all 400000 rays complete on the GPU K-pool.
+
+Cross-backend energy differs ~7-8% here (CUDA K-pool and CPU per-ray draw statistically
+distinct crystal populations from the same wide distribution — sampling variance, not a
+parity bug), so this file does NOT assert a tight cross-backend energy bound; the milder
+random-geometry parity contract is covered by CudaRandomGeometryParity and the parity
+battery. Here we assert the isomorphism invariants that were actually broken (no
+fallback / no storm / real output) plus CUDA cross-seed self-consistency (the halo is
+seed-stable, proving the output is genuine geometry rather than garbage neighbor reads).
+
+@pytest.mark.slow: needs the CUDA-enabled shared-lib build (LUMICE_LIB) + an NVIDIA
+device. CUDA-gated, so it is inert on non-CUDA hosts (CI, macOS).
+"""
+from __future__ import annotations
+
+import math
+import os
+import platform
+
+import pytest
+
+from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
+from test.e2e._parity_metrics import _raw_corr_ds as _raw_corr_ds_impl, _DS_BH, _DS_BW
+from test.e2e.runner import get_project_root
+
+_CONFIG_PATH = str(
+    get_project_root() / "test" / "e2e" / "configs" / "repro_cuda_geom_pool_degenerate.json"
+)
+_TIMEOUT = 600
+_SEEDS = (42, 7, 123)
+
+# CUDA cross-seed block-mean corr floor. The halo is seed-stable, so two CUDA
+# runs at different sim_seed must correlate strongly even on this noisy geometry.
+# Measured on dev49 (RTX 4060Ti): ~0.98; floor set with margin below that.
+_T_SELF_CORR = 0.90
+
+_CUDA_AVAILABLE = (
+    platform.system() in ("Linux", "Windows") and os.environ.get("LUMICE_HAS_CUDA") == "1"
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _CUDA_AVAILABLE,
+        reason=(
+            "CUDA backend requires Linux/Windows + LUMICE_HAS_CUDA=1 + "
+            "LUMICE_CUDA_ENABLED=ON build with an NVIDIA device. Skipping on this host."
+        ),
+    ),
+]
+
+
+def _run_cuda(seed: int) -> BufferedSimResult:
+    return run_scene_capi_buffered(
+        _CONFIG_PATH, sim_seed=seed, backend="cuda", timeout_sec=_TIMEOUT
+    )
+
+
+def _storm_count(result: BufferedSimResult) -> int:
+    """Count the per-ray PolygonFaceOfTri WARNING lines (the fallback-driven storm)."""
+    return sum("PolygonFaceOfTri" in line for line in result.log_lines)
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_cuda_degenerate_no_fallback_no_storm(seed: int) -> None:
+    """Degenerate K-shape pool must run on CUDA end-to-end: no fallback, no storm."""
+    r = _run_cuda(seed)
+
+    # The core isomorphism invariant that was broken: the backend must NOT drop
+    # to legacy CPU on encountering a degenerate pool slot.
+    assert r.routed_backend == "cuda", (
+        f"seed={seed}: routed_backend={r.routed_backend!r} (expected 'cuda'). "
+        f"The CUDA backend dropped mid-Run — the degenerate-slot fallback regression."
+    )
+    assert not r.fell_back, (
+        f"seed={seed}: CUDA fell back to legacy (fell_back=True). BuildGeomPool must "
+        f"tolerate a degenerate K-shape pool slot, not throw BackendUnavailableError."
+    )
+
+    # The fallback's downstream symptom: legacy InitRayFirstMs emits one
+    # PolygonFaceOfTri WARNING per ray of a degenerate ci. Zero on the fixed path.
+    storm = _storm_count(r)
+    assert storm == 0, (
+        f"seed={seed}: {storm} PolygonFaceOfTri WARNING(s) observed. This per-ray "
+        f"log storm is emitted only on the legacy CPU fallback path — its presence "
+        f"means the CUDA backend dropped."
+    )
+
+    # Real output, not a frame-collapsed / all-rays-dropped image.
+    assert math.isfinite(r.snapshot_intensity) and r.snapshot_intensity > 0.0, (
+        f"seed={seed}: snapshot_intensity={r.snapshot_intensity} — expected a finite "
+        f"positive image (degenerate rays are dropped, but non-degenerate ones must render)."
+    )
+
+
+def test_cuda_degenerate_cross_seed_self_consistency() -> None:
+    """Two CUDA seeds must produce the same halo structure (seed-stable), proving the
+    tolerated-degenerate path renders genuine geometry, not neighbor-aliased garbage."""
+    a = _run_cuda(_SEEDS[0])
+    b = _run_cuda(_SEEDS[1])
+    for label, r in (("A", a), ("B", b)):
+        assert r.routed_backend == "cuda" and not r.fell_back, (
+            f"cross-seed run {label}: routed={r.routed_backend!r} fell_back={r.fell_back} "
+            f"— backend dropped, self-consistency check is meaningless."
+        )
+    corr = _raw_corr_ds_impl(a, b, _DS_BH, _DS_BW)
+    assert corr >= _T_SELF_CORR, (
+        f"CUDA cross-seed block-mean corr={corr:.4f} < {_T_SELF_CORR}. The degenerate "
+        f"geometry halo should be seed-stable; a low corr suggests the tolerated "
+        f"degenerate slots are still corrupting output."
+    )


### PR DESCRIPTION
## 概述

scrum-cuda-geometry-randomization-landing（392）的生产改动：把几何随机化（K-shape pool）从 Metal 落地推进到 CUDA。承接 #214（闭式表达）/ #217（Metal geom_clock 落地）。

3 个 commit（其中 1 个纯测试对齐、1 个生产修复、1 个回归测试）：

## 改动

**392.1 — CUDA crystal-count 断言对齐**（`053dbe72`，test-only）
- `CudaBackendCrystalCount` 断言 3→4，对齐 K-shape pool 跨层和语义（Metal 侧 #213 已更新，CUDA 漏更新的遗留红测试）。

**392.2 — CUDA 退化几何 parity blocker 修复**（`d2d5064b` fix + `59cb3d49` test）
- 白盒根因：`BuildGeomPool` 把 ring0-合法退化槽位（`MakeCrystal` 返回 0-tri Crystal）误升级为 `throw BackendUnavailableError` → catch 转 legacy CPU fallback → legacy `InitRayFirstMs` 无节流 `LOG_WARNING` 风暴。日志风暴是**下游后果**，非独立根因。
- 修复：`BuildGeomPool` 退化槽位由 throw 改为容忍（镜像 Metal `UploadCrystalPool` 已验证的模式）；CUDA + Metal 各两 kernel 的 per-ray 形状拾取加 `tri_cnt==0` 护栏——防「删 throw 抄 Metal」引入的潜伏 bug（退化槽位 `tri_id = shape_off + 0` 静默误读隔壁形状三角形）。保留 `UploadCrystalGeometry`/`BeginSession` 的致命 throw（唯一触发点确认是 `BuildGeomPool`）。
- 回归测试用 issue 复现场景（std=0.50/geom_clock=64），红→绿双态验证。

## 验证

- dev49（RTX 4060 Ti）：gtest `Cuda*:*ComponentMask*` 13 passed / 0 failed / 2 skip；CUDA parity battery 11/11；新回归测试红→绿双态确认。
- Mac：`build.sh -tj/-gtj` 全绿（含 GUI + Metal parity 零回归）+ 快/慢 e2e 全绿。
- 门禁三连（policy / new-refs / format）全绿；两位 code reviewer APPROVE（Critical/Major=0）。

## 范围

生产接口无变化（`geom_clock` 字段已在 #217 落地）；本 PR 是退化处理的 parity 修复 + 测试对齐。scrum-392 的 explore 子任务（392.3 async 证伪 / 392.4 CUDA moat 实测）为生产零改动，不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
