### PR TITLE
chore(dead-weight-closeout): delete orphaned Server::CommitConfigFromFile, fix stale ExitRayRecord size comments

### DIFF
--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -102,7 +102,8 @@ class MetalTraceBackend : public TraceBackend {
   void SetCaptureRayMask(bool enable);
   void ReadbackRayMask(std::vector<uint64_t>& masks, std::vector<float>& weights) const;
   // [PARITY-ONLY] Exit seam buffer-egress contract — see base class.
-  // Returns rich `ExitRayRecord` (36B each) — see core/exit_seam.hpp.
+  // Returns rich `ExitRayRecord` (96B each, size single-sourced by the
+  // static_assert in core/exit_seam.hpp) — see core/exit_seam.hpp.
   // Not invoked on the production path; DrainExits is the production exit
   // seam. Retained as a parity testing contract — virtual override stays
   // for the parity harness.

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -35,7 +35,8 @@ namespace lumice {
 //   2) Host pointers do not cross the seam, except at two explicit boundaries:
 //        - HostRayBatch: the ingest boundary (only at the first MS layer).
 //        - ReadbackExitRays: the sole device->host boundary (exit-ray
-//          buffer-egress — N `ExitRayRecord`s, each 36B carrying
+//          buffer-egress — N `ExitRayRecord`s, each 96B (size single-sourced
+//          by the static_assert in core/exit_seam.hpp) carrying
 //          {dir, weight, path, crystal_id, ms_layer_idx}).
 //      Ray data and layer-local buffers otherwise live as backend-owned,
 //      opaque, device-resident handles. (scrum-258.1: ReadbackImage was
@@ -54,7 +55,8 @@ namespace lumice {
 //          The only host-visible side-effect is reading ContinuationCount() —
 //          a single 4-byte cudaMemcpy.
 //        - ReadbackExitRays performs a single device->host copy of
-//          N `ExitRayRecord`s (36B each) for N exit rays.
+//          N `ExitRayRecord`s (96B each, size single-sourced by the
+//          static_assert in core/exit_seam.hpp) for N exit rays.
 //
 //   4) Metal co-design as a second orthogonal view. The contract is validated
 //      by at least one Metal skeleton implementation so the seam does not
@@ -390,7 +392,8 @@ class TraceBackend {
   // contract. Copies the world-space exit rays captured this session
   // (one entry per ray that left the crystal in the final MS layer) into
   // the caller-provided vector and returns the exit-ray count. Each record
-  // is a 36B `ExitRayRecord` carrying {dir, weight, path, crystal_id,
+  // is a 96B `ExitRayRecord` (size single-sourced by the static_assert in
+  // core/exit_seam.hpp) carrying {dir, weight, path, crystal_id,
   // ms_layer_idx}; see core/exit_seam.hpp. The simulator routes these
   // through the legacy consumer projection (O(exit rays)), replacing the
   // per-batch O(W*H) image readback.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ void WarnIfLastScatteringLayerProbNonzero(const nlohmann::json& j_cfg) {
 void WarnIfLastScatteringLayerProbNonzero(const std::filesystem::path& config_path) {
   std::ifstream f(config_path);
   if (!f.is_open()) {
-    return;  // let CommitConfigFromFile report the real "cannot open" error.
+    return;  // let LUMICE_SceneFromJsonFile report the real "cannot open" error.
   }
   try {
     nlohmann::json j;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -6,7 +6,6 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdlib>
-#include <fstream>
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -1578,27 +1577,6 @@ Error Server::CommitConfig(const std::string& config_str) {
     return Error::InvalidJson(e.what());
   } catch (...) {
     ILOG_ERROR(impl_->GetLogger(), "CommitConfig: Unknown error");
-    return Error::InvalidJson("Unknown JSON parsing error");
-  }
-}
-
-Error Server::CommitConfigFromFile(const std::filesystem::path& filename) {
-  if (!impl_) {
-    return Error::ServerNotReady("Server is terminated");
-  }
-  std::ifstream f(filename);
-  if (!f.is_open()) {
-    return Error::InvalidConfig("Cannot open file: " + filename.u8string());
-  }
-  try {
-    nlohmann::json config_json;
-    f >> config_json;
-    return impl_->CommitConfig(config_json);
-  } catch (const nlohmann::json::parse_error& e) {
-    ILOG_ERROR(impl_->GetLogger(), "CommitConfigFromFile: JSON parse error: {}", e.what());
-    return Error::InvalidJson(e.what());
-  } catch (...) {
-    ILOG_ERROR(impl_->GetLogger(), "CommitConfigFromFile: Unknown error");
     return Error::InvalidJson("Unknown JSON parsing error");
   }
 }

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -2,7 +2,6 @@
 #define INCLUDE_SERVER_H_
 
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
@@ -259,21 +258,6 @@ class Server {
    * @return Error object indicating success or failure
    */
   Error CommitConfig(const nlohmann::json& config_json, bool* out_reused = nullptr);
-
-  /**
-   * @brief Commit configuration from file
-   * @param filename Path to JSON configuration file
-   * @return Error object indicating success or failure
-   * @note The configuration format should follow V3 configuration schema
-   * @see configuration.md for configuration format details
-   * @example
-   *   auto err = server.CommitConfigFromFile("config.json");
-   *   if (err) {
-   *     std::cerr << "Error: " << err.message << std::endl;
-   *     return;
-   *   }
-   */
-  Error CommitConfigFromFile(const std::filesystem::path& filename);
 
   /**
    * @brief Get all render results


### PR DESCRIPTION
## 背景

收口两处「举证责任在保留方」的死重（来自 backlog 的三条同主题条目合并立项）。

## 改动

**A — 删 `Server::CommitConfigFromFile(path)`**（零调用点）

v4.12 把 `LUMICE_Config` 及三个旧 C API commit 入口移除后，这个 core `Server` 公开方法失去了唯一消费者。全仓 grep 确认零调用点，剩余命中全是散文/记录（`lumice.h` 的 v4.12 移除记录、旧 API docstring）。

姊妹方法 `Server::CommitConfig(const std::string&)` **仍是活的**（`bench/bench_scene.cpp:73` 直调，bench target 走 core C++ API 不经 C API），未动。

连带清理两个因此变成未使用的 include（`server.hpp` 的 `<filesystem>`、`server.cpp` 的 `<fstream>`），并修正 `main.cpp:88` 一条因删除而悬空的注释 —— 改为指向实际报「cannot open」错误的 `LUMICE_SceneFromJsonFile`。

**B — 修正 4 处 `ExitRayRecord` 尺寸陈旧注释（36B → 96B）**

`trace_backend.hpp:38/57/393` 与 `metal_trace_backend.hpp:105` 都把该记录写成 36B；实际是 96B（`task-331.1` 的 `component_mask` 使末尾 8B 对齐，88B → 96B）。四处均补上「尺寸单源在 `core/exit_seam.hpp` 的 `static_assert`」的指向，避免再次漂移。`exit_seam.hpp` 自己的逐字段布局注释本就准确，未动。

## 范围收缩（非蔓延）

原计划还要删 `ClosedFormPyramidResult::path_tag_union`（生产侧确实零消费者）。**开工前一手核验推翻了这个前提，故未执行**：`test/golden-analytic/core/test_closed_form_pyramid.cpp:593` 的 `SpecialisedConfigurationsAgreeAndNoSpecialCaseBranches` 是独立于 golden 快照比对的第二类消费者，整条测试的断言主体就是该字段的 OR-union 集合包含关系，用来检测闭式求解器有没有为 shoulder / apex / face-drop 偷偷加 special-case 分支。生产侧字段注释（`geo3d_closedform.hpp:88-96`）明确写着这是为该检查有意设计的可测试性机制 —— 不是顺手挂的死重。删它会连带废掉这条回归测试，故字段保留。

## 验证

- `./scripts/build.sh -tj release` — 5/5 测试通过（含 golden-analytic pyramid 套件）
- `./scripts/format.sh --check` — exit 0
- `python3 scripts/check_policies.py` — exit 0
- `python3 scripts/check_new_refs.py --range <merge-base>..HEAD` — exit 0
- code review：round 1 REQUEST_CHANGES（记录滞后，非代码问题）→ round 2 **APPROVE**（Critical=0 / Major=0）

预期零行为变化：diff 全是删除与注释。

🤖 Generated with [Claude Code](https://claude.com/claude-code)