### PR TITLE
chore: route src/ diagnostics through the logger, gate bare prints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,22 @@ Release artifacts land in `build/cmake_install/`. Debug builds stay in `build/cm
 - Do not use raw `new` / `delete`.
 - Do not use `using namespace`.
 - Keep code comments in English.
+- Logging: all diagnostic output goes through the logger — `ILOG_*` (core/server, `src/util/logger.hpp`)
+  or `GUI_LOG_*` (GUI, `src/gui/gui_logger.hpp`). A raw `printf` / `fprintf` / `std::cout` / `std::cerr`
+  bypasses the unified sinks, the level filter and the format, so it is invisible exactly where a user
+  looks: the GUI log panel, the file sink they enabled, and — on Windows, where the GUI calls
+  `FreeConsole()` unless a diagnostic flag was passed — anywhere at all. Two files under `src/` are
+  exempt, and both are exemptions with a name and an owner rather than a per-line escape hatch:
+  `src/main.cpp`, whose stdout **is** the CLI's product output (two of its lines are parsed contracts —
+  the `[BENCHMARK]` JSON and `ColorClassSignal:`, so a log prefix would break the e2e suite); and
+  `src/util/fatal.hpp`, the single owner of the pre-abort trap, where unbuffered stderr is the whole
+  point — a per-message-unflushed file sink can lose the line precisely when it matters. For an
+  unrecoverable invariant call `lumice::FatalAbort(...)` instead of hand-rolling print-then-`abort()`.
+  Enforced by the `no-bare-print` rule in `scripts/check_policies.py`, which also scans `.cu` / `.metal`
+  so a GPU backend cannot reopen the side channel. `test/` is deliberately out of scope: test binaries
+  are their own harness with no app logger to bypass, and some of their output is a parsed contract
+  (the regen driver reads gui_test's `PSNR=` line). Device-side `printf` in a CUDA kernel stays a
+  legitimate debugging tool — the gate does not stop you adding one while working, only from landing it.
 - Public API boundary: `src/gui/` code must only access core/config functionality
   through the C API (`src/include/lumice.h`). Direct `#include` of `core/` or `config/`
   headers from `src/gui/` is prohibited.

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -94,6 +94,29 @@ POLICY_DOC = REPO_ROOT / "doc" / "env-var-policy.md"
 
 CXX_SUFFIXES = {".cpp", ".cc", ".hpp", ".h", ".mm", ".inl"}
 
+# The bare-print rule scans GPU sources too, so a CUDA/Metal backend cannot
+# reintroduce a stderr side channel that bypasses the logger. This is a SEPARATE
+# set rather than a widening of CXX_SUFFIXES on purpose: the other checks in this
+# file were written and validated against host C++ only, and sweeping .cu/.metal
+# into all of them at once would change ten rules' scope as a side effect of
+# adding one. Widen CXX_SUFFIXES itself only after auditing each check.
+PRINT_SCAN_SUFFIXES = CXX_SUFFIXES | {".cu", ".cuh", ".metal"}
+
+# The only two translation units under src/ allowed to write to a stdio stream.
+# Both are exceptions with a name and an owner, which is why the rule needs no
+# per-line escape hatch and no "print followed by abort" pattern matching:
+#   - main.cpp    : the CLI's stdout IS its product output, not logging. Two of
+#                   its lines are parsed by the e2e suite ([BENCHMARK] json and
+#                   ColorClassSignal:), so a log prefix would break the harness.
+#   - util/fatal.hpp : the single owner of the pre-abort trap, where unbuffered
+#                   stderr is the point (see the rationale in that header).
+BARE_PRINT_ALLOWED = frozenset(
+    {
+        SRC / "main.cpp",
+        SRC / "util" / "fatal.hpp",
+    }
+)
+
 
 @dataclass
 class Violation:
@@ -198,6 +221,18 @@ USING_NAMESPACE = re.compile(r"\busing\s+namespace\b")
 # pinned: PR#182 was specifically about `__builtin_popcountll`; extend the
 # alternation when a new MSVC-unsafe family surfaces.
 MSVC_UNSAFE_BUILTIN = re.compile(r"\b__builtin_(?:popcount|ctz|clz)\w*")
+# Stream-writing calls that bypass the logger's sinks / level filter / format.
+# Buffer-writing formatters (snprintf, vsnprintf, sprintf, asprintf) are NOT
+# listed: they produce a string, they do not emit output, so they are not a
+# logging bypass. The leading \b is what excludes them: there is no word boundary
+# before `printf` inside `snprintf`, so the buffer forms cannot match, while the
+# `v?f?` prefix admits the four stream forms (printf/fprintf/vprintf/vfprintf)
+# that can. Only qualified std:: stream objects are matched, which is sound here
+# because `using namespace` is itself banned (check_no_using_namespace above), so
+# an unqualified `cout` cannot compile. std::endl/std::flush need no entry: they
+# cannot appear without one of the stream objects below.
+BARE_PRINT_CALL = re.compile(r"\b(?:std::)?(?:v?f?printf|puts|fputs|fputc|putc|putchar)\s*\(")
+BARE_PRINT_STREAM = re.compile(r"\bstd::(?:cout|cerr|clog)\b")
 
 
 def check_getenv_centralization() -> list[Violation]:
@@ -1087,6 +1122,49 @@ def check_gui_test_suite_args_sync() -> list[Violation]:
     return out
 
 
+def check_no_bare_print() -> list[Violation]:
+    """No raw stdio/iostream output under src/ — logging goes through spdlog.
+
+    A bare print bypasses the unified sinks, the level filter and the format, so
+    it is invisible in exactly the places a user looks: the GUI log panel, the
+    file sink they enabled, and — on Windows, where the GUI calls FreeConsole()
+    unless a diagnostic flag was passed — anywhere at all.
+
+    Scope note: `test/` is not scanned. Test binaries are their own harness and
+    several of their lines are parsed contracts (regen_gui_test_refs.py reads the
+    `[<group>] <tag>: PSNR=... dB` line out of gui_test's stderr). Nothing there
+    is a logging bypass, because there is no app logger to bypass.
+
+    Honest limitation: device-side printf inside a CUDA kernel is a legitimate
+    debugging tool. This rule does not stop you from adding one while you work —
+    it stops one from landing. That is the intended trade, not an oversight.
+
+    Known gap: strip_comments() blanks comments but preserves string literals, so
+    a literal containing e.g. `printf(` would be flagged. No such literal exists
+    today; if one appears, prefer rewording it over weakening the pattern.
+    """
+    out: list[Violation] = []
+    for path in sorted(SRC.rglob("*")):
+        if path.suffix not in PRINT_SCAN_SUFFIXES or not path.is_file():
+            continue
+        if path in BARE_PRINT_ALLOWED:
+            continue
+        for lineno, _orig, code in code_lines(path):
+            if BARE_PRINT_CALL.search(code) or BARE_PRINT_STREAM.search(code):
+                out.append(
+                    Violation(
+                        path,
+                        lineno,
+                        "no-bare-print",
+                        "raw stdio/iostream output bypasses the logger's sinks, level "
+                        "filter and format. Use ILOG_* (core/server) or GUI_LOG_* (gui); "
+                        "for an unrecoverable-invariant trap use lumice::FatalAbort "
+                        "(util/fatal.hpp). See AGENTS.md.",
+                    )
+                )
+    return out
+
+
 CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
@@ -1099,6 +1177,7 @@ CHECKS = [
     check_no_msvc_unsafe_builtin,
     check_no_default_constructed_crystal_slots,
     check_gui_test_suite_args_sync,
+    check_no_bare_print,
 ]
 
 
@@ -1122,7 +1201,7 @@ def main() -> int:
         "Policy check passed (env centralization, knob registration, GUI API boundary, "
         "reconciler-widget-include, using-namespace, struct-layout parity, no-config-by-value-copy, "
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
-        "no-default-constructed-crystal-slots, gui-test-suite-args-sync)."
+        "no-default-constructed-crystal-slots, gui-test-suite-args-sync, no-bare-print)."
     )
     return 0
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -227,12 +227,20 @@ MSVC_UNSAFE_BUILTIN = re.compile(r"\b__builtin_(?:popcount|ctz|clz)\w*")
 # logging bypass. The leading \b is what excludes them: there is no word boundary
 # before `printf` inside `snprintf`, so the buffer forms cannot match, while the
 # `v?f?` prefix admits the four stream forms (printf/fprintf/vprintf/vfprintf)
-# that can. Only qualified std:: stream objects are matched, which is sound here
-# because `using namespace` is itself banned (check_no_using_namespace above), so
-# an unqualified `cout` cannot compile. std::endl/std::flush need no entry: they
-# cannot appear without one of the stream objects below.
+# that can. std::endl/std::flush need no entry: they cannot appear without one of
+# the stream objects below.
+#
+# The `std::` on the stream form is optional, and the trailing `<<` is what makes
+# that safe — it distinguishes a stream write from a variable that merely happens
+# to be named `cerr`. Matching the unqualified spelling is not redundant with the
+# `using namespace` ban: that check is bound to CXX_SUFFIXES and so does not see
+# .cu/.metal, and extending it there would be wrong rather than merely noisy,
+# since GPU dialects require namespace imports (`using namespace metal;` heads
+# lumice_trace.metal, and CUDA has the same idiom for cooperative_groups). This
+# rule therefore carries its own weight on GPU sources instead of resting on a
+# premise that does not hold there.
 BARE_PRINT_CALL = re.compile(r"\b(?:std::)?(?:v?f?printf|puts|fputs|fputc|putc|putchar)\s*\(")
-BARE_PRINT_STREAM = re.compile(r"\bstd::(?:cout|cerr|clog)\b")
+BARE_PRINT_STREAM = re.compile(r"\b(?:std::)?(?:cout|cerr|clog)\s*<<")
 
 
 def check_getenv_centralization() -> list[Violation]:

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -1144,6 +1144,9 @@ def check_no_bare_print() -> list[Violation]:
     today; if one appears, prefer rewording it over weakening the pattern.
     """
     out: list[Violation] = []
+    # Not cxx_sources(): that helper is bound to CXX_SUFFIXES, which excludes
+    # .cu/.metal. Walking here is deliberate, not an oversight — see the
+    # PRINT_SCAN_SUFFIXES note above for why the set stays separate.
     for path in sorted(SRC.rglob("*")):
         if path.suffix not in PRINT_SCAN_SUFFIXES or not path.is_file():
             continue

--- a/src/core/geo3d_closedform.cpp
+++ b/src/core/geo3d_closedform.cpp
@@ -4,11 +4,10 @@
 #include <array>
 #include <cassert>
 #include <cmath>
-#include <cstdio>
-#include <cstdlib>
 
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
+#include "util/fatal.hpp"
 
 namespace lumice {
 
@@ -570,8 +569,7 @@ int InsertOrFindVertex(double x, double y, double z, float* pool, int* cnt, doub
     // Unconditional (survives NDEBUG): silent overflow into adjacent
     // face_vtx_cnt / face_vtx corrupts subsequent iterations and eventually
     // segfaults on a bogus index. Trap here for a clean crash.
-    std::fprintf(stderr, "FATAL: pyramid vertex pool overflow (%d >= %d)\n", *cnt, kClosedFormPyramidMaxVtx);
-    std::abort();
+    FatalAbort("pyramid vertex pool overflow (%d >= %d)", *cnt, kClosedFormPyramidMaxVtx);
   }
   int idx = *cnt;
   pool[idx * 3 + 0] = static_cast<float>(x);
@@ -590,9 +588,8 @@ void AppendFaceVtx(ClosedFormPyramidResult* r, int face_slot, int vtx_idx) {
     }
   }
   if (*cnt >= kClosedFormPyramidMaxFaceVtx) {
-    std::fprintf(stderr, "FATAL: pyramid face polygon size overflow at slot=%d (%d >= %d)\n", face_slot, *cnt,
-                 kClosedFormPyramidMaxFaceVtx);
-    std::abort();
+    FatalAbort("pyramid face polygon size overflow at slot=%d (%d >= %d)", face_slot, *cnt,
+               kClosedFormPyramidMaxFaceVtx);
   }
   r->face_vtx[face_slot][(*cnt)++] = vtx_idx;
 }

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -9,7 +9,6 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
-#include <cstdio>
 #include <fstream>
 #include <future>
 #include <optional>
@@ -145,7 +144,7 @@ std::shared_ptr<spdlog::sinks::basic_file_sink_mt> g_file_log_sink;
 std::string g_log_file_path;
 
 void GlfwErrorCallback(int error, const char* description) {
-  fprintf(stderr, "GLFW Error %d: %s\n", error, description);
+  GUI_LOG_ERROR("GLFW Error {}: {}", error, description);
 }
 
 float GetAspectRatio(AspectPreset preset) {

--- a/src/gui/font_init.hpp
+++ b/src/gui/font_init.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdio>
 #include <cstring>
 
 #include "IconsFontAwesome6.h"
 #include "gui/fa_solid_900_embed.h"
+#include "gui/gui_logger.hpp"
 #include "imgui.h"
 
 namespace lumice::gui {
@@ -27,7 +27,7 @@ inline void LoadFontAtlas(ImGuiIO& io) {
     ImFont* icon_font =
         io.Fonts->AddFontFromMemoryTTF(icon_buf, static_cast<int>(kFaSolid900Size), 13.0f, &icon_cfg, kIconRanges);
     if (!icon_font) {
-      fprintf(stderr, "[gui] WARNING: FA icon font failed to load; ICON_FA_* glyphs will be blank.\n");
+      GUI_LOG_WARNING("FA icon font failed to load; ICON_FA_* glyphs will be blank.");
     }
   }
 }

--- a/src/gui/gl_init.cpp
+++ b/src/gui/gl_init.cpp
@@ -3,9 +3,8 @@
 #ifdef _WIN32
 #include <GLFW/glfw3.h>
 
-#include <cstdio>
-
 #include "gui/gl_common.h"
+#include "gui/gui_logger.hpp"
 #endif
 
 namespace lumice::gui {
@@ -14,7 +13,7 @@ bool InitGLLoader() {
 #ifdef _WIN32
   int version = gladLoadGL(glfwGetProcAddress);
   if (version == 0) {
-    fprintf(stderr, "Failed to initialize OpenGL loader (GLAD)\n");
+    GUI_LOG_ERROR("Failed to initialize OpenGL loader (GLAD)");
     return false;
   }
   return true;

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -8,7 +8,6 @@
 #endif
 
 #include <chrono>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -59,6 +58,43 @@ int main(int argc, char** argv) {
   timeBeginPeriod(1);
 #endif
 
+  // Set up GUI-side log sinks (independent from Core's spdlog).
+  // GUI logs go through GUI's own spdlog logger; Core logs arrive via C API callback
+  // (registered further down, next to LUMICE_CreateServer).
+  //
+  // This runs FIRST, before GLFW / GL / ImGui init, because every failure those
+  // stages can report is itself logged: a sink installed after them would silently
+  // drop exactly the startup diagnostics a user needs. Nothing here depends on a
+  // window, a GL context or an ImGui context — ImGuiLogSink is a plain ring buffer
+  // that the log panel reads later. On Windows it must stay AFTER the FreeConsole
+  // block above, so the stdout sink is built against the final console state.
+  {
+    // ImGui ring buffer sink (shared between GUI logger and Core callback)
+    gui::g_imgui_log_sink = std::make_shared<gui::ImGuiLogSink>();
+
+    // File sink (default level=off, enabled via GUI checkbox)
+    std::filesystem::path log_path;
+    if (const char* home = std::getenv("HOME")) {
+      log_path = std::filesystem::path(home) / "lumice.log";
+    } else {
+      log_path = "lumice.log";
+    }
+    log_path = std::filesystem::absolute(log_path);
+    gui::g_log_file_path = log_path.u8string();
+    gui::g_file_log_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);
+    gui::g_file_log_sink->set_level(spdlog::level::off);
+
+    // Set GUI logger sinks: stdout + ImGui + file, then apply our custom formatter to all.
+    auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    gui::SetGuiLoggerSinks({ stdout_sink, gui::g_imgui_log_sink, gui::g_file_log_sink });
+    gui::GetGuiLogger().set_formatter(lumice::CreateLumiceFormatter(gui::kGuiLogPattern));
+
+    // Flush strategy: warning+ immediately, all levels every 1s
+    // spdlog::err = our warning level (see spdlog_levels.hpp)
+    gui::GetGuiLogger().flush_on(spdlog::level::err);
+    spdlog::flush_every(std::chrono::seconds(1));
+  }
+
   // Parse --skip-calibration flag early.
   bool skip_calibration = false;
   for (int i = 1; i < argc; ++i) {
@@ -70,7 +106,7 @@ int main(int argc, char** argv) {
 
   glfwSetErrorCallback(gui::GlfwErrorCallback);
   if (!glfwInit()) {
-    fprintf(stderr, "Failed to initialize GLFW\n");
+    GUI_LOG_ERROR("Failed to initialize GLFW");
     return 1;
   }
 
@@ -104,7 +140,7 @@ int main(int argc, char** argv) {
   }
   GLFWwindow* window = glfwCreateWindow(init_w, init_h, "Lumice", nullptr, nullptr);
   if (!window) {
-    fprintf(stderr, "Failed to create GLFW window\n");
+    GUI_LOG_ERROR("Failed to create GLFW window");
     glfwTerminate();
     return 1;
   }
@@ -143,42 +179,15 @@ int main(int argc, char** argv) {
   // Create Lumice server.
   gui::g_server = LUMICE_CreateServer();
 
-  // Set up GUI-side log sinks (independent from Core's spdlog).
-  // GUI logs go through GUI's own spdlog logger; Core logs arrive via C API callback.
-  {
-    // ImGui ring buffer sink (shared between GUI logger and Core callback)
-    gui::g_imgui_log_sink = std::make_shared<gui::ImGuiLogSink>();
-
-    // File sink (default level=off, enabled via GUI checkbox)
-    std::filesystem::path log_path;
-    if (const char* home = std::getenv("HOME")) {
-      log_path = std::filesystem::path(home) / "lumice.log";
-    } else {
-      log_path = "lumice.log";
+  // Bridge Core logs into the GUI ring buffer. Kept here rather than in the sink
+  // block at the top of main(): the callback only carries meaning once a server
+  // exists to emit Core logs, so it pairs with LUMICE_CreateServer above.
+  LUMICE_SetLogCallback([](LUMICE_LogLevel level, const char* /*name*/, const char* message) {
+    if (gui::g_imgui_log_sink) {
+      auto spd_level = static_cast<spdlog::level::level_enum>(level);
+      gui::g_imgui_log_sink->ReceiveExternal(spd_level, message);
     }
-    log_path = std::filesystem::absolute(log_path);
-    gui::g_log_file_path = log_path.u8string();
-    gui::g_file_log_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);
-    gui::g_file_log_sink->set_level(spdlog::level::off);
-
-    // Set GUI logger sinks: stdout + ImGui + file, then apply our custom formatter to all.
-    auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    gui::SetGuiLoggerSinks({ stdout_sink, gui::g_imgui_log_sink, gui::g_file_log_sink });
-    gui::GetGuiLogger().set_formatter(lumice::CreateLumiceFormatter(gui::kGuiLogPattern));
-
-    // Flush strategy: warning+ immediately, all levels every 1s
-    // spdlog::err = our warning level (see spdlog_levels.hpp)
-    gui::GetGuiLogger().flush_on(spdlog::level::err);
-    spdlog::flush_every(std::chrono::seconds(1));
-
-    // Register C API callback to receive Core logs → pipe into ImGui ring buffer
-    LUMICE_SetLogCallback([](LUMICE_LogLevel level, const char* /*name*/, const char* message) {
-      if (gui::g_imgui_log_sink) {
-        auto spd_level = static_cast<spdlog::level::level_enum>(level);
-        gui::g_imgui_log_sink->ReceiveExternal(spd_level, message);
-      }
-    });
-  }
+  });
 
   // Parse CLI arguments for log level.
   // --log-level / -v / -d control GUI log level (global logger, LOG_* macros).

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -58,9 +58,9 @@ int main(int argc, char** argv) {
   timeBeginPeriod(1);
 #endif
 
-  // Set up GUI-side log sinks (independent from Core's spdlog).
-  // GUI logs go through GUI's own spdlog logger; Core logs arrive via C API callback
-  // (registered further down, next to LUMICE_CreateServer).
+  // Set up the GUI-side log sinks that carry no side effect (independent from
+  // Core's spdlog). GUI logs go through GUI's own spdlog logger; Core logs arrive
+  // via C API callback, registered further down next to LUMICE_CreateServer.
   //
   // This runs FIRST, before GLFW / GL / ImGui init, because every failure those
   // stages can report is itself logged: a sink installed after them would silently
@@ -68,25 +68,17 @@ int main(int argc, char** argv) {
   // window, a GL context or an ImGui context — ImGuiLogSink is a plain ring buffer
   // that the log panel reads later. On Windows it must stay AFTER the FreeConsole
   // block above, so the stdout sink is built against the final console state.
+  //
+  // The file sink is deliberately NOT created here: it truncates ~/lumice.log on
+  // construction, and it defaults to level=off, so hoisting it would buy no extra
+  // coverage while wiping the previous run's log on every launch that dies before
+  // this point — the launch a user is most likely to be diagnosing.
   {
     // ImGui ring buffer sink (shared between GUI logger and Core callback)
     gui::g_imgui_log_sink = std::make_shared<gui::ImGuiLogSink>();
 
-    // File sink (default level=off, enabled via GUI checkbox)
-    std::filesystem::path log_path;
-    if (const char* home = std::getenv("HOME")) {
-      log_path = std::filesystem::path(home) / "lumice.log";
-    } else {
-      log_path = "lumice.log";
-    }
-    log_path = std::filesystem::absolute(log_path);
-    gui::g_log_file_path = log_path.u8string();
-    gui::g_file_log_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);
-    gui::g_file_log_sink->set_level(spdlog::level::off);
-
-    // Set GUI logger sinks: stdout + ImGui + file, then apply our custom formatter to all.
     auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    gui::SetGuiLoggerSinks({ stdout_sink, gui::g_imgui_log_sink, gui::g_file_log_sink });
+    gui::SetGuiLoggerSinks({ stdout_sink, gui::g_imgui_log_sink });
     gui::GetGuiLogger().set_formatter(lumice::CreateLumiceFormatter(gui::kGuiLogPattern));
 
     // Flush strategy: warning+ immediately, all levels every 1s
@@ -178,6 +170,30 @@ int main(int argc, char** argv) {
 
   // Create Lumice server.
   gui::g_server = LUMICE_CreateServer();
+
+  // File sink (default level=off, enabled via the GUI checkbox). Constructed here
+  // rather than in the sink block at the top of main() because construction
+  // truncates the file — see the note there. Only the log panel reads
+  // g_file_log_sink / g_log_file_path, and that runs in the frame loop below, so
+  // publishing them this late is not observable.
+  {
+    std::filesystem::path log_path;
+    if (const char* home = std::getenv("HOME")) {
+      log_path = std::filesystem::path(home) / "lumice.log";
+    } else {
+      log_path = "lumice.log";
+    }
+    log_path = std::filesystem::absolute(log_path);
+    gui::g_log_file_path = log_path.u8string();
+    gui::g_file_log_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.string(), true);
+    gui::g_file_log_sink->set_level(spdlog::level::off);
+
+    auto sinks = gui::GetGuiLogger().sinks();
+    sinks.push_back(gui::g_file_log_sink);
+    gui::SetGuiLoggerSinks(std::move(sinks));
+    // Re-apply: set_formatter clones into each sink, so the new one needs it too.
+    gui::GetGuiLogger().set_formatter(lumice::CreateLumiceFormatter(gui::kGuiLogPattern));
+  }
 
   // Bridge Core logs into the GUI ring buffer. Kept here rather than in the sink
   // block at the top of main(): the callback only carries meaning once a server

--- a/src/util/fatal.hpp
+++ b/src/util/fatal.hpp
@@ -47,4 +47,8 @@ namespace lumice {
 
 }  // namespace lumice
 
+// Implementation detail of the two declarations above, not part of the interface —
+// do not let it leak into the preprocessor namespace of every including TU.
+#undef LUMICE_PRINTF_FORMAT
+
 #endif  // LUMICE_UTIL_FATAL_HPP

--- a/src/util/fatal.hpp
+++ b/src/util/fatal.hpp
@@ -1,0 +1,50 @@
+#ifndef LUMICE_UTIL_FATAL_HPP
+#define LUMICE_UTIL_FATAL_HPP
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+namespace lumice {
+
+// Unrecoverable-invariant trap: write a diagnostic to stderr, then abort.
+//
+// POLICY: this header is the single owner of the "print and die" idiom, and one
+// of only two places under src/ allowed to write to a stdio stream directly (the
+// other is main.cpp, whose stdout IS the CLI's product output). Enforced by the
+// no-bare-print rule in scripts/check_policies.py. Everything that is not a
+// pre-abort trap must go through the logger (ILOG_* / GUI_LOG_*).
+//
+// Deliberately NOT routed through spdlog, for two reasons:
+//   - stderr is unbuffered, so the message is guaranteed to land before
+//     std::abort() tears the process down. The shared dist_sink's file sink is
+//     not flushed per message, so a log line emitted here could be lost exactly
+//     when it matters most.
+//   - the caller is on a corrupt-state path by definition. Depending on the
+//     logger's allocation, formatting and locking to report that corruption is
+//     how a diagnostic turns into a second, more confusing crash.
+//
+// `fmt` takes a printf-style format string; a "FATAL: " prefix and a trailing
+// newline are added here, so call sites pass the bare message.
+#if defined(__GNUC__) || defined(__clang__)
+#define LUMICE_PRINTF_FORMAT(fmt_idx, first_arg_idx) __attribute__((format(printf, fmt_idx, first_arg_idx)))
+#else
+#define LUMICE_PRINTF_FORMAT(fmt_idx, first_arg_idx)
+#endif
+
+[[noreturn]] inline void FatalAbort(const char* fmt, ...) LUMICE_PRINTF_FORMAT(1, 2);
+
+[[noreturn]] inline void FatalAbort(const char* fmt, ...) {
+  std::va_list args;  // NOLINT(cppcoreguidelines-init-variables) — initialized by va_start
+  va_start(args, fmt);
+  std::fprintf(stderr, "FATAL: ");
+  std::vfprintf(stderr, fmt, args);
+  std::fprintf(stderr, "\n");
+  va_end(args);
+  std::fflush(stderr);
+  std::abort();
+}
+
+}  // namespace lumice
+
+#endif  // LUMICE_UTIL_FATAL_HPP


### PR DESCRIPTION
## 背景

`src/` 下散着一批裸 `printf` / `fprintf` / `std::cerr`。它们绕过统一 spdlog 的 sink、级别过滤与格式，
于是在用户真正会看的地方全都不可见：GUI 日志面板、用户勾选的 file sink，以及——Windows 上 GUI 启动
若无 `-v`/`-d`/`--log-level` 会先 `FreeConsole()`——任何地方。

这是复发主题：task-254 已就 `MetalTraceBackend` 裸 `NSLog` 提过同样要求（那处已统一），之后又累积了
5 处新的 GUI 站点。软约束没兜住，所以**本 PR 的重心是门禁**，清理只是让门禁能从零起步的前置。

## 43 处命中的分诊

| 类 | 位置 | 数量 | 处置 |
|----|------|------|------|
| 注释/文档注释里的假阳性 | 各处 | 4 | — |
| CLI 产品输出 | `src/main.cpp` | 32 | **保留**（白名单） |
| fatal-abort trap | `geo3d_closedform.cpp` | 2 | **提取具名 helper** |
| GUI bootstrap 诊断 | `src/gui/` | 5 | **转 `GUI_LOG_*`** |
| 测试 harness 输出 | `test/` | 大量 | **不动**（不在扫描范围） |

`main.cpp` 保留的理由：那不是日志而是 CLI 的产品输出，其中两条是**机器解析契约**——
`[BENCHMARK]` JSON 被 `test_benchmark_infinite_no_hang.py` 解析，`ColorClassSignal:` 被
`test_raypath_color.py` 解析，套上日志前缀会直接打断 harness。该文件本就把两个通道分清了
（真诊断走 `LOG_WARNING`）。

## 最终规则

> **`src/` 下禁裸 print，`src/main.cpp` 与 `src/util/fatal.hpp` 除外。**

没有函数粒度、没有行内豁免、没有「print 后跟 abort」模式匹配。关键取舍是**把例外变成有名字的符号**：
不教 checker 认那个模式（两处之一是跨行 `fprintf`，模式匹配对格式敏感、脆），而是给它一个 owner
`lumice::FatalAbort`，把 unbuffered stderr 语义关进实现细节——那正是让消息能在 `abort()` 前落地的东西，
而共享 dist_sink 的 file sink 不是逐条 flush 的。

之所以能用**严格全树门禁**而不是 `check_new_refs.py` 那套 diff-scoped 机制：后者存在是因为 41% 的
tracked 文件带历史引用、清不动；这里存量只有 7 处，能清到零，不需要 grandfathering。

门禁通过独立后缀集覆盖 `.cu`/`.cuh`/`.metal`，故 GPU 后端无法重开这条旁路；**没有**放宽全局
`CXX_SUFFIXES`，否则另外 14 条 check 的作用域会作为副作用一起变。

## 一处顺带修掉的真问题

`GlfwErrorCallback` 注册后**全生命周期常驻**，运行期任何 GLFW 错误此前只进 stderr。
更隐蔽的是字体加载警告：它是非致命的（app 继续跑，只是图标空白），却在 sink 装配前发出——
光换 logger 不够。故把 sink 装配前移到 `main()` 开头（Windows `FreeConsole` 之后，保持 stdout sink
对最终 console 状态构建），整块对 GLFW/GL/ImGui 零依赖。
**file sink 例外**：它默认 `level=off`，前移买不到覆盖，却会让每次早期失败启动都截断
`~/lumice.log`——正是排查「反复启动即崩溃」时要看的那份，故只有它留在 `LUMICE_CreateServer()` 旁边。

## 验证

| 项 | 结果 |
|----|------|
| `build.sh -gtj release` / `-sj release` | exit 0 / exit 0 |
| CTest | 5/5 |
| `gui_test` | 468/468 + real-timing 6/6 |
| `pytest -m "not slow"`（CI 等价） | 80 passed, 1 skipped |
| `pytest -m slow` | 48 passed, 29 skipped |
| `check_policies.py` / `check_new_refs.py --range` / `format.sh --check` | 全 exit 0 |
| `src/main.cpp` | `git diff` 确认零改动 |

**红绿双态**（门禁的核心证据）：在 base commit 的 scratch worktree 上跑新 checker → exit 1，
精确报出预测的 7 处，**零误报**——`server.hpp:249` 文档注释里的 `std::cerr` 示例被 `strip_comments()`
排除，`main.cpp` 的 32 处被白名单排除。当前树 exit 0。只验绿态不构成证据。

**正则边界单测**：`snprintf`/`vsnprintf`/`sprintf`/`asprintf` 全不命中（缓冲区格式化不是日志旁路），
`auto cerr = f();` / `int cout = 3;` / `os<<` / `ss<<` 亦不命中。

## 诚实边界

- `gl_init.cpp` 的改动在 `#ifdef _WIN32` 内，本机 macOS 未编译该行，真实验证依赖本 PR 的 Windows CI。
- CUDA kernel 里的 device `printf` 仍是合法调试工具：门禁不阻止临时插桩，只阻止它 land。有意取舍。
- checker 已知 gap：`strip_comments()` 不剥字符串字面量，故字面量含 `printf(` 会误报。当前无此类字面量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)