### PR TITLE
fix: strong-randomization downstream contracts (filter/render/consumer)

### DIFF
--- a/doc/crystal-geometry-representation.md
+++ b/doc/crystal-geometry-representation.md
@@ -193,14 +193,18 @@ Precisely, as-built after PR #214 (do not over-read "as-built" as "every §1 art
   reversal is deleted** — `FillPerFaceTopology` and `poly_face_tri_id_` survive only as
   historical comments (`c_api.cpp` / `crystal.hpp`), not live code. The `C(n,3)` solver + dedup
   no longer feed the prism/pyramid factories. GUI required zero changes (C-API boundary).
-- **Retained (honest).** `Crystal::PolygonFaceOfTri` (triangle → polygon-face) is **still live**
-  (`simulator.cpp:84`, `crystal.cpp:641`, Metal `metal_trace_backend.mm`): the triangle mesh is
-  still generated (fan-triangulated from the closed-form outlines) for the paths that consume
-  triangles, and those paths still map a triangle back to its polygon face. This is a bounded
-  `argmax` on a *known-correct* per-face representation, not the old discover-topology-from-
-  coordinates reversal, so it is not in the epsilon-defect family — but it is not zero, and the
-  §2 "back-mapping is the substrate of the index-defect family" critique is only *mostly*
-  retired, not entirely.
+- **Retained-then-deleted.** At PR #214 landing, `Crystal::PolygonFaceOfTri` (triangle →
+  polygon-face) was still live: the triangle mesh was still generated (fan-triangulated from the
+  closed-form outlines) for the paths that consumed triangles, and those paths mapped a triangle
+  back to its polygon face via a bounded `argmax` on a *known-correct* per-face representation —
+  not the old discover-topology-from-coordinates reversal, so it was not in the epsilon-defect
+  family, but it was not zero either. PR #219 (commit `b53eca1f`) subsequently removed this
+  entirely: entry-point sampling was rewritten to sample the closed-form polygon geometry
+  directly (each sub-triangle now carries its own present-face id), so `PolygonFaceOfTri` and the
+  triangle-Mesh hot path it served have no live callers in `src/` — only historical-contrast
+  comments remain (`simulator.cpp`, `metal_trace_backend.mm`, `cuda_trace_backend.cu`). The §2
+  "back-mapping is the substrate of the index-defect family" critique is now fully retired for
+  this reversal, not merely mostly.
 - **Concave pyramids** remain on the old path (§5).
 
 ## 5. What it does **not** dissolve (honest limits)

--- a/doc/filter-architecture.md
+++ b/doc/filter-architecture.md
@@ -135,6 +135,23 @@ simulator output  →  RenderConsumer  →  projection  →  XYZ accumulate
 is removed in task-revert (Design A target, removed in task-revert 219.4).  Any attempt
 to apply filters at the consumer level is a design violation.
 
+### Empty-batch contract
+
+Because the filter gate runs simulator-side and can legitimately reject **every** ray in a
+given `Consume()` batch (see the §7 branch table — a low pass-rate filter's "this batch got
+zero survivors" is a normal tail event, not a malformed state), `outgoing_d_` and
+`outgoing_w_` may both be empty while `rays_` is non-empty. `RenderConsumer` **must tolerate
+this**: with `outgoing_w_.size() == 0` the copy, projection, and accumulation loops are all
+no-ops and `snapshot_intensity_` stays zero. The consumer may **not** assume that a non-empty
+`rays_` implies non-empty `outgoing_*`; the only sizing invariant it may rely on is the
+`outgoing_d_.size() == 3 * outgoing_w_.size()` parallel-array relationship documented in
+`sim_data.hpp` (asserted at `src/server/render.cpp:248`).
+
+> A stale assertion at `render.cpp:248` used to encode "`rays_` non-empty ⟹ `outgoing_w_`
+> non-empty", causing a Debug-only `SIGABRT` whenever a filtered batch happened to empty out.
+> It was replaced with the size-consistency check above, because the emptied-batch state it
+> tripped on is exactly what Design A allows.
+
 ---
 
 ## §5 Data Flow Invariants
@@ -371,6 +388,7 @@ anchor points for future contributors:
 | Binding model, GUI linked-group invariants | `src/gui/gui_state.hpp:294-328` |
 | Filter ↔ crystal per-entry config | `src/config/proj_config.hpp` — `ScatteringSetting` |
 | Simulator-side filter check (Design A gate) | `src/core/simulator.cpp` — `CollectData()` |
+| Empty-batch consumer contract (Design A) | `src/server/render.cpp:248` |
 | FilterSpec algorithm interface | `src/core/filter_spec.hpp` |
 | EV pipeline (single-lane, P99 anchor) | `doc/ev-pipeline-architecture.md` |
 | Filter JSON schema | `doc/configuration.md` |

--- a/doc/filter-architecture_zh.md
+++ b/doc/filter-architecture_zh.md
@@ -121,6 +121,20 @@ simulator 输出  →  RenderConsumer  →  投影  →  XYZ 累积
 `RenderConfig` 不持有 filter 字段。先前存在的 `ms_filter_` 字段将在 task-revert（Design A 目标，219.4 删除）中移除。
 在 consumer 层应用 filter 是设计违规。
 
+### 空批次契约（Empty-batch contract）
+
+由于 filter 门控在 simulator 端执行，且可以合法地拒绝某个 `Consume()` 批次中的**全部** ray
+（见 §7 分支表——低通过率 filter 出现「这一批零幸存」是正常的分布尾部事件，而非畸形状态），
+`outgoing_d_` 与 `outgoing_w_` **可能同时为空而 `rays_` 非空**。`RenderConsumer` **必须容忍这一状态**：
+当 `outgoing_w_.size() == 0` 时，拷贝、投影、累积循环全部退化为 no-op，`snapshot_intensity_` 保持为零。
+consumer **不得**假设「`rays_` 非空 ⟹ `outgoing_*` 非空」；它唯一可依赖的尺寸不变式是 `sim_data.hpp`
+中记录的 `outgoing_d_.size() == 3 * outgoing_w_.size()` parallel-array 关系（在
+`src/server/render.cpp:248` 处断言）。
+
+> `render.cpp:248` 曾有一处陈旧断言编码「`rays_` 非空 ⟹ `outgoing_w_` 非空」，导致只要某个过滤后的批次恰好
+> 被清空，Debug 构建就会 `SIGABRT`。现已替换为上述尺寸自洽检查——因为它当年触发的「空批次」状态正是
+> Design A 允许的。
+
 ---
 
 ## §5 数据流不变式
@@ -231,6 +245,7 @@ P99.5 在 poller 线程中计算（`server_poller.cpp::PollOnce`），基于 sta
 | 绑定模型、GUI linked-group 不变式 | `src/gui/gui_state.hpp:294-328` |
 | Filter ↔ 晶体 per-entry 配置 | `src/config/proj_config.hpp` — `ScatteringSetting` |
 | Simulator 端 filter 检查（Design A 门控） | `src/core/simulator.cpp` — `CollectData()` |
+| 空批次 consumer 契约（Design A） | `src/server/render.cpp:248` |
 | FilterSpec 算法接口 | `src/core/filter_spec.hpp` |
 | C API anchor 字段（F1 anchor lane） | `src/include/lumice.h` — `LUMICE_RawXyzResult.anchor_p995_y` / `anchor_snapshot_intensity` |
 | Filter JSON schema | `doc/configuration.md` |

--- a/doc/numerical-robustness.md
+++ b/doc/numerical-robustness.md
@@ -43,10 +43,19 @@ bar." Argmax needs no knowledge of the geometry's scale and is robust as angular
 separations shrink. Keep a **sanity floor** (`kFaceCoplanarFloor = 1e-2`, ~8.1° slack)
 only to reject genuine non-matches, never as the selector.
 
-✅ Golden templates already in the tree:
-- `crystal.cpp::BuildPolygonFaceData` — argmax triangle→plane assignment.
-- `simulator.cpp::PolygonFaceOfTri` — argmax triangle→polygon-face.
-- `crystal.cpp::FillHexFnMap` pri loop — `p > p_comp` is argmax over the 6 prism refs.
+⚠️ **Superseded, not a live template anymore.** The three functions below were the
+argmax golden templates at the time this convention was written; the closed-form
+representation swap (PR #214) then deleted all three (`BuildPolygonFaceData` and
+`FillHexFnMap` in PR #219 commits `135bca77`/`0d6413f0`, `PolygonFaceOfTri` in PR #219
+commit `b53eca1f`) because the reversal they performed is no longer needed at all —
+`Crystal::PopulateFromCfGeom` (`crystal.cpp`) assigns face data straight from the
+closed-form output instead of reverse-engineering it via argmax. The **convention**
+(prefer argmax over first-match/threshold) still applies to any *new* triangle↔plane
+or normal-classification code; there is currently no live in-tree example of it to
+point to.
+- ~~`crystal.cpp::BuildPolygonFaceData` — argmax triangle→plane assignment.~~ (deleted)
+- ~~`simulator.cpp::PolygonFaceOfTri` — argmax triangle→polygon-face.~~ (deleted)
+- ~~`crystal.cpp::FillHexFnMap` pri loop — `p > p_comp` is argmax over the 6 prism refs.~~ (deleted)
 
 ### 2. Prefer **relative / normalized tolerances** for scale-variant quantities
 - **Areas**: compare relative to a characteristic area, not an absolute floor.
@@ -171,5 +180,5 @@ files, pointing the author here. Scope TBD in the hardening backlog.
 - **病灶族**：绝对 epsilon 作用在尺度可变的几何量（夹角随 wedge 缩、薄片厚 0.02-0.04、面积∝长²、det∝模长积），极端几何下失效。
 - **八条约定**：①匹配用 argmax 不用绝对阈值 ②尺度可变量用相对/归一化容差 ③几何生成走 double、热追踪保 float ④谓词单一真源(防漏网兄弟) ⑤归一化/除法加零保护、用 `<eps` 不用 `==0` ⑥信 ground truth 不信 proxy 指标、哨兵要反向验证有检测力 ⑦测试覆盖极端尾部(wedge 89°+、近退化) ⑧自由符号代数结构性盲于退化——选错代数模型，任何容差救不了。
 - **第 8 条（选模型，不是调 ε）**：自由/超越符号是"通用点"的代数，只判"对所有取值成立的恒等式"(`p(α)≡0 ⟺ p 是零多项式`)；几何退化是"特定取值下的巧合"(`a1=a2 ⟹ α=β`、三面共点、某边先消失)，自由符号模型按定义看不见——这是**范畴错误**，不是可打补丁的实现 bug。病例：pyramid oracle 把锥角当自由符号 α/β，正规锥体 `k·(α−β)` 真零却判不出，落到内嵌 double-Horner + 128-ULP refuse 滤波器，其 ambiguous→refuse 受 FMA 收缩影响、平台相关(同码 macOS 出 14 顶点、Ampere ARM64 出全错 18；前三平台绿是舍入侥幸)。**判据 = 二选一**：要么把参数**钉进对运算封闭且零测试可判定的数域**(六方族 = `QS3 = ℚ(√3)`，且输入参数本身也须落域内)做精确整数/有理算术；要么**老实认 double 近似**、按约定②用尺度相对容差 + fixture 离精确边界。中间"自由符号假装精确"两头不占。**绕不开精确计算的两种正解**：测试/构建期 → 离线 CAS(sympy 真·代数数)一次算死存盘；运行时生产 → 钉数域精确整数 or 认近似(本仓库生产 `geo3d_closedform.*` 全 double、退化产近零面积面即可，从未需运行时精确)。落地示例：`test_closed_form_pyramid.cpp` 的三件契约测试(`TopologyMatchesGoldenConstants`/`VertexPlaneSelfConsistency`/`DegenerateContractSafe`)各断言生产真持有的契约，均不对退化情形仲裁"谁更精确"。
-- **金标准模板**：`crystal.cpp:699` 相对面积、`BuildPolygonFaceData`/`PolygonFaceOfTri`/`FillHexFnMap` pri 的 argmax。
+- **金标准模板**：`crystal.cpp:699` 相对面积仍在；`BuildPolygonFaceData`/`PolygonFaceOfTri`/`FillHexFnMap` pri 的 argmax **三者均已被闭式表达重构删除**（PR #214 起收尾于 PR #219，`135bca77`/`0d6413f0`/`b53eca1f`）——它们做的三角→面/面号反推整类需求已消失，非它们各自被换了新实现；约定①本身仍适用于任何新写的匹配代码，只是当前树内已无该模式的在场例子。
 - **已知欠账**：SolvePlanes 系列 det 绝对阈值未归一化(脆但当前未触发)。

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -45,6 +45,20 @@ Checks:
      implementation. Scope is intentionally narrow: only the popcount/ctz/clz
      families are pinned (task-popcount-helper), extend the regex when a new
      MSVC-unsafe `__builtin_*` family surfaces.
+  9. no-default-constructed-crystal-slots — no `std::vector<Crystal>` in src/
+     may be sized by `resize()`, `assign(n)`, or a count-ctor, and none may be
+     grown with an argument-less `emplace_back()`. All four produce
+     default-constructed `Crystal` elements: `face_cnt == 0`, no polygon faces,
+     `fn_period_ == -1`, null normal/distance tables. That state is the same
+     one the closed-form validity gate returns for a degenerate crystal, so
+     consumers that iterate the container cannot tell "never filled in" from
+     "legitimately empty", and a partially-filled container (e.g. a per-ci loop
+     that `continue`s on empty populations) silently hands out untouched slots.
+     Every such container must instead be filled element-by-element with real
+     crystals via `push_back`/`emplace_back(args...)`, so its size and its
+     populated prefix are the same thing by construction. The invariant is
+     pinned here rather than in a comment because the failure is silent: a
+     default slot reads as a valid empty crystal all the way to the GPU.
 
 Add a new check as a function returning a list of Violation and append it to
 CHECKS. Keep each check deterministic and artifact-inspecting.
@@ -849,6 +863,72 @@ def check_no_msvc_unsafe_builtin() -> list[Violation]:
     return out
 
 
+# `std::vector<Crystal> name;` / `std::vector<Crystal> name(...)` — the leading
+# boundary keeps it from matching `std::vector<CrystalConfig>` and friends.
+CRYSTAL_VECTOR_DECL = re.compile(r"std::vector\s*<\s*Crystal\s*>\s*&?\s*([A-Za-z_]\w*)")
+# Operations that materialise default-constructed elements. `reserve` is
+# deliberately absent: it allocates without constructing, which is exactly the
+# pattern this check wants people to use.
+CRYSTAL_VECTOR_DEFAULT_FILL = ("resize", "assign")
+
+
+def check_no_default_constructed_crystal_slots() -> list[Violation]:
+    out: list[Violation] = []
+    for path in cxx_sources(SRC):
+        lines = list(code_lines(path))
+        names: set[str] = set()
+        for _lineno, _orig, code in lines:
+            for m in CRYSTAL_VECTOR_DECL.finditer(code):
+                names.add(m.group(1))
+        if not names:
+            continue
+        # A count-ctor on the declaration line itself: `std::vector<Crystal> v(n);`
+        # is the same hazard spelled differently. `v(a, b)` (iterator range) and
+        # `v(other)` (copy) are fine, so only a single non-empty argument counts.
+        for lineno, _orig, code in lines:
+            for m in CRYSTAL_VECTOR_DECL.finditer(code):
+                tail = code[m.end():].lstrip()
+                if tail.startswith("(") and not tail.startswith("()"):
+                    inner = tail[1: tail.find(")")] if ")" in tail else ""
+                    if inner.strip() and "," not in inner:
+                        out.append(
+                            Violation(
+                                path,
+                                lineno,
+                                "no-default-constructed-crystal-slots",
+                                f"`{m.group(1)}` is sized by a count-ctor, which fills it with "
+                                "default-constructed Crystals (face_cnt == 0, no polygon faces). "
+                                "Reserve and push_back real crystals instead, so size == populated.",
+                            )
+                        )
+        for lineno, _orig, code in lines:
+            for name in names:
+                for op in CRYSTAL_VECTOR_DEFAULT_FILL:
+                    if re.search(rf"\b{re.escape(name)}\s*\.\s*{op}\s*\(", code):
+                        out.append(
+                            Violation(
+                                path,
+                                lineno,
+                                "no-default-constructed-crystal-slots",
+                                f"`{name}.{op}(...)` fills the vector with default-constructed "
+                                "Crystals (face_cnt == 0, no polygon faces, fn_period_ == -1). "
+                                "A consumer cannot distinguish those slots from a legitimately "
+                                "empty crystal. Reserve and push_back real crystals instead.",
+                            )
+                        )
+                if re.search(rf"\b{re.escape(name)}\s*\.\s*emplace_back\s*\(\s*\)", code):
+                    out.append(
+                        Violation(
+                            path,
+                            lineno,
+                            "no-default-constructed-crystal-slots",
+                            f"`{name}.emplace_back()` appends a default-constructed Crystal. "
+                            "Pass the crystal to append, or push_back one built by a factory.",
+                        )
+                    )
+    return out
+
+
 CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
@@ -859,6 +939,7 @@ CHECKS = [
     check_no_config_by_value_copy,
     check_gui_state_field_tier_registration,
     check_no_msvc_unsafe_builtin,
+    check_no_default_constructed_crystal_slots,
 ]
 
 
@@ -881,7 +962,8 @@ def main() -> int:
     print(
         "Policy check passed (env centralization, knob registration, GUI API boundary, "
         "reconciler-widget-include, using-namespace, struct-layout parity, no-config-by-value-copy, "
-        "gui-state-field-tier-registration, no-msvc-unsafe-builtin)."
+        "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
+        "no-default-constructed-crystal-slots)."
     )
     return 0
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -872,6 +872,41 @@ CRYSTAL_VECTOR_DECL = re.compile(r"std::vector\s*<\s*Crystal\s*>\s*&?\s*([A-Za-z
 CRYSTAL_VECTOR_DEFAULT_FILL = ("resize", "assign")
 
 
+def _paren_inner(tail_after_open_paren: str) -> str:
+    """Text between an already-consumed `(` and its depth-matched `)`.
+
+    Tracks nesting depth (rather than a naive first-`)` scan) so a nested
+    call inside the argument list — as either the whole sole argument
+    (`resize(ComputeCount(w, h))`) or a later argument
+    (`v(a.begin(), a.end())`) — does not end the scan early.
+    """
+    depth = 1
+    for i, ch in enumerate(tail_after_open_paren):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return tail_after_open_paren[:i]
+    return tail_after_open_paren
+
+
+def _has_top_level_comma(inner: str) -> bool:
+    """True if `inner` (already extracted via `_paren_inner`) has a comma at
+    its own nesting depth 0 — i.e. a real second argument, not one belonging
+    to a nested call that is itself a single argument.
+    """
+    depth = 0
+    for ch in inner:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            return True
+    return False
+
+
 def check_no_default_constructed_crystal_slots() -> list[Violation]:
     """Flag `std::vector<Crystal>` sites that materialise default-constructed
     elements (single-argument `resize`/`assign`, count-ctor, no-arg
@@ -899,14 +934,26 @@ def check_no_default_constructed_crystal_slots() -> list[Violation]:
         if not names:
             continue
         # A count-ctor on the declaration line itself: `std::vector<Crystal> v(n);`
-        # is the same hazard spelled differently. `v(a, b)` (iterator range) and
-        # `v(other)` (copy) are fine, so only a single non-empty argument counts.
+        # is the same hazard spelled differently. Excluded as safe: `v(a, b)`
+        # (iterator range — comma present); `v(other)` where `other` is another
+        # known `std::vector<Crystal>` name (copy-ctor); and any argument
+        # containing whitespace, which is either an expression (`v(w * h)`,
+        # conservatively treated as out of scope for this text-only check) or,
+        # critically, a `type name` pair — because at this parsing depth a
+        # function *declaration* (`std::vector<Crystal> Build(int n);`) is
+        # indistinguishable from a variable declaration, and only the real
+        # count-ctor's argument is guaranteed to be whitespace-free.
         for lineno, _orig, code in lines:
             for m in CRYSTAL_VECTOR_DECL.finditer(code):
                 tail = code[m.end():].lstrip()
                 if tail.startswith("(") and not tail.startswith("()"):
-                    inner = tail[1: tail.find(")")] if ")" in tail else ""
-                    if inner.strip() and "," not in inner:
+                    inner = _paren_inner(tail[1:]).strip()
+                    if (
+                        inner
+                        and not _has_top_level_comma(inner)
+                        and not re.search(r"\s", inner)
+                        and inner not in names
+                    ):
                         out.append(
                             Violation(
                                 path,
@@ -922,15 +969,18 @@ def check_no_default_constructed_crystal_slots() -> list[Violation]:
         # with real values and are safe; only the single-argument forms
         # (`resize(n)`; `assign(n)` isn't even valid C++, but a stray
         # single-argument call is still worth flagging) materialise defaults.
+        # No whitespace-based exclusion here (unlike the count-ctor branch
+        # above): a `name.resize(...)` call can never be mistaken for a
+        # function declaration, so an expression argument (`resize(w * h)`)
+        # is still the real hazard and must stay flagged.
         for lineno, _orig, code in lines:
             for name in names:
                 for op in CRYSTAL_VECTOR_DEFAULT_FILL:
                     m = re.search(rf"\b{re.escape(name)}\s*\.\s*{op}\s*\(", code)
                     if not m:
                         continue
-                    tail = code[m.end():]
-                    inner = tail[: tail.find(")")] if ")" in tail else tail
-                    if inner.strip() and "," not in inner:
+                    inner = _paren_inner(code[m.end():])
+                    if inner.strip() and not _has_top_level_comma(inner):
                         out.append(
                             Violation(
                                 path,

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -873,6 +873,22 @@ CRYSTAL_VECTOR_DEFAULT_FILL = ("resize", "assign")
 
 
 def check_no_default_constructed_crystal_slots() -> list[Violation]:
+    """Flag `std::vector<Crystal>` sites that materialise default-constructed
+    elements (single-argument `resize`/`assign`, count-ctor, no-arg
+    `emplace_back()`).
+
+    Scope: text-matches direct `std::vector<Crystal> name` declarations only —
+    type aliases (`using CrystalVec = std::vector<Crystal>;`) and indirect
+    holders (a `std::vector<Crystal>` wrapped in a struct member and exposed
+    elsewhere) are not recognised and can bypass this check undetected.
+
+    Any `resize()`/`push_back`-based reshape of a `std::vector<Crystal>` is
+    rejected wholesale, even a hypothetical safe `resize()` immediately
+    followed by a loop that fills every new index — the win of one uniform,
+    mechanically-verifiable rule (no case-by-case safety proof required) is
+    judged worth that false-positive rate; push_back/emplace_back(args...) is
+    the one sanctioned shape.
+    """
     out: list[Violation] = []
     for path in cxx_sources(SRC):
         lines = list(code_lines(path))
@@ -901,10 +917,20 @@ def check_no_default_constructed_crystal_slots() -> list[Violation]:
                                 "Reserve and push_back real crystals instead, so size == populated.",
                             )
                         )
+        # Same "no comma == hazard" rule as the count-ctor check above:
+        # `resize(n, value)` / `assign(n, value)` / `assign(first, last)` fill
+        # with real values and are safe; only the single-argument forms
+        # (`resize(n)`; `assign(n)` isn't even valid C++, but a stray
+        # single-argument call is still worth flagging) materialise defaults.
         for lineno, _orig, code in lines:
             for name in names:
                 for op in CRYSTAL_VECTOR_DEFAULT_FILL:
-                    if re.search(rf"\b{re.escape(name)}\s*\.\s*{op}\s*\(", code):
+                    m = re.search(rf"\b{re.escape(name)}\s*\.\s*{op}\s*\(", code)
+                    if not m:
+                        continue
+                    tail = code[m.end():]
+                    inner = tail[: tail.find(")")] if ")" in tail else tail
+                    if inner.strip() and "," not in inner:
                         out.append(
                             Violation(
                                 path,

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -294,8 +294,8 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
   size_t crystal_cnt = ms_info.setting_.size();
   // task-exit-seam-crystal-count: record final MS layer setting count for
   // Simulator to feed SimData.crystal_count_. Semantics: last layer only,
-  // not cross-layer sum (mirrors Metal `last_layer_crystals_` /
-  // CUDA `final_layer_crystals_`).
+  // not cross-layer sum (mirrors CUDA `final_layer_crystals_`; Metal keeps no
+  // host-side final-layer mirror since the emit gate moved on-device).
   if (ms_idx_ + 1 == spec_.scene->ms_.size()) {
     last_layer_crystal_count_ = crystal_cnt;
   }

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -2118,7 +2118,10 @@ struct CudaTraceBackend::Impl {
   // Multi-CI 全量: the final layer may hold several crystals; DrainExits indexes
   // these per-exit by ExitRayRecord.crystal_id. Populated in BeginSession from
   // the last MS layer's settings (proto crystals — filter only needs topology).
-  // Mirrors Metal last_layer_crystals_[ci] (metal_trace_backend.mm:2403-2409).
+  // Metal used to keep the same per-ci mirror; it no longer does — its emit
+  // gate runs filter+prob on-device, so ReadbackExitRays returns no records
+  // and the mirror had no reader left. CUDA still drains on the host, so this
+  // one is live.
   std::vector<FilterConfig>     final_layer_filter_configs_;
   std::vector<Crystal>          final_layer_crystals_;
   std::vector<AxisDistribution> final_layer_axis_dists_;
@@ -3429,9 +3432,9 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
 
   // Capture final-layer host filter state PER-CI — DrainExits applies FilterSpec
   // on records tagged with the final ms_layer_idx, indexed by ExitRayRecord
-  // .crystal_id (mirrors Metal last_layer_crystals_[ci], metal:2403-2409). Proto
-  // crystals (deterministic rng) suffice: the host filter only needs the face
-  // topology (GetFn), which is param-determined, not the exact traced instance.
+  // .crystal_id. Proto crystals (deterministic rng) suffice: the host filter
+  // only needs the face topology (GetFn), which is param-determined, not the
+  // exact traced instance.
   const auto& last_ms_layer = spec.scene->ms_.back();
   const size_t last_ci_cnt = last_ms_layer.setting_.size();
   RandomNumberGenerator drain_proto_rng(0xC0FEFEEDu);

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -498,17 +498,19 @@ __device__ inline unsigned long long ApplyLayerColorBits(unsigned long long carr
                                                           const uint8_t* d_and_term_counts,
                                                           const uint8_t* d_color_bit_map,
                                                           const uint8_t* path, uint32_t path_len,
-                                                          const uint8_t* getfn_bytes,
-                                                          const uint32_t* getfn_offsets,
-                                                          uint32_t gate_slot, const float* ray_dir,
+                                                          const uint8_t* poly_fn,
+                                                          uint32_t gate_slot, uint32_t poly_off,
+                                                          const float* ray_dir,
                                                           uint32_t crystal_config_id) {
   unsigned long long m = carried;
   for (uint32_t g = 0u; g < static_cast<uint32_t>(kColorMaxGroupsPerSlot); ++g) {
+    // gate_slot selects the color DESCRIPTOR row (per (layer,ci)); poly_off is
+    // this ray's own polygon offset for the per-instance GetFn remap.
     const uint32_t color_slot_idx = gate_slot * static_cast<uint32_t>(kColorMaxGroupsPerSlot) + g;
     bool matched_c = false;
     const uint32_t c_smask = lm_filter::DeviceFilterSummandMask(
-        d_color_filter_desc[color_slot_idx], d_complex_sub_desc, d_and_term_counts, path, path_len, getfn_bytes,
-        getfn_offsets, gate_slot, ray_dir, crystal_config_id, &matched_c);
+        d_color_filter_desc[color_slot_idx], d_complex_sub_desc, d_and_term_counts, path, path_len, poly_fn,
+        poly_off, ray_dir, crystal_config_id, &matched_c);
     for (uint32_t k = 0u; k < kDeviceFilterMaxOrClauses; ++k) {
       if ((c_smask & (1u << k)) != 0u) {
         const uint8_t bit = d_color_bit_map[color_slot_idx * kDeviceFilterMaxOrClauses + k];
@@ -640,8 +642,7 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
                                        // 296.5 filter gate inputs. ms_mode==0 dispatches pass
                                        // nullptr/0 — DeviceFilterCheck branches are never executed.
                                        const DeviceFilterDesc* __restrict__ d_filter_desc,
-                                       const uint32_t* __restrict__ d_getfn_offsets,
-                                       const uint8_t* __restrict__ d_getfn_bytes,
+                                       const uint8_t* __restrict__ d_poly_fn,
                                        const DeviceFilterDesc* __restrict__ d_complex_sub_desc,
                                        // task-device-flat-and-terms: parallel flat AND-term counts
                                        // buffer, indexed via each Complex parent's `and_terms_start`.
@@ -884,8 +885,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
         const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                    static_cast<uint32_t>(crystal_id);
         const bool filter_pass = lm_filter::DeviceFilterCheck(
-            d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
-            d_getfn_offsets, gate_slot, exit_world, crystal_config_id);
+            d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_poly_fn,
+            poly_off, exit_world, crystal_config_id);
         if (filter_pass) {
           // task-358.3: Fork-C physical-bit produce branch removed. `this_mask`
           // now starts from the carried mask and is OR-accumulated by ONLY the
@@ -897,8 +898,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           // branch skip (AC4 zero-cost). Mirrors MSL lumice_trace.metal.
           if (color_params.has_color_groups != 0u) {
             this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
-                                            d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-                                            gate_slot, exit_world, crystal_config_id);
+                                            d_color_bit_map, path_rec, rec_len, d_poly_fn,
+                                            gate_slot, poly_off, exit_world, crystal_config_id);
           }
           // Prob gate (prob-pass → continuation; prob-fail → mid-exit). The
           // gate_stream advances on each pcg_uniform draw so the per-bounce
@@ -952,8 +953,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
         const uint32_t gate_slot_e = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                      static_cast<uint32_t>(crystal_id);
         const bool filter_pass_e = lm_filter::DeviceFilterCheck(
-            d_filter_desc[gate_slot_e], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
-            d_getfn_offsets, gate_slot_e, exit_world, crystal_config_id);
+            d_filter_desc[gate_slot_e], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_poly_fn,
+            poly_off, exit_world, crystal_config_id);
         if (filter_pass_e) {
           lm_pcg::PcgStream gate_f;
           gate_f.seed       = gate_final_mixed_seed;
@@ -976,8 +977,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
             unsigned long long this_mask = carried_component;
             if (color_params.has_color_groups != 0u) {
               this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
-                                              d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-                                              gate_slot_e, exit_world, crystal_config_id);
+                                              d_color_bit_map, path_rec, rec_len, d_poly_fn,
+                                              gate_slot_e, poly_off, exit_world, crystal_config_id);
             }
             EmitToDeviceXyz(d_xyz_buf, d_landed_weight, exit_world,
                             cmf_x, cmf_y, cmf_z, w_refl_e,
@@ -1101,8 +1102,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           const uint32_t gate_slot = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                    static_cast<uint32_t>(crystal_id);
           const bool filter_pass = lm_filter::DeviceFilterCheck(
-              d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
-              d_getfn_offsets, gate_slot, exit_world, crystal_config_id);
+              d_filter_desc[gate_slot], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_poly_fn,
+              poly_off, exit_world, crystal_config_id);
           if (filter_pass) {
             // task-358.3: Fork-C produce branch retired; only Design-2 color
             // pass accumulates into this_mask (per-bounce mid-exit sibling of
@@ -1110,8 +1111,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
             unsigned long long this_mask = carried_component;
             if (color_params.has_color_groups != 0u) {
               this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
-                                              d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-                                              gate_slot, exit_world, crystal_config_id);
+                                              d_color_bit_map, path_rec, rec_len, d_poly_fn,
+                                              gate_slot, poly_off, exit_world, crystal_config_id);
             }
             bool do_continue = (lm_pcg::pcg_uniform(gate_stream) < ms_prob);
             if (do_continue) {
@@ -1152,8 +1153,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
           const uint32_t gate_slot_r = static_cast<uint32_t>(ms_layer_idx) * filter_desc_max_ci +
                                        static_cast<uint32_t>(crystal_id);
           const bool filter_pass_r = lm_filter::DeviceFilterCheck(
-              d_filter_desc[gate_slot_r], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_getfn_bytes,
-              d_getfn_offsets, gate_slot_r, exit_world, crystal_config_id);
+              d_filter_desc[gate_slot_r], d_complex_sub_desc, d_and_term_counts, path_rec, rec_len, d_poly_fn,
+              poly_off, exit_world, crystal_config_id);
           if (filter_pass_r) {
             lm_pcg::PcgStream gate_f;
             gate_f.seed       = gate_final_mixed_seed;
@@ -1171,8 +1172,8 @@ __global__ void trace_single_ms_kernel(const float* __restrict__ d_dirs,        
               unsigned long long this_mask = carried_component;
               if (color_params.has_color_groups != 0u) {
                 this_mask = ApplyLayerColorBits(this_mask, d_color_filter_desc, d_complex_sub_desc, d_and_term_counts,
-                                                d_color_bit_map, path_rec, rec_len, d_getfn_bytes, d_getfn_offsets,
-                                                gate_slot_r, exit_world, crystal_config_id);
+                                                d_color_bit_map, path_rec, rec_len, d_poly_fn,
+                                                gate_slot_r, poly_off, exit_world, crystal_config_id);
               }
               EmitToDeviceXyz(d_xyz_buf, d_landed_weight, exit_world,
                               cmf_x, cmf_y, cmf_z, w_refr,
@@ -1670,6 +1671,7 @@ struct CudaTraceBackend::Impl {
   // Möller-Trumbore.
   float* d_poly_n_ = nullptr;  // 3 × poly_cnt (outward polygon normals, AoS)
   float* d_poly_d_ = nullptr;  // poly_cnt (plane constant: p·n + d = 0)
+  uint8_t* d_poly_fn_ = nullptr;  // per-instance GetFn table, one uint8 per polygon (single/fallback path; parallel to d_poly_n_)
   uint32_t poly_cnt_ = 0;
 
   // --- Multi-MS continuation (296.4) ---------------------------------------
@@ -1706,6 +1708,7 @@ struct CudaTraceBackend::Impl {
   // slots; pool_*_off_/pool_*_cnt_ index each slot (slot = ci_pool_slot_base_[flat_ci]).
   float*    d_pool_poly_n_      = nullptr;  // 3 × Σ poly_cnt (over ALL pool slots incl. K-shape)
   float*    d_pool_poly_d_      = nullptr;  //     Σ poly_cnt
+  uint8_t*  d_pool_poly_fn_     = nullptr;  // per-instance GetFn table over ALL pool slots (parallel to d_pool_poly_n_)
   float*    d_pool_tri_vtx_     = nullptr;  // 9 × Σ tri_cnt
   float*    d_pool_tri_norm_    = nullptr;  // 3 × Σ tri_cnt
   float*    d_pool_tri_area_    = nullptr;  //     Σ tri_cnt
@@ -2010,19 +2013,19 @@ struct CudaTraceBackend::Impl {
   uint8_t n_ms_layers_  = 0u;
 
   // --- Filter buffers (296.5) ----------------------------------------------
-  // Mirrors Metal's filter_desc_buf_ / getfn_offsets_buf_ / getfn_bytes_buf_ /
-  // complex_sub_desc_buf_ quartet (metal_trace_backend.mm:724-734). The CUDA
-  // kernel emit gate (ms_mode==1) consumes these via DeviceFilterCheck; the
-  // 1-byte dummy fallback covers no-filter sessions so the kernel pointers are
-  // always non-null even on the ms_mode==0 path (which doesn't read them).
+  // Mirrors Metal's filter_desc_buf_ / complex_sub_desc_buf_ pair
+  // (metal_trace_backend.mm:724-734). The CUDA kernel emit gate (ms_mode==1)
+  // consumes these via DeviceFilterCheck; the 1-byte dummy fallback covers
+  // no-filter sessions so the kernel pointers are always non-null even on the
+  // ms_mode==0 path (which doesn't read them). The per-instance GetFn table is
+  // NOT here — it rides alongside the polygon-normal geometry as
+  // d_poly_fn_ / d_pool_poly_fn_ and is indexed by the ray's own poly_off.
   DeviceFilterDesc* d_filter_desc_       = nullptr;  // n_slot DeviceFilterDescs (or 1B dummy)
-  uint32_t*         d_getfn_offsets_     = nullptr;  // (n_slot + 1) uint32 prefix-sum (or 1B dummy)
-  uint8_t*          d_getfn_bytes_       = nullptr;  // flat GetFn byte stream (or 1B dummy)
   DeviceFilterDesc* d_complex_sub_desc_  = nullptr;  // flat Complex sub-descs (or 1B dummy)
   // task-device-flat-and-terms: parallel flat buffer, one uint8 per OR-clause
   // across all Complex descs (physical + color). CUDA uses an INDEPENDENT
   // allocation (no Metal-style 30-buffer cap to worry about); mirrors the
-  // discipline of `d_color_bit_map_` / `d_getfn_bytes_`. 1-byte dummy in the
+  // discipline of `d_color_bit_map_`. 1-byte dummy in the
   // no-Complex fallback so the kernel pointer stays bindable.
   uint8_t*          d_and_term_counts_   = nullptr;
   uint32_t          filter_desc_max_ci_  = 0u;       // per-layer ci stride (MVP=1)
@@ -2234,6 +2237,7 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
   if (!keep_persistent_buffers) {
     cudaFree(d_poly_n_);     d_poly_n_ = nullptr;
     cudaFree(d_poly_d_);     d_poly_d_ = nullptr;
+    cudaFree(d_poly_fn_);    d_poly_fn_ = nullptr;
     cudaFree(d_tri_vtx_);    d_tri_vtx_ = nullptr;
     cudaFree(d_tri_norm_);   d_tri_norm_ = nullptr;
     cudaFree(d_tri_area_);   d_tri_area_ = nullptr;
@@ -2242,6 +2246,7 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     // the per-batch keep_persistent path so it is uploaded once per scene).
     cudaFree(d_pool_poly_n_);      d_pool_poly_n_ = nullptr;
     cudaFree(d_pool_poly_d_);      d_pool_poly_d_ = nullptr;
+    cudaFree(d_pool_poly_fn_);     d_pool_poly_fn_ = nullptr;
     cudaFree(d_pool_tri_vtx_);     d_pool_tri_vtx_ = nullptr;
     cudaFree(d_pool_tri_norm_);    d_pool_tri_norm_ = nullptr;
     cudaFree(d_pool_tri_area_);    d_pool_tri_area_ = nullptr;
@@ -2259,8 +2264,6 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     // increment 4: filter descriptors + wl pool persist across the keep path;
     // free + invalidate them only here on full teardown (d_wl_pool_ freed below).
     cudaFree(d_filter_desc_);      d_filter_desc_ = nullptr;
-    cudaFree(d_getfn_offsets_);    d_getfn_offsets_ = nullptr;
-    cudaFree(d_getfn_bytes_);      d_getfn_bytes_ = nullptr;
     cudaFree(d_complex_sub_desc_); d_complex_sub_desc_ = nullptr;
     // task-device-flat-and-terms: parallel flat buffer for AND-term counts;
     // rebuilt alongside d_complex_sub_desc_ (including the color-rebuild
@@ -2393,8 +2396,10 @@ void CudaTraceBackend::Impl::EnsureGeomCapacity(size_t poly_cnt, size_t tri_cnt)
   if (poly_cnt > alloc_poly_cap_) {
     cudaFree(d_poly_n_); d_poly_n_ = nullptr;
     cudaFree(d_poly_d_); d_poly_d_ = nullptr;
+    cudaFree(d_poly_fn_); d_poly_fn_ = nullptr;
     CheckCuda(cudaMalloc(&d_poly_n_, 3 * poly_cnt * sizeof(float)), "EnsureGeomCapacity cudaMalloc d_poly_n");
     CheckCuda(cudaMalloc(&d_poly_d_, poly_cnt * sizeof(float)), "EnsureGeomCapacity cudaMalloc d_poly_d");
+    CheckCuda(cudaMalloc(&d_poly_fn_, poly_cnt * sizeof(uint8_t)), "EnsureGeomCapacity cudaMalloc d_poly_fn");
     alloc_poly_cap_ = static_cast<uint32_t>(poly_cnt);
   }
   if (tri_cnt > alloc_tri_cap_) {
@@ -2459,6 +2464,9 @@ void CudaTraceBackend::Impl::UploadCrystalGeometry(const Crystal& crystal) {
                        cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_n");
   CheckCuda(cudaMemcpy(d_poly_d_, crystal.GetPolygonFaceDist(), poly_cnt * sizeof(float),
                        cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_d");
+  const std::vector<uint8_t> h_poly_fn = detail::BuildDeviceGetFnBytes(crystal);
+  CheckCuda(cudaMemcpy(d_poly_fn_, h_poly_fn.data(), poly_cnt * sizeof(uint8_t),
+                       cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_fn");
 
   std::vector<float>    h_tri_vtx, h_tri_norm, h_tri_area;
   std::vector<uint16_t> h_tri2poly;
@@ -2653,6 +2661,7 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
   pool_shape_count_this_batch_ = 0u;
 
   std::vector<float>    h_poly_n, h_poly_d, h_tri_vtx, h_tri_norm, h_tri_area;
+  std::vector<uint8_t>  h_poly_fn;
   std::vector<uint16_t> h_tri2poly;
   uint32_t poly_acc = 0u, tri_acc = 0u;
 
@@ -2718,6 +2727,8 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
         const float* pd = crystal.GetPolygonFaceDist();
         h_poly_n.insert(h_poly_n.end(), pn, pn + 3 * poly_cnt);
         h_poly_d.insert(h_poly_d.end(), pd, pd + poly_cnt);
+        const std::vector<uint8_t> fn = detail::BuildDeviceGetFnBytes(crystal);
+        h_poly_fn.insert(h_poly_fn.end(), fn.begin(), fn.end());
         // Triangle geometry built on the fly from cf_geom_ (AppendCfGeomTriangles),
         // not the crystal's triangle Mesh cache. face_id is the compact present-face
         // LOCAL id carried by each sub-tri (no PolygonFaceOfTri reverse lookup, no
@@ -2739,6 +2750,7 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
   // Free any prior pool (scene change), then allocate + H2D-upload once.
   cudaFree(d_pool_poly_n_);      d_pool_poly_n_ = nullptr;
   cudaFree(d_pool_poly_d_);      d_pool_poly_d_ = nullptr;
+  cudaFree(d_pool_poly_fn_);     d_pool_poly_fn_ = nullptr;
   cudaFree(d_pool_tri_vtx_);     d_pool_tri_vtx_ = nullptr;
   cudaFree(d_pool_tri_norm_);    d_pool_tri_norm_ = nullptr;
   cudaFree(d_pool_tri_area_);    d_pool_tri_area_ = nullptr;
@@ -2748,6 +2760,7 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
 
   CheckCuda(cudaMalloc(&d_pool_poly_n_,      3 * poly_acc * sizeof(float)),    "BuildGeomPool malloc pool_poly_n");
   CheckCuda(cudaMalloc(&d_pool_poly_d_,          poly_acc * sizeof(float)),    "BuildGeomPool malloc pool_poly_d");
+  CheckCuda(cudaMalloc(&d_pool_poly_fn_,         poly_acc * sizeof(uint8_t)),  "BuildGeomPool malloc pool_poly_fn");
   CheckCuda(cudaMalloc(&d_pool_tri_vtx_,     9 * tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_vtx");
   CheckCuda(cudaMalloc(&d_pool_tri_norm_,    3 * tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_norm");
   CheckCuda(cudaMalloc(&d_pool_tri_area_,        tri_acc * sizeof(float)),     "BuildGeomPool malloc pool_tri_area");
@@ -2757,6 +2770,8 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
                        cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_poly_n");
   CheckCuda(cudaMemcpy(d_pool_poly_d_, h_poly_d.data(), h_poly_d.size() * sizeof(float),
                        cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_poly_d");
+  CheckCuda(cudaMemcpy(d_pool_poly_fn_, h_poly_fn.data(), h_poly_fn.size() * sizeof(uint8_t),
+                       cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_poly_fn");
   CheckCuda(cudaMemcpy(d_pool_tri_vtx_, h_tri_vtx.data(), h_tri_vtx.size() * sizeof(float),
                        cudaMemcpyHostToDevice), "BuildGeomPool H2D pool_tri_vtx");
   CheckCuda(cudaMemcpy(d_pool_tri_norm_, h_tri_norm.data(), h_tri_norm.size() * sizeof(float),
@@ -3057,8 +3072,6 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   }
   // Free any prior session's filter buffers (cudaFree on nullptr is a no-op).
   cudaFree(d_filter_desc_);       d_filter_desc_       = nullptr;
-  cudaFree(d_getfn_offsets_);     d_getfn_offsets_     = nullptr;
-  cudaFree(d_getfn_bytes_);       d_getfn_bytes_       = nullptr;
   cudaFree(d_complex_sub_desc_);  d_complex_sub_desc_  = nullptr;
   cudaFree(d_and_term_counts_);   d_and_term_counts_   = nullptr;
   // task-358.2: free any prior session's independent color-region buffers.
@@ -3087,11 +3100,6 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
     dummy.type = kDeviceFilterTypeNone;
     ck(cudaMemcpy(d_filter_desc_, &dummy, sizeof(DeviceFilterDesc), cudaMemcpyHostToDevice),
        "cudaMemcpy d_filter_desc (dummy)");
-    uint32_t dummy_offsets[2] = {0u, 0u};
-    ck(cudaMalloc(&d_getfn_offsets_, sizeof(dummy_offsets)), "cudaMalloc d_getfn_offsets (dummy)");
-    ck(cudaMemcpy(d_getfn_offsets_, dummy_offsets, sizeof(dummy_offsets), cudaMemcpyHostToDevice),
-       "cudaMemcpy d_getfn_offsets (dummy)");
-    ck(cudaMalloc(&d_getfn_bytes_, 1u), "cudaMalloc d_getfn_bytes (dummy)");
     ck(cudaMalloc(&d_complex_sub_desc_, sizeof(DeviceFilterDesc)), "cudaMalloc d_complex_sub_desc (dummy)");
     // task-device-flat-and-terms: 1-byte dummy so the kernel pointer stays
     // bindable in no-Complex sessions (the Complex branch is never entered).
@@ -3135,14 +3143,17 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   size_t n_slot = n_layers * max_ci;
   filter_n_slot_ = static_cast<uint32_t>(n_slot);
 
-  // Build per-slot descriptors + per-slot GetFn byte stripes via a private
-  // proto RNG (private to keep the session's main rng_ pristine for the first
-  // TraceLayer's per-batch MakeCrystal). Hex prism GetFn is shape-invariant
-  // across orientation/aspect, so any sampled instance suffices for the
-  // canonical bytes + GetFn table (mirrors Metal proto_rng pattern).
+  // Build per-slot descriptors via a private proto RNG (private to keep the
+  // session's main rng_ pristine for the first TraceLayer's per-batch
+  // MakeCrystal). The descriptor fields sampled here (symmetry, sigma_a,
+  // d_applicable, Complex sub-descs) are shape-invariant across
+  // orientation/aspect, so any sampled instance suffices (mirrors Metal
+  // proto_rng pattern). The per-instance GetFn table is NOT built here — it
+  // rides alongside each pool crystal's polygon geometry (built in
+  // BuildGeomPool / UploadCrystalGeometry) and is indexed by the ray's own
+  // poly_off.
   RandomNumberGenerator proto_rng(0xC0FEFEEDu);
   std::vector<DeviceFilterDesc> descs(n_slot);
-  std::vector<std::vector<uint8_t>> per_slot_bytes(n_slot);
   std::vector<DeviceFilterDesc> all_sub_descs;
   // task-device-flat-and-terms: parallel flat buffer of per-OR-clause AND-term
   // counts, indexed via `and_terms_start` on each Complex parent desc.
@@ -3155,7 +3166,6 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
       Crystal proto = MakeCrystal(proto_rng, setting.crystal_.param_);
       size_t slot = mi * max_ci + ci;
       descs[slot] = detail::BuildDeviceFilterDesc(setting.filter_, proto, setting.crystal_.axis_);
-      per_slot_bytes[slot] = detail::BuildDeviceGetFnBytes(proto);
       if (descs[slot].type == kDeviceFilterTypeComplex) {
         const auto* complex_p = std::get_if<ComplexFilterParam>(&setting.filter_.param_);
         // BuildDeviceFilterDesc produces Complex only when the variant carries
@@ -3168,8 +3178,8 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
       }
     }
     // Trailing slots (ms.setting_.size() < max_ci) keep zero-init
-    // DeviceFilterDesc{type=kDeviceFilterTypeNone} + empty GetFn stripe, so an
-    // out-of-range gate_slot surfaces as a pass-through true.
+    // DeviceFilterDesc{type=kDeviceFilterTypeNone}, so an out-of-range gate_slot
+    // surfaces as a pass-through true.
   }
 
   // Upload descriptors.
@@ -3177,28 +3187,8 @@ void CudaTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& spec) {
   ck(cudaMalloc(&d_filter_desc_, descs_bytes), "cudaMalloc d_filter_desc");
   ck(cudaMemcpy(d_filter_desc_, descs.data(), descs_bytes, cudaMemcpyHostToDevice), "cudaMemcpy d_filter_desc");
 
-  // Upload GetFn prefix-sum offsets + flat byte stream.
-  std::vector<uint32_t> offsets(n_slot + 1u, 0u);
-  for (size_t i = 0; i < n_slot; ++i) {
-    offsets[i + 1] = offsets[i] + static_cast<uint32_t>(per_slot_bytes[i].size());
-  }
-  size_t offsets_bytes = offsets.size() * sizeof(uint32_t);
-  ck(cudaMalloc(&d_getfn_offsets_, offsets_bytes), "cudaMalloc d_getfn_offsets");
-  ck(cudaMemcpy(d_getfn_offsets_, offsets.data(), offsets_bytes, cudaMemcpyHostToDevice),
-     "cudaMemcpy d_getfn_offsets");
-
-  size_t total_bytes = offsets.back();
-  size_t alloc_bytes = std::max<size_t>(total_bytes, 1u);  // 1-byte floor so the buffer is always bindable
-  ck(cudaMalloc(&d_getfn_bytes_, alloc_bytes), "cudaMalloc d_getfn_bytes");
-  if (total_bytes > 0) {
-    std::vector<uint8_t> flat(total_bytes, 0u);
-    for (size_t i = 0; i < n_slot; ++i) {
-      if (!per_slot_bytes[i].empty()) {
-        std::memcpy(flat.data() + offsets[i], per_slot_bytes[i].data(), per_slot_bytes[i].size());
-      }
-    }
-    ck(cudaMemcpy(d_getfn_bytes_, flat.data(), total_bytes, cudaMemcpyHostToDevice), "cudaMemcpy d_getfn_bytes");
-  }
+  // per-instance GetFn is uploaded as d_pool_poly_fn_/d_poly_fn_ in
+  // BuildGeomPool/UploadCrystalGeometry; no shared prototype GetFn table here.
 
   // Upload Complex sub-descs (1-byte dummy fallback when none present, so the
   // kernel pointer is always bindable; DeviceFilterCheck only reads through it
@@ -3973,6 +3963,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
     std::unique_ptr<Crystal> ci_crystal_fb;  // fallback path only (avoids Crystal default-ctor)
     uint32_t ci_cfg_id;
     const float* geom_poly_n; const float* geom_poly_d; uint32_t geom_poly_cnt;
+    const uint8_t* geom_poly_fn;
     const float* geom_tri_vtx; const float* geom_tri_norm; const float* geom_tri_area;
     const uint16_t* geom_tri_to_poly; uint32_t geom_tri_cnt;
     // K-shape: the (shape-table pointer, pool_shape_count) pair passed to
@@ -3989,6 +3980,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       ci_cfg_id = (ci_crystal_fb->config_id_ == kInvalidId)
                       ? kInvalidIdU16 : static_cast<uint32_t>(ci_crystal_fb->config_id_);
       geom_poly_n = impl_->d_poly_n_; geom_poly_d = impl_->d_poly_d_; geom_poly_cnt = impl_->poly_cnt_;
+      geom_poly_fn = impl_->d_poly_fn_;
       geom_tri_vtx = impl_->d_tri_vtx_; geom_tri_norm = impl_->d_tri_norm_;
       geom_tri_area = impl_->d_tri_area_; geom_tri_to_poly = impl_->d_tri_to_poly_;
       geom_tri_cnt = impl_->tri_cnt_;
@@ -4026,6 +4018,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       // shape table + the +offset multiply that produces effective pointers;
       // everything else (from_poly / hit_poly / path_rec) stays 0-based.
       geom_poly_n = impl_->d_pool_poly_n_;   geom_poly_d = impl_->d_pool_poly_d_;
+      geom_poly_fn = impl_->d_pool_poly_fn_;
       geom_poly_cnt = impl_->pool_poly_cnt_[slot_base_ci];  // representative — kernel reads per-ray
       geom_tri_vtx = impl_->d_pool_tri_vtx_; geom_tri_norm = impl_->d_pool_tri_norm_;
       geom_tri_area = impl_->d_pool_tri_area_; geom_tri_to_poly = impl_->d_pool_tri_to_poly_;
@@ -4258,8 +4251,7 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
         gate_split.lo,
         gate_split.hi,
         impl_->d_filter_desc_,
-        impl_->d_getfn_offsets_,
-        impl_->d_getfn_bytes_,
+        geom_poly_fn,
         impl_->d_complex_sub_desc_,
         impl_->d_and_term_counts_,
         impl_->filter_desc_max_ci_,

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -2465,6 +2465,7 @@ void CudaTraceBackend::Impl::UploadCrystalGeometry(const Crystal& crystal) {
   CheckCuda(cudaMemcpy(d_poly_d_, crystal.GetPolygonFaceDist(), poly_cnt * sizeof(float),
                        cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_d");
   const std::vector<uint8_t> h_poly_fn = detail::BuildDeviceGetFnBytes(crystal);
+  assert(h_poly_fn.size() == poly_cnt && "poly_fn stripe length must equal poly_cnt");
   CheckCuda(cudaMemcpy(d_poly_fn_, h_poly_fn.data(), poly_cnt * sizeof(uint8_t),
                        cudaMemcpyHostToDevice), "UploadCrystalGeometry cudaMemcpy d_poly_fn");
 
@@ -2728,6 +2729,7 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
         h_poly_n.insert(h_poly_n.end(), pn, pn + 3 * poly_cnt);
         h_poly_d.insert(h_poly_d.end(), pd, pd + poly_cnt);
         const std::vector<uint8_t> fn = detail::BuildDeviceGetFnBytes(crystal);
+        assert(fn.size() == poly_cnt && "poly_fn stripe length must equal poly_cnt");
         h_poly_fn.insert(h_poly_fn.end(), fn.begin(), fn.end());
         // Triangle geometry built on the fly from cf_geom_ (AppendCfGeomTriangles),
         // not the crystal's triangle Mesh cache. face_id is the compact present-face

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -739,6 +739,14 @@ struct MetalTraceBackend::Impl {
   // Polygon geometry (uploaded per-layer; capacity-resized lazily).
   id<MTLBuffer> poly_n_buf  = nil;
   id<MTLBuffer> poly_d_buf  = nil;
+  // per-instance GetFn table, one uchar (canonical face-number) per
+  // ABSOLUTE pool polygon, laid out in lock-step with poly_n_buf/poly_d_buf so
+  // the trace kernel indexes it by the ray's own shape_poly_off + LOCAL path
+  // index. Replaces the former per-(layer,ci) prototype getfn table, whose
+  // shared stripe mis-mapped degenerate pool instances under strong shape
+  // randomization (the emit gate read another face's canonical value → the
+  // entry_exit filter collapsed to 0). Allocated in EnsurePolyBuffers.
+  id<MTLBuffer> poly_fn_buf = nil;
   size_t        poly_capacity = 0;
 
   // First-layer root rays (uploaded from host).
@@ -1030,14 +1038,13 @@ struct MetalTraceBackend::Impl {
   //     (ms_layer, ci) flattened as `ms_layer * max_ci + ci` (see
   //     filter_desc_strides_). Same crystal/filter pair across layers does
   //     NOT dedup — keeps lookup O(1).
-  //   * getfn_offsets_buf_: uint32[n_slot + 1] prefix sum of poly_face_cnt per
-  //     (ms_layer, ci); last entry = total bytes.
-  //   * getfn_bytes_buf_: flat uchar stream, slot i lives in
-  //     [offsets[i], offsets[i+1]); content = crystal.GetFn(poly_idx) per
-  //     poly_idx (D1 layout).
+  // the GetFn remap table is no longer part of this per-slot
+  // filter state. It was a per-(layer,ci) prototype stripe (getfn_offsets_buf_
+  // + getfn_bytes_buf_) built from a single fixed-seed crystal, which mis-mapped
+  // degenerate pool instances under strong shape randomization. It is replaced
+  // by the per-instance poly_fn_buf (built in UploadCrystalPool, indexed by the
+  // ray's absolute polygon offset).
   id<MTLBuffer> filter_desc_buf_    = nil;
-  id<MTLBuffer> getfn_offsets_buf_  = nil;
-  id<MTLBuffer> getfn_bytes_buf_    = nil;
   // Complex filter sub-spec flat buffer (267.1b). For each top-level Complex
   // desc, `sub_desc_start` indexes here and `or_clause_count` +
   // `and_term_counts[]` describe the OR/AND layout. Sub-descs are always
@@ -1288,6 +1295,12 @@ void MetalTraceBackend::Impl::EnsurePolyBuffers(size_t poly_cnt) {
   poly_d_buf  = [device newBufferWithLength:poly_cnt * sizeof(float)
                                     options:MTLResourceStorageModeShared];
   assert(poly_d_buf != nil);
+  // per-instance GetFn table, one uchar per absolute pool polygon.
+  // newBufferWithLength:0 returns nil on some drivers; poly_cnt is >= 1 here
+  // (UploadCrystalPool early-returns on an empty pool before calling this).
+  poly_fn_buf = [device newBufferWithLength:poly_cnt * sizeof(uint8_t)
+                                    options:MTLResourceStorageModeShared];
+  assert(poly_fn_buf != nil);
 }
 
 void MetalTraceBackend::Impl::EnsureRootBuffers(size_t n) {
@@ -1471,20 +1484,26 @@ void MetalTraceBackend::Impl::EnsureWlPoolBuffer() {
 }
 
 // scrum-267 task-msl-filter-match-port (Step 4): upload per-session filter
-// descriptors + GetFn tables for the future fused emit gate (sub-task 2).
-// Layout: one DeviceFilterDesc per (ms_layer, ci) slot, flat-indexed as
-// `ms_layer * max_ci + ci` (max_ci = max setting_.size() across layers); one
-// GetFn byte stripe per slot with a uint prefix-sum offsets array. All
-// hexagonal crystals share `poly_face_cnt_ == 8`, so a prototype crystal made
-// with a fixed seed is enough to derive GetFn — current Metal backend supports
-// hex prism only (BeginSession asserts already enforce that elsewhere). Per
-// plan §3 D1 + Step 4 + Round-2 Minor-3 refinement.
+// descriptors for the fused emit gate. Layout: one DeviceFilterDesc per
+// (ms_layer, ci) slot, flat-indexed as `ms_layer * max_ci + ci` (max_ci = max
+// setting_.size() across layers).
+//
+// this function no longer builds a GetFn remap table. The former
+// design derived GetFn from a single fixed-seed prototype crystal per slot
+// (assuming "all hexagonal crystals share poly_face_cnt_ == 8, so any sampled
+// instance suffices"). That invariant is false under strong shape
+// randomization: degenerate face_distance draws drop lateral faces per
+// instance, so the prototype's local->canonical mapping mis-mapped the actual
+// traced instances (entry_exit filter collapsed to 0 at gauss std >= 0.30).
+// The GetFn table is now per-instance (poly_fn_buf, built in UploadCrystalPool
+// from each pool crystal's own GetFn and indexed by the ray's absolute polygon
+// offset). The proto crystal is still built here only for BuildDeviceFilterDesc
+// (canonical bytes / symmetry / sigma_a), which are filter-config-derived and
+// crystal-topology-independent.
 void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spec) {
   filter_desc_count_ = 0;
   filter_desc_max_ci_ = 0;
   filter_desc_buf_ = nil;
-  getfn_offsets_buf_ = nil;
-  getfn_bytes_buf_ = nil;
   complex_sub_desc_buf_ = nil;
   and_term_counts_base_offset_ = 0u;
   // task-358.1: reset color state up-front; the descriptor append below turns
@@ -1493,26 +1512,19 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
   color_desc_offset_ = 0u;
   color_bits_offset_ = 0u;
   // scrum-267 task-fused-emit-gate Step 3a (R5 fix): the trace kernel's emit
-  // gate unconditionally binds filter_desc_buf_ / getfn_offsets_buf_ /
-  // getfn_bytes_buf_ / complex_sub_desc_buf_ at buffer slots 24-27 (plan §3
-  // originally reserved 27-30 but Metal's per-stage buffer-index ceiling is
-  // 30 — see DECISION in progress.md). Metal disallows nil-buffer bindings,
-  // so each early-return path must still allocate a 1-byte dummy. The kernel
-  // never reads through them in the
-  // no-filter case (DeviceFilterCheck on a None desc returns true and the gate
-  // proceeds, but on the ms_mode==0 path the gate is never entered; the
-  // ms_mode==1 path only fires when there are MS layers, which co-occurs with
-  // EnsureFilterBuffers having a real desc array).
+  // gate unconditionally binds filter_desc_buf_ / complex_sub_desc_buf_ (slots
+  // 23/26) plus the per-instance poly_fn_buf (slot 25, allocated in
+  // EnsurePolyBuffers). Metal disallows nil-buffer bindings, so each early-
+  // return path must still allocate a 1-byte dummy for the filter descriptor
+  // buffers. The kernel never reads through them in the no-filter case
+  // (DeviceFilterCheck on a None desc returns true and the gate proceeds, but on
+  // the ms_mode==0 path the gate is never entered; the ms_mode==1 path only
+  // fires when there are MS layers, which co-occurs with EnsureFilterBuffers
+  // having a real desc array).
   auto alloc_filter_dummies = [&]() {
     filter_desc_buf_ = [device newBufferWithLength:1
                                           options:MTLResourceStorageModeShared];
     assert(filter_desc_buf_ != nil);
-    getfn_offsets_buf_ = [device newBufferWithLength:1
-                                            options:MTLResourceStorageModeShared];
-    assert(getfn_offsets_buf_ != nil);
-    getfn_bytes_buf_ = [device newBufferWithLength:1
-                                          options:MTLResourceStorageModeShared];
-    assert(getfn_bytes_buf_ != nil);
     complex_sub_desc_buf_ = [device newBufferWithLength:1
                                                options:MTLResourceStorageModeShared];
     assert(complex_sub_desc_buf_ != nil);
@@ -1543,14 +1555,16 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
   filter_desc_max_ci_ = max_ci;
   size_t n_slot = n_layers * max_ci;
 
-  // Build per-slot prototype crystals via a private RNG so the session's main
-  // rng stream (used for trace) is not advanced. Hex-prism GetFn(poly_idx) is
-  // shape-invariant for hex faces; any sampled instance suffices for the
-  // canonical_bytes + GetFn table contents (Round-2 Minor-3 acknowledgement:
-  // canonical computation is fn_period=6-invariant for hex crystals).
+  // Build a per-slot prototype crystal via a private RNG so the session's main
+  // rng stream (used for trace) is not advanced. The prototype feeds
+  // BuildDeviceFilterDesc only, whose canonical_bytes / symmetry / sigma_a are
+  // filter-config-derived and crystal-topology-independent — so any instance is
+  // fine HERE. (the prototype is NOT used to build a GetFn remap
+  // table anymore; the actual per-instance GetFn is uploaded via poly_fn_buf in
+  // UploadCrystalPool. The old "any sampled instance suffices for the GetFn
+  // table" assumption is exactly what strong shape randomization broke.)
   RandomNumberGenerator proto_rng(0xC0FEFEEDu);
   std::vector<DeviceFilterDesc> descs(n_slot);
-  std::vector<std::vector<uint8_t>> per_slot_bytes(n_slot);
   // Flat sub-desc buffer for Complex filters (267.1b). Inlined collection so a
   // Complex slot's `sub_desc_start` is recorded BEFORE pushing its sub-descs —
   // avoids needing a separate (slot, ComplexFilterParam) map for a second pass.
@@ -1568,7 +1582,6 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
       Crystal proto = MakeCrystal(proto_rng, setting.crystal_.param_);
       size_t slot = mi * max_ci + ci;
       descs[slot] = detail::BuildDeviceFilterDesc(setting.filter_, proto, setting.crystal_.axis_);
-      per_slot_bytes[slot] = detail::BuildDeviceGetFnBytes(proto);
       // Inline Complex sub-desc collection — see plan §3 D5 / Step 3 rationale.
       if (descs[slot].type == kDeviceFilterTypeComplex) {
         const auto* complex_p = std::get_if<ComplexFilterParam>(&setting.filter_.param_);
@@ -1742,32 +1755,8 @@ void MetalTraceBackend::Impl::EnsureFilterBuffers(const SessionSpec& session_spe
                 color_desc_region * sizeof(DeviceFilterDesc));
   }
 
-  // Upload GetFn prefix-sum offsets + flat byte stream.
-  std::vector<uint32_t> offsets(n_slot + 1, 0u);
-  for (size_t i = 0; i < n_slot; ++i) {
-    offsets[i + 1] = offsets[i] + static_cast<uint32_t>(per_slot_bytes[i].size());
-  }
-  size_t offsets_bytes = offsets.size() * sizeof(uint32_t);
-  getfn_offsets_buf_ = [device newBufferWithLength:offsets_bytes
-                                            options:MTLResourceStorageModeShared];
-  assert(getfn_offsets_buf_ != nil);
-  std::memcpy([getfn_offsets_buf_ contents], offsets.data(), offsets_bytes);
-
-  size_t total_bytes = offsets.back();
-  // newBufferWithLength:0 returns nil on some drivers — guard with a 1-byte
-  // minimum so the buffer is always bindable (kernel reads gated by offsets).
-  size_t alloc_bytes = std::max<size_t>(total_bytes, 1);
-  getfn_bytes_buf_ = [device newBufferWithLength:alloc_bytes
-                                          options:MTLResourceStorageModeShared];
-  assert(getfn_bytes_buf_ != nil);
-  if (total_bytes > 0) {
-    uint8_t* dst = static_cast<uint8_t*>([getfn_bytes_buf_ contents]);
-    for (size_t i = 0; i < n_slot; ++i) {
-      if (!per_slot_bytes[i].empty()) {
-        std::memcpy(dst + offsets[i], per_slot_bytes[i].data(), per_slot_bytes[i].size());
-      }
-    }
-  }
+  // the per-slot prototype GetFn table upload used to live here.
+  // The GetFn remap is now per-instance (poly_fn_buf, UploadCrystalPool).
 
   // Upload Complex sub-desc flat buffer (267.1b) + flat AND-term counts
   // (task-device-flat-and-terms) packed after it. Allocate a 1-byte dummy when
@@ -1866,6 +1855,7 @@ void MetalTraceBackend::Impl::UploadCrystalPool(const std::vector<Crystal>& pool
 
   auto* poly_n_ptr    = static_cast<float*>([poly_n_buf contents]);
   auto* poly_d_ptr    = static_cast<float*>([poly_d_buf contents]);
+  auto* poly_fn_ptr   = static_cast<uint8_t*>([poly_fn_buf contents]);
   auto* tri_vtx_ptr   = static_cast<float*>([tri_vtx_buf_ contents]);
   auto* tri_norm_ptr  = static_cast<float*>([tri_norm_buf_ contents]);
   auto* tri_area_ptr  = static_cast<float*>([tri_area_buf_ contents]);
@@ -1885,6 +1875,16 @@ void MetalTraceBackend::Impl::UploadCrystalPool(const std::vector<Crystal>& pool
                 poly_cnt * 3 * sizeof(float));
     std::memcpy(poly_d_ptr + poly_off, crystal.GetPolygonFaceDist(),
                 poly_cnt * sizeof(float));
+
+    // per-instance GetFn table. detail::BuildDeviceGetFnBytes returns
+    // exactly poly_cnt bytes = this instance's own GetFn(local) for each present
+    // face — the SAME single-source builder the retired per-slot prototype path
+    // used, now applied to the actual traced instance instead of a fixed-seed
+    // prototype. Written at this shape's absolute poly_off so the trace kernel's
+    // gate_poly_fn[shape_poly_off + local] lookup lands on the right instance.
+    const std::vector<uint8_t> fn_bytes = detail::BuildDeviceGetFnBytes(crystal);
+    assert(fn_bytes.size() == poly_cnt && "poly_fn stripe length must equal poly_cnt");
+    std::memcpy(poly_fn_ptr + poly_off, fn_bytes.data(), poly_cnt * sizeof(uint8_t));
 
     // Triangle geometry built on the fly from cf_geom_ (detail::BuildEntrySubTris,
     // the same helper CPU InitRay_p_fid uses) — NOT the crystal's triangle Mesh
@@ -2698,10 +2698,12 @@ void MetalTraceBackend::Impl::DispatchLayer(size_t num_rays,
   // Emit-gate filter state (scrum-267 task-fused-emit-gate Step 4b). Bound for
   // every dispatch (Metal disallows nil buffers). EnsureFilterBuffers guarantees
   // non-nil even in no-filter sessions via the 1-byte dummy fallback (R5 fix).
-  // Slots 23-26 carry filter descriptors.
+  // Slots 23/25/26 carry filter descriptors + the per-instance GetFn table.
+  // Slot 24 (the retired prototype prefix-sum table) is no longer bound — the
+  // kernel drops that param. poly_fn_buf is the per-instance GetFn
+  // table, bound at 25 in place of the former shared getfn byte stream.
   [enc setBuffer:filter_desc_buf_      offset:0 atIndex:23];
-  [enc setBuffer:getfn_offsets_buf_    offset:0 atIndex:24];
-  [enc setBuffer:getfn_bytes_buf_      offset:0 atIndex:25];
+  [enc setBuffer:poly_fn_buf           offset:0 atIndex:25];
   [enc setBuffer:complex_sub_desc_buf_ offset:0 atIndex:26];
   // cont_wl_idx propagates the photon's lifetime wavelength tag into the
   // continuation ring (slot 28) so the next layer's trace reads its optics
@@ -2853,8 +2855,6 @@ void MetalTraceBackend::Impl::Reset() {
   filter_desc_count_ = 0;
   filter_desc_max_ci_ = 0;
   filter_desc_buf_ = nil;
-  getfn_offsets_buf_ = nil;
-  getfn_bytes_buf_ = nil;
   complex_sub_desc_buf_ = nil;
   and_term_counts_base_offset_ = 0u;
   spec = SessionSpec{};

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1359,9 +1359,19 @@ void MetalTraceBackend::Impl::EnsureTriBuffers(size_t tri_cnt) {
   // task-260.5 Step 3: device-gen requires at least one triangle for the
   // area×facing categorical sampler. A zero-count crystal would underflow
   // categorical_sample in gen_root_kernel (n=0 → returns 0xffffffff → OOB
-  // index). Production configs always have tri_cnt > 0; this assert catches
-  // a future scene/config bug at the layer-prep stage rather than as a GPU
-  // hang.
+  // index). This assert catches such a crystal at the layer-prep stage
+  // rather than as a GPU hang.
+  //
+  // NOTE: the original claim here ("Production configs always have tri_cnt
+  // > 0") is FALSE. Under strong shape randomization, MakeCrystal's
+  // closed-form validity gate returns a default-constructed (empty) Crystal
+  // for degenerate face_distance draws — measured ~11.6% hit rate at
+  // face_distance gauss std=0.5 — and that empty Crystal reaches here with
+  // tri_cnt == 0. So this assert fires in Debug on *legitimate* randomized
+  // scenes, not just on a future config bug. Treat tri_cnt == 0 as a
+  // reachable input; the empty-Crystal-tolerance fix (make the device gen
+  // path skip / degrade instead of asserting) is tracked as separate work
+  // and is intentionally out of this change's scope.
   assert(tri_cnt > 0u && "EnsureTriBuffers: tri_cnt == 0 (gen_root_kernel cannot sample)");
   if (tri_cnt <= tri_buf_capacity_) {
     return;

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1285,20 +1285,23 @@ void MetalTraceBackend::Impl::EnsureClassLaneBuf(int w, int h) {
 }
 
 void MetalTraceBackend::Impl::EnsurePolyBuffers(size_t poly_cnt) {
-  if (poly_cnt <= poly_capacity) {
+  // poly_cnt == 0 (a whole pool of degenerate/empty crystals) is reachable —
+  // see EnsureTriBuffers. newBufferWithLength:0 returns nil on some drivers and
+  // Metal forbids nil bindings, so allocate a 1-polygon dummy for the zero case
+  // (the gen kernel's gp.tri_count==0 guard means these are never read then).
+  size_t need = std::max<size_t>(poly_cnt, 1u);
+  if (need <= poly_capacity && poly_n_buf != nil) {
     return;
   }
-  poly_capacity = poly_cnt;
-  poly_n_buf  = [device newBufferWithLength:poly_cnt * 3 * sizeof(float)
+  poly_capacity = need;
+  poly_n_buf  = [device newBufferWithLength:need * 3 * sizeof(float)
                                     options:MTLResourceStorageModeShared];
   assert(poly_n_buf != nil);
-  poly_d_buf  = [device newBufferWithLength:poly_cnt * sizeof(float)
+  poly_d_buf  = [device newBufferWithLength:need * sizeof(float)
                                     options:MTLResourceStorageModeShared];
   assert(poly_d_buf != nil);
   // per-instance GetFn table, one uchar per absolute pool polygon.
-  // newBufferWithLength:0 returns nil on some drivers; poly_cnt is >= 1 here
-  // (UploadCrystalPool early-returns on an empty pool before calling this).
-  poly_fn_buf = [device newBufferWithLength:poly_cnt * sizeof(uint8_t)
+  poly_fn_buf = [device newBufferWithLength:need * sizeof(uint8_t)
                                     options:MTLResourceStorageModeShared];
   assert(poly_fn_buf != nil);
 }
@@ -1369,37 +1372,31 @@ void MetalTraceBackend::Impl::EnsurePoolShapeTableBuffer(size_t shape_cnt) {
 }
 
 void MetalTraceBackend::Impl::EnsureTriBuffers(size_t tri_cnt) {
-  // task-260.5 Step 3: device-gen requires at least one triangle for the
-  // area×facing categorical sampler. A zero-count crystal would underflow
-  // categorical_sample in gen_root_kernel (n=0 → returns 0xffffffff → OOB
-  // index). This assert catches such a crystal at the layer-prep stage
-  // rather than as a GPU hang.
-  //
-  // NOTE: the original claim here ("Production configs always have tri_cnt
-  // > 0") is FALSE. Under strong shape randomization, MakeCrystal's
-  // closed-form validity gate returns a default-constructed (empty) Crystal
-  // for degenerate face_distance draws — measured ~11.6% hit rate at
-  // face_distance gauss std=0.5 — and that empty Crystal reaches here with
-  // tri_cnt == 0. So this assert fires in Debug on *legitimate* randomized
-  // scenes, not just on a future config bug. Treat tri_cnt == 0 as a
-  // reachable input; the empty-Crystal-tolerance fix (make the device gen
-  // path skip / degrade instead of asserting) is tracked as separate work
-  // and is intentionally out of this change's scope.
-  assert(tri_cnt > 0u && "EnsureTriBuffers: tri_cnt == 0 (gen_root_kernel cannot sample)");
-  if (tri_cnt <= tri_buf_capacity_) {
+  // tri_cnt == 0 (a whole pool of degenerate/empty crystals) is a REACHABLE
+  // input, not a bug: MakeCrystal's closed-form validity gate returns an empty
+  // Crystal for degenerate face_distance draws (~11.6% at gauss std=0.5), and
+  // at pool size 1 that empties the pool's triangle set. The device gen kernel's
+  // gp.tri_count==0 guard early-returns (0 rays) before touching the triangle
+  // buffers, so their contents are never read in that case — but Metal still
+  // forbids nil buffer bindings, so allocate a 1-triangle dummy when tri_cnt==0
+  // (formerly this asserted tri_cnt>0, which fired in Debug on legitimate
+  // strongly-randomized scenes; see the empty-Crystal contract). Grow-only:
+  // once a real pool sizes these up they stay large enough for later dummies.
+  size_t need = std::max<size_t>(tri_cnt, 1u);
+  if (need <= tri_buf_capacity_ && tri_vtx_buf_ != nil) {
     return;
   }
-  tri_buf_capacity_ = tri_cnt;
-  tri_vtx_buf_ = [device newBufferWithLength:tri_cnt * 9 * sizeof(float)
+  tri_buf_capacity_ = need;
+  tri_vtx_buf_ = [device newBufferWithLength:need * 9 * sizeof(float)
                                     options:MTLResourceStorageModeShared];
   assert(tri_vtx_buf_ != nil);
-  tri_norm_buf_ = [device newBufferWithLength:tri_cnt * 3 * sizeof(float)
+  tri_norm_buf_ = [device newBufferWithLength:need * 3 * sizeof(float)
                                      options:MTLResourceStorageModeShared];
   assert(tri_norm_buf_ != nil);
-  tri_area_buf_ = [device newBufferWithLength:tri_cnt * sizeof(float)
+  tri_area_buf_ = [device newBufferWithLength:need * sizeof(float)
                                      options:MTLResourceStorageModeShared];
   assert(tri_area_buf_ != nil);
-  tri_to_poly_buf_ = [device newBufferWithLength:tri_cnt * sizeof(uint32_t)
+  tri_to_poly_buf_ = [device newBufferWithLength:need * sizeof(uint32_t)
                                         options:MTLResourceStorageModeShared];
   assert(tri_to_poly_buf_ != nil);
 }
@@ -1849,6 +1846,18 @@ void MetalTraceBackend::Impl::UploadCrystalPool(const std::vector<Crystal>& pool
     tri_acc  += tri_cnt;
   }
 
+  // A pool whose crystals are all degenerate (each an empty Crystal from
+  // MakeCrystal's closed-form validity gate — a legitimate ~11.6% outcome at
+  // face_distance gauss std=0.5) has zero total polygons/triangles. This is a
+  // reachable input, not a bug: the gen kernel's gp.tri_count==0 guard early-
+  // returns (0 rays emitted) before it ever reads the pool tables, and the
+  // trace pass is then skipped by num_rays==0 gating. We keep the normal upload
+  // path (non-empty pool_shape_table_h_ so BuildGenRootParams' precondition
+  // holds); Ensure{Poly,Tri}Buffers allocate a 1-element dummy for the zero
+  // case so the buffers stay bindable (Metal forbids nil bindings) even when
+  // the very first pool of the session is all-degenerate. A PARTIALLY
+  // degenerate pool (tri_acc>0) uploads normally; the kernel's per-shape
+  // tri_cnt==0 branch routes rays that pick an empty shape to a zero-weight drop.
   EnsurePolyBuffers(poly_acc);
   EnsureTriBuffers(tri_acc);
   EnsurePoolShapeTableBuffer(pool.size());

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1007,15 +1007,19 @@ struct MetalTraceBackend::Impl {
 
   // Per-layer hop state (scrum-258.3 + scrum-267 task-fused-emit-gate +
   // scrum-267 task-device-resident-continuation Task 3).
-  // hop_ms_prob_ feeds the device emit gate's KernelParams.ms_prob.
-  // last_layer_* is still consumed by ReadbackExitRays for the final-layer
-  // host filter+prob path. The sibling per-ci hop vectors and the mid-exit
-  // host drain were removed in Task 3 once mid-exit emission + frame-transit
-  // both ran on-device.
+  // hop_ms_prob_ feeds the device emit gate's KernelParams.ms_prob for
+  // non-final layers; last_ms_prob_ does the same for the final layer
+  // (DispatchLayer's ms_mode == 0 branch). The sibling per-ci hop vectors and
+  // the mid-exit host drain were removed in Task 3 once mid-exit emission +
+  // frame-transit both ran on-device.
+  //
+  // The final layer no longer mirrors per-ci crystal/axis/filter state on the
+  // host: once the emit gate ran filter+prob+projection on-device,
+  // ReadbackExitRays stopped materialising per-exit records (it returns 0), so
+  // nothing consumed those mirrors. They were removed rather than kept — a
+  // resize()'d vector whose ci_n == 0 slots stay default-constructed is a trap
+  // for whoever adds the first reader back.
   float                           hop_ms_prob_[2]      = { 0.0f, 0.0f };
-  std::vector<Crystal>            last_layer_crystals_;
-  std::vector<AxisDistribution>   last_layer_axis_dists_;
-  std::vector<FilterConfig>       last_layer_filter_configs_;
   float                           last_ms_prob_      = 0.0f;
   uint8_t                         last_ms_layer_idx_ = 0u;
 
@@ -2824,16 +2828,13 @@ void MetalTraceBackend::Impl::Reset() {
   // scene.max_hits_; clear to make a session-mid leak obvious.
   face_seq_cap_ = 0;
   // scrum-258.3 + scrum-267 Task 3: per-layer filter+prob state.
-  // hop_ms_prob_ (device emit gate) + last_layer_* (final-layer host
-  // filter+prob in ReadbackExitRays) are populated by TraceLayer's ci loop in
-  // the next session; clear here so a stale layer's settings cannot bleed
-  // across sessions if BeginSession skips re-assigning a particular slot.
+  // hop_ms_prob_ / last_ms_prob_ (device emit gate) are populated by
+  // TraceLayer's ci loop in the next session; clear here so a stale layer's
+  // settings cannot bleed across sessions if BeginSession skips re-assigning a
+  // particular slot.
   for (int s = 0; s < 2; s++) {
     hop_ms_prob_[s] = 0.0f;
   }
-  last_layer_crystals_.clear();
-  last_layer_axis_dists_.clear();
-  last_layer_filter_configs_.clear();
   last_ms_prob_ = 0.0f;
   last_ms_layer_idx_ = 0u;
   // scrum-267 task-msl-filter-match-port (Step 4): per-session device filter
@@ -3138,14 +3139,10 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
     int in_slot = static_cast<int>((impl_->ms_idx - 1) & 1u);  // only used when !first_ms
 
     // scrum-258.3 Step 3 + scrum-267 Task 3 cleanup: per-layer filter+prob
-    // state. Non-final layers populate `hop_ms_prob_[out_slot]` (consumed by
-    // the device emit gate's `KernelParams.ms_prob` in DispatchLayer); the
-    // final layer populates `last_layer_*` (consumed by ReadbackExitRays for
-    // host filter+prob on the final-layer exits).
+    // state. Non-final layers populate `hop_ms_prob_[out_slot]`, the final
+    // layer populates `last_ms_prob_`; both are consumed by the device emit
+    // gate's `KernelParams.ms_prob` in DispatchLayer.
     if (last_layer) {
-      impl_->last_layer_crystals_.resize(crystal_cnt);
-      impl_->last_layer_axis_dists_.resize(crystal_cnt);
-      impl_->last_layer_filter_configs_.resize(crystal_cnt);
       impl_->last_ms_prob_ = ms_info.prob_;
       impl_->last_ms_layer_idx_ = static_cast<uint8_t>(impl_->ms_idx);
     } else {
@@ -3219,18 +3216,11 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
       impl_->ResolveLayerCrystalForCi(setting, use_host,
                                        first_ms ? roots.host : HostRayBatch{}, p_ci);
 
-      // scrum-258.3 Step 3 + scrum-267 Task 3 cleanup: final-layer only.
-      // Non-final layers no longer need per-ci crystal/axis/filter state —
+      // No layer keeps per-ci crystal/axis/filter state on the host any more —
       // transit_root_kernel pulls geometry from tri_*_buf_ (uploaded by
       // ResolveLayerCrystalForCi → UploadCrystal) and the emit gate consumes
-      // the device-side filter buffers (scrum-267 task-msl-filter-match-port).
-      // ReadbackExitRays still runs host filter+prob on the final-layer exits,
-      // so last_layer_* mirrors stay.
-      if (last_layer) {
-        impl_->last_layer_crystals_[ci] = impl_->current_crystal;
-        impl_->last_layer_axis_dists_[ci] = setting.crystal_.axis_;
-        impl_->last_layer_filter_configs_[ci] = setting.filter_;
-      }
+      // the device-side filter buffers, on the final layer as well as the
+      // intermediate ones.
 
       size_t in_count = 0;
       if (first_ms) {

--- a/src/core/crystal.hpp
+++ b/src/core/crystal.hpp
@@ -198,7 +198,17 @@ class Crystal {
 
   /**
    * @brief Default constructor
-   * @note Creates an empty crystal
+   * @note Creates an empty crystal: `CfGeom().face_cnt == 0`, no face slots
+   *       present, `PolygonFaceCount() == 0`, null normal/distance tables,
+   *       `FnPeriod() == -1`, `config_id_ == kInvalidId`.
+   * @note This is NOT a placeholder-only state. `CreatePrism` / `CreatePyramid`
+   *       return a bytewise-identical instance whenever the closed-form
+   *       validity gate rejects their input, and `MakeCrystal` feeds that gate
+   *       randomized height / face-distance draws — so a consumer holding a
+   *       `Crystal` built through the normal factory path must treat "empty" as
+   *       a reachable input rather than an impossible one. The state and that
+   *       equivalence are pinned by the `EmptyCrystalContract` tests in
+   *       test/unit-correctness/core/test_crystal.cpp.
    */
   Crystal();
 

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -697,13 +697,15 @@ kernel void trace_layer_kernel(
     //   * poly_n / poly_d / tri_* consume ABSOLUTE pool-wide
     //     polygon indices (to_face, cont_face, far_face all absolute).
     //   * path[] / DeviceFilterMatch*'s ApplyGetFn table consume PER-CRYSTAL
-    //     LOCAL polygon indices — GetFn bytes are keyed by (layer, ci) with a
-    //     stripe of length PolygonFaceCount, invariant across P_ci instances
-    //     (crystal randomisation only perturbs h / face_distance; topology
-    //     stable — see EnsureFilterBuffers comment + MakeCrystal). We MUST
-    //     convert absolute → local at the path[] write site by subtracting
-    //     shape_poly_off. At P_ci == 1 shape_poly_off == 0 so this is a no-op
-    //     bit-identical to the pre-K-pool path (AC2).
+    //     LOCAL polygon indices — GetFn bytes are now PER-INSTANCE (one stripe
+    //     of length PolygonFaceCount per pool crystal, built in
+    //     UploadCrystalPool from that instance's own GetFn; see ApplyGetFn_dev
+    //     comment above). The former per-(layer,ci) prototype table's "any
+    //     sampled instance suffices / topology stable" invariant does NOT hold
+    //     under strong shape randomization. We MUST convert absolute → local
+    //     at the path[] write site by subtracting shape_poly_off. At P_ci == 1
+    //     shape_poly_off == 0 so this is a no-op bit-identical to the
+    //     pre-K-pool path (AC2).
     if (rec_len < kRecCap) {
       path[rec_len] = ushort(to_face - shape_poly_off);
       rec_len += 1u;

--- a/src/core/metal/lumice_trace.metal
+++ b/src/core/metal/lumice_trace.metal
@@ -139,22 +139,25 @@ static inline void ReduceBuffer_dev(thread uchar* data, uint size, uchar symmetr
 }
 
 // --- ApplyGetFn ---
-// Remaps poly-index path to face-number space via the per-crystal GetFn byte
-// table (built on host by `BuildDeviceGetFnBytes`, see
-// core/device_filter_desc.{hpp,cpp}). `crystal_slot` indexes into the prefix-
-// sum offset table to locate this crystal's stripe. Writes face-numbers into
-// `out` (caller-owned thread buffer).
+// Remaps poly-index path to face-number space via the PER-INSTANCE GetFn byte
+// table `poly_fn` (one uchar per absolute pool polygon; built in
+// UploadCrystalPool from each pool crystal's own GetFn, so the local->canonical
+// mapping matches the exact instance the ray traversed). The
+// ray's own polygon slice starts at `poly_off` (== shape_poly_off), and
+// `path[i]` is that ray's LOCAL polygon index, so `poly_fn[poly_off + path[i]]`
+// is the absolute-indexed lookup. This replaces the former per-(layer,ci)
+// prototype table (getfn_bytes/getfn_offsets), whose "any sampled instance
+// suffices / topology stable" invariant is false under strong shape
+// randomization (degenerate face_distance draws drop lateral faces per
+// instance). Writes face-numbers into `out` (caller-owned thread buffer).
 static inline void ApplyGetFn_dev(thread const uchar* path, uint len,
-                                  device const uchar* getfn_bytes,
-                                  device const uint*  getfn_offsets,
-                                  uint  crystal_slot,
+                                  device const uchar* poly_fn,
+                                  uint  poly_off,
                                   thread uchar* out) {
-  uint base = getfn_offsets[crystal_slot];
-  // Stripe end (next prefix sum entry) bounds the per-crystal table; we
-  // trust path[k] < stripe_len because the kernel produces valid poly-indices
-  // and the parity harness controls the test inputs.
+  // We trust path[k] < this instance's poly_cnt because the kernel produces
+  // valid LOCAL poly-indices and the parity harness controls the test inputs.
   for (uint i = 0; i < len; i++) {
-    out[i] = getfn_bytes[base + path[i]];
+    out[i] = poly_fn[poly_off + path[i]];
   }
 }
 
@@ -167,12 +170,11 @@ static inline void ApplyGetFn_dev(thread const uchar* path, uint len,
 
 static inline bool DeviceFilterMatchRaypath(device const DeviceFilterDesc& f,
                                             thread const uchar* path, uint path_len,
-                                            device const uchar* getfn_bytes,
-                                            device const uint*  getfn_offsets,
-                                            uint  crystal_slot) {
+                                            device const uchar* poly_fn,
+                                            uint  poly_off) {
   if (path_len != f.canonical_len) { return false; }
   uchar buf[kDevRecCap];
-  ApplyGetFn_dev(path, path_len, getfn_bytes, getfn_offsets, crystal_slot, buf);
+  ApplyGetFn_dev(path, path_len, poly_fn, poly_off, buf);
   if (f.fn_period < 0 || f.symmetry == kDevSymNone) {
     for (uint i = 0; i < path_len; i++) {
       if (buf[i] != f.canonical_bytes[i]) { return false; }
@@ -188,20 +190,18 @@ static inline bool DeviceFilterMatchRaypath(device const DeviceFilterDesc& f,
 
 static inline bool DeviceFilterMatchEntryExit(device const DeviceFilterDesc& f,
                                               thread const uchar* path, uint path_len,
-                                              device const uchar* getfn_bytes,
-                                              device const uint*  getfn_offsets,
-                                              uint  crystal_slot) {
+                                              device const uchar* poly_fn,
+                                              uint  poly_off) {
   if (path_len == 0u) { return false; }
   if (path_len < f.min_len) { return false; }
   if (f.max_len != 0u && path_len > f.max_len) { return false; }
   if (!f.has_entry && !f.has_exit) { return true; }
-  // Resolve the ends in face-number space (single ApplyGetFn for the two
-  // bytes — buf small enough that we always remap the whole prefix/suffix).
+  // Resolve the ends in face-number space (per-instance poly_fn indexed by the
+  // ray's absolute polygon offset — see ApplyGetFn_dev).
   uchar ee[2];
-  uint base = getfn_offsets[crystal_slot];
   uint ee_len = 0u;
-  if (f.has_entry) { ee[ee_len++] = getfn_bytes[base + path[0]]; }
-  if (f.has_exit)  { ee[ee_len++] = getfn_bytes[base + path[path_len - 1u]]; }
+  if (f.has_entry) { ee[ee_len++] = poly_fn[poly_off + path[0]]; }
+  if (f.has_exit)  { ee[ee_len++] = poly_fn[poly_off + path[path_len - 1u]]; }
   if (f.fn_period < 0 || f.symmetry == kDevSymNone) {
     for (uint i = 0; i < ee_len; i++) {
       if (ee[i] != f.canonical_bytes[i]) { return false; }
@@ -237,17 +237,16 @@ static inline bool DeviceFilterMatchCrystal(device const DeviceFilterDesc& f,
 // ComplexSpec which uses SimpleSpecCreator on each sub-spec).
 static inline bool DeviceFilterMatchSimple(device const DeviceFilterDesc& f,
                                            thread const uchar* path, uint path_len,
-                                           device const uchar* getfn_bytes,
-                                           device const uint*  getfn_offsets,
-                                           uint  crystal_slot,
+                                           device const uchar* poly_fn,
+                                           uint  poly_off,
                                            thread const float* ray_dir,
                                            uint  ray_crystal_config_id) {
   if (f.type == kDevFilterTypeNone)     { return true; }
   if (f.type == kDevFilterTypeRaypath)  {
-    return DeviceFilterMatchRaypath(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot);
+    return DeviceFilterMatchRaypath(f, path, path_len, poly_fn, poly_off);
   }
   if (f.type == kDevFilterTypeEntryExit) {
-    return DeviceFilterMatchEntryExit(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot);
+    return DeviceFilterMatchEntryExit(f, path, path_len, poly_fn, poly_off);
   }
   if (f.type == kDevFilterTypeDirection) {
     return DeviceFilterMatchDirection(f, ray_dir);
@@ -268,9 +267,8 @@ static inline bool DeviceFilterMatchComplex(device const DeviceFilterDesc& f,
                                             device const DeviceFilterDesc* complex_sub_desc_buf,
                                             device const uchar* and_term_counts_buf,
                                             thread const uchar* path, uint path_len,
-                                            device const uchar* getfn_bytes,
-                                            device const uint*  getfn_offsets,
-                                            uint  crystal_slot,
+                                            device const uchar* poly_fn,
+                                            uint  poly_off,
                                             thread const float* ray_dir,
                                             uint  ray_crystal_config_id) {
   if (f.or_clause_count == 0) { return false; }  // see comment above
@@ -280,8 +278,8 @@ static inline bool DeviceFilterMatchComplex(device const DeviceFilterDesc& f,
     bool and_ok = true;
     for (uint and_j = 0; and_j < and_n; and_j++) {
       if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx],
-                                   path, path_len, getfn_bytes, getfn_offsets,
-                                   crystal_slot, ray_dir, ray_crystal_config_id)) {
+                                   path, path_len, poly_fn, poly_off,
+                                   ray_dir, ray_crystal_config_id)) {
         and_ok = false;
         // Short-circuit: skip the rest of this AND-clause so sub_idx lands at
         // the next OR-clause start. and_j sub-descs already consumed, jump the
@@ -303,18 +301,17 @@ static inline bool DeviceFilterMatch(device const DeviceFilterDesc& f,
                                      device const DeviceFilterDesc* complex_sub_desc_buf,
                                      device const uchar* and_term_counts_buf,
                                      thread const uchar* path, uint path_len,
-                                     device const uchar* getfn_bytes,
-                                     device const uint*  getfn_offsets,
-                                     uint  crystal_slot,
+                                     device const uchar* poly_fn,
+                                     uint  poly_off,
                                      thread const float* ray_dir,
                                      uint  ray_crystal_config_id) {
   if (f.type == kDevFilterTypeComplex) {
     return DeviceFilterMatchComplex(f, complex_sub_desc_buf, and_term_counts_buf,
-                                    path, path_len, getfn_bytes, getfn_offsets,
-                                    crystal_slot, ray_dir, ray_crystal_config_id);
+                                    path, path_len, poly_fn, poly_off,
+                                    ray_dir, ray_crystal_config_id);
   }
-  return DeviceFilterMatchSimple(f, path, path_len, getfn_bytes, getfn_offsets,
-                                 crystal_slot, ray_dir, ray_crystal_config_id);
+  return DeviceFilterMatchSimple(f, path, path_len, poly_fn, poly_off,
+                                 ray_dir, ray_crystal_config_id);
 }
 
 // Check = Match XOR (action == filter_out). Same algebra as
@@ -323,14 +320,13 @@ static inline bool DeviceFilterCheck(device const DeviceFilterDesc& f,
                                      device const DeviceFilterDesc* complex_sub_desc_buf,
                                      device const uchar* and_term_counts_buf,
                                      thread const uchar* path, uint path_len,
-                                     device const uchar* getfn_bytes,
-                                     device const uint*  getfn_offsets,
-                                     uint  crystal_slot,
+                                     device const uchar* poly_fn,
+                                     uint  poly_off,
                                      thread const float* ray_dir,
                                      uint  ray_crystal_config_id) {
   bool m = DeviceFilterMatch(f, complex_sub_desc_buf, and_term_counts_buf,
-                             path, path_len, getfn_bytes, getfn_offsets,
-                             crystal_slot, ray_dir, ray_crystal_config_id);
+                             path, path_len, poly_fn, poly_off,
+                             ray_dir, ray_crystal_config_id);
   return (f.action == 0u) ? m : !m;
 }
 
@@ -356,9 +352,8 @@ static inline uint DeviceFilterSummandMask(device const DeviceFilterDesc& f,
                                            device const DeviceFilterDesc* complex_sub_desc_buf,
                                            device const uchar* and_term_counts_buf,
                                            thread const uchar* path, uint path_len,
-                                           device const uchar* getfn_bytes,
-                                           device const uint*  getfn_offsets,
-                                           uint  crystal_slot,
+                                           device const uchar* poly_fn,
+                                           uint  poly_off,
                                            thread const float* ray_dir,
                                            uint  ray_crystal_config_id,
                                            thread bool* out_matched) {
@@ -373,8 +368,8 @@ static inline uint DeviceFilterSummandMask(device const DeviceFilterDesc& f,
       bool and_ok = true;
       for (uint and_j = 0u; and_j < and_n; and_j++) {
         if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx],
-                                     path, path_len, getfn_bytes, getfn_offsets,
-                                     crystal_slot, ray_dir, ray_crystal_config_id)) {
+                                     path, path_len, poly_fn, poly_off,
+                                     ray_dir, ray_crystal_config_id)) {
           and_ok = false;
           sub_idx += (and_n - and_j);  // skip rest of this AND-clause
           break;
@@ -390,8 +385,8 @@ static inline uint DeviceFilterSummandMask(device const DeviceFilterDesc& f,
     *out_matched = true;   // None passes but contributes 0 summands
     return 0u;
   }
-  bool m = DeviceFilterMatchSimple(f, path, path_len, getfn_bytes, getfn_offsets,
-                                   crystal_slot, ray_dir, ray_crystal_config_id);
+  bool m = DeviceFilterMatchSimple(f, path, path_len, poly_fn, poly_off,
+                                   ray_dir, ray_crystal_config_id);
   *out_matched = m;
   return m ? 1u : 0u;
 }
@@ -579,12 +574,16 @@ kernel void trace_layer_kernel(
     // Device-side emit gate state. The ms_mode==1 path calls DeviceFilterCheck
     // and draws a PCG prob to decide continuation vs mid-exit on-device.
     //   23 : filter desc array, indexed by ms_layer_idx * filter_desc_max_ci + ci
-    //   24 : per-slot prefix-sum offsets into gate_getfn_bytes
-    //   25 : flat GetFn(poly_idx) byte stream
+    //   25 : per-instance GetFn table `gate_poly_fn`, one uchar per ABSOLUTE
+    //        pool polygon (parallel to poly_n/poly_d at buffer 4/5). Indexed by
+    //        the ray's own shape_poly_off + LOCAL path index — see
+    //        ApplyGetFn_dev. (Buffer 24, the former per-(layer,ci)
+    //        prototype prefix-sum table, is retired: the shared-prototype getfn
+    //        table mis-mapped degenerate pool instances under strong shape
+    //        randomization.)
     //   26 : Complex filter sub-spec flat buffer
     device const DeviceFilterDesc* gate_filter_desc    [[buffer(23)]],
-    device const uint*             gate_getfn_offsets  [[buffer(24)]],
-    device const uchar*            gate_getfn_bytes    [[buffer(25)]],
+    device const uchar*            gate_poly_fn        [[buffer(25)]],
     device const DeviceFilterDesc* gate_sub_desc_buf   [[buffer(26)]],
     // scrum-268.8 (DR-3): cont_wl_idx propagates the photon's lifetime
     // wavelength tag into the continuation ring for the next layer.
@@ -802,24 +801,17 @@ kernel void trace_layer_kernel(
           for (uint k = 0u; k < gate_len; k++) { path_local[k] = uchar(path[k]); }
           uint gate_slot = prm.ms_layer_idx * prm.filter_desc_max_ci + prm.crystal_id;
           float ray_dir_w[3] = { wcx, wcy, wcz };
-          // 7th argument INTENTIONALLY passes `gate_slot` (NOT prm.crystal_id
-          // as in plan §4 Step 5 pseudo-code). `DeviceFilterCheck` forwards it
-          // to `DeviceFilterMatchRaypath` where it indexes
-          // `gate_getfn_offsets[slot..slot+1]` to locate the per-orbit GetFn
-          // byte stream. `EnsureFilterBuffers` lays out offsets keyed by
-          // `slot = mi * max_ci + ci` (= `gate_slot`), so passing
-          // `prm.crystal_id` would point at layer-0's orbit table for every
-          // layer and silently mis-match from ms_layer_idx ≥ 1. The plan
-          // pseudo-code conflated "which crystal" with "where in the slot
-          // layout" — gate_slot is the correct slot identity here. (See
-          // progress.md DECISION "DeviceFilterCheck 第 7 参数=gate_slot 非
-          // prm.crystal_id" for the full derivation; multi-MS filter parity
-          // proves this is the working form. Do NOT "fix" back to crystal_id.)
+          // `gate_slot = ms_layer_idx * filter_desc_max_ci + crystal_id` selects
+          // this dispatch's filter DESCRIPTOR (gate_filter_desc[gate_slot]) —
+          // keyed by (layer, ci) so ms_layer_idx ≥ 1 does not alias layer-0's
+          // descriptor. The GetFn REMAP, by contrast, is now per-INSTANCE:
+          // DeviceFilterCheck takes gate_poly_fn + this ray's shape_poly_off and
+          // indexes gate_poly_fn[shape_poly_off + path_local[i]].
           bool filter_pass = DeviceFilterCheck(
               gate_filter_desc[gate_slot], gate_sub_desc_buf, gate_and_term_counts,
               path_local, gate_len,
-              gate_getfn_bytes, gate_getfn_offsets,
-              gate_slot, ray_dir_w, prm.crystal_config_id);
+              gate_poly_fn, shape_poly_off,
+              ray_dir_w, prm.crystal_config_id);
           if (filter_pass) {
             // task-358.3: Fork-C physical-bits produce branch removed. `this_mask`
             // now starts from the carried mask and is OR-accumulated by ONLY the
@@ -845,8 +837,8 @@ kernel void trace_layer_kernel(
                 uint c_smask = DeviceFilterSummandMask(
                     gate_filter_desc[prm.color_desc_offset + color_slot_idx],
                     gate_sub_desc_buf, gate_and_term_counts,
-                    path_local, gate_len, gate_getfn_bytes, gate_getfn_offsets,
-                    gate_slot, ray_dir_w, prm.crystal_config_id, &matched_col);
+                    path_local, gate_len, gate_poly_fn, shape_poly_off,
+                    ray_dir_w, prm.crystal_config_id, &matched_col);
                 for (uint k = 0u; k < kDevComponentStride; k++) {
                   if ((c_smask & (1u << k)) != 0u) {
                     uchar bit = gate_component_bits[
@@ -970,8 +962,8 @@ kernel void trace_layer_kernel(
           bool filter_pass_f = DeviceFilterCheck(
               gate_filter_desc[gate_slot_f], gate_sub_desc_buf, gate_and_term_counts,
               path_local_f, gate_len_f,
-              gate_getfn_bytes, gate_getfn_offsets,
-              gate_slot_f, ray_dir_w_f, prm.crystal_config_id);
+              gate_poly_fn, shape_poly_off,
+              ray_dir_w_f, prm.crystal_config_id);
           // Final-layer prob draw — reuse the persistent gate_stream hoisted
           // above the hit loop (same one the ms_mode==1 branch consumes; only
           // one branch runs per dispatch because ms_mode is a dispatch-level
@@ -996,8 +988,8 @@ kernel void trace_layer_kernel(
                 uint c_smask_f = DeviceFilterSummandMask(
                     gate_filter_desc[prm.color_desc_offset + color_slot_idx_f],
                     gate_sub_desc_buf, gate_and_term_counts,
-                    path_local_f, gate_len_f, gate_getfn_bytes, gate_getfn_offsets,
-                    gate_slot_f, ray_dir_w_f, prm.crystal_config_id, &matched_col_f);
+                    path_local_f, gate_len_f, gate_poly_fn, shape_poly_off,
+                    ray_dir_w_f, prm.crystal_config_id, &matched_col_f);
                 for (uint k = 0u; k < kDevComponentStride; k++) {
                   if ((c_smask_f & (1u << k)) != 0u) {
                     uchar bit = gate_component_bits[

--- a/src/core/shared/filter_shared.h
+++ b/src/core/shared/filter_shared.h
@@ -133,15 +133,18 @@ LM_FN void ReduceBuffer_dev(uint8_t* data, uint32_t size, uint8_t symmetry, int3
 
 // --- ApplyGetFn (remap poly-index path → face-number space) -----------------
 //
-// `getfn_offsets[crystal_slot]` is the byte-start of this crystal's stripe in
-// the flat `getfn_bytes` array; for poly-index `p`, the face-number is
-// `getfn_bytes[base + p]`. The caller-owned `out` buffer must hold at least
-// `len` bytes. Trusts `path[k] < stripe_len` (kernel/test inputs control this).
-LM_FN void ApplyGetFn_dev(const uint8_t* path, uint32_t len, const uint8_t* getfn_bytes, const uint32_t* getfn_offsets,
-                          uint32_t crystal_slot, uint8_t* out) {
-  uint32_t base = getfn_offsets[crystal_slot];
+// `poly_fn` is the PER-INSTANCE GetFn byte table (one uchar per absolute pool
+// polygon; built from each pool crystal's own GetFn), and `poly_off` is the
+// start of the ray's own polygon slice, so `poly_fn[poly_off + path[i]]` is the
+// absolute-indexed lookup for this ray's LOCAL poly-index path. This replaces
+// the former per-(layer,ci) prototype table (getfn_bytes/getfn_offsets), whose
+// "any sampled instance suffices / topology stable" invariant is false under
+// strong shape randomization (degenerate face_distance draws drop lateral faces
+// per instance). The caller-owned `out` buffer must hold at least `len` bytes.
+// Trusts `path[k] < this instance's poly_cnt` (kernel/test inputs control this).
+LM_FN void ApplyGetFn_dev(const uint8_t* path, uint32_t len, const uint8_t* poly_fn, uint32_t poly_off, uint8_t* out) {
   for (uint32_t i = 0; i < len; ++i) {
-    out[i] = getfn_bytes[base + path[i]];
+    out[i] = poly_fn[poly_off + path[i]];
   }
 }
 
@@ -151,12 +154,12 @@ LM_FN void ApplyGetFn_dev(const uint8_t* path, uint32_t len, const uint8_t* getf
 // action_ at the end. Mirrors filter_spec.hpp:42-45.
 
 LM_FN bool DeviceFilterMatchRaypath(const DeviceFilterDesc& f, const uint8_t* path, uint32_t path_len,
-                                    const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot) {
+                                    const uint8_t* poly_fn, uint32_t poly_off) {
   if (path_len != f.canonical_len) {
     return false;
   }
   uint8_t buf[kDevRecCap];
-  ApplyGetFn_dev(path, path_len, getfn_bytes, getfn_offsets, crystal_slot, buf);
+  ApplyGetFn_dev(path, path_len, poly_fn, poly_off, buf);
   if (f.fn_period < 0 || f.symmetry == 0u /* kSymNone */) {
     for (uint32_t i = 0; i < path_len; ++i) {
       if (buf[i] != f.canonical_bytes[i]) {
@@ -175,8 +178,7 @@ LM_FN bool DeviceFilterMatchRaypath(const DeviceFilterDesc& f, const uint8_t* pa
 }
 
 LM_FN bool DeviceFilterMatchEntryExit(const DeviceFilterDesc& f, const uint8_t* path, uint32_t path_len,
-                                      const uint8_t* getfn_bytes, const uint32_t* getfn_offsets,
-                                      uint32_t crystal_slot) {
+                                      const uint8_t* poly_fn, uint32_t poly_off) {
   if (path_len == 0u) {
     return false;
   }
@@ -190,13 +192,12 @@ LM_FN bool DeviceFilterMatchEntryExit(const DeviceFilterDesc& f, const uint8_t* 
     return true;
   }
   uint8_t ee[2];
-  uint32_t base = getfn_offsets[crystal_slot];
   uint32_t ee_len = 0u;
   if (f.has_entry) {
-    ee[ee_len++] = getfn_bytes[base + path[0]];
+    ee[ee_len++] = poly_fn[poly_off + path[0]];
   }
   if (f.has_exit) {
-    ee[ee_len++] = getfn_bytes[base + path[path_len - 1u]];
+    ee[ee_len++] = poly_fn[poly_off + path[path_len - 1u]];
   }
   if (f.fn_period < 0 || f.symmetry == 0u /* kSymNone */) {
     for (uint32_t i = 0; i < ee_len; ++i) {
@@ -235,16 +236,16 @@ LM_FN bool DeviceFilterMatchCrystal(const DeviceFilterDesc& f, uint32_t ray_crys
 // each sub-spec; including Complex here would form a static cycle (mirrors
 // MSL discipline at lumice_trace.metal:213-218).
 LM_FN bool DeviceFilterMatchSimple(const DeviceFilterDesc& f, const uint8_t* path, uint32_t path_len,
-                                   const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
-                                   const float* ray_dir, uint32_t ray_crystal_config_id) {
+                                   const uint8_t* poly_fn, uint32_t poly_off, const float* ray_dir,
+                                   uint32_t ray_crystal_config_id) {
   if (f.type == kDeviceFilterTypeNone) {
     return true;
   }
   if (f.type == kDeviceFilterTypeRaypath) {
-    return DeviceFilterMatchRaypath(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot);
+    return DeviceFilterMatchRaypath(f, path, path_len, poly_fn, poly_off);
   }
   if (f.type == kDeviceFilterTypeEntryExit) {
-    return DeviceFilterMatchEntryExit(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot);
+    return DeviceFilterMatchEntryExit(f, path, path_len, poly_fn, poly_off);
   }
   if (f.type == kDeviceFilterTypeDirection) {
     return DeviceFilterMatchDirection(f, ray_dir);
@@ -261,8 +262,8 @@ LM_FN bool DeviceFilterMatchSimple(const DeviceFilterDesc& f, const uint8_t* pat
 // deferred-construction Complex filters).
 LM_FN bool DeviceFilterMatchComplex(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
                                     const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
-                                    const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
-                                    const float* ray_dir, uint32_t ray_crystal_config_id) {
+                                    const uint8_t* poly_fn, uint32_t poly_off, const float* ray_dir,
+                                    uint32_t ray_crystal_config_id) {
   if (f.or_clause_count == 0u) {
     return false;
   }
@@ -271,8 +272,8 @@ LM_FN bool DeviceFilterMatchComplex(const DeviceFilterDesc& f, const DeviceFilte
     uint32_t and_n = static_cast<uint32_t>(and_term_counts_buf[f.and_terms_start + or_i]);
     bool and_ok = true;
     for (uint32_t and_j = 0; and_j < and_n; ++and_j) {
-      if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, getfn_bytes, getfn_offsets,
-                                   crystal_slot, ray_dir, ray_crystal_config_id)) {
+      if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, poly_fn, poly_off, ray_dir,
+                                   ray_crystal_config_id)) {
         and_ok = false;
         // Skip remaining sub-descs in this AND-clause so sub_idx lands at the
         // next OR-clause start (matches MSL short-circuit at
@@ -293,24 +294,23 @@ LM_FN bool DeviceFilterMatchComplex(const DeviceFilterDesc& f, const DeviceFilte
 // DeviceFilterMatchSimple. Static call graph stays acyclic.
 LM_FN bool DeviceFilterMatch(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
                              const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
-                             const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
-                             const float* ray_dir, uint32_t ray_crystal_config_id) {
+                             const uint8_t* poly_fn, uint32_t poly_off, const float* ray_dir,
+                             uint32_t ray_crystal_config_id) {
   if (f.type == kDeviceFilterTypeComplex) {
-    return DeviceFilterMatchComplex(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, getfn_bytes,
-                                    getfn_offsets, crystal_slot, ray_dir, ray_crystal_config_id);
+    return DeviceFilterMatchComplex(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, poly_fn, poly_off,
+                                    ray_dir, ray_crystal_config_id);
   }
-  return DeviceFilterMatchSimple(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot, ray_dir,
-                                 ray_crystal_config_id);
+  return DeviceFilterMatchSimple(f, path, path_len, poly_fn, poly_off, ray_dir, ray_crystal_config_id);
 }
 
 // Check = Match XOR (action == filter_out). Same algebra as
 // filter_spec.hpp:42-45.
 LM_FN bool DeviceFilterCheck(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
                              const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
-                             const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
-                             const float* ray_dir, uint32_t ray_crystal_config_id) {
-  bool m = DeviceFilterMatch(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, getfn_bytes, getfn_offsets,
-                             crystal_slot, ray_dir, ray_crystal_config_id);
+                             const uint8_t* poly_fn, uint32_t poly_off, const float* ray_dir,
+                             uint32_t ray_crystal_config_id) {
+  bool m = DeviceFilterMatch(f, complex_sub_desc_buf, and_term_counts_buf, path, path_len, poly_fn, poly_off, ray_dir,
+                             ray_crystal_config_id);
   return (f.action == 0u) ? m : !m;
 }
 
@@ -335,8 +335,8 @@ LM_FN bool DeviceFilterCheck(const DeviceFilterDesc& f, const DeviceFilterDesc* 
 // or_clause_count upper bound); the component-bit table uses the same stride.
 LM_FN uint32_t DeviceFilterSummandMask(const DeviceFilterDesc& f, const DeviceFilterDesc* complex_sub_desc_buf,
                                        const uint8_t* and_term_counts_buf, const uint8_t* path, uint32_t path_len,
-                                       const uint8_t* getfn_bytes, const uint32_t* getfn_offsets, uint32_t crystal_slot,
-                                       const float* ray_dir, uint32_t ray_crystal_config_id, bool* out_matched) {
+                                       const uint8_t* poly_fn, uint32_t poly_off, const float* ray_dir,
+                                       uint32_t ray_crystal_config_id, bool* out_matched) {
   if (f.type == kDeviceFilterTypeComplex) {
     uint32_t mask = 0u;
     uint32_t sub_idx = f.sub_desc_start;
@@ -351,8 +351,8 @@ LM_FN uint32_t DeviceFilterSummandMask(const DeviceFilterDesc& f, const DeviceFi
       uint32_t and_n = static_cast<uint32_t>(and_term_counts_buf[f.and_terms_start + or_i]);
       bool and_ok = true;
       for (uint32_t and_j = 0u; and_j < and_n; ++and_j) {
-        if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, getfn_bytes, getfn_offsets,
-                                     crystal_slot, ray_dir, ray_crystal_config_id)) {
+        if (!DeviceFilterMatchSimple(complex_sub_desc_buf[sub_idx], path, path_len, poly_fn, poly_off, ray_dir,
+                                     ray_crystal_config_id)) {
           and_ok = false;
           sub_idx += (and_n - and_j);  // skip rest of this AND-clause
           break;
@@ -370,8 +370,7 @@ LM_FN uint32_t DeviceFilterSummandMask(const DeviceFilterDesc& f, const DeviceFi
     *out_matched = true;  // None passes but contributes 0 summands
     return 0u;
   }
-  bool m = DeviceFilterMatchSimple(f, path, path_len, getfn_bytes, getfn_offsets, crystal_slot, ray_dir,
-                                   ray_crystal_config_id);
+  bool m = DeviceFilterMatchSimple(f, path, path_len, poly_fn, poly_off, ray_dir, ray_crystal_config_id);
   *out_matched = m;
   return m ? 1u : 0u;
 }

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -245,7 +245,17 @@ void RenderConsumer::Consume(const SimData& data) {
 
   // Copy pre-filtered outgoing rays into contiguous buffers (Design A:
   // simulator-side filter has already dropped non-matching rays).
-  assert(!data.outgoing_w_.empty() || data.rays_.Empty());
+  //
+  // The original assertion here checked "rays_ non-empty => outgoing_w_
+  // non-empty", but that property is NOT something Design A ever promises: the
+  // simulator-side filter acts as an emit-gate, so an entire Consume() batch
+  // having every candidate ray rejected (outgoing_* empty while rays_ is
+  // non-empty) is a legitimate tail event, not a malformed state — normal
+  // per-batch pass rates are already well under 1% (see
+  // doc/filter-architecture.md §4 "Empty-batch contract"). What Design A DOES
+  // promise is the outgoing_d_/outgoing_w_ parallel-array sizing invariant
+  // documented in sim_data.hpp: three direction floats per weight.
+  assert(data.outgoing_d_.size() == 3 * data.outgoing_w_.size());
   size_t filtered_ray_num = outgoing_count;
   if (!data.outgoing_d_.empty()) {
     std::memcpy(d_buf_.get(), data.outgoing_d_.data(), filtered_ray_num * 3 * sizeof(float));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/server/test_stats_consumer.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_ray_num_semantics.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_render_consumer_component_lanes.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/server/test_render_consumer_empty_batch.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_component_compositor.cpp"
   # util/
   "${PROJ_TEST_DIR}/unit-correctness/util/test_color_space.cpp"

--- a/test/e2e/configs/degenerate_pipeline_gaussian_std020.json
+++ b/test/e2e/configs/degenerate_pipeline_gaussian_std020.json
@@ -1,0 +1,121 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2,
+        "face_distance": [
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.2
+          }
+        ]
+      },
+      "axis": {
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 0.8
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "entry_exit",
+      "entry": 3,
+      "exit": 5,
+      "action": "filter_in"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 550,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 400000,
+    "max_hits": 8,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 1,
+            "filter": 1
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360
+      },
+      "resolution": [
+        512,
+        256
+      ],
+      "visible": "full",
+      "ray_color": [
+        1,
+        1,
+        1
+      ],
+      "background_color": [
+        0,
+        0,
+        0
+      ]
+    }
+  ]
+}

--- a/test/e2e/configs/degenerate_pipeline_gaussian_std025.json
+++ b/test/e2e/configs/degenerate_pipeline_gaussian_std025.json
@@ -1,0 +1,121 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2,
+        "face_distance": [
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.25
+          }
+        ]
+      },
+      "axis": {
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 0.8
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "entry_exit",
+      "entry": 3,
+      "exit": 5,
+      "action": "filter_in"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 550,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 400000,
+    "max_hits": 8,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 1,
+            "filter": 1
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360
+      },
+      "resolution": [
+        512,
+        256
+      ],
+      "visible": "full",
+      "ray_color": [
+        1,
+        1,
+        1
+      ],
+      "background_color": [
+        0,
+        0,
+        0
+      ]
+    }
+  ]
+}

--- a/test/e2e/configs/degenerate_pipeline_gaussian_std040.json
+++ b/test/e2e/configs/degenerate_pipeline_gaussian_std040.json
@@ -1,0 +1,121 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.2,
+        "face_distance": [
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          },
+          {
+            "type": "gauss",
+            "mean": 1.0,
+            "std": 0.4
+          }
+        ]
+      },
+      "axis": {
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 0.8
+        }
+      }
+    }
+  ],
+  "filter": [
+    {
+      "id": 1,
+      "type": "entry_exit",
+      "entry": 3,
+      "exit": 5,
+      "action": "filter_in"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 550,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 400000,
+    "max_hits": 8,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 1,
+            "filter": 1
+          }
+        ]
+      }
+    ]
+  },
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360
+      },
+      "resolution": [
+        512,
+        256
+      ],
+      "visible": "full",
+      "ray_color": [
+        1,
+        1,
+        1
+      ],
+      "background_color": [
+        0,
+        0,
+        0
+      ]
+    }
+  ]
+}

--- a/test/e2e/configs/repro_empty_batch_assert.json
+++ b/test/e2e/configs/repro_empty_batch_assert.json
@@ -1,0 +1,15 @@
+{
+  "crystal": [{ "id": 1, "type": "prism",
+    "shape": { "height": 1.2, "face_distance": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0] },
+    "axis": { "azimuth": {"type":"uniform","mean":0.0,"std":360.0},
+              "roll": {"type":"uniform","mean":0.0,"std":360.0},
+              "zenith": {"type":"gauss","mean":90.0,"std":0.8} } }],
+  "filter": [{ "id": 1, "type": "entry_exit", "entry": 3, "exit": 5, "action": "filter_in" }],
+  "scene": { "light_source": { "type": "sun", "altitude": 20.0, "azimuth": 0, "diameter": 0.5,
+               "spectrum": [{"wavelength": 550, "weight": 1.0}] },
+    "ray_num": 400000, "max_hits": 8,
+    "scattering": [{ "prob": 0.0, "entries": [{"crystal": 1, "proportion": 1, "filter": 1}] }] },
+  "render": [{ "id": 1, "lens": { "type": "dual_fisheye_equal_area", "fov": 360 },
+               "resolution": [512, 256], "visible": "full",
+               "ray_color": [1,1,1], "background_color": [0,0,0] }]
+}

--- a/test/e2e/runner.py
+++ b/test/e2e/runner.py
@@ -25,17 +25,24 @@ def find_lumice_binary() -> Path:
 
     Raises FileNotFoundError with actionable message if not found.
     """
+    # Always return an ABSOLUTE path. LUMICE_BIN is frequently a relative path
+    # (CI's shared-lib E2E build does not install, so it points LUMICE_BIN at
+    # the build-tree binary `build/Release/bin/Lumice` — see ci.yml). A caller
+    # that runs the binary under a different cwd (e.g. subprocess(cwd=tmp_path)
+    # to isolate an image output) would otherwise resolve that relative path
+    # against the wrong directory and hit FileNotFoundError. resolve() makes the
+    # returned path cwd-independent.
     env_bin = os.environ.get("LUMICE_BIN")
     if env_bin:
         p = Path(env_bin)
         if p.is_file() and os.access(p, os.X_OK):
-            return p
+            return p.resolve()
         raise FileNotFoundError(f"LUMICE_BIN={env_bin} is not a valid executable")
 
     root = get_project_root()
     candidate = root / "build" / "cmake_install" / "Lumice"
     if candidate.is_file() and os.access(candidate, os.X_OK):
-        return candidate
+        return candidate.resolve()
 
     raise FileNotFoundError(
         f"Lumice binary not found at {candidate}. "

--- a/test/parity-cross-backend/backend/metal_filter_match_test_src.mm
+++ b/test/parity-cross-backend/backend/metal_filter_match_test_src.mm
@@ -26,8 +26,10 @@ struct FilterMatchTestParams {
 // Buffer layout (mirrors plan D6 binding contract — both this kernel and the
 // host harness must agree on indices):
 //   0  filter_desc_buf       : DeviceFilterDesc[n_filters]
-//   1  getfn_offsets_buf     : uint[n_crystals + 1]
-//   2  getfn_bytes_buf       : uchar[]
+//   1  (retired: the getfn_offsets prefix-sum table was dropped; the
+//       GetFn remap is now per-instance, indexed by the ray's poly_off)
+//   2  poly_fn_buf           : uchar[] per-instance GetFn table (single crystal
+//                              in this fixture → ray_cslot doubles as poly_off=0)
 //   3  ray_path_buf          : uchar[n * face_seq_cap]
 //   4  ray_path_len_buf      : uchar[n]
 //   5  ray_crystal_slot      : uint16[n]
@@ -46,8 +48,7 @@ struct FilterMatchTestParams {
 //                              KernelParams.and_term_counts_base_offset).
 kernel void filter_match_test_kernel(
     device const DeviceFilterDesc* filter_desc        [[buffer(0)]],
-    device const uint*             getfn_offsets      [[buffer(1)]],
-    device const uchar*            getfn_bytes        [[buffer(2)]],
+    device const uchar*            poly_fn            [[buffer(2)]],
     device const uchar*            ray_path           [[buffer(3)]],
     device const uchar*            ray_path_len       [[buffer(4)]],
     device const ushort*           ray_cslot          [[buffer(5)]],
@@ -74,11 +75,13 @@ kernel void filter_match_test_kernel(
   uint fi = ray_filter[tid];
   device const DeviceFilterDesc& f = filter_desc[fi];
   bool result;
+  // ray_cslot doubles as poly_off (0 for this single-crystal
+  // fixture, whose poly_fn stripe starts at absolute offset 0).
   if (prm.check_mode == 0u) {
-    result = DeviceFilterMatch(f, complex_sub_desc, and_term_counts, path_local, len, getfn_bytes, getfn_offsets,
+    result = DeviceFilterMatch(f, complex_sub_desc, and_term_counts, path_local, len, poly_fn,
                                (uint)ray_cslot[tid], dir_local, (uint)ray_cid[tid]);
   } else {
-    result = DeviceFilterCheck(f, complex_sub_desc, and_term_counts, path_local, len, getfn_bytes, getfn_offsets,
+    result = DeviceFilterCheck(f, complex_sub_desc, and_term_counts, path_local, len, poly_fn,
                                (uint)ray_cslot[tid], dir_local, (uint)ray_cid[tid]);
   }
   out_match[tid] = result ? 1u : 0u;

--- a/test/parity-cross-backend/backend/test_cuda_filter_parity.py
+++ b/test/parity-cross-backend/backend/test_cuda_filter_parity.py
@@ -191,8 +191,9 @@ def test_cuda_multi_ms_filter_image_parity_vs_legacy():
     Suspects on failure:
       - DeviceFilterDesc per-slot indexing wrong (gate_slot off by max_ci) →
         wrong filter applied at each layer → corr tanks.
-      - getfn_offsets prefix-sum wrong → ApplyGetFn_dev reads neighbour
-        stripes → predicate scrambles → both corr + energy fail.
+      - per-instance poly_fn indexing wrong (wrong poly_off / neighbour
+        instance's stripe) → ApplyGetFn_dev remaps to the wrong face-number
+        → predicate scrambles → both corr + energy fail.
       - mid-exit ms_layer_idx tag wrong → DrainExits routes a mid-exit through
         host filter and drops it → energy drops while corr stays plausible.
     """

--- a/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
+++ b/test/parity-cross-backend/backend/test_metal_filter_match_parity.mm
@@ -263,7 +263,7 @@ struct FilterMatchTestParams {
 // in are caller-owned MTLBuffers; the harness sets binding indices according
 // to the contract in `kFilterMatchTestKernelSrc`.
 size_t DispatchParity(MetalHarness& h,
-                      id<MTLBuffer> filter_desc, id<MTLBuffer> getfn_offsets, id<MTLBuffer> getfn_bytes,
+                      id<MTLBuffer> filter_desc, id<MTLBuffer> poly_fn,
                       id<MTLBuffer> ray_path, id<MTLBuffer> ray_path_len,
                       id<MTLBuffer> ray_cslot, id<MTLBuffer> ray_cid,
                       id<MTLBuffer> ray_dir, id<MTLBuffer> ray_filter,
@@ -277,8 +277,9 @@ size_t DispatchParity(MetalHarness& h,
     id<MTLComputeCommandEncoder> enc = [cb computeCommandEncoder];
     [enc setComputePipelineState:h.pso];
     [enc setBuffer:filter_desc      offset:0 atIndex:0];
-    [enc setBuffer:getfn_offsets    offset:0 atIndex:1];
-    [enc setBuffer:getfn_bytes      offset:0 atIndex:2];
+    // buffer(1) getfn_offsets retired; poly_fn is the per-instance
+    // GetFn table (single-crystal fixture → one stripe at offset 0).
+    [enc setBuffer:poly_fn          offset:0 atIndex:2];
     [enc setBuffer:ray_path         offset:0 atIndex:3];
     [enc setBuffer:ray_path_len     offset:0 atIndex:4];
     [enc setBuffer:ray_cslot        offset:0 atIndex:5];
@@ -691,8 +692,9 @@ void RunSweep(MetalHarness& h, const ParityFixture& fx, std::mt19937& rng,
 
   // Upload device-side state.
   id<MTLBuffer> filter_desc_buf = MakeShared(h.device, fx.descs.data(), fx.descs.size() * sizeof(DeviceFilterDesc));
-  uint32_t getfn_offsets[2] = { 0, static_cast<uint32_t>(fx.getfn.size()) };
-  id<MTLBuffer> offsets_buf = MakeShared(h.device, getfn_offsets, sizeof(getfn_offsets));
+  // fx.getfn is the single-crystal per-instance GetFn stripe (== the
+  // production poly_fn table for one shape at offset 0); the retired getfn_offsets
+  // prefix-sum table is no longer built or bound.
   id<MTLBuffer> getfn_buf = MakeShared(h.device, fx.getfn.data(), fx.getfn.size());
   // Complex sub-desc buffer — 1-byte dummy when empty so the buffer(11) bind
   // is always valid (Metal disallows nil); kernel reads gated by Complex
@@ -711,7 +713,7 @@ void RunSweep(MetalHarness& h, const ParityFixture& fx, std::mt19937& rng,
   prm.n = static_cast<uint32_t>(n_rays);
   prm.face_seq_cap = static_cast<uint32_t>(fx.face_seq_cap);
   prm.check_mode = check_mode;
-  DispatchParity(h, filter_desc_buf, offsets_buf, getfn_buf,
+  DispatchParity(h, filter_desc_buf, getfn_buf,
                  rb.path, rb.path_len, rb.cslot, rb.cid, rb.dir, rb.filter,
                  rb.out_match, prm, complex_sub_buf, and_term_buf);
 

--- a/test/parity-cross-backend/backend/test_metal_filter_strong_randomization.py
+++ b/test/parity-cross-backend/backend/test_metal_filter_strong_randomization.py
@@ -1,0 +1,122 @@
+"""Regression sentinel: entry_exit filter must not collapse on Metal under strong
+shape randomization.
+
+Guards the Metal per-instance GetFn-table fix. Before it, the Metal emit gate
+remapped each ray's LOCAL polygon path to canonical face-numbers through a
+single fixed-seed PROTOTYPE crystal's GetFn table, shared across the whole
+K-shape pool. Its implicit "topology stable / any sampled instance suffices"
+invariant is false under strong face_distance randomization: degenerate draws
+drop lateral faces per instance, so the prototype's local->canonical mapping
+mis-maps the actual traced instances. The `entry_exit 3->5` filtered output then
+collapsed to EXACTLY zero nonzero pixels on Metal at gauss std >= 0.30, while
+legacy CPU (which remaps on the live instance per record) stayed monotone. The
+fix uploads a per-instance poly_fn table indexed by the ray's own polygon offset.
+
+This test replays the ORIGINAL diagnosis scenario (the shared
+`degenerate_pipeline_gaussian_std0NN.json` configs, entry_exit 3->5, 400k rays)
+rather than a synthetic one, and pins two contracts across the std sweep:
+
+  1. Collapse signature: Metal filtered output is never zero at any std. This is
+     the crisp regression teeth -- the bug produced an exact 0.
+  2. Cross-backend magnitude: Metal's nonzero-pixel count stays same-magnitude as
+     legacy CPU. The residual gap (~3% at high std) is the K-shape pool
+     granularity difference -- CPU samples a fresh crystal per ray, the GPU pool
+     reuses each crystal across a batch -- not a filter-match defect; a generous
+     band tolerates it and CPU's per-run sampling noise while still tripping on a
+     re-collapse or gross regression.
+
+@pytest.mark.slow: uses the installed CLI binary (built by the shared-lib CI
+phase). Darwin-only (Metal).
+"""
+
+import os
+import platform
+import subprocess
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from test.e2e.runner import find_lumice_binary, get_project_root
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin", reason="Metal backend is only available on macOS"
+)
+
+_CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
+_TIMEOUT = 180
+
+# std sweep from the 397.1 diagnosis. std <= 0.25 agreed across backends before
+# the fix; std >= 0.30 is where Metal collapsed to 0. Keep the full sweep so the
+# test characterises the whole curve, not just the broken tail.
+_STD_TAGS = ["020", "025", "030", "040", "050"]
+
+# Cross-backend magnitude band. Measured post-fix: Metal is deterministic and
+# runs +0.3% (std=0) to +3.5% (std=0.4-0.5) above CPU's per-run mean, with CPU
+# carrying ~1% run-to-run sampling noise. 0.15 leaves comfortable margin over
+# that while a collapse (Metal 0 -> rel diff 1.0) or gross regression trips it.
+_MAGNITUDE_BAND = 0.15
+
+
+def _run_nonzero_pixels(config_path, backend, workdir):
+    """Run the CLI once for `config_path` on `backend` in `workdir` and return the
+    number of nonzero pixels in the produced filtered image (img_01.jpg).
+
+    backend: "cpu" (legacy, no env override) or "metal" (LUMICE_TRACE_BACKEND).
+    """
+    env = dict(os.environ)
+    if backend == "metal":
+        env["LUMICE_TRACE_BACKEND"] = "metal"
+    else:
+        env.pop("LUMICE_TRACE_BACKEND", None)  # legacy CPU is the unset default
+
+    binary = find_lumice_binary()
+    out_img = workdir / "img_01.jpg"
+    if out_img.exists():
+        out_img.unlink()
+    proc = subprocess.run(
+        [str(binary), "-f", str(config_path)],
+        cwd=str(workdir),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+    assert proc.returncode == 0, (
+        f"CLI ({backend}) exited {proc.returncode} for {config_path.name}\n"
+        f"stderr tail:\n{proc.stderr[-2000:]}"
+    )
+    assert out_img.exists(), (
+        f"CLI ({backend}) produced no img_01.jpg for {config_path.name}\n"
+        f"stdout tail:\n{proc.stdout[-1000:]}"
+    )
+    with Image.open(out_img) as img:
+        arr = np.asarray(img.convert("L"))
+    return int(np.count_nonzero(arr))
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("std_tag", _STD_TAGS)
+def test_metal_entry_exit_filter_no_collapse(std_tag, tmp_path):
+    config = _CONFIGS_DIR / f"degenerate_pipeline_gaussian_std{std_tag}.json"
+    assert config.exists(), f"missing fixture {config}"
+
+    cpu_nnz = _run_nonzero_pixels(config, "cpu", tmp_path)
+    metal_nnz = _run_nonzero_pixels(config, "metal", tmp_path)
+
+    std = int(std_tag) / 100.0
+    # CPU sanity: the entry_exit 3->5 filter always leaves a substantial pattern.
+    assert cpu_nnz > 1000, f"std={std}: CPU filtered output unexpectedly sparse ({cpu_nnz})"
+
+    # (1) Collapse signature: the bug produced EXACTLY 0 on Metal at std >= 0.30.
+    assert metal_nnz > 0, (
+        f"std={std}: Metal filtered output collapsed to 0 nonzero pixels while CPU "
+        f"has {cpu_nnz} -- the per-instance GetFn-table regression has returned."
+    )
+
+    # (2) Cross-backend magnitude: same order, within the K-granularity + noise band.
+    rel = abs(metal_nnz - cpu_nnz) / cpu_nnz
+    assert rel <= _MAGNITUDE_BAND, (
+        f"std={std}: Metal nnz {metal_nnz} vs CPU nnz {cpu_nnz} differ by "
+        f"{rel:.1%} > {_MAGNITUDE_BAND:.0%} band -- filter match no longer tracks CPU."
+    )

--- a/test/unit-correctness/core/test_crystal.cpp
+++ b/test/unit-correctness/core/test_crystal.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 #include <limits>
@@ -11,11 +12,13 @@
 #include <utility>
 
 #include "config/config_manager.hpp"
+#include "config/crystal_config.hpp"
 #include "core/crystal.hpp"
 #include "core/geo3d.hpp"
 #include "core/geo3d_closedform.hpp"
 #include "core/math.hpp"
 #include "core/simulator.hpp"
+#include "core/trace_ops.hpp"
 #include "util/logger.hpp"
 
 extern std::string config_file_name;
@@ -1405,6 +1408,172 @@ TEST(CrystalGeomStep1, CapacityConstantsBoundPyramidWorstCase) {
   // (see the kCrystalGeomMaxVtxPerFace comment in crystal.hpp).
   EXPECT_GE(kCrystalGeomMaxVtxPerFace, kClosedFormPyramidMaxFaceVtx);
   EXPECT_GE(kCrystalGeomMaxVtxPerFace, 7);
+}
+
+// ---------------------------------------------------------------------------
+// Empty-Crystal state contract.
+//
+// Two producers can hand downstream code a Crystal that bounds no volume:
+//   (a) `Crystal c;`             — the public default constructor;
+//   (b) `return Crystal();`      — the closed-form validity gate's reject
+//                                  branch in MakePrismClosedForm /
+//                                  MakePyramidClosedForm (crystal.cpp), which
+//                                  IS reachable from production input because
+//                                  CrystalMaker feeds it randomized h /
+//                                  face_distance draws.
+// The tests below pin, at run time, that (a) and (b) produce a byte-for-byte
+// identical state, and that that state is the "nothing populated" sentinel the
+// rest of the codebase tests for (`face_cnt == 0` / `PolygonFaceCount() == 0`).
+// Consumers therefore need exactly one defence, not two; and any future change
+// that makes the reject branch return a *partially* populated Crystal (e.g. a
+// plane set without corners) breaks these tests rather than surfacing as a
+// downstream out-of-bounds read.
+// ---------------------------------------------------------------------------
+
+// Assert that `c` is in the canonical empty state, field by field. Kept as a
+// helper so both producers are checked against the same predicate.
+void ExpectCanonicalEmptyCrystal(const Crystal& c, const char* who) {
+  const CrystalGeom& g = c.CfGeom();
+  EXPECT_EQ(g.face_cnt, 0) << who;
+  for (int slot = 0; slot < kCrystalGeomMaxFaces; slot++) {
+    EXPECT_FALSE(g.face_present[slot]) << who << " slot=" << slot;
+    EXPECT_EQ(g.face_vtx_cnt[slot], 0) << who << " slot=" << slot;
+    EXPECT_EQ(g.face_number[slot], 0) << who << " slot=" << slot;
+  }
+  for (int i = 0; i < kCrystalGeomMaxFaces * 4; i++) {
+    EXPECT_EQ(g.plane_coef[i], 0.0f) << who << " plane_coef[" << i << "]";
+  }
+  for (int i = 0; i < kCrystalGeomMaxFaces * 3; i++) {
+    EXPECT_EQ(g.face_normal[i], 0.0f) << who << " face_normal[" << i << "]";
+  }
+  for (int i = 0; i < kCrystalGeomMaxFaces * kCrystalGeomMaxVtxPerFace * 3; i++) {
+    EXPECT_EQ(g.face_vtx[i], 0.0f) << who << " face_vtx[" << i << "]";
+  }
+  // Polygon-face view derived from cf_geom_ — PopulateFromCfGeom never ran.
+  EXPECT_EQ(c.PolygonFaceCount(), 0u) << who;
+  EXPECT_EQ(c.GetPolygonFaceNormal(), nullptr) << who;
+  EXPECT_EQ(c.GetPolygonFaceDist(), nullptr) << who;
+  // Symmetry reduction is inapplicable (the factories set fn_period_ = 6 only
+  // on the success path), and GetFn must reject every index rather than read
+  // out of a null table.
+  EXPECT_EQ(c.FnPeriod(), -1) << who;
+  EXPECT_EQ(c.GetFn(0), kInvalidId) << who;
+  EXPECT_EQ(c.config_id_, kInvalidId) << who;
+  // On-demand triangulation of an empty geometry must yield an empty mesh, not
+  // a degenerate one — this is what the GPU device-gen tri buffers size from.
+  EXPECT_EQ(detail::CountEntrySubTris(g), 0u) << who;
+  const auto built = detail::BuildMeshFromCfGeom(g);
+  EXPECT_EQ(built.mesh.GetVtxCnt(), 0u) << who;
+  EXPECT_EQ(built.mesh.GetTriangleCnt(), 0u) << who;
+}
+
+// Byte-for-byte comparison of the flat POD geometry, so "equivalent" means
+// equivalent and not just "both report face_cnt == 0".
+bool CfGeomBytesEqual(const CrystalGeom& a, const CrystalGeom& b) {
+  return std::memcmp(&a, &b, sizeof(CrystalGeom)) == 0;
+}
+
+TEST(EmptyCrystalContract, DefaultConstructedStateIsPinnedFieldByField) {
+  Crystal c;
+  ExpectCanonicalEmptyCrystal(c, "default-constructed");
+
+  // Copy / move must carry the empty state through unchanged — these are the
+  // operations `std::vector<Crystal>` performs on reallocation, and the ones
+  // the backends use to stage a resolved crystal.
+  Crystal copied = c;  // NOLINT(performance-unnecessary-copy-initialization)
+  ExpectCanonicalEmptyCrystal(copied, "copy-constructed-from-empty");
+  Crystal moved = std::move(copied);
+  ExpectCanonicalEmptyCrystal(moved, "move-constructed-from-empty");
+
+  // Assigning an empty over a populated instance must fully clear it (a stale
+  // poly_face_data_ left behind would be read with poly_face_cnt_ == 0 above,
+  // but the pointer accessors are part of the pinned contract).
+  Crystal overwritten = Crystal::CreatePrism(1.0f);
+  ASSERT_GT(overwritten.PolygonFaceCount(), 0u) << "fixture precondition: prism must be populated";
+  overwritten = c;
+  ExpectCanonicalEmptyCrystal(overwritten, "copy-assigned-empty-over-populated");
+
+  Crystal overwritten2 = Crystal::CreatePrism(1.0f);
+  ASSERT_GT(overwritten2.PolygonFaceCount(), 0u) << "fixture precondition: prism must be populated";
+  Crystal donor;
+  overwritten2 = std::move(donor);
+  ExpectCanonicalEmptyCrystal(overwritten2, "move-assigned-empty-over-populated");
+}
+
+TEST(EmptyCrystalContract, DegenerateFactoryRejectEqualsDefaultConstruction) {
+  const Crystal reference;  // canonical empty state
+
+  // Prism reject branch: h <= kFloatEps fails IsValidClosedFormPrism, taking
+  // the silent `return Crystal();` path in MakePrismClosedForm.
+  Crystal prism_reject = Crystal::CreatePrism(0.0f);
+  ASSERT_EQ(prism_reject.CfGeom().face_cnt, 0)
+      << "fixture precondition: CreatePrism(0.0f) must hit the validity-gate reject branch; "
+      << "if this fires the gate changed and the rest of this test is vacuous";
+  ExpectCanonicalEmptyCrystal(prism_reject, "prism-validity-gate-reject");
+  EXPECT_TRUE(CfGeomBytesEqual(prism_reject.CfGeom(), reference.CfGeom()))
+      << "prism reject branch produced a cf_geom_ that differs bytewise from default construction";
+
+  // Prism reject branch reached through the *warning* arm instead (h > eps but
+  // the opposite-pair sums cannot bound a solid): all six distances negative.
+  {
+    float dist[6]{ -1, -1, -1, -1, -1, -1 };
+    Crystal prism_neg = Crystal::CreatePrism(1.2f, dist);
+    ASSERT_EQ(prism_neg.CfGeom().face_cnt, 0)
+        << "fixture precondition: all-negative face distances must fail the closed-form validity gate";
+    ExpectCanonicalEmptyCrystal(prism_neg, "prism-all-negative-dist-reject");
+    EXPECT_TRUE(CfGeomBytesEqual(prism_neg.CfGeom(), reference.CfGeom()));
+  }
+
+  // Pyramid reject branch: zero-volume input fails IsValidClosedFormPyramid
+  // (present face count < 4) and takes `return Crystal();` in
+  // MakePyramidClosedForm.
+  {
+    float dist[6]{ 0, 0, 0, 0, 0, 0 };
+    Crystal pyr_reject = Crystal::CreatePyramid(28.0f, 28.0f, 0.0f, 0.0f, 0.0f, dist);
+    ASSERT_EQ(pyr_reject.CfGeom().face_cnt, 0)
+        << "fixture precondition: zero-volume pyramid must hit the validity-gate reject branch";
+    ExpectCanonicalEmptyCrystal(pyr_reject, "pyramid-validity-gate-reject");
+    EXPECT_TRUE(CfGeomBytesEqual(pyr_reject.CfGeom(), reference.CfGeom()));
+  }
+}
+
+TEST(EmptyCrystalContract, MakeCrystalCanReturnTheEmptyStateFromRandomizedParams) {
+  // Reachability evidence for the empty state in *production* input terms: the
+  // parameters below are an ordinary randomized crystal config, not a
+  // hand-built empty Crystal. A wide face_distance spread drives some draws
+  // past the closed-form validity gate, so MakeCrystal — the single entry point
+  // every backend builds crystals through — hands back the same empty state the
+  // default constructor produces.
+  //
+  // Consumers must therefore treat "MakeCrystal returned an empty crystal" as a
+  // reachable input, not as an impossible one.
+  PrismCrystalParam param;
+  param.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.5f };
+  for (auto& d : param.d_) {
+    d = Distribution{ DistributionType::kGaussian, 1.0f, 0.8f };
+  }
+
+  RandomNumberGenerator rng(20260724u);
+  size_t empty_cnt = 0;
+  size_t populated_cnt = 0;
+  const Crystal reference;
+  for (int i = 0; i < 2000; i++) {
+    Crystal c = MakeCrystal(rng, CrystalParam{ param });
+    if (c.CfGeom().face_cnt == 0) {
+      empty_cnt++;
+      // Every empty crystal that reaches a consumer is the canonical state —
+      // there is no second, partially-populated flavour to defend against.
+      ASSERT_TRUE(CfGeomBytesEqual(c.CfGeom(), reference.CfGeom())) << "draw " << i;
+      ASSERT_EQ(c.PolygonFaceCount(), 0u) << "draw " << i;
+      ASSERT_EQ(c.FnPeriod(), -1) << "draw " << i;
+    } else {
+      populated_cnt++;
+    }
+  }
+  EXPECT_GT(empty_cnt, 0u) << "the randomized sweep produced no degenerate draw — the reachability claim "
+                           << "this test exists to pin is no longer exercised by these parameters";
+  EXPECT_GT(populated_cnt, 0u) << "the sweep produced only degenerate draws — parameters are unrealistic "
+                               << "and the test says nothing about production behaviour";
 }
 
 }  // namespace

--- a/test/unit-correctness/core/test_device_filter_check_host.cpp
+++ b/test/unit-correctness/core/test_device_filter_check_host.cpp
@@ -84,8 +84,9 @@ struct Fixture {
   Crystal crystal;
   AxisDistribution axis;
   std::vector<DeviceFilterDesc> descs;
+  // Per-instance GetFn table for the single fixture crystal (== poly_fn with
+  // poly_off 0). The former per-(layer,ci) prototype prefix-sum offsets are gone.
   std::vector<uint8_t> getfn;
-  uint32_t getfn_offsets[2] = { 0u, 0u };
   std::vector<DeviceFilterDesc> complex_subs;
   // task-device-flat-and-terms: parallel flat AND-term counts buffer,
   // indexed via each Complex parent's `and_terms_start`.
@@ -229,8 +230,6 @@ Fixture BuildFixture(bool d_applicable_axis) {
     fx.host_specs.push_back(FilterSpec::Create(cfg, fx.crystal, fx.axis));
   }
   fx.getfn = detail::BuildDeviceGetFnBytes(fx.crystal);
-  fx.getfn_offsets[0] = 0u;
-  fx.getfn_offsets[1] = static_cast<uint32_t>(fx.getfn.size());
   // Pad complex_subs with a dummy entry so the device-side ptr is always
   // valid (mirrors EnsureFilterBuffers' 1-element fallback for layouts with
   // no Complex filter at all — kept defensive here even though our fixture
@@ -309,8 +308,8 @@ bool HostCheck(const Fixture& fx, const Ray& r) {
 
 bool DeviceCheck(const Fixture& fx, const Ray& r) {
   return lm_filter::DeviceFilterCheck(fx.descs[r.filter_idx], fx.complex_subs.data(), fx.and_term_counts.data(),
-                                      r.raw_poly.data(), r.path_len, fx.getfn.data(), fx.getfn_offsets,
-                                      /*crystal_slot=*/0u, r.dir, static_cast<uint32_t>(r.crystal_config_id));
+                                      r.raw_poly.data(), r.path_len, fx.getfn.data(),
+                                      /*poly_off=*/0u, r.dir, static_cast<uint32_t>(r.crystal_config_id));
 }
 
 TEST(DeviceFilterCheckHost, RaypathEntryExitDirCrystalComplex_ParityWithFilterSpec) {

--- a/test/unit-correctness/scripts/test_check_new_refs.py
+++ b/test/unit-correctness/scripts/test_check_new_refs.py
@@ -1,11 +1,15 @@
 """Regression net for `scripts/check_new_refs.py`.
 
-Its sibling gate `scripts/check_policies.py` ships without tests, and that is
-fine: every one of its checks asks "is this symbol present in this file?", which
-is legible by reading. This one is a regex battery driving a unified-diff
-parser, and it is neither — five distinct defects were found on the same small
-surface in one day, one of them living *inside* the fix for another. Careful
-reading demonstrably does not converge here.
+Its sibling gate `scripts/check_policies.py` mostly ships without tests, and
+that is fine: most of its checks ask "is this symbol present in this file?",
+which is legible by reading. This one is a regex battery driving a
+unified-diff parser, and it is neither — five distinct defects were found on
+the same small surface in one day, one of them living *inside* the fix for
+another. Careful reading demonstrably does not converge here. (One check in
+`check_policies.py` shares that property —
+`check_no_default_constructed_crystal_slots` parses call-site arguments
+rather than matching a symbol, and has its own regression net,
+`test_check_policies_crystal_slots.py`, for the same reason.)
 
 What makes that worth a test file rather than more care: every defect failed
 *silently*. A broken parser does not crash, it attributes lines to a path that

--- a/test/unit-correctness/scripts/test_check_policies_crystal_slots.py
+++ b/test/unit-correctness/scripts/test_check_policies_crystal_slots.py
@@ -1,0 +1,162 @@
+"""Regression net for `check_no_default_constructed_crystal_slots` in
+`scripts/check_policies.py`.
+
+The rest of `check_policies.py` ships without tests on purpose (see the note
+in `test_check_new_refs.py`): most of its checks ask "is this symbol present
+in this file?", which is legible by reading. This one check is not — it
+parses call-site arguments (comma counting, paren depth, whitespace) to tell
+a hazardous single-argument `resize`/`assign`/count-ctor from a safe
+multi-argument or copy-ctor form, and across two rounds of code review that
+parsing logic produced four distinct silent defects on the same small
+surface: parameter-count-blind resize/assign, a copy-ctor false positive,
+a function-prototype false positive, and a nested-call comma miscount (in
+both directions — false negative for a single nested-call argument, false
+positive for a real two-argument iterator-range ctor whose first argument
+contains a nested call). Every one of those failed silently: the gate stayed
+green while quietly rejecting safe code or admitting unsafe code, which is
+exactly the failure this gate exists to prevent.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import check_policies  # noqa: E402
+
+
+@pytest.fixture
+def src_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(check_policies, "SRC", src)
+    return src
+
+
+def _violations(src_root: Path, body: str) -> list[check_policies.Violation]:
+    (src_root / "scratch.cpp").write_text(
+        f"#include <vector>\n#include \"crystal.hpp\"\n\n{body}\n", encoding="utf-8"
+    )
+    return check_policies.check_no_default_constructed_crystal_slots()
+
+
+# --- single-argument forms materialise default Crystals: must stay red -----
+
+
+def test_single_arg_resize_is_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.resize(4);\n"
+        "}\n",
+    )
+    assert len(out) == 1
+    assert out[0].rule == "no-default-constructed-crystal-slots"
+
+
+def test_single_arg_assign_is_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.assign(4);\n"
+        "}\n",
+    )
+    assert len(out) == 1
+
+
+def test_count_ctor_is_flagged(src_root: Path) -> None:
+    out = _violations(src_root, "std::vector<Crystal> v(4);\n")
+    assert len(out) == 1
+
+
+def test_nested_call_as_sole_resize_argument_is_flagged(src_root: Path) -> None:
+    """`resize(ComputeCount(w, h))` has one top-level argument even though a
+    naive first-`)` scan would see a comma inside it and wave it through."""
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.resize(ComputeCount(w, h));\n"
+        "}\n",
+    )
+    assert len(out) == 1
+
+
+# --- multi-argument / copy / range forms fill with real values: must stay green
+
+
+def test_two_arg_resize_is_not_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.resize(4, Crystal());\n"
+        "}\n",
+    )
+    assert out == []
+
+
+def test_two_arg_assign_is_not_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.assign(4, Crystal());\n"
+        "}\n",
+    )
+    assert out == []
+
+
+def test_copy_ctor_from_known_name_is_not_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "std::vector<Crystal> src_vec;\n"
+        "std::vector<Crystal> copy_ctor(src_vec);\n",
+    )
+    assert out == []
+
+
+def test_range_ctor_with_nested_calls_is_not_flagged(src_root: Path) -> None:
+    """`v(a.begin(), a.end())` is a real two-argument iterator-range ctor;
+    the first argument's own `)` must not be mistaken for the outer close."""
+    out = _violations(
+        src_root,
+        "std::vector<Crystal> src_vec;\n"
+        "std::vector<Crystal> ranged(src_vec.begin(), src_vec.end());\n",
+    )
+    assert out == []
+
+
+def test_function_prototype_is_not_flagged(src_root: Path) -> None:
+    """`std::vector<Crystal> Build(int n);` parses identically to a variable
+    count-ctor declaration at this text-matching depth; the `type name`
+    whitespace inside the parens is what distinguishes it."""
+    out = _violations(src_root, "std::vector<Crystal> Build(int n);\n")
+    assert out == []
+
+
+def test_no_arg_emplace_back_is_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.emplace_back();\n"
+        "}\n",
+    )
+    assert len(out) == 1
+
+
+def test_reserve_is_not_flagged(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "void F() {\n"
+        "  std::vector<Crystal> v;\n"
+        "  v.reserve(4);\n"
+        "}\n",
+    )
+    assert out == []

--- a/test/unit-correctness/server/test_render_consumer_empty_batch.cpp
+++ b/test/unit-correctness/server/test_render_consumer_empty_batch.cpp
@@ -1,0 +1,101 @@
+// Regression sentinel for the RenderConsumer::Consume empty-batch contract.
+//
+// Background: the assertion in RenderConsumer::Consume once read
+//   assert(!data.outgoing_w_.empty() || data.rays_.Empty());
+// which encodes "rays_ non-empty => outgoing_w_ non-empty". That property is
+// NOT something Design A promises: the simulator-side filter is an emit-gate, so
+// an entire Consume() batch having every candidate ray rejected (outgoing_*
+// empty while rays_ is non-empty) is a legitimate tail event, not a malformed
+// state. A low pass-rate filter tripped it in Debug builds (SIGABRT). The
+// assertion was rewritten to the real Design A invariant —
+// outgoing_d_.size() == 3 * outgoing_w_.size() (the parallel-array sizing
+// documented in sim_data.hpp). See doc/filter-architecture.md §4
+// "Empty-batch contract".
+//
+// Coverage:
+//   A. AllRaysFilteredOutDoesNotAbort — a non-empty rays_ with fully-empty
+//      outgoing_* must Consume() cleanly and leave snapshot_intensity_ at 0.
+//      Runs in every build type (does not depend on assert firing); this is the
+//      positive regression lock for the fix itself.
+//   B. MismatchedOutgoingSizesTripsAssert (Debug-only, #ifndef NDEBUG) — a
+//      deliberate outgoing_d_/outgoing_w_ size mismatch must still trip the new
+//      assertion, proving it is not a dead assert. Compiled out under NDEBUG
+//      where the assert is a no-op, so it never fires as a false "pass" in a
+//      Release CI run.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "config/color_class_table.hpp"
+#include "config/proj_config.hpp"
+#include "config/render_config.hpp"
+#include "config/sim_data.hpp"
+#include "server/render.hpp"
+
+namespace lumice {
+namespace {
+
+// Minimal render config: 64x64 equal-area fisheye looking straight up. Kept
+// local (not shared with test_render_consumer_component_lanes.cpp's
+// file-private MakeLaneRenderConfig) — cross-file reuse would need a refactor
+// whose cost outweighs a small copy here.
+RenderConfig MakeMinimalRenderConfig() {
+  RenderConfig cfg;
+  cfg.id_ = 0;
+  cfg.lens_.type_ = LensParam::kFisheyeEqualArea;
+  cfg.lens_.fov_ = 180.0f;
+  cfg.resolution_[0] = 64;
+  cfg.resolution_[1] = 64;
+  cfg.view_.az_ = 0.0f;
+  cfg.view_.el_ = 90.0f;
+  cfg.view_.ro_ = 0.0f;
+  cfg.visible_ = RenderConfig::kUpper;
+  return cfg;
+}
+
+// -----------------------------------------------------------------------------
+// A. Whole batch filtered out (outgoing_* empty, rays_ non-empty) → no abort.
+// -----------------------------------------------------------------------------
+TEST(RenderConsumerEmptyBatch, AllRaysFilteredOutDoesNotAbort) {
+  // Model "this batch had N candidate rays, all rejected by the filter": rays_
+  // carries a non-zero size while outgoing_d_/outgoing_w_ stay default-empty.
+  constexpr size_t kN = 128;
+  SimData data;
+  data.curr_wl_ = 550.0f;
+  data.rays_.Reset(kN);
+  data.rays_.size_ = kN;
+  // outgoing_d_/outgoing_w_/outgoing_component_ left empty on purpose.
+
+  RenderConfig cfg = MakeMinimalRenderConfig();
+  RenderConsumer rc(cfg);
+
+  EXPECT_NO_FATAL_FAILURE(rc.Consume(data));
+  rc.PrepareSnapshot();
+  EXPECT_FLOAT_EQ(rc.GetRawXyzResult().snapshot_intensity_, 0.0f);
+}
+
+// -----------------------------------------------------------------------------
+// B. The rewritten assertion is still live (Debug-only).
+// -----------------------------------------------------------------------------
+#ifndef NDEBUG
+TEST(RenderConsumerEmptyBatchDeathTest, MismatchedOutgoingSizesTripsAssert) {
+  RenderConfig cfg = MakeMinimalRenderConfig();
+  RenderConsumer rc(cfg);
+
+  SimData data;
+  data.curr_wl_ = 550.0f;
+  data.outgoing_w_ = { 0.5f, 0.7f };         // 2 weights
+  data.outgoing_d_ = { 0.0f, 0.0f, -1.0f };  // only 1 ray's worth of direction
+
+  EXPECT_DEATH(rc.Consume(data), "");
+}
+#else
+TEST(RenderConsumerEmptyBatchDeathTest, MismatchedOutgoingSizesTripsAssert) {
+  GTEST_SKIP() << "assert() is a no-op under NDEBUG (Release); the death test is "
+                  "meaningful only in a Debug build";
+}
+#endif
+
+}  // namespace
+}  // namespace lumice


### PR DESCRIPTION
## Problem

Under strong shape randomization (`face_distance` gauss std ≳ 0.30) or degenerate crystals, three downstream contracts around filter / render / consumer were failing. All three are fixed to the foundation here. This is scrum-397 (`strong-randomization-downstream-contracts`), developed in a separate worktree in parallel with the ongoing scrum-396 (gui-shape-randomization); the two change sets are almost entirely disjoint (this PR is render/device-backend/filter; 396 is C API leaf + GUI).

## The three issues and outcomes

**1. Debug `render.cpp` empty-batch assert — original attribution was wrong.**
A 2×2 control (deterministic crystal with 0 degeneracy warnings still fires; strongly-randomized with 109 degeneracy warnings but no filter never fires) proves the trigger is *the filter rejecting a whole batch*, **not** degenerate geometry. The old `assert(!outgoing_w_.empty() || rays_.Empty())` asserted a property Design A never promises — an entire filter-fail batch is a legitimate tail event (normal per-batch pass rate is already <1%), and the empty-batch downstream path is a full no-op. Fix: rewrite the assert to the size-consistency invariant Design A *does* promise (`outgoing_d_.size() == 3 * outgoing_w_.size()`), and document the empty-batch contract in `doc/filter-architecture.md` §4 (previously it lived only in two `> 0` code guards, which is exactly why it was misread as "contract drift").

**2. Strong-randomization `entry_exit 3→5` filtered output collapses to exactly 0 on Metal — real cross-backend bug.**
nnz sweep: std ≤ 0.25 both backends agree to ~1%; **std ≥ 0.30 Metal collapses to exactly 0 while CPU rises monotonically**; with the filter removed both agree to 0.1%. Root cause: `BeginSession` samples one *prototype* crystal with a fixed seed and builds a **shared** GetFn table per `(ms_layer, ci)` slot; under strong randomization the actually-sampled instances have a different `face_present` local-index packing, so entry/exit local indices index the shared table into the *wrong physical face* → systematic filter mis-verdict. CPU re-queries GetFn per live instance, so it has no shared-table stage. Fix: switch 8 device filter functions to per-instance `poly_fn`/`poly_off` absolute addressing (Metal + CUDA).

**3. Default-constructed `Crystal()` downstream — real (not theoretical) risk.**
Audit: the real risk is the `MakePrism/PyramidClosedForm` validity-gate reject branch `return Crystal();`, reachable directly from `CrystalMaker`'s random draws at a measured **233/2000 = 11.65%** (gauss std=0.5). Foundations pinned here: a new CI gate `no-default-constructed-crystal-slots` (`check_policies.py`), an `EmptyCrystalContract` runtime field-by-field test, and a contract note on the default ctor. The actual tolerance fix (device gen path) landed together with issue 2.

Related third bug (issue 1 → 2 → 3 relay): `EnsureTriBuffers`'s `assert(tri_cnt > 0u)` (comment "Production configs always have tri_cnt > 0") is falsified by the 11.65% empty-Crystal rate and fired 3/3 in Debug+Metal+strong-randomization. Made tolerant.

## Verification

- **Metal**: red/green + std-sweep sentinel `test_metal_filter_strong_randomization.py` (pre-fix binary reproduces the exact-0 collapse at std 0.30/0.40/0.50; post-fix 5/5 pass).
- **CUDA (dev49, hard gate — verified)**: docker rebuild `NINJA_EXIT=0`; parity battery **11/11**; `GPU_GEOM_CLOCK=64` deterministic convergence to CPU +2–3% proves per-instance pool addressing is correct.
- **CPU** stays the correctness baseline throughout.
- Local `ctest` 5/5, `check_policies.py` / `check_new_refs.py` clean.

## Honest boundary (deferred to backlog, out of scope)

CUDA default clock (`GPU_GEOM_CLOCK=0`) nnz undercounts CPU by 14–34% (monotonic in std). White-boxed as a **pre-existing K-granularity sampling-density difference unrelated to this filter bug** (pre-fix ≈ post-fix, bit-for-bit), filed in backlog, not fixed here.

## Note for scrum-396 (rebase-time)

The new `no-default-constructed-crystal-slots` CI gate will apply to 396 after it rebases onto this. If 396's core-single-source crystal sampling introduces any `vector<Crystal>` default growth, the gate will flag it — this is intentional (prevents the same class of bug), but 396 should be aware so a post-rebase CI red isn't surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
