### PR TITLE
feat: shape-scalar sync groups (symmetry-preserving shape randomization)

### DIFF
--- a/doc/c_api.md
+++ b/doc/c_api.md
@@ -29,7 +29,7 @@ Link against the `lumice` static library.
 ### Constants
 
 ```c
-#define LUMICE_API_VERSION 412        // ABI version, encoded major*100 + minor (v4.12)
+#define LUMICE_API_VERSION 413        // ABI version, encoded major*100 + minor (v4.13)
 #define LUMICE_MAX_RENDER_RESULTS 16  // Maximum capacity of the render result array
 #define LUMICE_MAX_STATS_RESULTS 1    // Maximum capacity of the stats result array
 ```
@@ -38,12 +38,31 @@ Link against the `lumice` static library.
 mismatch instead of hitting silent UB from a struct-layout drift, e.g.:
 
 ```c
-static_assert(LUMICE_API_VERSION >= 412, "Lumice header too old for this integration");
+static_assert(LUMICE_API_VERSION >= 413, "Lumice header too old for this integration");
 ```
 
 It is bumped on every BREAKING change to the public symbol set or struct layout.
 
-**v4.12 is such a break.** The wide `LUMICE_Config` value struct and everything that existed only
+**v4.13 is such a break.** `LUMICE_CrystalParam` gained a field appended at the end of the
+struct: `int sync_group[LUMICE_SHAPE_SCALAR_COUNT]`, alongside ten new `LUMICE_SHAPE_SCALAR_*`
+index constants. The core simulator has expressed shape-scalar sync groups (grouped shape
+scalars sharing one random draw per crystal instance — see
+[`configuration.md`'s Shape-Scalar Sync Groups](configuration.md#shape-scalar-sync-groups) for
+the full semantics) since v4.12, but `LUMICE_CrystalParam` had no slot for the declaration, so
+the only path a config file, the GUI, or a caller of this API ever takes silently dropped it on
+the floor — core always received an all-independent struct and nothing warned. The struct's
+layout changed, so callers must recompile; behavior does not change for an existing caller, since
+a zero-initialized `sync_group` (the same state a zeroed/`{}`-initialized `LUMICE_CrystalParam`
+already had) means every scalar independent, exactly as before. `LUMICE_SHAPE_SCALAR_*` indexes
+`sync_group[]` in **RNG draw order** (prism: `HEIGHT` then `FACE_0..FACE_5`; pyramid: `UPPER_H`
+then `PRISM_H` then `LOWER_H` then `FACE_0..FACE_5`), which is deliberately **not** the field
+declaration order of `LUMICE_CrystalParam` itself (`height` / `prism_h` / `upper_h` / `lower_h`
+— note `upper_h` and `prism_h` are transposed relative to the draw order). A group's leader —
+the member whose distribution the whole group is normalized to — is defined as its lowest
+`LUMICE_SHAPE_SCALAR_*` index, so this ordering is load-bearing: aligning it to the struct's
+field order would silently redefine which member of a mixed group owns the distribution.
+
+**v4.12 is also a break.** The wide `LUMICE_Config` value struct and everything that existed only
 to feed it were removed: `LUMICE_Config` itself, the three commit entry points
 (`LUMICE_CommitConfig` / `LUMICE_CommitConfigFromFile` / `LUMICE_CommitConfigStruct`),
 `LUMICE_ParseConfigString` / `LUMICE_ParseConfigFile` / `LUMICE_ConfigToJson`, the

--- a/doc/c_api_zh.md
+++ b/doc/c_api_zh.md
@@ -29,7 +29,7 @@ Lumice 提供了完整的C接口，方便与其他语言集成。C接口封装�
 ### 常量
 
 ```c
-#define LUMICE_API_VERSION 412        // ABI 版本，编码为 major*100 + minor（v4.12）
+#define LUMICE_API_VERSION 413        // ABI 版本，编码为 major*100 + minor（v4.13）
 #define LUMICE_MAX_RENDER_RESULTS 16  // 渲染结果数组最大容量
 #define LUMICE_MAX_STATS_RESULTS 1    // 统计结果数组最大容量
 ```
@@ -37,12 +37,14 @@ Lumice 提供了完整的C接口，方便与其他语言集成。C接口封装�
 `LUMICE_API_VERSION` 让调用方把编译时依赖的 ABI 钉死，在不匹配时编译期报错，而不是撞上结构体布局漂移导致的静默 UB：
 
 ```c
-static_assert(LUMICE_API_VERSION >= 412, "Lumice header too old for this integration");
+static_assert(LUMICE_API_VERSION >= 413, "Lumice header too old for this integration");
 ```
 
 公开符号集或结构体布局每发生一次 BREAKING 变更就 bump 一次。
 
-**v4.12 就是一次这样的 break。** 宽值结构体 `LUMICE_Config` 及所有只为喂养它而存在的东西被移除：`LUMICE_Config` 本身、三个提交入口（`LUMICE_CommitConfig` / `LUMICE_CommitConfigFromFile` / `LUMICE_CommitConfigStruct`）、`LUMICE_ParseConfigString` / `LUMICE_ParseConfigFile` / `LUMICE_ConfigToJson`、`LUMICE_ConfigCreateColorClasses` / `LUMICE_ConfigReleaseColorClasses` / `LUMICE_ConfigReleaseCompositions` 所有权辅助函数，以及 C++ RAII 头 `src/include/lumice_config_scope.hpp`。`LUMICE_Scene` 取代了它们全部。不提供任何 shim 或别名：调用已移除符号的代码会编译失败——这正是预期的迁移信号。
+**v4.13 就是一次这样的 break。** `LUMICE_CrystalParam` 在结构体末尾新增了一个字段：`int sync_group[LUMICE_SHAPE_SCALAR_COUNT]`，同时新增了十个 `LUMICE_SHAPE_SCALAR_*` 索引常量。核心仿真器自 v4.12 起就已经能表达形状标量 sync group（同组的若干形状标量在一个晶体实例上共享一次随机抽样——完整语义见[`configuration.md` 的形状标量 Sync Group 一节](configuration.md#shape-scalar-sync-groups)），但 `LUMICE_CrystalParam` 当时没有对应槽位，导致配置文件、GUI、以及任何调用方——三者都只能走这唯一一条通路——的声明会被静默丢在地上：核心侧永远收到"全部独立"，且没有任何警告。结构体布局发生了变化，调用方需要重新编译；但行为不变——零初始化的 `sync_group`（与此前一个被清零/`{}` 初始化的 `LUMICE_CrystalParam` 的状态相同）意味着每个标量都独立，与此前完全一致。`LUMICE_SHAPE_SCALAR_*` 按 **RNG 抽取顺序**索引 `sync_group[]`（prism：`HEIGHT` 之后是 `FACE_0..FACE_5`；pyramid：`UPPER_H` 之后是 `PRISM_H`、`LOWER_H`，再之后是 `FACE_0..FACE_5`），这个顺序刻意**不同于** `LUMICE_CrystalParam` 本身的字段声明顺序（`height` / `prism_h` / `upper_h` / `lower_h`——注意 `upper_h` 与 `prism_h` 相对抽取顺序是互换的）。一个组的 leader——即整个组的分布会被规范化到的那个成员——被定义为组内最小的 `LUMICE_SHAPE_SCALAR_*` 索引，所以这个顺序是有约束力的：若把它对齐到结构体字段顺序，会静默改变一个混合组里到底是哪个成员拥有分布。
+
+**v4.12 也是一次 break。** 宽值结构体 `LUMICE_Config` 及所有只为喂养它而存在的东西被移除：`LUMICE_Config` 本身、三个提交入口（`LUMICE_CommitConfig` / `LUMICE_CommitConfigFromFile` / `LUMICE_CommitConfigStruct`）、`LUMICE_ParseConfigString` / `LUMICE_ParseConfigFile` / `LUMICE_ConfigToJson`、`LUMICE_ConfigCreateColorClasses` / `LUMICE_ConfigReleaseColorClasses` / `LUMICE_ConfigReleaseCompositions` 所有权辅助函数，以及 C++ RAII 头 `src/include/lumice_config_scope.hpp`。`LUMICE_Scene` 取代了它们全部。不提供任何 shim 或别名：调用已移除符号的代码会编译失败——这正是预期的迁移信号。
 
 ### 数据类型
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -69,7 +69,8 @@ If the `axis` field is absent, the following defaults are used:
 ```json
 {
   "height": <value or distribution>,
-  "face_distance": [<6 values or distributions>]
+  "face_distance": [<6 values or distributions>],
+  "sync_group": { "height": <int>, "face_distance": [<6 ints>] }
 }
 ```
 
@@ -79,6 +80,7 @@ If the `axis` field is absent, the following defaults are used:
 |-------|------|----------|---------|-------------|
 | `height` | value/distribution | no | 1.0 | Height ratio h/a, where h is the prism height and a is the base diameter |
 | `face_distance` | array | no | [1,1,1,1,1,1] | Distance ratios for 6 faces; [1,1,1,1,1,1] for a regular hexagon |
+| `sync_group` | object | no | all independent | Shape-scalar sync groups — see [Shape-Scalar Sync Groups](#shape-scalar-sync-groups) below |
 
 `face_distance` values may be negative — a negative value is accepted and
 participates in geometry construction with its sign (it is not silently
@@ -110,7 +112,10 @@ dropped and contributes zero energy) rather than silently accepted.
   "lower_h": <value or distribution>,
   "upper_indices": [<3 integers>],
   "lower_indices": [<3 integers>],
-  "face_distance": [<6 values or distributions>]
+  "face_distance": [<6 values or distributions>],
+  "sync_group": {
+    "prism_h": <int>, "upper_h": <int>, "lower_h": <int>, "face_distance": [<6 ints>]
+  }
 }
 ```
 
@@ -124,6 +129,7 @@ dropped and contributes zero energy) rather than silently accepted.
 | `upper_indices` | integer array | no | [1,0,1] | Miller indices for the upper pyramid segment |
 | `lower_indices` | integer array | no | [1,0,1] | Miller indices for the lower pyramid segment |
 | `face_distance` | array | no | [1,1,1,1,1,1] | Distance ratios for 6 faces |
+| `sync_group` | object | no | all independent | Shape-scalar sync groups — see [Shape-Scalar Sync Groups](#shape-scalar-sync-groups) below |
 
 `face_distance` values may be negative — same construction and rejection
 semantics as the prism type above.
@@ -142,6 +148,109 @@ semantics as the prism type above.
   }
 }
 ```
+
+#### Shape-Scalar Sync Groups
+
+By default every randomizable shape scalar — `height` (prism), `prism_h` /
+`upper_h` / `lower_h` (pyramid), and each of the 6 `face_distance` entries
+(both types) — draws its own independent random sample, so a crystal built
+from distributions with a symmetric mean (e.g. all six `face_distance` means
+equal) is still perturbed into a generically unequal-sided hexagon on every
+sample: nothing keeps the *individual draws* symmetric, only their means.
+
+`sync_group` puts a subset of a crystal's shape scalars into the **same
+group**, so all of them **share a single random draw** for that crystal
+instance instead of drawing independently. This is how to express habits
+that require exact same-sample symmetry — most notably a trigonal (C3)
+hexagonal crystal, where faces 0/2/4 must always equal each other and faces
+1/3/5 must always equal each other, sample by sample.
+
+**Schema** — an optional object keyed by the scalar's own JSON field name
+(the same names used elsewhere in the shape object); `face_distance` takes a
+6-element integer array instead of a scalar, mirroring `face_distance` itself:
+
+```json
+"sync_group": {
+  "height": 1,                        // prism only
+  "prism_h": 1, "upper_h": 2, "lower_h": 2,   // pyramid only
+  "face_distance": [1, 2, 1, 2, 1, 2]         // both types
+}
+```
+
+- **`0` = independent** (the default — an absent `sync_group` key, or an
+  absent per-scalar entry, means every scalar independent, identical to the
+  behavior before sync groups existed). **`1..N` = group id**: every scalar
+  carrying the same id shares one draw. Group ids only need to express a
+  *partition* — they do not need to be dense or already sorted; `{1,2,1,2,1,2}`
+  and `{2,1,2,1,2,1}` describe the same two groups and are normalized to the
+  same canonical form on load (first-appearance renumbering, in the fixed
+  scalar order `height`/`upper_h`/`prism_h`/`lower_h`/`face_distance[0..5]` —
+  the RNG draw order, not the field declaration order above). A group left
+  with only one member collapses back to independent (`0`).
+- **Shared value, not a shared random variable**: a group draws exactly once
+  per crystal instance; every member of the group receives that same raw
+  value. It is not "these scalars are correlated" in some looser statistical
+  sense — they are bit-identical for that instance.
+- **The group's distribution comes from its leader**: the leader is the
+  group's first member in RNG draw order (for `face_distance`, the
+  lowest-indexed face in the group). Every other member's own distribution is
+  overwritten with the leader's at load time. If a non-leader member declared
+  a *different* distribution, that declaration is dropped and a warning is
+  logged — it is not silently ignored and not rejected as an error.
+- **Cross-kind groups (a height synced with a face distance) are mechanically
+  legal but produce a documented asymmetry**: heights are folded through
+  `abs()` before use (a negative height has no independent physical meaning)
+  while `face_distance` stays signed (a negative face distance is a legal,
+  origin-crossing plane offset — see above). A group mixing the two kinds
+  therefore shares the same *raw* draw, but the height member consumes its
+  absolute value while the face member keeps the sign — the two members are
+  not numerically equal in that case, only equal up to sign. The mechanism
+  does not forbid such a group; there is no dimensional-compatibility check.
+- **Physical scope, stated honestly**: `height` / `face_distance`
+  randomization only translates a face along its normal — it never rotates
+  the face's normal direction (see
+  [`geometry-randomization-value-and-measurement.md`](geometry-randomization-value-and-measurement.md)
+  for the underlying measurement). Sync groups inherit that limit: they do
+  not, by themselves, produce halo features at new angles. What they buy is
+  **habit fidelity** — an ensemble whose individual crystals are genuinely
+  symmetric (e.g. a true C3 trigonal population, not merely a C3-on-average
+  one), which matters whenever roll is *not* uniformly random (Parry /
+  Lowitz / fixed-roll configurations — under a full 360° uniform roll, the
+  ensemble average recovers six-fold symmetry regardless of per-instance
+  shape) — plus, as a side effect, syncing an opposite face pair (`i` and
+  `i+3`) guarantees their distances sum to a value with the same sign
+  structure they were configured with, which can reduce the geometric-validity
+  rejection rate under strong face-distance randomization.
+
+**C3 trigonal example** (verified: same-mean, same-spread Gaussian on every
+face, two alternating sync groups — this is the exact scenario the
+`SyncGroupPreview.C3GroupingCollapsesRandomDrawsToTwo` unit test exercises):
+
+```json
+{
+  "id": 1,
+  "type": "prism",
+  "shape": {
+    "height": 1.3,
+    "face_distance": [
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 }
+    ],
+    "sync_group": {
+      "face_distance": [1, 2, 1, 2, 1, 2]
+    }
+  }
+}
+```
+
+Each sampled crystal now has exactly two distinct face distances (faces
+0/2/4 share one draw, faces 1/3/5 share the other) instead of six
+independent ones — a strict trigonal habit on every sample, rather than only
+on average.
 
 #### Distribution Types
 
@@ -613,6 +722,9 @@ The render configuration defines the renderer parameters.
 - `crystal[].shape.face_distance` array length must be 6 (if specified)
 - `crystal[].shape.upper_indices` array length must be 3 (if specified)
 - `crystal[].shape.lower_indices` array length must be 3 (if specified)
+- `crystal[].shape.sync_group.face_distance` array length must be 6 (if specified); a shorter or
+  longer array is truncated/zero-padded rather than rejected — see [Shape-Scalar Sync
+  Groups](#shape-scalar-sync-groups)
 - `render[].resolution` array length must be 2
 
 ### Value Range Validation

--- a/doc/configuration_zh.md
+++ b/doc/configuration_zh.md
@@ -68,7 +68,8 @@
 ```json
 {
   "height": <数值或分布>,
-  "face_distance": [<6个数值或分布>]
+  "face_distance": [<6个数值或分布>],
+  "sync_group": { "height": <int>, "face_distance": [<6个int>] }
 }
 ```
 
@@ -78,6 +79,7 @@
 |------|------|------|--------|------|
 | `height` | 数值/分布 | 否 | 1.0 | 高度比 h/a，h是棱柱高度，a是底面直径 |
 | `face_distance` | 数组 | 否 | [1,1,1,1,1,1] | 6个面的距离比，正六边形为[1,1,1,1,1,1] |
+| `sync_group` | 对象 | 否 | 全部独立 | 形状标量 sync group，详见下方[形状标量 Sync Group](#形状标量-sync-group) |
 
 `face_distance` 允许负值：负值会被接受并按其符号参与几何构造（不再被静默折叠为
 正值）。构造后的网格会做实体性校验——若不满足闭合流形条件，该晶体会被拒绝
@@ -107,7 +109,10 @@
   "lower_h": <数值或分布>,
   "upper_indices": [<3个整数>],
   "lower_indices": [<3个整数>],
-  "face_distance": [<6个数值或分布>]
+  "face_distance": [<6个数值或分布>],
+  "sync_group": {
+    "prism_h": <int>, "upper_h": <int>, "lower_h": <int>, "face_distance": [<6个int>]
+  }
 }
 ```
 
@@ -121,6 +126,7 @@
 | `upper_indices` | 整数数组 | 否 | [1,0,1] | 上锥段Miller指数 |
 | `lower_indices` | 整数数组 | 否 | [1,0,1] | 下锥段Miller指数 |
 | `face_distance` | 数组 | 否 | [1,1,1,1,1,1] | 6个面的距离比 |
+| `sync_group` | 对象 | 否 | 全部独立 | 形状标量 sync group，详见下方[形状标量 Sync Group](#形状标量-sync-group) |
 
 `face_distance` 允许负值：构造与拒绝语义与上方 prism 类型一致。
 
@@ -138,6 +144,88 @@
   }
 }
 ```
+
+#### 形状标量 Sync Group
+
+默认情况下，晶体的每个可随机化形状标量——`height`（prism）、`prism_h` /
+`upper_h` / `lower_h`（pyramid），以及两种类型都有的 6 个 `face_distance`——
+各自独立抽样。即使把 6 个 `face_distance` 的均值都配成相等，每次抽样仍会各自
+被扰动成互不相等的不等边六边形：均值对称不代表单次抽样对称。
+
+`sync_group` 把一个晶体的若干形状标量划入**同一组**，使它们在该晶体实例上
+**共享同一次随机抽样**，而不是各自独立抽样。这是表达"每次抽样都严格对称"的
+habit（而不仅是均值对称）的唯一方式——最典型的场景是三方（C3）六棱柱：面
+0/2/4 须逐样本相等，面 1/3/5 须逐样本相等。
+
+**schema**——一个可选对象，键名与 shape 对象里该标量自身的 JSON 字段名相同；
+`face_distance` 取 6 元素整数数组（与 `face_distance` 本身的写法一致），而不是
+标量：
+
+```json
+"sync_group": {
+  "height": 1,                        // 仅 prism
+  "prism_h": 1, "upper_h": 2, "lower_h": 2,   // 仅 pyramid
+  "face_distance": [1, 2, 1, 2, 1, 2]         // 两种类型都有
+}
+```
+
+- **`0` = 独立**（默认值——缺省 `sync_group` 键，或缺省某个标量的条目，均等价于
+  全部独立，与 sync group 出现之前的行为完全一致）。**`1..N` = 组号**：组号相同
+  的标量共享一次抽样。组号只需要表达一个*划分*，不要求连续或已排序——
+  `{1,2,1,2,1,2}` 与 `{2,1,2,1,2,1}` 描述的是同一个划分，加载时会被规范化为同一
+  个标准形（按固定标量顺序——即 RNG 抽取顺序 `height`/`upper_h`/`prism_h`/
+  `lower_h`/`face_distance[0..5]`，而非上面结构体的字段声明顺序——首次出现即
+  重编号）。只剩一个成员的组会退化回独立（`0`）。
+- **共享的是同一个值，不是同一个随机变量**：一个组每个晶体实例只抽一次，组内
+  全部成员拿到同一个原始值；不是统计意义上"相关"，而是逐实例位级相等。
+- **组的分布取自其 leader**：leader 是该组在 RNG 抽取顺序上的第一个成员（对
+  `face_distance` 而言即组内下标最小的面）。其余成员各自声明的分布会在加载时
+  被 leader 的分布覆盖；若某个非 leader 成员声明了不同的分布，该声明会被丢弃
+  并记一条 WARN 日志——既不静默丢弃也不报错拒绝。
+- **跨类组（高度标量与面标量同组）机制上合法，但存在一个已记录的不对称**：
+  高度标量在使用前会取 `abs()`（负高度没有独立于朝向之外的物理含义），而
+  `face_distance` 保持带符号（负的面距离是合法的、跨越原点的平面偏移，见上文）。
+  这类组共享同一个*原始*抽样值，但高度成员取其绝对值而面成员保留符号——两者
+  并非数值相等，只是绝对值相等。机制不阻止这类组，也不做量纲可通约性校验。
+- **物理边界，如实说明**：`height` / `face_distance` 随机化只沿法向平移面，
+  从不旋转面的法向方向（背景见
+  [`geometry-randomization-value-and-measurement.md`](geometry-randomization-value-and-measurement.md)）。
+  sync group 继承这一边界：它本身不会在新的角度产生光晕特征。它买到的是
+  **habit 保真度**——一个逐个晶体都真正对称的 ensemble（例如真正的三方 C3
+  群体，而不只是均值 C3），这在 roll **不是**均匀随机时才真正显形（Parry /
+  Lowitz / 固定 roll 场景；roll 若做完整 360° 均匀随机，ensemble 平均本就会
+  统计性恢复六重对称，与单个晶体是否对称无关）；此外，把对面面对（`i` 与
+  `i+3`）设为同组还有一个副作用——两者之和的符号结构随之固定，可在强随机化下
+  降低几何合法性拒绝率。
+
+**C3 三方晶体示例**（已实测验证：全部面用相同均值、相同标准差的高斯分布，
+配两个交替的 sync group——与单元测试
+`SyncGroupPreview.C3GroupingCollapsesRandomDrawsToTwo` 覆盖的场景完全一致）：
+
+```json
+{
+  "id": 1,
+  "type": "prism",
+  "shape": {
+    "height": 1.3,
+    "face_distance": [
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 },
+      { "type": "gauss", "mean": 1.0, "std": 0.1 }
+    ],
+    "sync_group": {
+      "face_distance": [1, 2, 1, 2, 1, 2]
+    }
+  }
+}
+```
+
+每个采样出的晶体现在只有两个不同的面距离（面 0/2/4 共享一次抽样，面 1/3/5
+共享另一次），而不是六个各自独立的值——每次抽样都是严格的三方 habit，而不是
+仅在均值上如此。
 
 #### 分布类型（Distribution）
 
@@ -618,6 +706,9 @@
 - `crystal[].shape.face_distance` 数组长度必须为 6（如果指定）
 - `crystal[].shape.upper_indices` 数组长度必须为 3（如果指定）
 - `crystal[].shape.lower_indices` 数组长度必须为 3（如果指定）
+- `crystal[].shape.sync_group.face_distance` 数组长度必须为 6（如果指定）；比 6 短会将剩余槽位
+  按独立（0）处理，比 6 长会被截断，而不是报错拒绝——详见[形状标量 Sync
+  Group](#形状标量-sync-group)
 - `render[].resolution` 数组长度必须为 2
 
 ### 数值范围验证

--- a/src/config/config_compare.hpp
+++ b/src/config/config_compare.hpp
@@ -10,8 +10,10 @@ namespace lumice {
 // ---- Core math types ----
 
 inline bool operator==(const Distribution& a, const Distribution& b) {
-  static_assert(sizeof(Distribution) == 12, "Update operator== when Distribution fields change");
-  return a.type == b.type && a.center == b.center && a.spread == b.spread;
+  // Field comparison lives in core/math.hpp next to Distribution itself, so the
+  // sync-group normalization path shares it rather than keeping a second copy in
+  // step. See DistributionValueEqual for the static_assert guard.
+  return DistributionValueEqual(a, b);
 }
 
 inline bool operator==(const AxisDistribution& a, const AxisDistribution& b) {
@@ -21,14 +23,29 @@ inline bool operator==(const AxisDistribution& a, const AxisDistribution& b) {
 
 // ---- Crystal config ----
 
+// sync_group_ is compared in canonical form, on local copies: these operators are
+// the re-simulation trigger predicate, and two spellings of the same partition
+// (`[1,2,1,2,1,2]` vs `[2,1,2,1,2,1]`) must not cost the user a full re-run.
+// Canonicalizing here rather than demanding it of every caller is what makes that
+// hold for hand-built params too, not only for parsed ones.
 inline bool operator==(const PrismCrystalParam& a, const PrismCrystalParam& b) {
-  return a.h_ == b.h_ && std::equal(std::begin(a.d_), std::end(a.d_), std::begin(b.d_));
+  PrismCrystalParam ca = a;
+  PrismCrystalParam cb = b;
+  CanonicalizeSyncGroups(ca);
+  CanonicalizeSyncGroups(cb);
+  return a.h_ == b.h_ && std::equal(std::begin(a.d_), std::end(a.d_), std::begin(b.d_)) &&
+         std::equal(std::begin(ca.sync_group_), std::end(ca.sync_group_), std::begin(cb.sync_group_));
 }
 
 inline bool operator==(const PyramidCrystalParam& a, const PyramidCrystalParam& b) {
+  PyramidCrystalParam ca = a;
+  PyramidCrystalParam cb = b;
+  CanonicalizeSyncGroups(ca);
+  CanonicalizeSyncGroups(cb);
   return a.h_prs_ == b.h_prs_ && a.h_pyr_u_ == b.h_pyr_u_ && a.h_pyr_l_ == b.h_pyr_l_ &&
          std::equal(std::begin(a.d_), std::end(a.d_), std::begin(b.d_)) && a.wedge_angle_u_ == b.wedge_angle_u_ &&
-         a.wedge_angle_l_ == b.wedge_angle_l_;
+         a.wedge_angle_l_ == b.wedge_angle_l_ &&
+         std::equal(std::begin(ca.sync_group_), std::end(ca.sync_group_), std::begin(cb.sync_group_));
 }
 
 inline bool operator==(const CrystalConfig& a, const CrystalConfig& b) {

--- a/src/config/crystal_config.cpp
+++ b/src/config/crystal_config.cpp
@@ -1,19 +1,233 @@
 #include "config/crystal_config.hpp"
 
+#include <iterator>
 #include <nlohmann/json.hpp>
 #include <numeric>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include "core/math.hpp"
 #include "util/logger.hpp"
 
 namespace lumice {
 
+namespace {
+
+// Which ShapeScalar slots physically exist on each crystal type. A prism has one
+// height and six faces; a pyramid has three stacked heights and six faces.
+constexpr bool kApplicablePrism[kShapeScalarCount] = {
+  true,   // kShapeScalarHeight
+  false,  // kShapeScalarUpperH
+  false,  // kShapeScalarPrismH
+  false,  // kShapeScalarLowerH
+  true,  true, true, true, true, true,
+};
+constexpr bool kApplicablePyramid[kShapeScalarCount] = {
+  false,  // kShapeScalarHeight
+  true,   // kShapeScalarUpperH
+  true,   // kShapeScalarPrismH
+  true,   // kShapeScalarLowerH
+  true,  true, true, true, true, true,
+};
+
+void CanonicalizeSyncGroupsImpl(int sync_group[kShapeScalarCount], const bool applicable[kShapeScalarCount]) {
+  // Rule 1: a group declared on a slot this crystal type does not have is not a
+  // membership at all. Zeroing first is what makes rules 2 and 3 see the real
+  // member set.
+  for (int i = 0; i < kShapeScalarCount; i++) {
+    if (!applicable[i]) {
+      sync_group[i] = 0;
+    }
+  }
+
+  // Rule 2: a one-member group is independence spelled differently.
+  for (int i = 0; i < kShapeScalarCount; i++) {
+    if (sync_group[i] == 0) {
+      continue;
+    }
+    int members = 0;
+    for (int k = 0; k < kShapeScalarCount; k++) {
+      if (sync_group[k] == sync_group[i]) {
+        members++;
+      }
+    }
+    if (members < 2) {
+      sync_group[i] = 0;
+    }
+  }
+
+  // Rule 3: renumber 1..N by first appearance in ShapeScalar order, so the same
+  // partition always has the same integers. Linear scans over <= 10 slots — a map
+  // would cost more than it saves.
+  int old_id[kShapeScalarCount]{};
+  int new_id[kShapeScalarCount]{};
+  int assigned = 0;
+  for (int i = 0; i < kShapeScalarCount; i++) {
+    if (sync_group[i] == 0) {
+      continue;
+    }
+    int mapped = 0;
+    for (int k = 0; k < assigned; k++) {
+      if (old_id[k] == sync_group[i]) {
+        mapped = new_id[k];
+        break;
+      }
+    }
+    if (mapped == 0) {
+      old_id[assigned] = sync_group[i];
+      mapped = assigned + 1;
+      new_id[assigned] = mapped;
+      assigned++;
+    }
+    sync_group[i] = mapped;
+  }
+}
+
+// Leader-normalize one param's groups. `slots` maps a ShapeScalar index to the
+// Distribution living there, or nullptr for a slot this crystal type lacks.
+void NormalizeSyncGroupsImpl(const int sync_group[kShapeScalarCount], Distribution* const slots[kShapeScalarCount]) {
+  for (int i = 0; i < kShapeScalarCount; i++) {
+    if (sync_group[i] == 0 || slots[i] == nullptr) {
+      continue;
+    }
+    // The leader is this group's first occupied slot in ShapeScalar order, which
+    // — because that order is the RNG draw order — is also the member that
+    // actually consumes the draw.
+    int leader = -1;
+    for (int k = 0; k < i; k++) {
+      if (sync_group[k] == sync_group[i] && slots[k] != nullptr) {
+        leader = k;
+        break;
+      }
+    }
+    if (leader < 0) {
+      continue;  // i is itself the leader.
+    }
+    if (!DistributionValueEqual(*slots[i], *slots[leader])) {
+      LOG_WARNING(
+          "Crystal shape sync group {}: member at shape-scalar index {} declared a different distribution than its "
+          "group leader at index {}; overriding the member to match the leader.",
+          sync_group[i], i, leader);
+    }
+    *slots[i] = *slots[leader];
+  }
+}
+
+}  // namespace
+
+
+void CanonicalizeSyncGroups(PrismCrystalParam& p) {
+  CanonicalizeSyncGroupsImpl(p.sync_group_, kApplicablePrism);
+}
+
+void CanonicalizeSyncGroups(PyramidCrystalParam& p) {
+  CanonicalizeSyncGroupsImpl(p.sync_group_, kApplicablePyramid);
+}
+
+void NormalizeSyncGroups(PrismCrystalParam& p) {
+  Distribution* slots[kShapeScalarCount] = {
+    &p.h_, nullptr, nullptr, nullptr, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
+  };
+  NormalizeSyncGroupsImpl(p.sync_group_, slots);
+}
+
+void NormalizeSyncGroups(PyramidCrystalParam& p) {
+  Distribution* slots[kShapeScalarCount] = {
+    nullptr, &p.h_pyr_u_, &p.h_prs_, &p.h_pyr_l_, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
+  };
+  NormalizeSyncGroupsImpl(p.sync_group_, slots);
+}
+
+void PrepareSyncGroups(PrismCrystalParam& p) {
+  CanonicalizeSyncGroups(p);
+  NormalizeSyncGroups(p);
+}
+
+void PrepareSyncGroups(PyramidCrystalParam& p) {
+  CanonicalizeSyncGroups(p);
+  NormalizeSyncGroups(p);
+}
+
+
+namespace {
+
+// Read the optional "sync_group" sub-map. Keys name shape scalars the same way
+// the surrounding shape JSON names their distributions ("height", "prism_h",
+// "upper_h", "lower_h", "face_distance"), so a reader never has to know the
+// ShapeScalar integers. Absent key = every scalar independent, which is why an
+// older config file needs no edit at all.
+void ReadSyncGroupJson(const nlohmann::json& j, int sync_group[kShapeScalarCount],
+                       const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  for (int i = 0; i < kShapeScalarCount; i++) {
+    sync_group[i] = 0;
+  }
+  if (!j.contains("sync_group")) {
+    return;
+  }
+  const auto& sg = j.at("sync_group");
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sg.contains(scalar_keys[k].first)) {
+      sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
+    }
+  }
+  if (sg.contains("face_distance")) {
+    size_t i = 0;
+    for (const auto& elem : sg.at("face_distance")) {
+      if (i >= 6) {
+        break;
+      }
+      sync_group[kShapeScalarFace0 + i] = elem.get<int>();
+      i++;
+    }
+  }
+}
+
+// Write "sync_group" only when something is actually synced, so the serialized
+// form of every existing config stays byte-identical.
+void WriteSyncGroupJson(nlohmann::json& j, const int sync_group[kShapeScalarCount],
+                        const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  nlohmann::json sg = nlohmann::json::object();
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sync_group[scalar_keys[k].second] != 0) {
+      sg[scalar_keys[k].first] = sync_group[scalar_keys[k].second];
+    }
+  }
+  bool any_face = false;
+  for (int i = 0; i < 6; i++) {
+    any_face = any_face || sync_group[kShapeScalarFace0 + i] != 0;
+  }
+  if (any_face) {
+    // All six, zeros included — matching how face_distance itself serializes.
+    sg["face_distance"] = std::vector<int>(sync_group + kShapeScalarFace0, sync_group + kShapeScalarFace0 + 6);
+  }
+  if (!sg.empty()) {
+    j["sync_group"] = sg;
+  }
+}
+
+constexpr std::pair<const char*, int> kPrismSyncGroupKeys[] = {
+  { "height", kShapeScalarHeight },
+};
+constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
+  { "prism_h", kShapeScalarPrismH },
+  { "upper_h", kShapeScalarUpperH },
+  { "lower_h", kShapeScalarLowerH },
+};
+
+}  // namespace
+
+
 // convert to & from json object
 // ========== PrismCrystalParam ==========
 void to_json(nlohmann::json& j, const PrismCrystalParam& p) {
   j["height"] = p.h_;
   j["face_distance"] = p.d_;
+  // Canonicalize a local copy: serialization must not depend on the caller having
+  // normalized, and must not mutate what it was handed either.
+  PrismCrystalParam canon = p;
+  CanonicalizeSyncGroups(canon);
+  WriteSyncGroupJson(j, canon.sync_group_, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
 }
 
 void from_json(const nlohmann::json& j, PrismCrystalParam& p) {
@@ -36,6 +250,9 @@ void from_json(const nlohmann::json& j, PrismCrystalParam& p) {
       i++;
     }
   }
+
+  ReadSyncGroupJson(j, p.sync_group_, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+  PrepareSyncGroups(p);
 }
 
 
@@ -58,6 +275,9 @@ void to_json(nlohmann::json& j, const PyramidCrystalParam& p) {
   j["upper_wedge_angle"] = p.wedge_angle_u_;
   j["lower_wedge_angle"] = p.wedge_angle_l_;
   j["face_distance"] = p.d_;
+  PyramidCrystalParam canon = p;
+  CanonicalizeSyncGroups(canon);
+  WriteSyncGroupJson(j, canon.sync_group_, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
 }
 
 void from_json(const nlohmann::json& j, PyramidCrystalParam& p) {
@@ -99,6 +319,9 @@ void from_json(const nlohmann::json& j, PyramidCrystalParam& p) {
       i++;
     }
   }
+
+  ReadSyncGroupJson(j, p.sync_group_, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+  PrepareSyncGroups(p);
 }
 
 

--- a/src/config/crystal_config.cpp
+++ b/src/config/crystal_config.cpp
@@ -1,5 +1,6 @@
 #include "config/crystal_config.hpp"
 
+#include <array>
 #include <iterator>
 #include <nlohmann/json.hpp>
 #include <numeric>
@@ -14,29 +15,39 @@ namespace lumice {
 
 namespace {
 
-// Which ShapeScalar slots physically exist on each crystal type. A prism has one
-// height and six faces; a pyramid has three stacked heights and six faces.
-constexpr bool kApplicablePrism[kShapeScalarCount] = {
-  true,   // kShapeScalarHeight
-  false,  // kShapeScalarUpperH
-  false,  // kShapeScalarPrismH
-  false,  // kShapeScalarLowerH
-  true,  true, true, true, true, true,
-};
-constexpr bool kApplicablePyramid[kShapeScalarCount] = {
-  false,  // kShapeScalarHeight
-  true,   // kShapeScalarUpperH
-  true,   // kShapeScalarPrismH
-  true,   // kShapeScalarLowerH
-  true,  true, true, true, true, true,
-};
+// Which Distribution each ShapeScalar slot names on this crystal type, or nullptr
+// for a slot the type simply does not have. A prism has one height and six faces;
+// a pyramid has three stacked heights and six faces.
+//
+// These two functions are the SINGLE source of "does this slot physically exist
+// on this type". Both consumers derive from them and neither restates the fact:
+// leader normalization needs the addresses, canonicalization needs only the
+// nullptr pattern, and `IsShapeScalarApplicable` (below) exposes the same pattern
+// to the C API. A previous revision kept a separate `kApplicable*` bool table for
+// canonicalization; the two encodings had nothing tying them together, so adding
+// a crystal type or moving a slot could silently desynchronize them.
+using ShapeScalarSlots = std::array<Distribution*, kShapeScalarCount>;
 
-void CanonicalizeSyncGroupsImpl(int sync_group[kShapeScalarCount], const bool applicable[kShapeScalarCount]) {
+ShapeScalarSlots PrismSlots(PrismCrystalParam& p) {
+  return {
+    &p.h_, nullptr, nullptr, nullptr, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
+  };
+}
+
+ShapeScalarSlots PyramidSlots(PyramidCrystalParam& p) {
+  return {
+    nullptr, &p.h_pyr_u_, &p.h_prs_, &p.h_pyr_l_, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
+  };
+}
+
+// `slots` is read for its nullptr pattern only — never dereferenced — so this pass
+// works on exactly the same applicability fact NormalizeSyncGroupsImpl uses.
+void CanonicalizeSyncGroupsImpl(int sync_group[kShapeScalarCount], const ShapeScalarSlots& slots) {
   // Rule 1: a group declared on a slot this crystal type does not have is not a
   // membership at all. Zeroing first is what makes rules 2 and 3 see the real
   // member set.
   for (int i = 0; i < kShapeScalarCount; i++) {
-    if (!applicable[i]) {
+    if (slots[i] == nullptr) {
       sync_group[i] = 0;
     }
   }
@@ -86,7 +97,7 @@ void CanonicalizeSyncGroupsImpl(int sync_group[kShapeScalarCount], const bool ap
 
 // Leader-normalize one param's groups. `slots` maps a ShapeScalar index to the
 // Distribution living there, or nullptr for a slot this crystal type lacks.
-void NormalizeSyncGroupsImpl(const int sync_group[kShapeScalarCount], Distribution* const slots[kShapeScalarCount]) {
+void NormalizeSyncGroupsImpl(const int sync_group[kShapeScalarCount], const ShapeScalarSlots& slots) {
   for (int i = 0; i < kShapeScalarCount; i++) {
     if (sync_group[i] == 0 || slots[i] == nullptr) {
       continue;
@@ -118,25 +129,19 @@ void NormalizeSyncGroupsImpl(const int sync_group[kShapeScalarCount], Distributi
 
 
 void CanonicalizeSyncGroups(PrismCrystalParam& p) {
-  CanonicalizeSyncGroupsImpl(p.sync_group_, kApplicablePrism);
+  CanonicalizeSyncGroupsImpl(p.sync_group_, PrismSlots(p));
 }
 
 void CanonicalizeSyncGroups(PyramidCrystalParam& p) {
-  CanonicalizeSyncGroupsImpl(p.sync_group_, kApplicablePyramid);
+  CanonicalizeSyncGroupsImpl(p.sync_group_, PyramidSlots(p));
 }
 
 void NormalizeSyncGroups(PrismCrystalParam& p) {
-  Distribution* slots[kShapeScalarCount] = {
-    &p.h_, nullptr, nullptr, nullptr, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
-  };
-  NormalizeSyncGroupsImpl(p.sync_group_, slots);
+  NormalizeSyncGroupsImpl(p.sync_group_, PrismSlots(p));
 }
 
 void NormalizeSyncGroups(PyramidCrystalParam& p) {
-  Distribution* slots[kShapeScalarCount] = {
-    nullptr, &p.h_pyr_u_, &p.h_prs_, &p.h_pyr_l_, &p.d_[0], &p.d_[1], &p.d_[2], &p.d_[3], &p.d_[4], &p.d_[5],
-  };
-  NormalizeSyncGroupsImpl(p.sync_group_, slots);
+  NormalizeSyncGroupsImpl(p.sync_group_, PyramidSlots(p));
 }
 
 void PrepareSyncGroups(PrismCrystalParam& p) {

--- a/src/config/crystal_config.cpp
+++ b/src/config/crystal_config.cpp
@@ -157,6 +157,10 @@ void PrepareSyncGroups(PyramidCrystalParam& p) {
 
 namespace {
 
+// The one key covering all six face slots — its value is a 6-element array, so
+// the key is written once rather than once per face.
+constexpr const char* kFaceDistanceSyncKey = "face_distance";
+
 // Read the optional "sync_group" sub-map. Keys name shape scalars the same way
 // the surrounding shape JSON names their distributions ("height", "prism_h",
 // "upper_h", "lower_h", "face_distance"), so a reader never has to know the
@@ -176,9 +180,9 @@ void ReadSyncGroupJson(const nlohmann::json& j, int sync_group[kShapeScalarCount
       sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
     }
   }
-  if (sg.contains("face_distance")) {
+  if (sg.contains(kFaceDistanceSyncKey)) {
     size_t i = 0;
-    for (const auto& elem : sg.at("face_distance")) {
+    for (const auto& elem : sg.at(kFaceDistanceSyncKey)) {
       if (i >= 6) {
         break;
       }
@@ -204,7 +208,7 @@ void WriteSyncGroupJson(nlohmann::json& j, const int sync_group[kShapeScalarCoun
   }
   if (any_face) {
     // All six, zeros included — matching how face_distance itself serializes.
-    sg["face_distance"] = std::vector<int>(sync_group + kShapeScalarFace0, sync_group + kShapeScalarFace0 + 6);
+    sg[kFaceDistanceSyncKey] = std::vector<int>(sync_group + kShapeScalarFace0, sync_group + kShapeScalarFace0 + 6);
   }
   if (!sg.empty()) {
     j["sync_group"] = sg;
@@ -220,7 +224,51 @@ constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
   { "lower_h", kShapeScalarLowerH },
 };
 
+// Returns nullptr when the table names no key for `slot`. Unreachable while each
+// table covers every applicable non-face slot of its type, which
+// ShapeScalarSyncKeyNameApi.AgreesWithApplicabilityOnEverySlot pins; answering
+// nullptr rather than asserting keeps a slot added to the applicability map but
+// not to these tables from being handed an invented key name.
+const char* LookupSyncKey(const std::pair<const char*, int>* keys, size_t key_cnt, int slot) {
+  for (size_t k = 0; k < key_cnt; k++) {
+    if (keys[k].second == slot) {
+      return keys[k].first;
+    }
+  }
+  return nullptr;
+}
+
 }  // namespace
+
+
+bool IsShapeScalarApplicable(CrystalKind kind, int slot) {
+  if (slot < 0 || slot >= kShapeScalarCount) {
+    return false;
+  }
+  // Derived from the same slot maps the two sync-group passes scope themselves
+  // by, so applicability keeps exactly one definition. The local param exists
+  // only to give those maps addresses to point at — no Distribution is read, and
+  // nothing outlives this call.
+  if (kind == CrystalKind::kPrism) {
+    PrismCrystalParam probe;
+    return PrismSlots(probe)[slot] != nullptr;
+  }
+  PyramidCrystalParam probe;
+  return PyramidSlots(probe)[slot] != nullptr;
+}
+
+const char* ShapeScalarSyncKeyName(CrystalKind kind, int slot) {
+  if (!IsShapeScalarApplicable(kind, slot)) {
+    return nullptr;
+  }
+  if (slot >= kShapeScalarFace0) {
+    return kFaceDistanceSyncKey;
+  }
+  if (kind == CrystalKind::kPrism) {
+    return LookupSyncKey(kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys), slot);
+  }
+  return LookupSyncKey(kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys), slot);
+}
 
 
 // convert to & from json object

--- a/src/config/crystal_config.hpp
+++ b/src/config/crystal_config.hpp
@@ -95,18 +95,35 @@ void CanonicalizeSyncGroups(PyramidCrystalParam& p);
 //!   overwritten anyway, but only after a LOG_WARNING — neither silent nor
 //!   rejected.
 //!
-//!   PRECONDITION: CanonicalizeSyncGroups must have run first. Otherwise a slot
-//!   that rule 1 is about to zero (inapplicable to this type) could be picked as
-//!   the leader and donate its distribution to the whole group. Prefer
-//!   PrepareSyncGroups, which cannot get the order wrong.
+//!   No ordering precondition: this pass does NOT need CanonicalizeSyncGroups to
+//!   have run first. Both the members it rewrites and the leaders it elects are
+//!   scoped to slots this crystal type actually has, and that scoping is
+//!   structural — an inapplicable slot names no field to read or donate, so it
+//!   can be neither leader nor member no matter what its group number says. The
+//!   other two canonical-form rules cannot move the outcome either: collapsing a
+//!   singleton group turns one no-op (a lone member finds no earlier peer) into
+//!   another (group 0 is skipped), and renumbering is a bijection on non-zero ids
+//!   while this pass only ever compares ids for equality. Pinned by
+//!   NormalizeAloneExcludesInapplicableSlotWithoutCanonicalizeFirst, which runs
+//!   this pass on its own.
+//!
+//!   (An earlier revision of this comment claimed the opposite — that a slot
+//!   rule 1 is about to zero could be elected leader and donate its distribution.
+//!   It cannot: such a slot has no distribution to donate. Prefer
+//!   PrepareSyncGroups anyway, because both passes are needed, not because one
+//!   protects the other.)
 void NormalizeSyncGroups(PrismCrystalParam& p);
 void NormalizeSyncGroups(PyramidCrystalParam& p);
 
-//! @brief Canonicalize-then-normalize, in the only correct order.
+//! @brief Run both sync-group passes: canonicalize, then leader-normalize.
 //!
-//! @details The composed entry point every parse path should call, so the order
-//!   invariant is enforced by the implementation instead of by each caller's
-//!   memory.
+//! @details The composed entry point every parse path should call, so that
+//!   neither pass can be forgotten. Each answers a different question and both
+//!   are required: canonical form is what makes operator== (the re-simulation
+//!   trigger) see equal partitions as equal, leader normalization is what makes
+//!   the group's members carry one distribution. Their relative order does not
+//!   change the result (see NormalizeSyncGroups above); it is fixed here only so
+//!   there is one entry point rather than a choice at every call site.
 void PrepareSyncGroups(PrismCrystalParam& p);
 void PrepareSyncGroups(PyramidCrystalParam& p);
 

--- a/src/config/crystal_config.hpp
+++ b/src/config/crystal_config.hpp
@@ -9,9 +9,59 @@
 
 namespace lumice {
 
+//! @brief Index space for every randomizable crystal shape scalar.
+//!
+//! @details Slots are shared by both crystal types: a prism only owns
+//!   kShapeScalarHeight + the six faces, a pyramid only owns the three
+//!   pyramidal/prism heights + the six faces. Slots that do not apply to a type
+//!   are simply never read for that type (CanonicalizeSyncGroups zeroes their
+//!   sync group so an inapplicable declaration cannot leak into equality).
+//!
+//!   ⚠️ The order is deliberately chosen to be *verbatim the RNG draw order* in
+//!   simulator.cpp's CrystalMaker: prism draws h_ then d_[0..5]; pyramid draws
+//!   h_pyr_u_ -> h_prs_ -> h_pyr_l_ then d_[0..5]. That makes "a group's leader
+//!   = its lowest-index member applicable to the crystal type" identical to "the
+//!   member drawn first", so no second ordering definition is needed anywhere.
+//!
+//!   Note this is NOT the field declaration order of PyramidCrystalParam, and
+//!   NOT the field order of the C API's LUMICE_CrystalParam
+//!   (height/prism_h/upper_h/lower_h). The divergence is intentional; the C API
+//!   mirror carries the same warning.
+enum ShapeScalar : int {
+  kShapeScalarHeight = 0,  // PrismCrystalParam::h_ — prism only
+  kShapeScalarUpperH = 1,  // PyramidCrystalParam::h_pyr_u_ — pyramid only
+  kShapeScalarPrismH = 2,  // PyramidCrystalParam::h_prs_ — pyramid only
+  kShapeScalarLowerH = 3,  // PyramidCrystalParam::h_pyr_l_ — pyramid only
+  kShapeScalarFace0 = 4,   // d_[0] — both types
+  kShapeScalarFace1 = 5,
+  kShapeScalarFace2 = 6,
+  kShapeScalarFace3 = 7,
+  kShapeScalarFace4 = 8,
+  kShapeScalarFace5 = 9,
+  kShapeScalarCount = 10,
+};
+
+//! @brief Shape-scalar sync groups: 0 = independent, 1..N = group id.
+//!
+//! @details Members of one group share a SINGLE random draw (the group's first
+//!   applicable member consumes the RNG; the rest reuse its value without
+//!   consuming anything). Zero-initialized = every scalar independent = the
+//!   behavior before sync groups existed.
+//!
+//!   Deliberately a parallel array on the param structs rather than a field on
+//!   Distribution: that type is shared with the orientation distributions and
+//!   crosses the GPU device wire (pcg_shared.h), which is the wrong scope for a
+//!   host-only shape-sampling concept.
+//!
+//!   Heights fold with std::abs while face distances stay signed (see
+//!   CrystalMaker), so a group that mixes a height with a face distance shares
+//!   the same *raw* draw but the height member consumes |v|. The mechanism does
+//!   not forbid such a group; the asymmetry is documented, not validated away.
+
 struct PrismCrystalParam {
   Distribution h_{ DistributionType::kNoRandom, 1.0f, 0.0f };  // Height, equal to c/a in HP2.0
   Distribution d_[6]{};                                        // Distance to center for prism faces
+  int sync_group_[kShapeScalarCount]{};                        // Shape-scalar sync groups, 0 = independent
 };
 
 struct PyramidCrystalParam {
@@ -19,9 +69,46 @@ struct PyramidCrystalParam {
   Distribution h_pyr_u_{ DistributionType::kNoRandom, 0.0f, 0.0f };  // Upper pyramidal relative height, from 0.0 to 1.0
   Distribution h_pyr_l_{ DistributionType::kNoRandom, 0.0f, 0.0f };  // Lower pyramidal relative height, from 0.0 to 1.0
   Distribution d_[6]{};                                              // Distance to center for prism faces
+  int sync_group_[kShapeScalarCount]{};                              // Shape-scalar sync groups, 0 = independent
   float wedge_angle_u_ = 28.0f;  // Upper wedge angle (degrees). Default ≈ atan(√3/2 / 1.629), i.e. Miller {1,0,-1,1}
   float wedge_angle_l_ = 28.0f;  // Lower wedge angle (degrees)
 };
+
+//! @brief Rewrite sync_group_ into its canonical form. Three rules, all required:
+//!   1. slots not applicable to this crystal type are zeroed;
+//!   2. single-member groups are zeroed (a singleton group IS independence);
+//!   3. surviving groups are renumbered 1..N by first appearance in ShapeScalar order.
+//!
+//! @details Canonical form is not cosmetic: config_compare.hpp's operator== is
+//!   the re-simulation trigger predicate, so `[2,1,2,1,2,1]` and `[1,2,1,2,1,2]`
+//!   — the same partition — must compare equal or a semantic no-op would kick
+//!   off a full re-run. Applied on parse, on serialization, and inside
+//!   operator== (on local copies).
+void CanonicalizeSyncGroups(PrismCrystalParam& p);
+void CanonicalizeSyncGroups(PyramidCrystalParam& p);
+
+//! @brief Leader-normalize the distributions inside each sync group.
+//!
+//! @details The group's leader (lowest applicable ShapeScalar index, i.e. the
+//!   member drawn first) owns the distribution; every other member's
+//!   Distribution is overwritten with the leader's. A member that differed is
+//!   overwritten anyway, but only after a LOG_WARNING — neither silent nor
+//!   rejected.
+//!
+//!   PRECONDITION: CanonicalizeSyncGroups must have run first. Otherwise a slot
+//!   that rule 1 is about to zero (inapplicable to this type) could be picked as
+//!   the leader and donate its distribution to the whole group. Prefer
+//!   PrepareSyncGroups, which cannot get the order wrong.
+void NormalizeSyncGroups(PrismCrystalParam& p);
+void NormalizeSyncGroups(PyramidCrystalParam& p);
+
+//! @brief Canonicalize-then-normalize, in the only correct order.
+//!
+//! @details The composed entry point every parse path should call, so the order
+//!   invariant is enforced by the implementation instead of by each caller's
+//!   memory.
+void PrepareSyncGroups(PrismCrystalParam& p);
+void PrepareSyncGroups(PyramidCrystalParam& p);
 
 using CrystalParam = std::variant<PrismCrystalParam, PyramidCrystalParam>;
 

--- a/src/config/crystal_config.hpp
+++ b/src/config/crystal_config.hpp
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <variant>
 
+#include "core/crystal_kind.hpp"
 #include "core/math.hpp"
 
 namespace lumice {
@@ -126,6 +127,34 @@ void NormalizeSyncGroups(PyramidCrystalParam& p);
 //!   there is one entry point rather than a choice at every call site.
 void PrepareSyncGroups(PrismCrystalParam& p);
 void PrepareSyncGroups(PyramidCrystalParam& p);
+
+//! @brief Does shape-scalar `slot` physically exist on this crystal type?
+//!
+//! @details The runtime query onto the ONE table that answers this — the same
+//!   slot map CanonicalizeSyncGroups and NormalizeSyncGroups scope themselves
+//!   by. It exists so consumers outside this TU (the C API, and through it the
+//!   GUI, which may not include this header) can ask core rather than keep a
+//!   private truth table that has to be edited in lockstep. Out-of-range slots
+//!   answer false rather than trapping, so a caller iterating 0..N over a
+//!   mismatched slot count degrades to "not applicable" instead of reading
+//!   garbage.
+//!
+//!   O(1), no allocation, no side effects — safe to call per row per frame.
+bool IsShapeScalarApplicable(CrystalKind kind, int slot);
+
+//! @brief The JSON key under `shape.sync_group` that names shape-scalar `slot`.
+//!
+//! @details Returns a static string, or nullptr when the slot does not apply to
+//!   `kind` (or is out of range). All six face slots share the single key
+//!   "face_distance", whose value is a 6-element array — callers write it once,
+//!   not once per face.
+//!
+//!   Same motive as IsShapeScalarApplicable: this used to be a `{key, slot}`
+//!   literal table copied into three translation units (here, the C API, the GUI
+//!   file IO) with nothing but a comment tying them together. Drift had no
+//!   symptom — the layer that drifted would silently drop the field — so the
+//!   copies are gone and every layer reads this.
+const char* ShapeScalarSyncKeyName(CrystalKind kind, int slot);
 
 using CrystalParam = std::variant<PrismCrystalParam, PyramidCrystalParam>;
 

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -190,6 +190,19 @@ struct Distribution {
   float Scale() const;
 };
 
+//! @brief Field-by-field value equality for two Distributions.
+//!
+//! @details The single owner of "are these two distributions the same". Both
+//!   config_compare.hpp's operator==(Distribution, Distribution) — the
+//!   re-simulation trigger predicate — and the sync-group leader normalization in
+//!   crystal_config.cpp route here, so adding a field to Distribution cannot
+//!   leave one of them silently comparing the old subset. The static_assert is
+//!   what forces that update.
+inline bool DistributionValueEqual(const Distribution& a, const Distribution& b) {
+  static_assert(sizeof(Distribution) == 12, "Update DistributionValueEqual when Distribution fields change");
+  return a.type == b.type && a.center == b.center && a.spread == b.spread;
+}
+
 
 class RandomNumberGenerator {
  public:

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -33,6 +33,7 @@
 #include "core/optics.hpp"
 #include "core/shared/lat_path_selection.hpp"
 #include "util/env_knobs.hpp"
+#include "util/fatal.hpp"
 #include "util/illuminant.hpp"
 #include "util/logger.hpp"
 #include "util/queue.hpp"
@@ -338,35 +339,107 @@ void InitRayOtherMs(RandomNumberGenerator& rng, const RayBuffer init_data[2], si
 }
 
 
+namespace {
+
+// One shape-scalar draw per sync group, per crystal instance.
+//
+// A slot declaring group 0 is independent and draws as it always did. A slot in
+// group g draws once — whichever slot reaches the group first, which by
+// construction is its lowest ShapeScalar index because both Sample*ShapeScalars
+// walk the slots in enum order — and every later member of g reuses that raw
+// value WITHOUT consuming the RNG. That is what keeps the no-sync case's RNG
+// stream byte-identical to the pre-sync-group behavior: with every group 0, the
+// cache is never touched and Draw() degenerates to rng_.Get().
+//
+// The cache holds the RAW draw, before the std::abs() that heights apply. A
+// group mixing a height with a face distance therefore shares one draw and the
+// height member folds it at its own use site. That asymmetry is the documented,
+// deliberate consequence of allowing cross-kind groups at all — the mechanism
+// does not forbid them, and validating dimensional commensurability would cost
+// a type table, an error path and docs to buy only "one odd but still-valid
+// state becomes inexpressible".
+class SyncGroupSampler {
+ public:
+  explicit SyncGroupSampler(RandomNumberGenerator& rng) : rng_(rng) {}
+
+  float Draw(int group, const Distribution& dist) {
+    if (group == 0) {
+      return rng_.Get(dist);
+    }
+    for (int i = 0; i < cached_cnt_; i++) {
+      if (cached_group_[i] == group) {
+        return cached_value_[i];
+      }
+    }
+    const float value = rng_.Get(dist);
+    if (cached_cnt_ >= kShapeScalarCount) {
+      // Unreachable: each insert is a distinct group first seen at a distinct
+      // slot, and there are exactly kShapeScalarCount slots. Trapping rather
+      // than dropping the entry — a dropped entry would silently re-draw for a
+      // later member of the same group, i.e. break the group's whole contract.
+      FatalAbort("SyncGroupSampler cache overflow: %d groups over %d shape scalars", cached_cnt_, kShapeScalarCount);
+    }
+    cached_group_[cached_cnt_] = group;
+    cached_value_[cached_cnt_] = value;
+    cached_cnt_++;
+    return value;
+  }
+
+ private:
+  RandomNumberGenerator& rng_;
+  int cached_group_[kShapeScalarCount]{};
+  float cached_value_[kShapeScalarCount]{};
+  int cached_cnt_ = 0;
+};
+
+}  // namespace
+
+
+// Heights are folded with std::abs — a negative height has no physical
+// interpretation independent of crystal orientation. face_distance is signed:
+// negative d shifts the plane past the origin, still yielding a valid convex
+// body as long as opposite-pair sums d_i + d_{i+3} > 0 (verified downstream by
+// Crystal::CreatePrism's Euler-manifold gate; degenerate combos are rejected as
+// zero-triangle Crystals rather than silently absolute-valued at the sampler
+// boundary, which was hiding an entire input path from the geometry pipeline).
+float SamplePrismShapeScalars(RandomNumberGenerator& rng, const PrismCrystalParam& p, float dist_out[6]) {
+  SyncGroupSampler sampler{ rng };
+  const float h = std::abs(sampler.Draw(p.sync_group_[kShapeScalarHeight], p.h_));
+  for (int i = 0; i < 6; i++) {
+    dist_out[i] = sampler.Draw(p.sync_group_[kShapeScalarFace0 + i], p.d_[i]);
+  }
+  return h;
+}
+
+
+// Same rationale as the prism branch: heights fold, face_distance is signed.
+void SamplePyramidShapeScalars(RandomNumberGenerator& rng, const PyramidCrystalParam& p, float& h1, float& h2,
+                               float& h3, float dist_out[6]) {
+  SyncGroupSampler sampler{ rng };
+  h1 = std::abs(sampler.Draw(p.sync_group_[kShapeScalarUpperH], p.h_pyr_u_));
+  h2 = std::abs(sampler.Draw(p.sync_group_[kShapeScalarPrismH], p.h_prs_));
+  h3 = std::abs(sampler.Draw(p.sync_group_[kShapeScalarLowerH], p.h_pyr_l_));
+  for (int i = 0; i < 6; i++) {
+    dist_out[i] = sampler.Draw(p.sync_group_[kShapeScalarFace0 + i], p.d_[i]);
+  }
+}
+
+
 struct CrystalMaker {
   RandomNumberGenerator& rng_;
 
   Crystal operator()(const PrismCrystalParam& p) {
-    // Heights are folded with std::abs — a negative height has no physical
-    // interpretation independent of crystal orientation. face_distance is signed:
-    // negative d shifts the plane past the origin, still yielding a valid convex
-    // body as long as opposite-pair sums d_i + d_{i+3} > 0 (verified downstream
-    // by Crystal::CreatePrism's Euler-manifold gate; degenerate combos are
-    // rejected as zero-triangle Crystals rather than silently absolute-valued at
-    // the sampler boundary, which was hiding an entire input path from the
-    // geometry pipeline).
-    float h = std::abs(rng_.Get(p.h_));
     float dist[6]{};
-    for (int i = 0; i < 6; i++) {
-      dist[i] = rng_.Get(p.d_[i]);
-    }
+    const float h = SamplePrismShapeScalars(rng_, p, dist);
     return Crystal::CreatePrism(h, dist);
   }
 
   Crystal operator()(const PyramidCrystalParam& p) {
-    // Same rationale as the prism branch: heights fold, face_distance is signed.
-    float h1 = std::abs(rng_.Get(p.h_pyr_u_));
-    float h2 = std::abs(rng_.Get(p.h_prs_));
-    float h3 = std::abs(rng_.Get(p.h_pyr_l_));
+    float h1 = 0.f;
+    float h2 = 0.f;
+    float h3 = 0.f;
     float dist[6]{};
-    for (int i = 0; i < 6; i++) {
-      dist[i] = rng_.Get(p.d_[i]);
-    }
+    SamplePyramidShapeScalars(rng_, p, h1, h2, h3, dist);
     return Crystal::CreatePyramid(p.wedge_angle_u_, p.wedge_angle_l_, h1, h2, h3, dist);
   }
 };
@@ -378,6 +451,9 @@ Crystal MakeCrystal(RandomNumberGenerator& rng, const CrystalParam& param) {
 
 
 bool IsDeterministic(const CrystalParam& param) {
+  // sync_group_ deliberately plays no part here: the predicate asks whether the
+  // RNG is consumed at all, and a group whose members are all kNoRandom consumes
+  // nothing either way. Verified, not overlooked.
   auto all_no_random = [](const Distribution* d, size_t n) {
     return !std::any_of(d, d + n, [](const auto& x) { return x.type != DistributionType::kNoRandom; });
   };

--- a/src/core/trace_ops.hpp
+++ b/src/core/trace_ops.hpp
@@ -65,6 +65,21 @@ void FillRayOtherInfo(const Crystal& curr_crystal, RayBuffer buffer_data[2]);
 // Allocate the all_data buffer with expected total-ray capacity for a session.
 RayBuffer AllocateAllData(const SceneConfig& config, size_t ray_num);
 
+// Sample the raw prism shape scalars, honoring PrismCrystalParam::sync_group_
+// (draw order: height, then face_distance[0..5] — the same order MakeCrystal's
+// prism branch has always used). Exposed beyond MakeCrystal so tests can assert
+// on the raw scalars and on the RNG draw count directly: MakeCrystal folds them
+// into closed-form Crystal geometry, which may reject or degenerate the very
+// inputs a sampling test needs to see.
+// Returns h (already abs()'d); dist_out receives the 6 signed face distances.
+float SamplePrismShapeScalars(RandomNumberGenerator& rng, const PrismCrystalParam& p, float dist_out[6]);
+
+// Same for pyramid. Draw order is h_pyr_u_ -> h_prs_ -> h_pyr_l_ ->
+// face_distance[0..5] — NOT the struct declaration order; see ShapeScalar.
+// h1/h2/h3 are already abs()'d.
+void SamplePyramidShapeScalars(RandomNumberGenerator& rng, const PyramidCrystalParam& p, float& h1, float& h2,
+                               float& h3, float dist_out[6]);
+
 // Build a Crystal from a CrystalParam variant using the given RNG. Matches
 // the file-local CrystalMaker visitor used by Simulator (for non-deterministic
 // params each call samples a fresh shape using the RNG).

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -33,6 +33,17 @@ int g_crystal_mesh_hash = 0;  // Hash of crystal params for change detection
 static LUMICE_CrystalMesh g_last_mesh{};
 static bool g_last_mesh_valid = false;
 
+// Salt bases for CrystalParamHash's ten ShapeDist fields (height/prism_h/upper_h/lower_h then the
+// six face_distance entries) and the two single-slot alpha salts. This is the single source both
+// the hash_shape() call sites below and HashSaltSlotsAreDistinct's compile-time proof read from —
+// two independently hand-typed copies of the same literals could drift out of sync (e.g. a call
+// site's salt changed without updating the proof's copy) while the assert keeps compiling green,
+// silently certifying a layout that is no longer the one actually hashed.
+constexpr int kShapeSaltBaseCount = 10;
+constexpr int kShapeSaltBases[kShapeSaltBaseCount] = { 31, 37, 43, 49, 59, 63, 67, 71, 75, 79 };
+constexpr int kAlphaSaltCount = 2;
+constexpr int kAlphaSalts[kAlphaSaltCount] = { 55, 57 };  // upper_alpha / lower_alpha
+
 int CrystalParamHash(const CrystalConfig& c) {
   // Simple hash to detect parameter changes
   int h = static_cast<int>(c.type);
@@ -58,35 +69,30 @@ int CrystalParamHash(const CrystalConfig& c) {
   // 31/37/41/43 + 47/53 while a ShapeDist was three slots wide; at four, 41's block would have
   // swallowed lower_h's 43. See HashSaltSlotsAreDistinct below — the assertion, not this comment,
   // is what keeps the property true.
-  h ^= hash_shape(c.height, 31);
-  h ^= hash_shape(c.prism_h, 37);
-  h ^= hash_shape(c.upper_h, 43);
-  h ^= hash_shape(c.lower_h, 49);
-  h ^= hash_float(c.upper_alpha) * 55;
-  h ^= hash_float(c.lower_alpha) * 57;
+  h ^= hash_shape(c.height, kShapeSaltBases[0]);
+  h ^= hash_shape(c.prism_h, kShapeSaltBases[1]);
+  h ^= hash_shape(c.upper_h, kShapeSaltBases[2]);
+  h ^= hash_shape(c.lower_h, kShapeSaltBases[3]);
+  h ^= hash_float(c.upper_alpha) * kAlphaSalts[0];
+  h ^= hash_float(c.lower_alpha) * kAlphaSalts[1];
   for (int i = 0; i < 6; i++) {
     // Stride 4, not 3: each ShapeDist now spans salt..salt+3, so a stride of 3 would give face i's
     // sync_group slot the same multiplier as face i+1's type slot, letting two changes cancel.
-    h ^= hash_shape(c.face_distance[i], 59 + i * 4);
+    h ^= hash_shape(c.face_distance[i], kShapeSaltBases[4 + i]);
   }
   return h;
 }
 
 // Compile-time proof of the property CrystalParamHash relies on: no two slots share a multiplier.
-// A hand-checked list of constants is exactly the kind of claim that rots the next time someone
-// adds a shape field or shifts a salt, so it is asserted rather than argued in a comment. The
-// slots in use are each ShapeDist base's base..base+3 (ten of them: the four isolated scalars plus
-// the six face_distance blocks at 59 + i*4) and the two single-slot alpha salts.
+// Reads kShapeSaltBases/kAlphaSalts directly (the same constants the hash_shape call sites above
+// use) rather than a second hand-typed copy, so the proof cannot silently drift from what is
+// actually hashed. The slots in use are each ShapeDist base's base..base+3 (ten of them: the four
+// isolated scalars plus the six face_distance blocks) and the two single-slot alpha salts.
 constexpr bool HashSaltSlotsAreDistinct() {
-  constexpr int kShapeBaseCount = 10;
-  constexpr int kShapeBases[kShapeBaseCount] = { 31, 37, 43, 49, 59, 63, 67, 71, 75, 79 };
-  constexpr int kAlphaSaltCount = 2;
-  constexpr int kAlphaSalts[kAlphaSaltCount] = { 55, 57 };  // upper_alpha / lower_alpha
-
-  constexpr int kSlotCount = kShapeBaseCount * 4 + kAlphaSaltCount;
+  constexpr int kSlotCount = kShapeSaltBaseCount * 4 + kAlphaSaltCount;
   int slots[kSlotCount] = {};
   int n = 0;
-  for (int base : kShapeBases) {
+  for (int base : kShapeSaltBases) {
     for (int k = 0; k < 4; k++) {
       slots[n++] = base + k;
     }

--- a/src/gui/crystal_preview.cpp
+++ b/src/gui/crystal_preview.cpp
@@ -43,23 +43,68 @@ int CrystalParamHash(const CrystalConfig& c) {
   };
   // Each shape field is a ShapeDist: hash all three components ({type, center, spread}) so a change
   // to the distribution type or spread (not just the center) is detected and re-uploads the mesh.
+  // A ShapeDist occupies four consecutive salt slots: type/center/spread plus sync_group. The
+  // group MUST be hashed — changing only the grouping changes the geometry (synced scalars share
+  // one draw), and a hash blind to it leaves the stale mesh on screen, which reads as "the feature
+  // does not work" rather than as a caching bug.
   auto hash_shape = [&](const ShapeDist& d, int salt) {
     int hh = static_cast<int>(d.type) * salt;
     hh ^= hash_float(d.center) * (salt + 1);
     hh ^= hash_float(d.spread) * (salt + 2);
+    hh ^= d.sync_group * (salt + 3);
     return hh;
   };
+  // Salts are spaced ≥4 apart because each ShapeDist consumes four consecutive slots. They were
+  // 31/37/41/43 + 47/53 while a ShapeDist was three slots wide; at four, 41's block would have
+  // swallowed lower_h's 43. See HashSaltSlotsAreDistinct below — the assertion, not this comment,
+  // is what keeps the property true.
   h ^= hash_shape(c.height, 31);
   h ^= hash_shape(c.prism_h, 37);
-  h ^= hash_shape(c.upper_h, 41);
-  h ^= hash_shape(c.lower_h, 43);
-  h ^= hash_float(c.upper_alpha) * 47;
-  h ^= hash_float(c.lower_alpha) * 53;
+  h ^= hash_shape(c.upper_h, 43);
+  h ^= hash_shape(c.lower_h, 49);
+  h ^= hash_float(c.upper_alpha) * 55;
+  h ^= hash_float(c.lower_alpha) * 57;
   for (int i = 0; i < 6; i++) {
-    h ^= hash_shape(c.face_distance[i], 59 + i * 3);
+    // Stride 4, not 3: each ShapeDist now spans salt..salt+3, so a stride of 3 would give face i's
+    // sync_group slot the same multiplier as face i+1's type slot, letting two changes cancel.
+    h ^= hash_shape(c.face_distance[i], 59 + i * 4);
   }
   return h;
 }
+
+// Compile-time proof of the property CrystalParamHash relies on: no two slots share a multiplier.
+// A hand-checked list of constants is exactly the kind of claim that rots the next time someone
+// adds a shape field or shifts a salt, so it is asserted rather than argued in a comment. The
+// slots in use are each ShapeDist base's base..base+3 (ten of them: the four isolated scalars plus
+// the six face_distance blocks at 59 + i*4) and the two single-slot alpha salts.
+constexpr bool HashSaltSlotsAreDistinct() {
+  constexpr int kShapeBaseCount = 10;
+  constexpr int kShapeBases[kShapeBaseCount] = { 31, 37, 43, 49, 59, 63, 67, 71, 75, 79 };
+  constexpr int kAlphaSaltCount = 2;
+  constexpr int kAlphaSalts[kAlphaSaltCount] = { 55, 57 };  // upper_alpha / lower_alpha
+
+  constexpr int kSlotCount = kShapeBaseCount * 4 + kAlphaSaltCount;
+  int slots[kSlotCount] = {};
+  int n = 0;
+  for (int base : kShapeBases) {
+    for (int k = 0; k < 4; k++) {
+      slots[n++] = base + k;
+    }
+  }
+  for (int salt : kAlphaSalts) {
+    slots[n++] = salt;
+  }
+  for (int i = 0; i < kSlotCount; i++) {
+    for (int j = i + 1; j < kSlotCount; j++) {
+      if (slots[i] == slots[j]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+static_assert(HashSaltSlotsAreDistinct(),
+              "CrystalParamHash salt slots collide; two fields would share a multiplier and could cancel");
 
 bool HasActiveShapeRandomization(const CrystalConfig& c) {
   auto is_random = [](const ShapeDist& d) { return d.type != ShapeDistType::kNoRandom; };
@@ -200,6 +245,11 @@ bool BuildCrystalMeshData(const CrystalConfig& cr, unsigned long long sample_see
   for (int i = 0; i < 6; i++) {
     param.face_distance[i] = ToLumiceDistribution(cr.face_distance[i]);
   }
+  // Sync groups (v4.13) via the same shared translation the commit path uses (file_io.cpp's
+  // FillCrystalParam). Filled for both types — the slots the current type does not use are
+  // dropped by core's canonicalization, and sharing one function is what guarantees the preview
+  // and the simulation see the same crystal.
+  FillSyncGroupArray(cr, param.sync_group);
 
   *out = {};
   if (LUMICE_GetCrystalMesh(&param, sample_seed, out) != LUMICE_OK) {

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -78,7 +78,7 @@ constexpr float kEditModalMinWidth = 820.0f;
 //
 // Held at 420 for the Crystal-tab shape property table. Fixed columns
 // (Param kShapeParamColWidth=60 + Rand kShapeRandColWidth=36 + Spread
-// kShapeSpreadColWidth=60) sum to ~156; the stretch Value column then gets a
+// kShapeSpreadColWidth=60 + Sync kShapeSyncColWidth=40) sum to ~196; the stretch Value column then gets a
 // long slider + input(kInputWidth=60) pair with the "%.4f" Prism-H number
 // readable, plus inner borders / cell padding. (The GUI is uniform-only, so there
 // is no Type column; that reclaimed width goes to the Value slider.)
@@ -93,6 +93,11 @@ constexpr float kEditModalMinHeightVertical = 0.0f;
 constexpr float kShapeParamColWidth = 60.0f;
 constexpr float kShapeRandColWidth = 36.0f;
 constexpr float kShapeSpreadColWidth = 60.0f;
+// Sync (shape-scalar sync group): a ~20px square swatch button plus cell padding, widened to
+// kShapeSyncColWidth so the "Sync" header text is not clipped by the column (the swatch itself
+// would fit in 24). Starting value — the owner walkthrough after this task lands is what settles
+// the final swatch width and palette.
+constexpr float kShapeSyncColWidth = 40.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;
@@ -582,7 +587,7 @@ static void RenderCrystalPreviewPane(GuiState& /*state*/) {
 
 // Render a wedge-angle parameter (upper_alpha / lower_alpha) as one property-table row. These are
 // structurally NOT randomizable (owner: "no need, don't do it"), so only the Parameter + Value
-// columns are filled; the Random / Type / Spread columns are advanced but left BLANK. Blank here
+// columns are filled; the Rand / Spread / Sync columns are advanced but left BLANK. Blank here
 // means "not applicable" — visually distinct from the greyed-but-present state a randomizable row
 // shows when its Randomize checkbox is off. Advances all kShapeTableColumnCount columns.
 static bool RenderWedgeTableRow(const char* label, float* value) {
@@ -593,7 +598,7 @@ static bool RenderWedgeTableRow(const char* label, float* value) {
   bool changed = SliderWithPresetEdit(label, value, 0.1f, 90.0f, "%.3f", SliderScale::kLinear, kWedgePresets,
                                       kWedgePresetCount, /*trailing_label=*/false);
   // Wedge angles are non-randomizable: advance the remaining (kShapeTableColumnCount - content)
-  // columns as intentionally-empty cells (Random / Type / Spread). Driven by the shared constant
+  // columns as intentionally-empty cells (Rand / Spread / Sync). Driven by the shared constant
   // rather than a hardcoded 3, so the blank count tracks any column-count change automatically —
   // kShapeTableColumnCount is load-bearing here, not just asserted in a comment. Empty (not skipped)
   // keeps the grid a rectangle and the headers aligned.
@@ -625,9 +630,9 @@ static void RenderCrystalModal(GuiState& /*state*/) {
   ImGui::Spacing();
 
   // -- Shape parameters (property table) --
-  // Every randomizable shape scalar is one RenderShapeDistTableRow (4 aligned columns:
-  // Param | Value | Rand | Spread); the two Pyramid wedge angles are non-randomizable
-  // RenderWedgeTableRow rows (Rand/Spread blank). See gui/slider_mapping.hpp for the
+  // Every randomizable shape scalar is one RenderShapeDistTableRow (5 aligned columns:
+  // Param | Value | Rand | Spread | Sync); the two Pyramid wedge angles are non-randomizable
+  // RenderWedgeTableRow rows (Rand/Spread/Sync blank). See gui/slider_mapping.hpp for the
   // three-H-mapping conventions. Column count is pinned to kShapeTableColumnCount (panels.hpp) so
   // the TableSetupColumn declarations and the TableNextColumn sequences in the row helpers cannot
   // drift (ImGui silently misaligns rather than asserting on a mismatch).
@@ -637,12 +642,13 @@ static void RenderCrystalModal(GuiState& /*state*/) {
   // Shared column setup: identical fixed widths in the main params table and the Face Distance table
   // below, so the 6 face rows line up column-for-column with the parameter rows. Value is the only
   // WidthStretch column, so a narrow (vertical-layout) table compresses the slider first rather than
-  // clipping the fixed Rand/Type/Spread cells.
+  // clipping the fixed Rand/Spread/Sync cells.
   const auto setup_shape_columns = []() {
     ImGui::TableSetupColumn("Param", ImGuiTableColumnFlags_WidthFixed, kShapeParamColWidth);
     ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch, 1.0f);
     ImGui::TableSetupColumn("Rand", ImGuiTableColumnFlags_WidthFixed, kShapeRandColWidth);
     ImGui::TableSetupColumn("Spread", ImGuiTableColumnFlags_WidthFixed, kShapeSpreadColWidth);
+    ImGui::TableSetupColumn("Sync", ImGuiTableColumnFlags_WidthFixed, kShapeSyncColWidth);
   };
 
   if (ImGui::BeginTable("##shape_params", kShapeTableColumnCount, kTableFlags)) {

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -36,6 +36,10 @@ namespace {
 // the reset (the developer must add a line here or accept the omission).
 // Does not touch name / type / zenith / azimuth / roll — type lives in a radio
 // button above, name is layer-scoped metadata, axis lives in a sibling tab.
+// A ShapeDist's sync_group needs no line of its own: every statement below assigns or copies a
+// whole ShapeDist, so the group rides along and lands back on the default 0 (independent). It is
+// listed here only because the "one line per field" discipline above would otherwise make its
+// absence read as an oversight.
 void ResetCrystalShapeParams(CrystalConfig& c) {
   CrystalConfig defaults;
   c.height = defaults.height;

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -587,7 +587,7 @@ static void RenderCrystalPreviewPane(GuiState& /*state*/) {
 
 // Render a wedge-angle parameter (upper_alpha / lower_alpha) as one property-table row. These are
 // structurally NOT randomizable (owner: "no need, don't do it"), so only the Parameter + Value
-// columns are filled; the Rand / Spread / Sync columns are advanced but left BLANK. Blank here
+// columns are filled; the Sync / Rand / Spread columns are advanced but left BLANK. Blank here
 // means "not applicable" — visually distinct from the greyed-but-present state a randomizable row
 // shows when its Randomize checkbox is off. Advances all kShapeTableColumnCount columns.
 static bool RenderWedgeTableRow(const char* label, float* value) {
@@ -598,7 +598,7 @@ static bool RenderWedgeTableRow(const char* label, float* value) {
   bool changed = SliderWithPresetEdit(label, value, 0.1f, 90.0f, "%.3f", SliderScale::kLinear, kWedgePresets,
                                       kWedgePresetCount, /*trailing_label=*/false);
   // Wedge angles are non-randomizable: advance the remaining (kShapeTableColumnCount - content)
-  // columns as intentionally-empty cells (Rand / Spread / Sync). Driven by the shared constant
+  // columns as intentionally-empty cells (Sync / Rand / Spread). Driven by the shared constant
   // rather than a hardcoded 3, so the blank count tracks any column-count change automatically —
   // kShapeTableColumnCount is load-bearing here, not just asserted in a comment. Empty (not skipped)
   // keeps the grid a rectangle and the headers aligned.
@@ -631,8 +631,8 @@ static void RenderCrystalModal(GuiState& /*state*/) {
 
   // -- Shape parameters (property table) --
   // Every randomizable shape scalar is one RenderShapeDistTableRow (5 aligned columns:
-  // Param | Value | Rand | Spread | Sync); the two Pyramid wedge angles are non-randomizable
-  // RenderWedgeTableRow rows (Rand/Spread/Sync blank). See gui/slider_mapping.hpp for the
+  // Param | Value | Sync | Rand | Spread); the two Pyramid wedge angles are non-randomizable
+  // RenderWedgeTableRow rows (Sync/Rand/Spread blank). See gui/slider_mapping.hpp for the
   // three-H-mapping conventions. Column count is pinned to kShapeTableColumnCount (panels.hpp) so
   // the TableSetupColumn declarations and the TableNextColumn sequences in the row helpers cannot
   // drift (ImGui silently misaligns rather than asserting on a mismatch).
@@ -642,13 +642,16 @@ static void RenderCrystalModal(GuiState& /*state*/) {
   // Shared column setup: identical fixed widths in the main params table and the Face Distance table
   // below, so the 6 face rows line up column-for-column with the parameter rows. Value is the only
   // WidthStretch column, so a narrow (vertical-layout) table compresses the slider first rather than
-  // clipping the fixed Rand/Spread/Sync cells.
+  // clipping the fixed Sync/Rand/Spread cells.
   const auto setup_shape_columns = []() {
     ImGui::TableSetupColumn("Param", ImGuiTableColumnFlags_WidthFixed, kShapeParamColWidth);
     ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+    // Sync sits BEFORE Rand, not after Spread: sync is not a randomization sub-property. It forces
+    // the final value of a geometric parameter to be shared, and works with randomization off just
+    // as well as on — placing it after the Rand/Spread pair read as "a third knob of the randomizer".
+    ImGui::TableSetupColumn("Sync", ImGuiTableColumnFlags_WidthFixed, kShapeSyncColWidth);
     ImGui::TableSetupColumn("Rand", ImGuiTableColumnFlags_WidthFixed, kShapeRandColWidth);
     ImGui::TableSetupColumn("Spread", ImGuiTableColumnFlags_WidthFixed, kShapeSpreadColWidth);
-    ImGui::TableSetupColumn("Sync", ImGuiTableColumnFlags_WidthFixed, kShapeSyncColWidth);
   };
 
   if (ImGui::BeginTable("##shape_params", kShapeTableColumnCount, kTableFlags)) {

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -77,9 +77,9 @@ constexpr float kEditModalMinWidth = 820.0f;
 // vertical modal is exactly 2× the horizontal modal height plus chrome.
 //
 // Held at 420 for the Crystal-tab shape property table. Fixed columns
-// (Param kShapeParamColWidth=60 + Rand kShapeRandColWidth=36 + Spread
-// kShapeSpreadColWidth=60 + Sync kShapeSyncColWidth=40) sum to ~196; the stretch Value column then gets a
-// long slider + input(kInputWidth=60) pair with the "%.4f" Prism-H number
+// (Param kShapeParamColWidth=52 + Sync kShapeSyncColWidth=29 + Rand
+// kShapeRandColWidth=29 + Spread kShapeSpreadColWidth=60) sum to ~170; the stretch Value column then
+// gets a long slider + input(kInputWidth=60) pair with the "%.4f" Prism-H number
 // readable, plus inner borders / cell padding. (The GUI is uniform-only, so there
 // is no Type column; that reclaimed width goes to the Value slider.)
 constexpr float kEditModalMinWidthVertical = 420.0f;
@@ -90,14 +90,23 @@ constexpr float kEditModalMinHeightVertical = 0.0f;
 // length instead of starving it: Rand only needs the checkbox + "Rand" header,
 // Spread fits "100.0000" (%.4f). Shared by the main params table and the Face
 // Distance table so their columns line up.
-constexpr float kShapeParamColWidth = 60.0f;
-constexpr float kShapeRandColWidth = 36.0f;
+//
+// Settled by measuring the owner-walkthrough references rather than by eye: ImGui renders each of
+// these ~9 px wider than declared (cell padding ×2 + inner border), and what actually sets the floor
+// for all three narrow columns is TEXT — the header string or the longest row label — never the
+// control. Param fits its widest label ("Prism H" / "Upper H" / "Lower A", 7 chars ≈ 48 px) with
+// symmetric ~6 px margins; the 26 px reclaimed from the three of them all goes to the Value slider
+// (vertical layout: 181 → 207 px). Anything that lengthens a header or a row label has to revisit
+// these — sync_column_layout_budget in test_gui_interaction.cpp is what notices.
+constexpr float kShapeParamColWidth = 52.0f;
+constexpr float kShapeRandColWidth = 29.0f;
 constexpr float kShapeSpreadColWidth = 60.0f;
-// Sync (shape-scalar sync group): a ~20px square swatch button plus cell padding, widened to
-// kShapeSyncColWidth so the "Sync" header text is not clipped by the column (the swatch itself
-// would fit in 24). Starting value — the owner walkthrough after this task lands is what settles
-// the final swatch width and palette.
-constexpr float kShapeSyncColWidth = 40.0f;
+// Sync (shape-scalar sync group): a square swatch button one frame tall (~19 px), so like Rand this
+// column is sized by its 4-character header, not by its control. That it lands on the SAME number as
+// kShapeRandColWidth is a coincidence of two identical constraints, not evidence that they are one
+// concept — kept as two constants so a later header rename on either column cannot silently drag the
+// other along.
+constexpr float kShapeSyncColWidth = 29.0f;
 
 static ActiveModal g_active_modal = ActiveModal::kNone;
 static int g_modal_layer_idx = -1;

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -655,12 +655,18 @@ static void RenderCrystalModal(GuiState& /*state*/) {
     setup_shape_columns();
     ImGui::TableHeadersRow();
 
+    // Slots are named constants, never bare integers or field order — see the SLOT-ORDER TRAP note
+    // on ShapeScalarAt (UPPER_H is slot 1, PRISM_H slot 2, the reverse of the rows' visual order).
     if (cr.type == CrystalType::kPrism) {
-      RenderShapeDistTableRow("Height##modal_cr", cr.height, 0.01f, 100.0f, "%.2f", SliderScale::kLog);
+      RenderShapeDistTableRow("Height##modal_cr", cr, LUMICE_SHAPE_SCALAR_HEIGHT, 0.01f, 100.0f, "%.2f",
+                              SliderScale::kLog);
     } else {
-      RenderShapeDistTableRow("Prism H##modal_cr", cr.prism_h, 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear);
-      RenderShapeDistTableRow("Upper H##modal_cr", cr.upper_h, 0.0f, 1.0f, "%.3f", SliderScale::kLinear);
-      RenderShapeDistTableRow("Lower H##modal_cr", cr.lower_h, 0.0f, 1.0f, "%.3f", SliderScale::kLinear);
+      RenderShapeDistTableRow("Prism H##modal_cr", cr, LUMICE_SHAPE_SCALAR_PRISM_H, 0.0f, 100.0f, "%.4f",
+                              SliderScale::kLogLinear);
+      RenderShapeDistTableRow("Upper H##modal_cr", cr, LUMICE_SHAPE_SCALAR_UPPER_H, 0.0f, 1.0f, "%.3f",
+                              SliderScale::kLinear);
+      RenderShapeDistTableRow("Lower H##modal_cr", cr, LUMICE_SHAPE_SCALAR_LOWER_H, 0.0f, 1.0f, "%.3f",
+                              SliderScale::kLinear);
       RenderWedgeTableRow("Upper A##modal_cr", &cr.upper_alpha);
       RenderWedgeTableRow("Lower A##modal_cr", &cr.lower_alpha);
     }
@@ -681,7 +687,8 @@ static void RenderCrystalModal(GuiState& /*state*/) {
       for (int i = 0; i < 6; i++) {
         char label[32];
         snprintf(label, sizeof(label), "Face %d##modal_fd", i + 3);
-        RenderShapeDistTableRow(label, cr.face_distance[i], 0.0f, kFaceSpreadMax, "%.3f", SliderScale::kLinear);
+        RenderShapeDistTableRow(label, cr, LUMICE_SHAPE_SCALAR_FACE_0 + i, 0.0f, kFaceSpreadMax, "%.3f",
+                                SliderScale::kLinear);
       }
       ImGui::EndTable();
     }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include "gui/app.hpp"
@@ -170,6 +171,81 @@ static json SerializeShapeDist(const ShapeDist& d) {
   return j;
 }
 
+// SYNC: these two key tables must stay byte-identical to kPrismSyncGroupKeys /
+// kPyramidSyncGroupKeys in src/server/c_api.cpp and src/config/crystal_config.cpp. This is the
+// third copy: the GUI may not include core/config headers (public-API boundary), and c_api.cpp's
+// copy is TU-private, so the table is duplicated rather than shared. There is no compile-time
+// mechanism tying the three together — a single character of drift here means a .lmc the GUI
+// writes declares a group under a key core never reads, and the declaration silently degenerates
+// to "all independent" with nothing to warn. These SYNC comments are the only defense; changing a
+// key name means editing all three.
+// "face_distance" is common to both types and handled separately (a 6-element array, mirroring how
+// face_distance itself serializes).
+static constexpr std::pair<const char*, int> kPrismSyncGroupKeys[] = {
+  { "height", LUMICE_SHAPE_SCALAR_HEIGHT },
+};
+static constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
+  { "prism_h", LUMICE_SHAPE_SCALAR_PRISM_H },
+  { "upper_h", LUMICE_SHAPE_SCALAR_UPPER_H },
+  { "lower_h", LUMICE_SHAPE_SCALAR_LOWER_H },
+};
+
+// Write shape.sync_group. Emits nothing when nothing is synced, so every .lmc written before
+// v4.13 (and every all-independent crystal today) keeps its byte-identical wire form — the same
+// "non-default only" convention face_distance already follows here.
+// Mirrors WriteSyncGroupJson in src/server/c_api.cpp / src/config/crystal_config.cpp.
+static void WriteSyncGroupJson(json& shape_j, const int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
+                               const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  json sg = json::object();
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sync_group[scalar_keys[k].second] != 0) {
+      sg[scalar_keys[k].first] = sync_group[scalar_keys[k].second];
+    }
+  }
+  bool any_face = false;
+  for (int i = 0; i < 6; i++) {
+    any_face = any_face || sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] != 0;
+  }
+  if (any_face) {
+    // All six, zeros included — matching how face_distance itself serializes.
+    sg["face_distance"] =
+        std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
+  }
+  if (!sg.empty()) {
+    shape_j["sync_group"] = sg;
+  }
+}
+
+// Read shape.sync_group. An absent key leaves every slot 0 (all independent), which is why an
+// older .lmc needs no migration. Mirrors ReadSyncGroupJson in the two files named above.
+static void ReadSyncGroupJson(const json& shape_j, int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
+                              const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; i++) {
+    sync_group[i] = 0;
+  }
+  if (!shape_j.contains("sync_group") || !shape_j.at("sync_group").is_object()) {
+    return;
+  }
+  const auto& sg = shape_j.at("sync_group");
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sg.contains(scalar_keys[k].first) && sg.at(scalar_keys[k].first).is_number_integer()) {
+      sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
+    }
+  }
+  if (sg.contains("face_distance") && sg.at("face_distance").is_array()) {
+    size_t i = 0;
+    for (const auto& elem : sg.at("face_distance")) {
+      if (i >= 6) {
+        break;
+      }
+      if (elem.is_number_integer()) {
+        sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = elem.get<int>();
+      }
+      i++;
+    }
+  }
+}
+
 // Field-sync guard for SerializeCrystal.
 // If CrystalConfig gains/loses a field, sizeof changes and this fires. Developer must then
 // audit BOTH SerializeCrystal (below) and FillCrystalParam (further down this file) for
@@ -181,10 +257,13 @@ static json SerializeShapeDist(const ShapeDist& d) {
 //   height, prism_h, upper_h, lower_h (now ShapeDist; serialize + c-api yes),
 //   upper_alpha, lower_alpha (bare float, pyramid-only/yes),
 //   face_distance[6] (now ShapeDist[6]; conditional serialize / c-api yes),
+//   ShapeDist::sync_group (v4.13; conditional serialize via WriteSyncGroupJson / c-api yes
+//     via FillSyncGroupArray — one int in each of the ten ShapeDist members),
 //   zenith, azimuth, roll (AxisDist, yes/yes).
-// Size grew 112 → 192 when the five shape scalars became ShapeDist (12 B each: +80 B total).
+// Size grew 112 → 192 when the five shape scalars became ShapeDist (12 B each: +80 B total),
+// then 192 → 232 when ShapeDist gained sync_group (+4 B × 10 ShapeDist members).
 #if defined(__APPLE__) && defined(__aarch64__)
-static_assert(sizeof(CrystalConfig) == 192,
+static_assert(sizeof(CrystalConfig) == 232,
               "CrystalConfig size changed; audit SerializeCrystal and FillCrystalParam for new/renamed fields");
 #endif
 static json SerializeCrystal(const CrystalConfig& c, int id) {
@@ -221,6 +300,17 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
     j["shape"]["face_distance"] = { SerializeShapeDist(c.face_distance[0]), SerializeShapeDist(c.face_distance[1]),
                                     SerializeShapeDist(c.face_distance[2]), SerializeShapeDist(c.face_distance[3]),
                                     SerializeShapeDist(c.face_distance[4]), SerializeShapeDist(c.face_distance[5]) };
+  }
+
+  // shape.sync_group: the embedded per-ShapeDist groups gathered back into the wire form's
+  // parallel array. Only the keys applicable to this crystal type are consulted, matching how the
+  // shape scalars themselves are written above.
+  int sg[LUMICE_SHAPE_SCALAR_COUNT];
+  FillSyncGroupArray(c, sg);
+  if (c.type == CrystalType::kPrism) {
+    WriteSyncGroupJson(j["shape"], sg, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+  } else {
+    WriteSyncGroupJson(j["shape"], sg, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
   }
 
   j["axis"]["zenith"] = SerializeAxisDist(c.zenith);
@@ -668,6 +758,16 @@ static CrystalConfig ParseCrystal(const json& j) {
         c.face_distance[i] = ParseShapeDist(s["face_distance"][i], 1.0f);
       }
     }
+    // shape.sync_group: read into the wire form's parallel array, then scatter back into each
+    // ShapeDist. Must come AFTER the shape parses above — those assign whole ShapeDist values and
+    // would overwrite an already-scattered group with the default 0.
+    int sg[LUMICE_SHAPE_SCALAR_COUNT];
+    if (c.type == CrystalType::kPrism) {
+      ReadSyncGroupJson(s, sg, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+    } else {
+      ReadSyncGroupJson(s, sg, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+    }
+    ApplySyncGroupArray(sg, c);
   }
 
   if (j.contains("axis")) {
@@ -956,7 +1056,7 @@ static void FillAxisDist(const AxisDist& src, LUMICE_Distribution* dst) {
 // Helper: fill a LUMICE_CrystalParam from GUI CrystalConfig.
 // `dst->id` is deliberately NOT set: LUMICE_SceneAddCrystal ignores any incoming .id and
 // assigns its own sequential id, returned via out_id (lumice.h "Incremental build" contract).
-// Field-sync guard: see the static_assert(sizeof(CrystalConfig) == 112) near
+// Field-sync guard: see the static_assert(sizeof(CrystalConfig) == 232) near
 // SerializeCrystal above. One copy guards both functions (same TU, identical
 // condition); this comment keeps the pairing obvious to readers.
 static void FillCrystalParam(const CrystalConfig& c, LUMICE_CrystalParam* dst) {
@@ -973,6 +1073,10 @@ static void FillCrystalParam(const CrystalConfig& c, LUMICE_CrystalParam* dst) {
   for (int i = 0; i < 6; i++) {
     dst->face_distance[i] = ToLumiceDistribution(c.face_distance[i]);
   }
+  // Sync groups (v4.13). Same shared translation the preview path uses (crystal_preview.cpp's
+  // BuildCrystalMeshData) — the two must agree or the preview shows a crystal the simulator never
+  // traces. Raw values; core canonicalizes.
+  FillSyncGroupArray(c, dst->sync_group);
   FillAxisDist(c.zenith, &dst->zenith);
   FillAxisDist(c.azimuth, &dst->azimuth);
   FillAxisDist(c.roll, &dst->roll);

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -171,35 +171,26 @@ static json SerializeShapeDist(const ShapeDist& d) {
   return j;
 }
 
-// SYNC: these two key tables must stay byte-identical to kPrismSyncGroupKeys /
-// kPyramidSyncGroupKeys in src/server/c_api.cpp and src/config/crystal_config.cpp. This is the
-// third copy: the GUI may not include core/config headers (public-API boundary), and c_api.cpp's
-// copy is TU-private, so the table is duplicated rather than shared. There is no compile-time
-// mechanism tying the three together — a single character of drift here means a .lmc the GUI
-// writes declares a group under a key core never reads, and the declaration silently degenerates
-// to "all independent" with nothing to warn. These SYNC comments are the only defense; changing a
-// key name means editing all three.
-// "face_distance" is common to both types and handled separately (a 6-element array, mirroring how
-// face_distance itself serializes).
-static constexpr std::pair<const char*, int> kPrismSyncGroupKeys[] = {
-  { "height", LUMICE_SHAPE_SCALAR_HEIGHT },
-};
-static constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
-  { "prism_h", LUMICE_SHAPE_SCALAR_PRISM_H },
-  { "upper_h", LUMICE_SHAPE_SCALAR_UPPER_H },
-  { "lower_h", LUMICE_SHAPE_SCALAR_LOWER_H },
-};
+// The sync_group schema key names come from core, read through LUMICE_ShapeScalarSyncKeyName.
+// The GUI may not include core/config headers (public-API boundary), so this file used to carry a
+// third hand-maintained copy of the {key, slot} table, kept in step with core's and the C API's by
+// comment alone. Drift had no symptom to notice: a .lmc the GUI wrote would declare a group under a
+// key core never reads, and the declaration would silently degenerate to "all independent".
+// The face slots all answer "face_distance", whose value is one 6-element array, so they are
+// handled as a block rather than per slot.
 
 // Write shape.sync_group. Emits nothing when nothing is synced, so every .lmc written before
 // v4.13 (and every all-independent crystal today) keeps its byte-identical wire form — the same
 // "non-default only" convention face_distance already follows here.
-// Mirrors WriteSyncGroupJson in src/server/c_api.cpp / src/config/crystal_config.cpp.
 static void WriteSyncGroupJson(json& shape_j, const int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
-                               const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+                               LUMICE_CrystalKind kind) {
   json sg = json::object();
-  for (size_t k = 0; k < scalar_key_cnt; k++) {
-    if (sync_group[scalar_keys[k].second] != 0) {
-      sg[scalar_keys[k].first] = sync_group[scalar_keys[k].second];
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_FACE_0; slot++) {
+    // A null key means the slot does not apply to this type, so an inapplicable declaration never
+    // reaches the file in the first place.
+    const char* key = LUMICE_ShapeScalarSyncKeyName(kind, slot);
+    if (key != nullptr && sync_group[slot] != 0) {
+      sg[key] = sync_group[slot];
     }
   }
   bool any_face = false;
@@ -208,7 +199,7 @@ static void WriteSyncGroupJson(json& shape_j, const int sync_group[LUMICE_SHAPE_
   }
   if (any_face) {
     // All six, zeros included — matching how face_distance itself serializes.
-    sg["face_distance"] =
+    sg[LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] =
         std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
   }
   if (!sg.empty()) {
@@ -217,9 +208,9 @@ static void WriteSyncGroupJson(json& shape_j, const int sync_group[LUMICE_SHAPE_
 }
 
 // Read shape.sync_group. An absent key leaves every slot 0 (all independent), which is why an
-// older .lmc needs no migration. Mirrors ReadSyncGroupJson in the two files named above.
-static void ReadSyncGroupJson(const json& shape_j, int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
-                              const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+// older .lmc needs no migration. The is_number_integer / is_array guards are this file's standing
+// tolerance for hand-edited or damaged .lmc files, unrelated to where the key names come from.
+static void ReadSyncGroupJson(const json& shape_j, int sync_group[LUMICE_SHAPE_SCALAR_COUNT], LUMICE_CrystalKind kind) {
   for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; i++) {
     sync_group[i] = 0;
   }
@@ -227,14 +218,16 @@ static void ReadSyncGroupJson(const json& shape_j, int sync_group[LUMICE_SHAPE_S
     return;
   }
   const auto& sg = shape_j.at("sync_group");
-  for (size_t k = 0; k < scalar_key_cnt; k++) {
-    if (sg.contains(scalar_keys[k].first) && sg.at(scalar_keys[k].first).is_number_integer()) {
-      sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_FACE_0; slot++) {
+    const char* key = LUMICE_ShapeScalarSyncKeyName(kind, slot);
+    if (key != nullptr && sg.contains(key) && sg.at(key).is_number_integer()) {
+      sync_group[slot] = sg.at(key).get<int>();
     }
   }
-  if (sg.contains("face_distance") && sg.at("face_distance").is_array()) {
+  const char* face_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+  if (sg.contains(face_key) && sg.at(face_key).is_array()) {
     size_t i = 0;
-    for (const auto& elem : sg.at("face_distance")) {
+    for (const auto& elem : sg.at(face_key)) {
       if (i >= 6) {
         break;
       }
@@ -308,9 +301,9 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
   int sg[LUMICE_SHAPE_SCALAR_COUNT];
   FillSyncGroupArray(c, sg);
   if (c.type == CrystalType::kPrism) {
-    WriteSyncGroupJson(j["shape"], sg, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+    WriteSyncGroupJson(j["shape"], sg, LUMICE_CRYSTAL_PRISM);
   } else {
-    WriteSyncGroupJson(j["shape"], sg, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+    WriteSyncGroupJson(j["shape"], sg, LUMICE_CRYSTAL_PYRAMID);
   }
 
   j["axis"]["zenith"] = SerializeAxisDist(c.zenith);
@@ -763,9 +756,9 @@ static CrystalConfig ParseCrystal(const json& j) {
     // would overwrite an already-scattered group with the default 0.
     int sg[LUMICE_SHAPE_SCALAR_COUNT];
     if (c.type == CrystalType::kPrism) {
-      ReadSyncGroupJson(s, sg, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+      ReadSyncGroupJson(s, sg, LUMICE_CRYSTAL_PRISM);
     } else {
-      ReadSyncGroupJson(s, sg, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+      ReadSyncGroupJson(s, sg, LUMICE_CRYSTAL_PYRAMID);
     }
     ApplySyncGroupArray(sg, c);
   }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -197,9 +197,10 @@ static void WriteSyncGroupJson(json& shape_j, const int sync_group[LUMICE_SHAPE_
   for (int i = 0; i < 6; i++) {
     any_face = any_face || sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] != 0;
   }
-  if (any_face) {
+  const char* face_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+  if (any_face && face_key != nullptr) {
     // All six, zeros included — matching how face_distance itself serializes.
-    sg[LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] =
+    sg[face_key] =
         std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
   }
   if (!sg.empty()) {
@@ -225,7 +226,7 @@ static void ReadSyncGroupJson(const json& shape_j, int sync_group[LUMICE_SHAPE_S
     }
   }
   const char* face_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
-  if (sg.contains(face_key) && sg.at(face_key).is_array()) {
+  if (face_key != nullptr && sg.contains(face_key) && sg.at(face_key).is_array()) {
     size_t i = 0;
     for (const auto& elem : sg.at(face_key)) {
       if (i >= 6) {

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -84,6 +84,17 @@ struct ShapeDist {
   ShapeDistType type = ShapeDistType::kNoRandom;
   float center = 0.0f;
   float spread = 0.0f;
+  // Shape-scalar sync group (v4.13). 0 = independent; equal non-zero values across scalars of the
+  // same crystal mean "draw once, share the value" (core PrepareSyncGroups). The GUI keeps it
+  // EMBEDDED in each ShapeDist rather than as a CrystalConfig-level parallel array: CrystalConfig
+  // has exactly the ten ShapeDist members the core's kShapeScalarCount indexes, so embedding keeps
+  // "a scalar and its group" one object — copies, comparisons and the modal's edit buffer carry it
+  // for free. The parallel-array form the C API needs is produced at the two translation boundaries
+  // only, by FillSyncGroupArray / ApplySyncGroupArray below.
+  // Canonicalization / leader normalization are NOT done here — core's from_json owns them for both
+  // the preview path (LUMICE_GetCrystalMesh) and the commit path (LUMICE_SceneAddCrystal), so the
+  // GUI passes raw user numbering through verbatim and never becomes a second authority.
+  int sync_group = 0;
 
   ShapeDist() = default;
   ShapeDist(ShapeDistType t, float c, float s) : type(t), center(c), spread(s) {}
@@ -99,7 +110,7 @@ struct ShapeDist {
   ShapeDist(float v) : center(v) {}  // NOLINT(google-explicit-constructor)
 
   friend bool operator==(const ShapeDist& a, const ShapeDist& b) {
-    return a.type == b.type && a.center == b.center && a.spread == b.spread;
+    return a.type == b.type && a.center == b.center && a.spread == b.spread && a.sync_group == b.sync_group;
   }
   friend bool operator!=(const ShapeDist& a, const ShapeDist& b) { return !(a == b); }
 };
@@ -155,6 +166,57 @@ struct CrystalConfig {
   }
   friend bool operator!=(const CrystalConfig& a, const CrystalConfig& b) { return !(a == b); }
 };
+
+// ---- Shape-scalar sync groups: GUI embedded form <-> C API parallel-array form ----
+//
+// SLOT-ORDER TRAP: the LUMICE_SHAPE_SCALAR_* index space is NOT this struct's field declaration
+// order — UPPER_H is slot 1 and PRISM_H slot 2, the reverse of how CrystalConfig (and the GUI
+// modal) orders them. A translation written by field position instead of by name lands prism_h's
+// group on upper_h and vice versa, which JSON-round-trips cleanly and only shows up as the wrong
+// pair of pyramid heights moving together. So the mapping is spelled out ONCE, by named constant,
+// in ShapeScalarAt below; both directions and both call sites go through it.
+//
+// Single mapping authority. face_distance[0..5] occupies the six contiguous slots at the end.
+static_assert(LUMICE_SHAPE_SCALAR_FACE_5 == LUMICE_SHAPE_SCALAR_FACE_0 + 5 &&
+                  LUMICE_SHAPE_SCALAR_COUNT == LUMICE_SHAPE_SCALAR_FACE_0 + 6,
+              "LUMICE_SHAPE_SCALAR_FACE_* must be six contiguous slots ending the index space");
+inline const ShapeDist& ShapeScalarAt(const CrystalConfig& c, int slot) {
+  switch (slot) {
+    case LUMICE_SHAPE_SCALAR_HEIGHT:
+      return c.height;
+    case LUMICE_SHAPE_SCALAR_UPPER_H:
+      return c.upper_h;
+    case LUMICE_SHAPE_SCALAR_PRISM_H:
+      return c.prism_h;
+    case LUMICE_SHAPE_SCALAR_LOWER_H:
+      return c.lower_h;
+    default:
+      assert(slot >= LUMICE_SHAPE_SCALAR_FACE_0 && slot < LUMICE_SHAPE_SCALAR_COUNT);
+      return c.face_distance[slot - LUMICE_SHAPE_SCALAR_FACE_0];
+  }
+}
+inline ShapeDist& ShapeScalarAt(CrystalConfig& c, int slot) {
+  return const_cast<ShapeDist&>(ShapeScalarAt(static_cast<const CrystalConfig&>(c), slot));
+}
+
+// Embedded -> parallel array, for LUMICE_CrystalParam::sync_group[]. Both C API call sites
+// (file_io.cpp's commit path and crystal_preview.cpp's preview path) MUST produce the identical
+// array — a divergence would render one crystal in the preview and simulate a different one, with
+// nothing to notice it. Sharing this one function is what makes that mechanical rather than a
+// convention two files are expected to keep.
+// Values pass through verbatim; canonicalization belongs to core (see ShapeDist::sync_group).
+inline void FillSyncGroupArray(const CrystalConfig& c, int sync_group[LUMICE_SHAPE_SCALAR_COUNT]) {
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_COUNT; slot++) {
+    sync_group[slot] = ShapeScalarAt(c, slot).sync_group;
+  }
+}
+
+// Parallel array -> embedded. The inverse of FillSyncGroupArray, used by the .lmc parse path.
+inline void ApplySyncGroupArray(const int sync_group[LUMICE_SHAPE_SCALAR_COUNT], CrystalConfig& c) {
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_COUNT; slot++) {
+    ShapeScalarAt(c, slot).sync_group = sync_group[slot];
+  }
+}
 
 // Wavelength/weight pair for user-defined discrete spectra.
 struct WlWeight {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -479,8 +479,9 @@ void ShapeTableParamLabel(const char* label) {
   }
 }
 
-bool RenderShapeDistTableRow(const char* label, ShapeDist& dist, float center_min, float center_max,
+bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, float center_min, float center_max,
                              const char* center_fmt, SliderScale center_scale) {
+  ShapeDist& dist = ShapeScalarAt(cr, slot);  // single mapping authority (gui_state.hpp)
   bool changed = false;
   // No PushID wrapper: the center slider keeps its original `label`-derived id (so existing
   // ItemInputValue paths — e.g. "##Height##modal_cr_input" — stay valid), and each extra widget

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -517,25 +517,20 @@ ImVec4 SyncGroupColor(int group) {
 // Height; Pyramid draws Prism/Upper/Lower H; the six faces are drawn by both) — the same condition,
 // promoted from an implicit `if` in the renderer to a predicate the Sync widget can also ask.
 //
-// This is also, deliberately, the same truth table core applies: crystal_config.cpp's
-// kApplicablePrism / kApplicablePyramid — "does this shape-scalar slot physically exist on this
-// crystal type" — agree with it on all ten slots for both types. That agreement is what lets the
-// MIRROR side of the Sync widget (leader election, propagation, membership listing) reproduce core's
-// rule rather than approximate it; see FindGroupLeaderSlot.
+// The question "does this shape-scalar slot physically exist on this crystal type" is core's to
+// answer, and this forwards it verbatim: LUMICE_IsShapeScalarApplicable reads the one slot table in
+// crystal_config.cpp that Canonicalize and Normalize also read. The GUI holds no copy of it. That
+// identity — not an agreement between two hand-kept tables — is what lets the MIRROR side of the Sync
+// widget (leader election, propagation, membership listing) reproduce core's rule rather than
+// approximate it; see FindGroupLeaderSlot.
 //
 // A group number on a scalar belonging to the OTHER crystal type is therefore not visible, and lies
 // dormant across a type switch — not cleared, not shown, not joined. That matches core, which zeroes
 // exactly those slots in CanonicalizeSyncGroups, and it is the smallest GUI-side behavior that
 // neither invents a cross-type editing model nor destroys data the user may switch back to.
 bool IsShapeScalarVisible(CrystalType type, int slot) {
-  if (slot >= LUMICE_SHAPE_SCALAR_FACE_0) {
-    return true;  // face_distance[0..5]: both types
-  }
-  if (type == CrystalType::kPrism) {
-    return slot == LUMICE_SHAPE_SCALAR_HEIGHT;
-  }
-  return slot == LUMICE_SHAPE_SCALAR_PRISM_H || slot == LUMICE_SHAPE_SCALAR_UPPER_H ||
-         slot == LUMICE_SHAPE_SCALAR_LOWER_H;
+  const auto kind = (type == CrystalType::kPrism) ? LUMICE_CRYSTAL_PRISM : LUMICE_CRYSTAL_PYRAMID;
+  return LUMICE_IsShapeScalarApplicable(kind, slot) != 0;
 }
 
 // Can the user CREATE a sync membership on this scalar? Strictly narrower than IsShapeScalarVisible
@@ -568,8 +563,9 @@ bool IsShapeScalarSyncable(CrystalType type, int slot) {
 // approximation of the core rule — it IS the core rule (lumice.h LUMICE_CrystalParam::sync_group:
 // "the group's first applicable member (lowest LUMICE_SHAPE_SCALAR_* index) consumes the RNG and
 // owns the distribution"), evaluated over the same applicable set: core's NormalizeSyncGroupsImpl
-// takes the argmin over slots its kApplicable* table admits, and IsShapeScalarVisible is that table
-// (see its comment). So the value the user sees snap in on join is the value core will actually draw
+// takes the argmin over the slots its slot table admits, and IsShapeScalarVisible queries that very
+// table through the C API (see its comment). So the value the user sees snap in on join is the value
+// core will actually draw
 // with. `exclude_slot` keeps a row from electing itself as its own leader while it is joining.
 //
 // The scan MUST stay scoped by IsShapeScalarVisible and never by IsShapeScalarSyncable. Electing a

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -802,7 +802,15 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
   ImGui::TableNextColumn();
   changed |= SliderWithInput(label, &dist.center, center_min, center_max, center_fmt, center_scale, false);
 
-  // Col 2 — Randomize checkbox. The GUI is uniform-only, so enabling sets type=Uniform; NO_RANDOM is
+  // Col 2 — sync group swatch + picker popup. Ahead of Rand/Spread because sync is not a property of
+  // randomization: it constrains the row's final value and is equally usable with Rand off. Left
+  // BLANK for a non-syncable scalar, the same way the wedge rows leave their inapplicable columns
+  // blank (edit_modals.cpp RenderWedgeTableRow) — the column is still advanced so the grid stays a
+  // rectangle.
+  ImGui::TableNextColumn();
+  const bool group_changed = syncable && RenderSyncCell(label, cr, slot);
+
+  // Col 3 — Randomize checkbox. The GUI is uniform-only, so enabling sets type=Uniform; NO_RANDOM is
   // expressed via this checkbox being off. Text-less (the header names the column); the ## suffix
   // embeds `label` so the id is unique.
   ImGui::TableNextColumn();
@@ -820,7 +828,7 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
     changed = true;
   }
 
-  // Col 3 — spread input. Rendered even when not randomized, but wrapped in BeginDisabled so it greys
+  // Col 4 — spread input. Rendered even when not randomized, but wrapped in BeginDisabled so it greys
   // out ("available to enable") and cannot be interacted with while dist is NO_RANDOM (spread==0),
   // preserving the disabled-state semantics. A plain number input (not a slider — saves horizontal
   // space in the narrow vertical layout). Same units as center; clamped to [0, center_max].
@@ -836,16 +844,12 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
 
   ImGui::EndDisabled();
 
-  // Col 4 — sync group swatch + picker popup. Left BLANK for a non-syncable scalar, the same way the
-  // wedge rows leave their inapplicable columns blank (edit_modals.cpp RenderWedgeTableRow) — the
-  // column is still advanced so the grid stays a rectangle.
-  ImGui::TableNextColumn();
-  const bool group_changed = syncable && RenderSyncCell(label, cr, slot);
-
-  // A value edit on a row that is in a group writes through to the whole group. Evaluated after the
-  // Sync cell so an edit made in the same frame the row joined a group propagates the joined value
-  // rather than the discarded one. Joining itself does not go through here — that path snapshots
-  // FROM the leader (JoinSyncGroup), it does not push TO the group.
+  // A value edit on a row that is in a group writes through to the whole group. Evaluated after ALL
+  // the cells, hence after the Sync cell, so an edit made in the same frame the row joined a group
+  // propagates the joined value rather than the discarded one — the reason this lives at the end of
+  // the function rather than next to the Value column, and the reason moving the Sync cell earlier in
+  // the column order does not disturb it. Joining itself does not go through here: that path
+  // snapshots FROM the leader (JoinSyncGroup), it does not push TO the group.
   if (changed) {
     PropagateToSyncGroup(cr, slot);
   }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -479,6 +479,267 @@ void ShapeTableParamLabel(const char* label) {
   }
 }
 
+
+// ---- Sync column: shape-scalar sync groups (the Sync cell of a shape-table row) ----
+namespace {
+
+// Row names indexed by LUMICE_SHAPE_SCALAR_*, used in the popup's membership lists. The order is
+// the SLOT index space, not CrystalConfig's field order: UPPER_H is slot 1 and PRISM_H slot 2 (see
+// the SLOT-ORDER TRAP note in gui_state.hpp), so this table reads "Upper H" before "Prism H" even
+// though the modal draws Prism H first. The strings match what ShapeTableParamLabel prints for the
+// corresponding rows, because a membership list naming rows the user cannot find is worse than none.
+const char* const kShapeScalarLabels[LUMICE_SHAPE_SCALAR_COUNT] = {
+  "Height", "Upper H", "Prism H", "Lower H", "Face 3", "Face 4", "Face 5", "Face 6", "Face 7", "Face 8",
+};
+
+// Group colors are DERIVED from the group number, never stored (D7): a stored color would have to
+// round-trip through JSON, the C API and the .lmc format for a purely cosmetic property. Low
+// saturation so a filled cell stays readable behind the group number and does not fight the table's
+// own row striping. Groups beyond the table length wrap — a 7th group reusing group 1's color is a
+// cosmetic collision, not an error state, and the number in the swatch remains unambiguous (this is
+// also why the number is drawn at all: color alone is not accessible).
+const ImVec4 kSyncGroupPalette[] = {
+  ImVec4(0.36f, 0.55f, 0.75f, 1.00f),  // blue
+  ImVec4(0.75f, 0.55f, 0.36f, 1.00f),  // amber
+  ImVec4(0.45f, 0.68f, 0.48f, 1.00f),  // green
+  ImVec4(0.70f, 0.48f, 0.66f, 1.00f),  // orchid
+  ImVec4(0.42f, 0.66f, 0.70f, 1.00f),  // teal
+  ImVec4(0.76f, 0.52f, 0.48f, 1.00f),  // terracotta
+};
+constexpr int kSyncGroupPaletteCount = static_cast<int>(sizeof(kSyncGroupPalette) / sizeof(kSyncGroupPalette[0]));
+
+// Swatch fill for a non-zero group. Group 0 (independent) has no color — it renders as an outline.
+ImVec4 SyncGroupColor(int group) {
+  return kSyncGroupPalette[(group - 1) % kSyncGroupPaletteCount];
+}
+
+// Is this scalar drawn as a row for `type`? Mirrors RenderCrystalModal's type branch (Prism draws
+// Height; Pyramid draws Prism/Upper/Lower H; the six faces are drawn by both) — the same condition,
+// promoted from an implicit `if` in the renderer to a predicate the Sync widget can also ask.
+//
+// Everything the widget does is scoped by this: the popup enumerates only visible slots, the leader
+// search only considers visible slots, and propagation only writes visible slots. So a group number
+// on a scalar belonging to the OTHER crystal type lies dormant across a type switch — not cleared,
+// not shown, not joined. That is deliberate: D1 permits such a grouping to exist in storage (no
+// commensurability check), and leaving it alone is the smallest GUI-side behavior that neither
+// invents a cross-type editing model nor destroys data the user may switch back to.
+bool IsShapeScalarVisible(CrystalType type, int slot) {
+  if (slot >= LUMICE_SHAPE_SCALAR_FACE_0) {
+    return true;  // face_distance[0..5]: both types
+  }
+  if (type == CrystalType::kPrism) {
+    return slot == LUMICE_SHAPE_SCALAR_HEIGHT;
+  }
+  return slot == LUMICE_SHAPE_SCALAR_PRISM_H || slot == LUMICE_SHAPE_SCALAR_UPPER_H ||
+         slot == LUMICE_SHAPE_SCALAR_LOWER_H;
+}
+
+// The slot whose value the group carries: the lowest-indexed applicable member. This is not a GUI
+// approximation of the core rule — it IS the core rule (lumice.h LUMICE_CrystalParam::sync_group:
+// "the group's first applicable member (lowest LUMICE_SHAPE_SCALAR_* index) consumes the RNG and
+// owns the distribution"), evaluated over the same applicable set IsShapeScalarVisible defines. So
+// the value the user sees snap in on join is the value core will actually draw with. `exclude_slot`
+// keeps a row from electing itself as its own leader while it is joining.
+// Returns -1 when the group has no other member (or group == 0).
+int FindGroupLeaderSlot(const CrystalConfig& cr, int group, int exclude_slot) {
+  if (group == 0) {
+    return -1;
+  }
+  for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    if (s == exclude_slot || !IsShapeScalarVisible(cr.type, s)) {
+      continue;
+    }
+    if (ShapeScalarAt(cr, s).sync_group == group) {
+      return s;
+    }
+  }
+  return -1;
+}
+
+// Group id for "+ New group": one past the largest id anywhere in the crystal. Scans ALL ten slots,
+// including ones the current type does not draw, so a new group cannot collide with a dormant group
+// belonging to the other crystal type. Ids abandoned along the way are not recycled — core
+// renumbers on parse anyway (canonicalization), and reusing a number the user just emptied would
+// re-color a row they had visually separated.
+int NextUnusedSyncGroup(const CrystalConfig& cr) {
+  int max_group = 0;
+  for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    max_group = std::max(max_group, ShapeScalarAt(cr, s).sync_group);
+  }
+  return max_group + 1;
+}
+
+// Copy `slot`'s distribution onto the rest of its group (type, center and spread — NOT the group id
+// itself). Called after an edit to any row that is in a group: a subordinate row stays editable and
+// writing through it updates the whole group, which the owner picked over greying subordinates out.
+void PropagateToSyncGroup(CrystalConfig& cr, int slot) {
+  const ShapeDist src = ShapeScalarAt(cr, slot);
+  if (src.sync_group == 0) {
+    return;
+  }
+  for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    if (s == slot || !IsShapeScalarVisible(cr.type, s)) {
+      continue;
+    }
+    ShapeDist& dst = ShapeScalarAt(cr, s);
+    if (dst.sync_group != src.sync_group) {
+      continue;
+    }
+    dst.type = src.type;
+    dst.center = src.center;
+    dst.spread = src.spread;
+  }
+}
+
+// Join `slot` to `group`, snapshotting the group leader's distribution into it. Joining is visibly
+// destructive of the row's own value — that self-explains the semantics better than a confirmation
+// dialog would, and Cancel on the modal is the undo. A group with no other member (a fresh "+ New
+// group") has no leader, so the row keeps its value and simply becomes the group's first member.
+void JoinSyncGroup(CrystalConfig& cr, int slot, int group) {
+  ShapeDist& dist = ShapeScalarAt(cr, slot);
+  dist.sync_group = group;
+  const int leader = FindGroupLeaderSlot(cr, group, slot);
+  if (leader < 0) {
+    return;
+  }
+  const ShapeDist& src = ShapeScalarAt(cr, leader);
+  dist.type = src.type;
+  dist.center = src.center;
+  dist.spread = src.spread;
+}
+
+// Comma-separated names of `group`'s visible members, empty if the group has none.
+std::string SyncGroupMemberList(const CrystalConfig& cr, int group) {
+  std::string members;
+  for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    if (!IsShapeScalarVisible(cr.type, s) || ShapeScalarAt(cr, s).sync_group != group) {
+      continue;
+    }
+    if (!members.empty()) {
+      members += ", ";
+    }
+    members += kShapeScalarLabels[s];
+  }
+  return members;
+}
+
+// Draw the group swatch: filled + numbered for a group, hollow outline for independent. Purely
+// visual — the click is owned by the caller's Button, which this paints over.
+void DrawSyncSwatch(const ImVec2& p_min, float side, int group) {
+  ImDrawList* draw_list = ImGui::GetWindowDrawList();
+  if (group == 0) {
+    // Independent: a hollow outline. Distinct at a glance from any filled group cell, and it still
+    // reads as a clickable target rather than an empty cell.
+    draw_list->AddRect(p_min, ImVec2(p_min.x + side, p_min.y + side), ImGui::GetColorU32(ImGuiCol_TextDisabled), 2.0f);
+    return;
+  }
+  // Number centered in the swatch, in whichever of black/white contrasts with the fill. Derived
+  // from the fill's luminance rather than fixed, so a later palette edit cannot silently produce
+  // an unreadable cell.
+  const ImVec4 fill = SyncGroupColor(group);
+  const float luma = 0.299f * fill.x + 0.587f * fill.y + 0.114f * fill.z;
+  const ImU32 text_col = luma > 0.55f ? IM_COL32(0, 0, 0, 255) : IM_COL32(255, 255, 255, 255);
+  char num[16];
+  snprintf(num, sizeof(num), "%d", group);
+  const ImVec2 text_size = ImGui::CalcTextSize(num);
+  draw_list->AddText(ImVec2(p_min.x + (side - text_size.x) * 0.5f, p_min.y + (side - text_size.y) * 0.5f), text_col,
+                     num);
+}
+
+// Body of the group picker popup (caller owns Begin/EndPopup). Returns true if the row's group
+// changed. Item ids are anchored with "###" so they stay put as membership text changes.
+bool RenderSyncPopupItems(CrystalConfig& cr, int slot) {
+  ShapeDist& dist = ShapeScalarAt(cr, slot);
+  bool changed = false;
+
+  // "None" first: leaving a group is selecting None, because a group is an equivalence relation
+  // and not an object — there is nothing to delete, and the last member leaving is what makes a
+  // group disappear (D7). Leaving does NOT restore the pre-join value: no shadow copy is kept,
+  // and the modal's Cancel is the undo path.
+  if (ImGui::Selectable("None###sync_none") && dist.sync_group != 0) {
+    dist.sync_group = 0;
+    changed = true;
+  }
+
+  // Existing groups, with their membership spelled out: the decision the user is making is "join
+  // the group that has Face 3 and Face 5 in it", not "join group 1".
+  bool listed_any = false;
+  const int group_upper_bound = NextUnusedSyncGroup(cr);  // exclusive: one past the largest id in use
+  for (int group = 1; group < group_upper_bound; ++group) {
+    const std::string members = SyncGroupMemberList(cr, group);
+    if (members.empty()) {
+      continue;
+    }
+    listed_any = true;
+    // "###sync_group_N" anchors the id to the group number alone: the visible part carries the
+    // membership list, which changes as rows join and leave, and an id derived from it would change
+    // with it.
+    char item[192];
+    snprintf(item, sizeof(item), "%d  (%s)###sync_group_%d", group, members.c_str(), group);
+    // Re-selecting the row's current group is a no-op, not a re-snapshot: the row IS the value the
+    // group would hand it back, and treating it as a join would be a needless self-overwrite.
+    if (ImGui::Selectable(item) && dist.sync_group != group) {
+      JoinSyncGroup(cr, slot, group);
+      changed = true;
+    }
+  }
+  if (listed_any) {
+    ImGui::Separator();
+  }
+
+  // An explicit item rather than a side effect of clicking through the swatch: "make a new group"
+  // is a distinct intent from "pick an existing one" (D7 settled the popup as the single path).
+  if (ImGui::Selectable("+  New group###sync_new")) {
+    JoinSyncGroup(cr, slot, NextUnusedSyncGroup(cr));
+    changed = true;
+  }
+  return changed;
+}
+
+// Sync cell: a group-colored square button that opens the group picker. Returns true if the row's
+// group (and hence, via the snapshot, possibly its value) changed.
+//
+// The button's visible label is EMPTY and its id is "##sync_<label>" — the group number is drawn
+// on top by hand rather than being part of the label. That is not decoration: ImGui hashes the
+// whole id string (only "###" restarts the hash — imgui.cpp ImHashStr), so a number in the label
+// would make the widget's id change every time the user regrouped, and every test path addressing
+// it would drift out from under them. Same reason the swatch is a Button and not a ColorButton:
+// Button registers with the test engine, so the cell is reachable by a real click.
+bool RenderSyncCell(const char* label, CrystalConfig& cr, int slot) {
+  const int group = ShapeScalarAt(cr, slot).sync_group;
+
+  char btn_id[96];
+  snprintf(btn_id, sizeof(btn_id), "##sync_%s", label);
+
+  // Square, exactly one frame tall: the swatch must not be what sets the row height, or the modal's
+  // fixed-height content pane (edit_modals.cpp kModalContentHeight, budgeted in rows) would need a
+  // scrollbar once Face Distance is expanded.
+  const float side = ImGui::GetFrameHeight();
+  const ImVec2 p_min = ImGui::GetCursorScreenPos();
+
+  const ImVec4 fill = group != 0 ? SyncGroupColor(group) : ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+  ImGui::PushStyleColor(ImGuiCol_Button, fill);
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(fill.x, fill.y, fill.z, group != 0 ? 0.80f : 0.25f));
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(fill.x, fill.y, fill.z, group != 0 ? 0.60f : 0.40f));
+  const bool clicked = ImGui::Button(btn_id, ImVec2(side, side));
+  ImGui::PopStyleColor(3);
+  DrawSyncSwatch(p_min, side, group);
+
+  char popup_id[96];
+  snprintf(popup_id, sizeof(popup_id), "##sync_popup_%s", label);
+  if (clicked) {
+    ImGui::OpenPopup(popup_id);
+  }
+  bool changed = false;
+  if (ImGui::BeginPopup(popup_id)) {
+    changed = RenderSyncPopupItems(cr, slot);
+    ImGui::EndPopup();
+  }
+  return changed;
+}
+
+}  // namespace
+
 bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, float center_min, float center_max,
                              const char* center_fmt, SliderScale center_scale) {
   ShapeDist& dist = ShapeScalarAt(cr, slot);  // single mapping authority (gui_state.hpp)
@@ -488,8 +749,15 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
   // gets a `label`-suffixed unique id so multiple rows do not collide and GUI tests can target each.
   ImGui::TableNextRow();
 
-  // Col 0 — Parameter name.
+  // Col 0 — Parameter name. A grouped row also gets its name cell tinted in the group's color (at
+  // low alpha, so the text stays readable): together with the filled Sync swatch this makes group
+  // membership pre-attentive — the eye finds the rows that move together without reading numbers.
+  // CellBg draws above the table's RowBg striping, so the two do not fight.
   ImGui::TableNextColumn();
+  if (dist.sync_group != 0) {
+    const ImVec4 tint = SyncGroupColor(dist.sync_group);
+    ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(ImVec4(tint.x, tint.y, tint.z, 0.28f)));
+  }
   ShapeTableParamLabel(label);
 
   // Col 1 — center value: slider + input, filling the (stretch) Value column. trailing_label=false
@@ -531,9 +799,18 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
 
   ImGui::EndDisabled();
 
-  // Col 4 — sync group. Placeholder cell until the widget lands; the column already exists so the
-  // grid stays a rectangle and the column-count assert below stays satisfied.
+  // Col 4 — sync group swatch + picker popup.
   ImGui::TableNextColumn();
+  const bool group_changed = RenderSyncCell(label, cr, slot);
+
+  // A value edit on a row that is in a group writes through to the whole group. Evaluated after the
+  // Sync cell so an edit made in the same frame the row joined a group propagates the joined value
+  // rather than the discarded one. Joining itself does not go through here — that path snapshots
+  // FROM the leader (JoinSyncGroup), it does not push TO the group.
+  if (changed) {
+    PropagateToSyncGroup(cr, slot);
+  }
+  changed |= group_changed;
 
   // Make kShapeTableColumnCount load-bearing at the consumption site, not just a comment: assert the
   // row consumed exactly that many columns. Bumping the constant + adding a TableSetupColumn without

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -517,12 +517,16 @@ ImVec4 SyncGroupColor(int group) {
 // Height; Pyramid draws Prism/Upper/Lower H; the six faces are drawn by both) — the same condition,
 // promoted from an implicit `if` in the renderer to a predicate the Sync widget can also ask.
 //
-// Everything the Sync widget does is scoped by this — via IsShapeScalarSyncable below, which adds a
-// second, commensurability-driven narrowing on top. So a group number on a scalar belonging to the
-// OTHER crystal type lies dormant across a type switch — not cleared, not shown, not joined. That is
-// deliberate: D1 permits such a grouping to exist in storage (no commensurability check), and leaving
-// it alone is the smallest GUI-side behavior that neither invents a cross-type editing model nor
-// destroys data the user may switch back to.
+// This is also, deliberately, the same truth table core applies: crystal_config.cpp's
+// kApplicablePrism / kApplicablePyramid — "does this shape-scalar slot physically exist on this
+// crystal type" — agree with it on all ten slots for both types. That agreement is what lets the
+// MIRROR side of the Sync widget (leader election, propagation, membership listing) reproduce core's
+// rule rather than approximate it; see FindGroupLeaderSlot.
+//
+// A group number on a scalar belonging to the OTHER crystal type is therefore not visible, and lies
+// dormant across a type switch — not cleared, not shown, not joined. That matches core, which zeroes
+// exactly those slots in CanonicalizeSyncGroups, and it is the smallest GUI-side behavior that
+// neither invents a cross-type editing model nor destroys data the user may switch back to.
 bool IsShapeScalarVisible(CrystalType type, int slot) {
   if (slot >= LUMICE_SHAPE_SCALAR_FACE_0) {
     return true;  // face_distance[0..5]: both types
@@ -534,19 +538,28 @@ bool IsShapeScalarVisible(CrystalType type, int slot) {
          slot == LUMICE_SHAPE_SCALAR_LOWER_H;
 }
 
-// Can this scalar be SYNCED at all? Strictly narrower than IsShapeScalarVisible (syncable ⊂ visible):
-// sharing one drawn value only means something between scalars that are commensurable — same unit,
-// same semantics. Counting each type's randomizable scalars leaves exactly two rows with nothing to
-// pair with:
+// Can the user CREATE a sync membership on this scalar? Strictly narrower than IsShapeScalarVisible
+// (syncable ⊂ visible): sharing one drawn value only means something between scalars that are
+// commensurable — same unit, same semantics. Counting each type's randomizable scalars leaves exactly
+// two rows with nothing to pair with:
 //   - prism  HEIGHT  — the only axial length; the six face distances are dimensionless ratios.
 //   - pyramid PRISM_H — a c/a-axis length; upper_h/lower_h are 0..1 relative heights (those two ARE
 //     each other's pair, and are exactly the use case the generalized sync group exists for).
-// So a Sync control on those two rows would offer an operation that can never be meaningful. Barring
-// them here is a UI-affordance narrowing only: storage still permits such a group (lumice.h runs no
-// commensurability check), a hand-authored config carrying one keeps it, and the GUI treats it the
-// same way it treats a group belonging to the other crystal type — not cleared, not shown, not
-// joinable. NextUnusedSyncGroup deliberately does NOT use this predicate: new ids must not collide
-// with a dormant one either.
+// So a Sync control on those two rows would offer an operation that can never be meaningful.
+//
+// SCOPE — this predicate governs the CREATION side only: whether the row draws a Sync swatch, and
+// hence whether the user can open the picker on it to join a group or start a new one. It must NOT
+// reach the side of the widget that REPORTS existing state (leader election, propagation, membership
+// listing): core is the sole authority on sync semantics and the GUI mirrors it verbatim, so a
+// GUI-only affordance narrowing that also changed what the GUI reports would make the table show a
+// distribution the simulation does not use. That is exactly the divergence this narrowing once
+// caused, and the separation is now load-bearing rather than advisory — the mirror side is written
+// against IsShapeScalarVisible and does not read this predicate at all.
+//
+// Barring these two rows is therefore a UI affordance only: storage still permits such a group
+// (lumice.h runs no commensurability check), a hand-authored config carrying one keeps it, and the
+// GUI reports it faithfully — it simply offers no way to build one. NextUnusedSyncGroup deliberately
+// does NOT use this predicate either: new ids must not collide with a dormant one.
 bool IsShapeScalarSyncable(CrystalType type, int slot) {
   return IsShapeScalarVisible(type, slot) && slot != LUMICE_SHAPE_SCALAR_HEIGHT && slot != LUMICE_SHAPE_SCALAR_PRISM_H;
 }
@@ -554,23 +567,26 @@ bool IsShapeScalarSyncable(CrystalType type, int slot) {
 // The slot whose value the group carries: the lowest-indexed applicable member. This is not a GUI
 // approximation of the core rule — it IS the core rule (lumice.h LUMICE_CrystalParam::sync_group:
 // "the group's first applicable member (lowest LUMICE_SHAPE_SCALAR_* index) consumes the RNG and
-// owns the distribution"), evaluated over the applicable set IsShapeScalarSyncable defines. So the
-// value the user sees snap in on join is the value core will actually draw with. `exclude_slot` keeps
-// a row from electing itself as its own leader while it is joining.
+// owns the distribution"), evaluated over the same applicable set: core's NormalizeSyncGroupsImpl
+// takes the argmin over slots its kApplicable* table admits, and IsShapeScalarVisible is that table
+// (see its comment). So the value the user sees snap in on join is the value core will actually draw
+// with. `exclude_slot` keeps a row from electing itself as its own leader while it is joining.
 //
-// Note the deliberate divergence from core here: core's "first applicable member" ranges over ALL
-// slots, so for a hand-authored group containing e.g. height + face_0, core's leader is height while
-// the GUI's is face_0. That is the same trade the dormant-across-type-switch case already makes — the
-// GUI can only elect a leader among rows it lets the user edit, and electing an unreachable one would
-// show a group with no editable owner. The mismatch is confined to groups the GUI itself cannot
-// build; core still owns what is actually drawn with.
+// The scan MUST stay scoped by IsShapeScalarVisible and never by IsShapeScalarSyncable. Electing a
+// leader over the narrower set answers a different question — "which member can the user edit" — and
+// for a hand-authored group such as height + face_0 it returns face_0 where core returns height. The
+// table would then display, and hand out on join, a distribution core overwrites on commit: the row
+// silently reverts and the rendered halo comes from a value never shown. A GUI predicate may
+// constrain what the user can CREATE; it may not change what the GUI REPORTS about state that
+// already exists. Groups containing a row with no Sync control are unreachable to the picker but
+// perfectly legal in storage, and this function is how they get reported truthfully.
 // Returns -1 when the group has no other member (or group == 0).
 int FindGroupLeaderSlot(const CrystalConfig& cr, int group, int exclude_slot) {
   if (group == 0) {
     return -1;
   }
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (s == exclude_slot || !IsShapeScalarSyncable(cr.type, s)) {
+    if (s == exclude_slot || !IsShapeScalarVisible(cr.type, s)) {
       continue;
     }
     if (ShapeScalarAt(cr, s).sync_group == group) {
@@ -596,18 +612,26 @@ int NextUnusedSyncGroup(const CrystalConfig& cr) {
 // Copy `slot`'s distribution onto the rest of its group (type, center and spread — NOT the group id
 // itself). Called after an edit to any row that is in a group: a subordinate row stays editable and
 // writing through it updates the whole group, which the owner picked over greying subordinates out.
-// Gated at BOTH ends by IsShapeScalarSyncable — the source row as well as the destinations. A row
-// with no Sync control must not be a group writer either: a prism Height carrying a hand-authored
-// group id is still an editable row, so without the source-side gate, dragging it would move a face
-// distance that shows a swatch Height itself does not. A value jump with no visible cause is worse
-// than the group simply lying dormant, which is what the rest of the widget already does with it.
+// Gated at BOTH ends by IsShapeScalarVisible — the source row as well as the destinations — because
+// core's normalization writes the leader's distribution over EVERY applicable member of the group,
+// with no notion of a member that is exempt. Propagating over the narrower syncable set would leave
+// the group internally disagreeing in exactly the members core then rewrites, so a commit would
+// silently move a row the user did not touch (and log the leader-override warning). Writing the whole
+// group instead makes core's normalize a no-op: it finds the members already equal, overrides
+// nothing, warns about nothing, and the GUI and the simulation hold the same state.
+//
+// The rows with no Sync control are thus still group writers and still written to. That is the
+// mirror side of the widget, and it is not in tension with the affordance narrowing: what a row
+// cannot do is JOIN a group (IsShapeScalarSyncable, at the swatch). Once it is in one — which only a
+// hand-authored config can arrange — it is a member like any other, and the Param-name tint in
+// RenderShapeDistTableRow is what keeps the value movement from being unexplained on screen.
 void PropagateToSyncGroup(CrystalConfig& cr, int slot) {
   const ShapeDist src = ShapeScalarAt(cr, slot);
-  if (src.sync_group == 0 || !IsShapeScalarSyncable(cr.type, slot)) {
+  if (src.sync_group == 0 || !IsShapeScalarVisible(cr.type, slot)) {
     return;
   }
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (s == slot || !IsShapeScalarSyncable(cr.type, s)) {
+    if (s == slot || !IsShapeScalarVisible(cr.type, s)) {
       continue;
     }
     ShapeDist& dst = ShapeScalarAt(cr, s);
@@ -637,13 +661,16 @@ void JoinSyncGroup(CrystalConfig& cr, int slot, int group) {
   dist.spread = src.spread;
 }
 
-// Comma-separated names of `group`'s syncable members, empty if the group has none. A member the
-// current type does not draw, or draws without a Sync control, is deliberately absent: the list names
-// the rows the user can go and find.
+// Comma-separated names of `group`'s members as the current type draws them, empty if the group has
+// none. Scoped by IsShapeScalarVisible, so a row that is drawn but carries no Sync control (a prism
+// Height in a hand-authored group) IS listed: the popup item is a description of the group the user
+// is about to join, and omitting a member whose value the group carries would understate what
+// joining costs. A member belonging to the other crystal type stays absent — it is not drawn at all,
+// and core does not count it either (CanonicalizeSyncGroups zeroes those slots).
 std::string SyncGroupMemberList(const CrystalConfig& cr, int group) {
   std::string members;
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (!IsShapeScalarSyncable(cr.type, s) || ShapeScalarAt(cr, s).sync_group != group) {
+    if (!IsShapeScalarVisible(cr.type, s) || ShapeScalarAt(cr, s).sync_group != group) {
       continue;
     }
     if (!members.empty()) {
@@ -780,18 +807,29 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
   // gets a `label`-suffixed unique id so multiple rows do not collide and GUI tests can target each.
   ImGui::TableNextRow();
 
-  // Whether this row participates in sync at all. Gates BOTH the Sync cell and the Param-name tint
-  // below: showing a group's color on a row that offers no way to reach that group would be the
-  // "displayed but unreachable" state the predicate exists to prevent, and it is strictly more
-  // confusing than showing nothing.
+  // The two sides of the Sync widget, kept as separate variables on purpose (see the predicates'
+  // comments): `syncable` is the CREATION affordance and gates the Sync cell alone; `visible` is the
+  // MIRROR scope core's rules are evaluated over, and gates the Param-name tint below.
   const bool syncable = IsShapeScalarSyncable(cr.type, slot);
+  const bool visible = IsShapeScalarVisible(cr.type, slot);
 
   // Col 0 — Parameter name. A grouped row also gets its name cell tinted in the group's color (at
   // low alpha, so the text stays readable): together with the filled Sync swatch this makes group
   // membership pre-attentive — the eye finds the rows that move together without reading numbers.
   // CellBg draws above the table's RowBg striping, so the two do not fight.
+  //
+  // Tinting on `visible`, not `syncable`, is what keeps that promise complete: a row with no Sync
+  // control can still be a group member (hand-authored), and PropagateToSyncGroup does move its
+  // value with the group. Tinting on the narrower predicate would leave that one row changing with
+  // nothing on screen to attribute it to — the tint IS the visible cause. The cell has no swatch, so
+  // it still reads as "in this group, but not editable from here".
+  //
+  // `visible` is true at every present call site (edit_modals.cpp only emits a row inside the type
+  // branch that draws it), so the guard is currently a tautology. It is spelled out anyway: this is
+  // the mirror scope, naming it keeps the two sides of the widget symmetrical at the point of use,
+  // and a caller that ever emits rows unconditionally does not silently start tinting dormant groups.
   ImGui::TableNextColumn();
-  if (syncable && dist.sync_group != 0) {
+  if (visible && dist.sync_group != 0) {
     const ImVec4 tint = SyncGroupColor(dist.sync_group);
     ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(ImVec4(tint.x, tint.y, tint.z, 0.28f)));
   }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -517,12 +517,12 @@ ImVec4 SyncGroupColor(int group) {
 // Height; Pyramid draws Prism/Upper/Lower H; the six faces are drawn by both) — the same condition,
 // promoted from an implicit `if` in the renderer to a predicate the Sync widget can also ask.
 //
-// Everything the widget does is scoped by this: the popup enumerates only visible slots, the leader
-// search only considers visible slots, and propagation only writes visible slots. So a group number
-// on a scalar belonging to the OTHER crystal type lies dormant across a type switch — not cleared,
-// not shown, not joined. That is deliberate: D1 permits such a grouping to exist in storage (no
-// commensurability check), and leaving it alone is the smallest GUI-side behavior that neither
-// invents a cross-type editing model nor destroys data the user may switch back to.
+// Everything the Sync widget does is scoped by this — via IsShapeScalarSyncable below, which adds a
+// second, commensurability-driven narrowing on top. So a group number on a scalar belonging to the
+// OTHER crystal type lies dormant across a type switch — not cleared, not shown, not joined. That is
+// deliberate: D1 permits such a grouping to exist in storage (no commensurability check), and leaving
+// it alone is the smallest GUI-side behavior that neither invents a cross-type editing model nor
+// destroys data the user may switch back to.
 bool IsShapeScalarVisible(CrystalType type, int slot) {
   if (slot >= LUMICE_SHAPE_SCALAR_FACE_0) {
     return true;  // face_distance[0..5]: both types
@@ -534,19 +534,43 @@ bool IsShapeScalarVisible(CrystalType type, int slot) {
          slot == LUMICE_SHAPE_SCALAR_LOWER_H;
 }
 
+// Can this scalar be SYNCED at all? Strictly narrower than IsShapeScalarVisible (syncable ⊂ visible):
+// sharing one drawn value only means something between scalars that are commensurable — same unit,
+// same semantics. Counting each type's randomizable scalars leaves exactly two rows with nothing to
+// pair with:
+//   - prism  HEIGHT  — the only axial length; the six face distances are dimensionless ratios.
+//   - pyramid PRISM_H — a c/a-axis length; upper_h/lower_h are 0..1 relative heights (those two ARE
+//     each other's pair, and are exactly the use case the generalized sync group exists for).
+// So a Sync control on those two rows would offer an operation that can never be meaningful. Barring
+// them here is a UI-affordance narrowing only: storage still permits such a group (lumice.h runs no
+// commensurability check), a hand-authored config carrying one keeps it, and the GUI treats it the
+// same way it treats a group belonging to the other crystal type — not cleared, not shown, not
+// joinable. NextUnusedSyncGroup deliberately does NOT use this predicate: new ids must not collide
+// with a dormant one either.
+bool IsShapeScalarSyncable(CrystalType type, int slot) {
+  return IsShapeScalarVisible(type, slot) && slot != LUMICE_SHAPE_SCALAR_HEIGHT && slot != LUMICE_SHAPE_SCALAR_PRISM_H;
+}
+
 // The slot whose value the group carries: the lowest-indexed applicable member. This is not a GUI
 // approximation of the core rule — it IS the core rule (lumice.h LUMICE_CrystalParam::sync_group:
 // "the group's first applicable member (lowest LUMICE_SHAPE_SCALAR_* index) consumes the RNG and
-// owns the distribution"), evaluated over the same applicable set IsShapeScalarVisible defines. So
-// the value the user sees snap in on join is the value core will actually draw with. `exclude_slot`
-// keeps a row from electing itself as its own leader while it is joining.
+// owns the distribution"), evaluated over the applicable set IsShapeScalarSyncable defines. So the
+// value the user sees snap in on join is the value core will actually draw with. `exclude_slot` keeps
+// a row from electing itself as its own leader while it is joining.
+//
+// Note the deliberate divergence from core here: core's "first applicable member" ranges over ALL
+// slots, so for a hand-authored group containing e.g. height + face_0, core's leader is height while
+// the GUI's is face_0. That is the same trade the dormant-across-type-switch case already makes — the
+// GUI can only elect a leader among rows it lets the user edit, and electing an unreachable one would
+// show a group with no editable owner. The mismatch is confined to groups the GUI itself cannot
+// build; core still owns what is actually drawn with.
 // Returns -1 when the group has no other member (or group == 0).
 int FindGroupLeaderSlot(const CrystalConfig& cr, int group, int exclude_slot) {
   if (group == 0) {
     return -1;
   }
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (s == exclude_slot || !IsShapeScalarVisible(cr.type, s)) {
+    if (s == exclude_slot || !IsShapeScalarSyncable(cr.type, s)) {
       continue;
     }
     if (ShapeScalarAt(cr, s).sync_group == group) {
@@ -572,13 +596,18 @@ int NextUnusedSyncGroup(const CrystalConfig& cr) {
 // Copy `slot`'s distribution onto the rest of its group (type, center and spread — NOT the group id
 // itself). Called after an edit to any row that is in a group: a subordinate row stays editable and
 // writing through it updates the whole group, which the owner picked over greying subordinates out.
+// Gated at BOTH ends by IsShapeScalarSyncable — the source row as well as the destinations. A row
+// with no Sync control must not be a group writer either: a prism Height carrying a hand-authored
+// group id is still an editable row, so without the source-side gate, dragging it would move a face
+// distance that shows a swatch Height itself does not. A value jump with no visible cause is worse
+// than the group simply lying dormant, which is what the rest of the widget already does with it.
 void PropagateToSyncGroup(CrystalConfig& cr, int slot) {
   const ShapeDist src = ShapeScalarAt(cr, slot);
-  if (src.sync_group == 0) {
+  if (src.sync_group == 0 || !IsShapeScalarSyncable(cr.type, slot)) {
     return;
   }
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (s == slot || !IsShapeScalarVisible(cr.type, s)) {
+    if (s == slot || !IsShapeScalarSyncable(cr.type, s)) {
       continue;
     }
     ShapeDist& dst = ShapeScalarAt(cr, s);
@@ -608,11 +637,13 @@ void JoinSyncGroup(CrystalConfig& cr, int slot, int group) {
   dist.spread = src.spread;
 }
 
-// Comma-separated names of `group`'s visible members, empty if the group has none.
+// Comma-separated names of `group`'s syncable members, empty if the group has none. A member the
+// current type does not draw, or draws without a Sync control, is deliberately absent: the list names
+// the rows the user can go and find.
 std::string SyncGroupMemberList(const CrystalConfig& cr, int group) {
   std::string members;
   for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
-    if (!IsShapeScalarVisible(cr.type, s) || ShapeScalarAt(cr, s).sync_group != group) {
+    if (!IsShapeScalarSyncable(cr.type, s) || ShapeScalarAt(cr, s).sync_group != group) {
       continue;
     }
     if (!members.empty()) {
@@ -749,12 +780,18 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
   // gets a `label`-suffixed unique id so multiple rows do not collide and GUI tests can target each.
   ImGui::TableNextRow();
 
+  // Whether this row participates in sync at all. Gates BOTH the Sync cell and the Param-name tint
+  // below: showing a group's color on a row that offers no way to reach that group would be the
+  // "displayed but unreachable" state the predicate exists to prevent, and it is strictly more
+  // confusing than showing nothing.
+  const bool syncable = IsShapeScalarSyncable(cr.type, slot);
+
   // Col 0 — Parameter name. A grouped row also gets its name cell tinted in the group's color (at
   // low alpha, so the text stays readable): together with the filled Sync swatch this makes group
   // membership pre-attentive — the eye finds the rows that move together without reading numbers.
   // CellBg draws above the table's RowBg striping, so the two do not fight.
   ImGui::TableNextColumn();
-  if (dist.sync_group != 0) {
+  if (syncable && dist.sync_group != 0) {
     const ImVec4 tint = SyncGroupColor(dist.sync_group);
     ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(ImVec4(tint.x, tint.y, tint.z, 0.28f)));
   }
@@ -799,9 +836,11 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, flo
 
   ImGui::EndDisabled();
 
-  // Col 4 — sync group swatch + picker popup.
+  // Col 4 — sync group swatch + picker popup. Left BLANK for a non-syncable scalar, the same way the
+  // wedge rows leave their inapplicable columns blank (edit_modals.cpp RenderWedgeTableRow) — the
+  // column is still advanced so the grid stays a rectangle.
   ImGui::TableNextColumn();
-  const bool group_changed = RenderSyncCell(label, cr, slot);
+  const bool group_changed = syncable && RenderSyncCell(label, cr, slot);
 
   // A value edit on a row that is in a group writes through to the whole group. Evaluated after the
   // Sync cell so an edit made in the same frame the row joined a group propagates the joined value

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -529,6 +529,11 @@ bool RenderShapeDistTableRow(const char* label, ShapeDist& dist, float center_mi
   }
 
   ImGui::EndDisabled();
+
+  // Col 4 — sync group. Placeholder cell until the widget lands; the column already exists so the
+  // grid stays a rectangle and the column-count assert below stays satisfied.
+  ImGui::TableNextColumn();
+
   // Make kShapeTableColumnCount load-bearing at the consumption site, not just a comment: assert the
   // row consumed exactly that many columns. Bumping the constant + adding a TableSetupColumn without
   // updating this helper then trips here instead of silently misaligning the grid (the drift mode the

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -62,10 +62,10 @@ constexpr float kShapeDistDefaultSpreadFraction = 0.2f;
 // structure-consumption sites (RenderShapeDistTableRow / the wedge + face rows' TableNextColumn
 // sequences). ImGui does NOT hard-assert when a row emits a different number of columns than the
 // header declares — it silently misaligns — so keeping every site pinned to this one constant is
-// how the "columns everywhere" invariant is enforced. Columns: Param | Value | Rand | Spread.
+// how the "columns everywhere" invariant is enforced. Columns: Param | Value | Rand | Spread | Sync.
 // (The GUI edits uniform-only — no distribution-type column; non-uniform types loaded from JSON are
 // downgraded to uniform on load, see file_io.cpp ParseShapeDist.)
-constexpr int kShapeTableColumnCount = 4;
+constexpr int kShapeTableColumnCount = 5;
 
 // Emit the Parameter (first) column of a shape-table row: strip any "##id" suffix from `label` and
 // show the human-readable name. Shared so the randomizable rows (RenderShapeDistTableRow) and the

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -74,7 +74,7 @@ constexpr int kShapeTableColumnCount = 5;
 void ShapeTableParamLabel(const char* label);
 
 // Render one crystal shape distribution as a property-table row:
-//   [Param label] [center slider+input] [Randomize checkbox] [spread input]
+//   [Param label] [center slider+input] [Randomize checkbox] [spread input] [sync-group swatch]
 // The spread column is wrapped in BeginDisabled(!randomize) so a not-yet-randomized field still
 // shows it (greyed = "available to turn on"), matching the owner's "everything on the surface"
 // design — no hidden state, the table stays a regular rectangle. Enabling randomization sets the
@@ -82,8 +82,17 @@ void ShapeTableParamLabel(const char* label);
 // to NO_RANDOM and zeroes the (now meaningless) spread. Must be called between BeginTable/EndTable,
 // and advances exactly kShapeTableColumnCount columns — every row helper in this table (this one and
 // the file-local wedge row) must honor that column count or ImGui silently misaligns the grid.
+//
+// Takes the whole `cr` plus the LUMICE_SHAPE_SCALAR_* `slot` this row edits, rather than the single
+// ShapeDist& it used to: the Sync column's popup enumerates the OTHER scalars of the same crystal
+// (group membership lists, leader lookup, next free group number), so the row needs to see its
+// siblings. Resolution goes through gui_state.hpp's ShapeScalarAt — the one mapping authority —
+// so no second slot→field table exists to drift.
+// Callers MUST pass a named LUMICE_SHAPE_SCALAR_* constant, never a bare integer: the slot order is
+// NOT CrystalConfig's field order (UPPER_H is slot 1, PRISM_H slot 2 — see the SLOT-ORDER TRAP note
+// in gui_state.hpp), so a positional guess lands one pyramid height's grouping on the other.
 // Returns true if any value changed. Does NOT call MarkDirty() — caller is responsible.
-bool RenderShapeDistTableRow(const char* label, ShapeDist& dist, float center_min, float center_max,
+bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot, float center_min, float center_max,
                              const char* center_fmt = "%.3f", SliderScale center_scale = SliderScale::kLinear);
 
 // ---- Axis preset classification ----

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -62,7 +62,7 @@ constexpr float kShapeDistDefaultSpreadFraction = 0.2f;
 // structure-consumption sites (RenderShapeDistTableRow / the wedge + face rows' TableNextColumn
 // sequences). ImGui does NOT hard-assert when a row emits a different number of columns than the
 // header declares — it silently misaligns — so keeping every site pinned to this one constant is
-// how the "columns everywhere" invariant is enforced. Columns: Param | Value | Rand | Spread | Sync.
+// how the "columns everywhere" invariant is enforced. Columns: Param | Value | Sync | Rand | Spread.
 // (The GUI edits uniform-only — no distribution-type column; non-uniform types loaded from JSON are
 // downgraded to uniform on load, see file_io.cpp ParseShapeDist.)
 constexpr int kShapeTableColumnCount = 5;
@@ -74,7 +74,7 @@ constexpr int kShapeTableColumnCount = 5;
 void ShapeTableParamLabel(const char* label);
 
 // Render one crystal shape distribution as a property-table row:
-//   [Param label] [center slider+input] [Randomize checkbox] [spread input] [sync-group swatch]
+//   [Param label] [center slider+input] [sync-group swatch] [Randomize checkbox] [spread input]
 // The spread column is wrapped in BeginDisabled(!randomize) so a not-yet-randomized field still
 // shows it (greyed = "available to turn on"), matching the owner's "everything on the surface"
 // design — no hidden state, the table stays a regular rectangle. Enabling randomization sets the

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -1086,6 +1086,25 @@ typedef enum LUMICE_CrystalKind_ {
 // Returns non-zero if `face` is a legal face number for the given crystal kind.
 int LUMICE_IsLegalFace(LUMICE_CrystalKind kind, int face);
 
+// Returns non-zero if shape-scalar `slot` (a LUMICE_SHAPE_SCALAR_* index) physically exists on
+// this crystal kind: a prism has .height + the six .face_distance, a pyramid has
+// .upper_h/.prism_h/.lower_h + the six .face_distance. Out-of-range slots answer zero.
+//
+// This is core's own applicability table, not a second copy of it — the same one canonicalization
+// scopes itself by when it zeroes a group declared on a slot the type does not have. Ask it rather
+// than reimplementing the rule: a GUI-side copy that drifted from core is what once made the
+// crystal table display a distribution the simulation did not use.
+int LUMICE_IsShapeScalarApplicable(LUMICE_CrystalKind kind, int slot);
+
+// Returns the JSON key naming shape-scalar `slot` inside a crystal's `shape.sync_group` object,
+// or NULL when the slot does not apply to this kind (or is out of range). The returned string is
+// static storage — do not free it.
+//
+// All six face slots share the one key "face_distance", whose value is a 6-element array; write it
+// once, not once per face. Use this instead of spelling the key names out: they are core's schema,
+// a layer that misspells one silently drops the field rather than reporting an error.
+const char* LUMICE_ShapeScalarSyncKeyName(LUMICE_CrystalKind kind, int slot);
+
 // =============== Raypath Validation ===============
 // Validation state for raypath text input (GUI border color + OK gate).
 typedef enum LUMICE_RaypathValidationState_ {

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -35,7 +35,7 @@ extern "C" {
 // callers of the removed symbols fail to compile, which is the intended migration signal.
 // The LUMICE_MAX_CONFIG_* ceilings survive the struct: they are now the Scene's Add*/Set*
 // per-kind soft caps, not the dimensions of an inline array.
-#define LUMICE_API_VERSION 412
+#define LUMICE_API_VERSION 413
 #define LUMICE_MAX_RENDER_RESULTS 16
 #define LUMICE_MAX_STATS_RESULTS 1
 
@@ -284,12 +284,42 @@ typedef struct LUMICE_Distribution_ {
   float spread;  // role depends on type (see table above); unused for NO_RANDOM
 } LUMICE_Distribution;
 
+// Index space for LUMICE_CrystalParam.sync_group[] — one slot per randomizable shape scalar.
+// A prism only owns HEIGHT + the six faces, a pyramid only owns UPPER_H/PRISM_H/LOWER_H + the six
+// faces; a slot that does not apply to the crystal type is simply never read for that type.
+//
+// ⚠️ The order mirrors core ShapeScalar (src/config/crystal_config.hpp) VERBATIM, and that order is
+// the RNG draw order — which is what makes "a group's leader = its lowest-index applicable member"
+// identical to "the member drawn first", so no second ordering definition is needed on either side.
+// It is therefore DELIBERATELY NOT the field declaration order of LUMICE_CrystalParam below
+// (height / prism_h / upper_h / lower_h — note UPPER_H and PRISM_H are swapped relative to it).
+// Do not "tidy up" the divergence: aligning these two orders silently redefines which member of a
+// mixed group owns the distribution. The core header carries the same warning.
+#define LUMICE_SHAPE_SCALAR_HEIGHT 0   // .height — prism only
+#define LUMICE_SHAPE_SCALAR_UPPER_H 1  // .upper_h — pyramid only
+#define LUMICE_SHAPE_SCALAR_PRISM_H 2  // .prism_h — pyramid only
+#define LUMICE_SHAPE_SCALAR_LOWER_H 3  // .lower_h — pyramid only
+#define LUMICE_SHAPE_SCALAR_FACE_0 4   // .face_distance[0] — both types
+#define LUMICE_SHAPE_SCALAR_FACE_1 5
+#define LUMICE_SHAPE_SCALAR_FACE_2 6
+#define LUMICE_SHAPE_SCALAR_FACE_3 7
+#define LUMICE_SHAPE_SCALAR_FACE_4 8
+#define LUMICE_SHAPE_SCALAR_FACE_5 9
+#define LUMICE_SHAPE_SCALAR_COUNT 10
+
 // BREAKING (v4.10): the five shape scalars below
 // (height/prism_h/upper_h/lower_h/face_distance[6]) were promoted from bare float to
 // LUMICE_Distribution so a randomizable shape can be expressed through the C struct path (they
 // map to core PrismCrystalParam.h_/d_[6] and PyramidCrystalParam.h_prs_/h_pyr_u_/h_pyr_l_, all
 // already Distribution in core). upper_wedge_angle/lower_wedge_angle stay bare float, mirroring
 // core's wedge_angle_u_/l_ (not Distribution). Layout changed; callers must recompile.
+//
+// BREAKING (v4.13): `sync_group[LUMICE_SHAPE_SCALAR_COUNT]` appended at the end (and the ten
+// LUMICE_SHAPE_SCALAR_* index constants added above). Core has expressed shape-scalar sync groups
+// since v4.12, but this struct had no slot for them, so the C API — the only path a config file,
+// the GUI or a python caller ever takes — dropped the declaration on the floor: core always
+// received all-zero and nothing warned. Layout changed; callers must recompile. Behavior does not:
+// a zero-initialized struct means every scalar independent, exactly as before.
 typedef struct LUMICE_CrystalParam_ {
   int id;
   int type;  // 0=prism, 1=pyramid
@@ -315,6 +345,23 @@ typedef struct LUMICE_CrystalParam_ {
   LUMICE_Distribution zenith;
   LUMICE_Distribution azimuth;
   LUMICE_Distribution roll;
+
+  // Shape-scalar sync groups (v4.13), indexed by LUMICE_SHAPE_SCALAR_*: 0 = independent,
+  // 1..N = group id. Members of one group share a SINGLE random draw — the group's first
+  // applicable member (lowest LUMICE_SHAPE_SCALAR_* index) consumes the RNG and owns the
+  // distribution; the rest reuse its value without consuming anything, and a member whose own
+  // distribution differs is overwritten (with a warning, not silently). Mirrors core
+  // PrismCrystalParam/PyramidCrystalParam::sync_group_ (src/config/crystal_config.hpp).
+  //
+  // ZERO-INIT CONTRACT: after `LUMICE_CrystalParam cp{}` (or memset(0)) every scalar is
+  // independent — IDENTICAL to pre-v4.13 behavior, and the serialized JSON stays byte-identical
+  // (the "sync_group" key is emitted only when something is actually synced). No existing caller
+  // needs to change anything.
+  //
+  // Group ids are canonicalized by core on parse: singleton groups collapse to 0 and surviving
+  // groups are renumbered 1..N by first appearance, so {2,1,2,1,2,1} and {1,2,1,2,1,2} are the
+  // same partition and compare equal. Ids need not be dense or ordered on the way in.
+  int sync_group[LUMICE_SHAPE_SCALAR_COUNT];
 } LUMICE_CrystalParam;
 
 // Filter type discriminant for LUMICE_FilterParam.type.

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -274,6 +274,78 @@ static void ColorPredicateToJson(const LUMICE_ColorPredicate& p, nlohmann::json&
   }
 }
 
+// SYNC: these two key tables must stay byte-identical to kPrismSyncGroupKeys /
+// kPyramidSyncGroupKeys in src/config/crystal_config.cpp (private to that TU's anonymous
+// namespace, hence duplicated rather than shared). The core from_json looks the keys up by name;
+// a single character of drift here means the C API emits a key core never reads, and a declared
+// sync group silently degenerates back to "all independent" with no warning anywhere.
+// "face_distance" is common to both types and handled separately (a 6-element array, mirroring
+// how face_distance itself serializes).
+static constexpr std::pair<const char*, int> kPrismSyncGroupKeys[] = {
+  { "height", LUMICE_SHAPE_SCALAR_HEIGHT },
+};
+static constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
+  { "prism_h", LUMICE_SHAPE_SCALAR_PRISM_H },
+  { "upper_h", LUMICE_SHAPE_SCALAR_UPPER_H },
+  { "lower_h", LUMICE_SHAPE_SCALAR_LOWER_H },
+};
+
+// struct -> JSON. Passes sync_group through verbatim: canonicalization (drop inapplicable slots,
+// collapse singletons, renumber) and leader normalization belong to core's from_json, which every
+// path that actually consumes this JSON runs exactly once. Re-implementing them here would be a
+// second authority for the same semantics.
+// Writes nothing at all when no scalar is synced, keeping the wire form of every pre-v4.13 config
+// byte-identical. Mirrors WriteSyncGroupJson in src/config/crystal_config.cpp.
+static void WriteSyncGroupJson(nlohmann::json& shape_j, const int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
+                               const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  nlohmann::json sg = nlohmann::json::object();
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sync_group[scalar_keys[k].second] != 0) {
+      sg[scalar_keys[k].first] = sync_group[scalar_keys[k].second];
+    }
+  }
+  bool any_face = false;
+  for (int i = 0; i < 6; i++) {
+    any_face = any_face || sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] != 0;
+  }
+  if (any_face) {
+    // All six, zeros included — matching how face_distance itself serializes.
+    sg["face_distance"] =
+        std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
+  }
+  if (!sg.empty()) {
+    shape_j["sync_group"] = sg;
+  }
+}
+
+// JSON -> struct. Absent "sync_group" leaves every slot 0 (all independent), which is why an
+// older config file needs no edit. Mirrors ReadSyncGroupJson in src/config/crystal_config.cpp.
+static void ReadSyncGroupJson(const nlohmann::json& shape_j, int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
+                              const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+  for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; i++) {
+    sync_group[i] = 0;
+  }
+  if (!shape_j.contains("sync_group")) {
+    return;
+  }
+  const auto& sg = shape_j.at("sync_group");
+  for (size_t k = 0; k < scalar_key_cnt; k++) {
+    if (sg.contains(scalar_keys[k].first)) {
+      sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
+    }
+  }
+  if (sg.contains("face_distance")) {
+    size_t i = 0;
+    for (const auto& elem : sg.at("face_distance")) {
+      if (i >= 6) {
+        break;
+      }
+      sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = elem.get<int>();
+      i++;
+    }
+  }
+}
+
 // Non-static (declared in server/c_api_internal.hpp) so both ConfigToJson and
 // LUMICE_GetCrystalMesh consume the SAME crystal-shape translation table. Returns
 // {"type","shape"} only — id/axis are the caller's responsibility (ConfigToJson adds
@@ -300,6 +372,14 @@ nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr) {
     fd.push_back(DistributionToJson(cr.face_distance[fi]));
   }
   j["shape"]["face_distance"] = fd;
+  // Only the keys applicable to this crystal type are emitted, so an inapplicable declaration
+  // never reaches the wire in the first place (core's canonicalization zeroes such slots anyway,
+  // as defense in depth).
+  if (cr.type == 0) {
+    WriteSyncGroupJson(j["shape"], cr.sync_group, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+  } else {
+    WriteSyncGroupJson(j["shape"], cr.sync_group, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+  }
   return j;
 }
 
@@ -1534,6 +1614,15 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
         return err;
       }
     }
+  }
+
+  // Sync groups: read verbatim, only the keys this crystal type owns. Canonicalization and
+  // leader normalization stay in core's from_json (see WriteSyncGroupJson's note); this struct
+  // holds what the caller / config file declared.
+  if (type_str == "prism") {
+    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+  } else {
+    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
   }
 
   // Axis distributions. The two cases are deliberately NOT symmetric, mirroring core:

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -302,9 +302,10 @@ static void WriteSyncGroupJson(nlohmann::json& shape_j, const int sync_group[LUM
   for (int i = 0; i < 6; i++) {
     any_face = any_face || sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] != 0;
   }
-  if (any_face) {
+  const char* face_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+  if (any_face && face_key != nullptr) {
     // All six, zeros included — matching how face_distance itself serializes.
-    sg[ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] =
+    sg[face_key] =
         std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
   }
   if (!sg.empty()) {
@@ -330,7 +331,7 @@ static void ReadSyncGroupJson(const nlohmann::json& shape_j, int sync_group[LUMI
     }
   }
   const char* face_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
-  if (sg.contains(face_key)) {
+  if (face_key != nullptr && sg.contains(face_key)) {
     size_t i = 0;
     for (const auto& elem : sg.at(face_key)) {
       if (i >= 6) {

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -3129,6 +3129,16 @@ int LUMICE_IsLegalFace(LUMICE_CrystalKind kind, int face) {
   return ns::IsLegalFace(core_kind, face) ? 1 : 0;
 }
 
+int LUMICE_IsShapeScalarApplicable(LUMICE_CrystalKind kind, int slot) {
+  auto core_kind = (kind == LUMICE_CRYSTAL_PRISM) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
+  return ns::IsShapeScalarApplicable(core_kind, slot) ? 1 : 0;
+}
+
+const char* LUMICE_ShapeScalarSyncKeyName(LUMICE_CrystalKind kind, int slot) {
+  auto core_kind = (kind == LUMICE_CRYSTAL_PRISM) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
+  return ns::ShapeScalarSyncKeyName(core_kind, slot);
+}
+
 
 // =============== Raypath Validation ===============
 LUMICE_ErrorCode LUMICE_ValidateRaypathText(const char* text, LUMICE_CrystalKind kind,

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -274,21 +274,12 @@ static void ColorPredicateToJson(const LUMICE_ColorPredicate& p, nlohmann::json&
   }
 }
 
-// SYNC: these two key tables must stay byte-identical to kPrismSyncGroupKeys /
-// kPyramidSyncGroupKeys in src/config/crystal_config.cpp (private to that TU's anonymous
-// namespace, hence duplicated rather than shared). The core from_json looks the keys up by name;
-// a single character of drift here means the C API emits a key core never reads, and a declared
-// sync group silently degenerates back to "all independent" with no warning anywhere.
-// "face_distance" is common to both types and handled separately (a 6-element array, mirroring
-// how face_distance itself serializes).
-static constexpr std::pair<const char*, int> kPrismSyncGroupKeys[] = {
-  { "height", LUMICE_SHAPE_SCALAR_HEIGHT },
-};
-static constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
-  { "prism_h", LUMICE_SHAPE_SCALAR_PRISM_H },
-  { "upper_h", LUMICE_SHAPE_SCALAR_UPPER_H },
-  { "lower_h", LUMICE_SHAPE_SCALAR_LOWER_H },
-};
+// The sync_group schema key names come from core (ns::ShapeScalarSyncKeyName), which owns them.
+// This layer used to carry its own copy of the {key, slot} table; the core from_json looks the keys
+// up by name, so a single character of drift meant the C API emitted a key core never reads and a
+// declared sync group silently degenerated back to "all independent" with no warning anywhere.
+// The face slots all answer "face_distance", whose value is one 6-element array, so they are
+// handled as a block rather than per slot.
 
 // struct -> JSON. Passes sync_group through verbatim: canonicalization (drop inapplicable slots,
 // collapse singletons, renumber) and leader normalization belong to core's from_json, which every
@@ -297,11 +288,14 @@ static constexpr std::pair<const char*, int> kPyramidSyncGroupKeys[] = {
 // Writes nothing at all when no scalar is synced, keeping the wire form of every pre-v4.13 config
 // byte-identical. Mirrors WriteSyncGroupJson in src/config/crystal_config.cpp.
 static void WriteSyncGroupJson(nlohmann::json& shape_j, const int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
-                               const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+                               ns::CrystalKind kind) {
   nlohmann::json sg = nlohmann::json::object();
-  for (size_t k = 0; k < scalar_key_cnt; k++) {
-    if (sync_group[scalar_keys[k].second] != 0) {
-      sg[scalar_keys[k].first] = sync_group[scalar_keys[k].second];
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_FACE_0; slot++) {
+    // A null key means the slot does not apply to this type, so an inapplicable declaration never
+    // reaches the wire in the first place.
+    const char* key = ns::ShapeScalarSyncKeyName(kind, slot);
+    if (key != nullptr && sync_group[slot] != 0) {
+      sg[key] = sync_group[slot];
     }
   }
   bool any_face = false;
@@ -310,7 +304,7 @@ static void WriteSyncGroupJson(nlohmann::json& shape_j, const int sync_group[LUM
   }
   if (any_face) {
     // All six, zeros included — matching how face_distance itself serializes.
-    sg["face_distance"] =
+    sg[ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] =
         std::vector<int>(sync_group + LUMICE_SHAPE_SCALAR_FACE_0, sync_group + LUMICE_SHAPE_SCALAR_FACE_0 + 6);
   }
   if (!sg.empty()) {
@@ -321,7 +315,7 @@ static void WriteSyncGroupJson(nlohmann::json& shape_j, const int sync_group[LUM
 // JSON -> struct. Absent "sync_group" leaves every slot 0 (all independent), which is why an
 // older config file needs no edit. Mirrors ReadSyncGroupJson in src/config/crystal_config.cpp.
 static void ReadSyncGroupJson(const nlohmann::json& shape_j, int sync_group[LUMICE_SHAPE_SCALAR_COUNT],
-                              const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
+                              ns::CrystalKind kind) {
   for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; i++) {
     sync_group[i] = 0;
   }
@@ -329,14 +323,16 @@ static void ReadSyncGroupJson(const nlohmann::json& shape_j, int sync_group[LUMI
     return;
   }
   const auto& sg = shape_j.at("sync_group");
-  for (size_t k = 0; k < scalar_key_cnt; k++) {
-    if (sg.contains(scalar_keys[k].first)) {
-      sync_group[scalar_keys[k].second] = sg.at(scalar_keys[k].first).get<int>();
+  for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_FACE_0; slot++) {
+    const char* key = ns::ShapeScalarSyncKeyName(kind, slot);
+    if (key != nullptr && sg.contains(key)) {
+      sync_group[slot] = sg.at(key).get<int>();
     }
   }
-  if (sg.contains("face_distance")) {
+  const char* face_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+  if (sg.contains(face_key)) {
     size_t i = 0;
-    for (const auto& elem : sg.at("face_distance")) {
+    for (const auto& elem : sg.at(face_key)) {
       if (i >= 6) {
         break;
       }
@@ -376,9 +372,9 @@ nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr) {
   // never reaches the wire in the first place (core's canonicalization zeroes such slots anyway,
   // as defense in depth).
   if (cr.type == 0) {
-    WriteSyncGroupJson(j["shape"], cr.sync_group, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+    WriteSyncGroupJson(j["shape"], cr.sync_group, ns::CrystalKind::kPrism);
   } else {
-    WriteSyncGroupJson(j["shape"], cr.sync_group, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+    WriteSyncGroupJson(j["shape"], cr.sync_group, ns::CrystalKind::kPyramid);
   }
   return j;
 }
@@ -1620,9 +1616,9 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   // leader normalization stay in core's from_json (see WriteSyncGroupJson's note); this struct
   // holds what the caller / config file declared.
   if (type_str == "prism") {
-    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, kPrismSyncGroupKeys, std::size(kPrismSyncGroupKeys));
+    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, ns::CrystalKind::kPrism);
   } else {
-    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
+    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, ns::CrystalKind::kPyramid);
   }
 
   // Axis distributions. The two cases are deliberately NOT symmetric, mirroring core:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/core/test_proj.cpp"
   # config/
   "${PROJ_TEST_DIR}/unit-correctness/config/test_json.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/config/test_crystal_sync_group.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/config/test_config_snapshot.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/config/test_render_config.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/config/test_sim_data.cpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/core/test_geo3d.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_optics.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_crystal.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/core/test_crystal_sync_group_sampling.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_rng.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_distribution_slots.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/core/test_filter.cpp"

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -762,6 +762,104 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // AC1 of the Sync column: a C3 grouping BUILT BY CLICKING reaches the geometry. The 404.3 tests
+  // above inject sync_group into the config and check the data path; this one starts from an
+  // all-independent crystal and drives the actual widget — swatch button, then popup item — the way
+  // a user would, then asserts on the mesh the simulator would trace.
+  //
+  // It lives in this file, not next to the other Sync-column tests in test_gui_interaction.cpp,
+  // because gui_test is ONE binary (test/gui/CMakeLists.txt compiles both into add_executable):
+  // the PrismFacePlaneOffsets / CountDistinct probes are already defined in this translation unit,
+  // and this repo copies a test helper only across binaries, never within one.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_built_in_ui_reaches_geometry");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = false;  // OK is what commits; this is the full user path
+      ctx->Yield(2);
+      auto& entry = gui::g_state.layers[0].entries[0];
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(2);
+
+      // Randomize all six faces first. Without randomization every face keeps the same default
+      // 1.0 and "grouped faces are equal" would hold for a build that ignored sync_group entirely.
+      for (int i = 0; i < 6; ++i) {
+        char rnd_id[64];
+        snprintf(rnd_id, sizeof(rnd_id), "**/##rnd_Face %d##modal_fd", i + 3);
+        ctx->ItemClick(rnd_id);
+        ctx->Yield(2);
+      }
+
+      // Face 3/5/7 (indices 0/2/4) → group 1, Face 4/6/8 (1/3/5) → group 2. Each group is opened
+      // with "+ New group" on its first member and joined via its "###sync_group_N" item after that.
+      const int kGroupMembers[2][3] = { { 3, 5, 7 }, { 4, 6, 8 } };
+      for (int g = 0; g < 2; ++g) {
+        for (int m = 0; m < 3; ++m) {
+          char swatch[64];
+          snprintf(swatch, sizeof(swatch), "**/##sync_Face %d##modal_fd", kGroupMembers[g][m]);
+          ctx->ItemClick(swatch);
+          ctx->Yield(2);
+          if (m == 0) {
+            ctx->ItemClick("**/###sync_new");
+          } else {
+            char item[64];
+            snprintf(item, sizeof(item), "**/###sync_group_%d", g + 1);
+            ctx->ItemClick(item);
+          }
+          ctx->Yield(2);
+        }
+      }
+
+      ctx->ItemClose("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
+      ctx->Yield(3);
+
+      // The committed entry carries the grouping the clicks described.
+      const auto& cr = gui::CrystalOf(gui::g_state, entry);
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(cr.face_distance[i].sync_group, (i % 2 == 0) ? 1 : 2);
+        IM_CHECK_EQ(cr.face_distance[i].type, gui::ShapeDistType::kUniform);
+      }
+      // ...and so does the scene handed to core: face_distance's sync_group array is the canonical
+      // [1,2,1,2,1,2]. Read off the commit path, not off g_state again, because the grouping being
+      // present in the GUI and reaching the simulator are separate claims (404.1 found the CLI path
+      // dropping sync_group while the GUI-side data was perfectly correct).
+      const auto scene_j = CommitSceneJson(gui::g_state);
+      const auto& sg = scene_j["crystal"][0]["shape"]["sync_group"]["face_distance"];
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(sg[i].get<int>(), (i % 2 == 0) ? 1 : 2);
+      }
+
+      // White-box on the geometry: two draws, six faces. The eye cannot verify this symmetry in a
+      // halo image, which is the entire reason the feature exists — so it is asserted on the mesh.
+      LUMICE_CrystalMesh mesh{};
+      IM_CHECK(gui::BuildCrystalMeshData(cr, 12345, &mesh));
+      const auto off = PrismFacePlaneOffsets(mesh);
+      IM_CHECK_EQ(CountDistinct(off, 1e-5f), (size_t)2);
+      IM_CHECK(std::fabs(off[0] - off[2]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[2] - off[4]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[1] - off[3]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[3] - off[5]) <= 1e-5f);
+      // The two groups drew separately: a mesh where all six faces collapsed to one value would
+      // satisfy every equality above.
+      IM_CHECK(std::fabs(off[0] - off[1]) > 1e-5f);
+
+      // Control on the same randomized crystal: ungrouped, the six faces draw six distinct values.
+      // Without it, "2 distinct" would also pass on a build that ignored face_distance randomization.
+      gui::CrystalConfig ungrouped = cr;
+      for (int i = 0; i < 6; ++i) {
+        ungrouped.face_distance[i].sync_group = 0;
+      }
+      LUMICE_CrystalMesh independent{};
+      IM_CHECK(gui::BuildCrystalMeshData(ungrouped, 12345, &independent));
+      IM_CHECK_EQ(CountDistinct(PrismFacePlaneOffsets(independent), 1e-5f), (size_t)6);
+    };
+  }
+
   // Test: custom-spectrum end-to-end round-trip (task-323).
   // Covers all 4 file_io write paths + 1 load path introduced by the discrete-spectrum work:
   //   1. GUI project save (root["sun"]["spectrum"]="custom" + "custom_spectrum" array)

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -1,6 +1,10 @@
+#include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <fstream>
+#include <limits>
 #include <nlohmann/json.hpp>
+#include <vector>
 
 #include "IconsFontAwesome6.h"
 #include "gui/export_fbo_renderer.hpp"  // RenderExportToRgba for GL pixel-level assertions
@@ -54,6 +58,54 @@ std::string CoreJson(const gui::GuiState& state) {
   std::string json;
   gui::BuildExportJsonOrWarn(state, &json, nullptr);
   return json;
+}
+
+// ===== Sync-group geometry probes (404.3) =====
+// Deliberate copies of the helpers in test/unit-correctness/server/test_c_api.cpp (namespace-local
+// there): gui_test and the gtest binary are separate targets with no shared TU, and lifting ~30
+// lines into a shared header for one mirrored pair would cost more than it saves. Kept
+// behaviourally identical so a failure here means the same thing it means there.
+//
+// Signed plane offset (centroid · unit normal) of every prism face (face numbers 3..8), in
+// face_number order. Measured off the geometry rather than assuming a face_number <->
+// face_distance[i] mapping, so the assertions stay true statements about "same-group faces sit at
+// the same distance" regardless of internal ordering. BuildCrystalMeshData's Y-Z swap is a
+// rotation and its AABB normalization a uniform scale, so both preserve the equalities asserted.
+std::vector<float> PrismFacePlaneOffsets(const LUMICE_CrystalMesh& mesh) {
+  std::vector<float> offsets(6, std::numeric_limits<float>::quiet_NaN());
+  for (int fi = 0; fi < mesh.face_count; ++fi) {
+    const int fn = mesh.face_numbers_by_face[fi];
+    if (fn < 3 || fn > 8) {
+      continue;  // basal / pyramidal
+    }
+    const int offset = mesh.face_vtx_offsets[fi];
+    const int count = mesh.face_vtx_counts[fi];
+    if (count <= 0) {
+      continue;
+    }
+    float c[3] = { 0.0f, 0.0f, 0.0f };
+    for (int k = 0; k < count; ++k) {
+      const float* p = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+      c[0] += p[0];
+      c[1] += p[1];
+      c[2] += p[2];
+    }
+    const float* n = mesh.face_normals + fi * 3;
+    offsets[fn - 3] = (c[0] * n[0] + c[1] * n[1] + c[2] * n[2]) / static_cast<float>(count);
+  }
+  return offsets;
+}
+
+// Number of distinct values in `v` under `tol`. Phrases "the three C3-equivalent faces collapsed
+// onto one distance" without naming which faces those are.
+size_t CountDistinct(const std::vector<float>& v, float tol) {
+  std::vector<float> uniq;
+  for (float x : v) {
+    if (std::none_of(uniq.begin(), uniq.end(), [&](float u) { return std::fabs(u - x) <= tol; })) {
+      uniq.push_back(x);
+    }
+  }
+  return uniq.size();
 }
 
 template <typename Fn>
@@ -495,6 +547,218 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
       // an untouched face stays the deterministic default (NO_RANDOM → bare number).
       IM_CHECK(fd[1].is_number());
       IM_CHECK_EQ(fd[1].get<float>(), 1.0f);
+    };
+  }
+
+  // ===================== shape-scalar sync groups (404.3) =====================
+  // The GUI carries sync groups but grows no control for them (that is 404.4), so these tests
+  // drive the data path directly: import → preview, save → load, and the preview's change
+  // detection. The three of them are what makes "a hand-authored config with sync_group works in
+  // the GUI" a checked statement rather than a claim.
+
+  // AC1: a grouping reaches the PREVIEW mesh. Grouped scalars share one draw, so a C3 grouping of
+  // randomized face distances must produce a mesh with exactly two distinct prism-face distances.
+  // White-box on the geometry — the whole point of the feature is a symmetry the eye cannot verify.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_reaches_preview_mesh");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      auto& cr = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[0]);
+      cr.type = gui::CrystalType::kPrism;
+      for (int i = 0; i < 6; ++i) {
+        cr.face_distance[i] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.0f, 0.1f };
+      }
+
+      // Control: six independent draws → six distinct distances. Without it the grouped case
+      // below would also pass on a mesh that ignored face_distance entirely.
+      LUMICE_CrystalMesh independent{};
+      IM_CHECK(gui::BuildCrystalMeshData(cr, 12345, &independent));
+      IM_CHECK_EQ(CountDistinct(PrismFacePlaneOffsets(independent), 1e-5f), (size_t)6);
+
+      // {FACE_0,FACE_2,FACE_4} and {FACE_1,FACE_3,FACE_5}: two draws, six faces.
+      for (int i = 0; i < 6; ++i) {
+        cr.face_distance[i].sync_group = (i % 2 == 0) ? 1 : 2;
+      }
+      LUMICE_CrystalMesh c3{};
+      IM_CHECK(gui::BuildCrystalMeshData(cr, 12345, &c3));
+      const auto off = PrismFacePlaneOffsets(c3);
+      IM_CHECK_EQ(CountDistinct(off, 1e-5f), (size_t)2);
+      // Named-face form of the same statement: it is faces 0/2/4 that agree, not some other
+      // three-way split that happens to give two distinct values.
+      IM_CHECK(std::fabs(off[0] - off[2]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[2] - off[4]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[1] - off[3]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[3] - off[5]) <= 1e-5f);
+      IM_CHECK(std::fabs(off[0] - off[1]) > 1e-5f);
+    };
+  }
+
+  // AC1, the import half: a HAND-AUTHORED core config carrying sync_group loads into the GUI's
+  // embedded form. This is the task's headline claim ("a config file with sync_group can be
+  // imported by the GUI"), and it runs through the same ParseCrystal the .lmc path uses.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_imports_from_core_json");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      const std::string core_json = R"({
+        "crystal": [
+          {"id": 1, "type": "prism",
+           "shape": {"height": 1.0,
+                     "face_distance": [1,1,1,1,1,1],
+                     "sync_group": {"height": 7, "face_distance": [1,2,1,2,1,2]}}}
+        ],
+        "scene": {
+          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "ray_num": 1000,
+          "max_hits": 8,
+          "scattering": [
+            {"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0}]}
+          ]
+        }
+      })";
+
+      gui::GuiState loaded = gui::InitDefaultState();
+      IM_CHECK(gui::DeserializeFromJson(core_json, loaded));
+      IM_CHECK_EQ(static_cast<int>(loaded.layers.size()), 1);
+      const auto& c = gui::CrystalOf(loaded, loaded.layers[0].entries[0]);
+      IM_CHECK_EQ(c.height.sync_group, 7);
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(c.face_distance[i].sync_group, (i % 2 == 0) ? 1 : 2);
+      }
+    };
+  }
+
+  // AC2: .lmc round-trip, every applicable slot. Two crystals because the wire form is type-gated
+  // exactly as the shape scalars themselves are: a prism writes height + face_distance, a pyramid
+  // writes prism_h/upper_h/lower_h + face_distance. Between them all ten LUMICE_SHAPE_SCALAR_*
+  // slots are exercised — a per-slot sweep, because a table that drops one key shows up only as
+  // "that one field's grouping vanished" (the failure mode 404.2 hit as key-name drift).
+  // The pyramid arm also guards the index-order trap: UPPER_H is slot 1 and PRISM_H slot 2, the
+  // reverse of the struct's field order, so distinct values here catch a positional mapping.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_lmc_roundtrip");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      auto& prism = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[0]);
+      prism.type = gui::CrystalType::kPrism;
+      prism.height.sync_group = 5;
+      for (int i = 0; i < 6; ++i) {
+        prism.face_distance[i].sync_group = (i % 2 == 0) ? 1 : 2;
+      }
+
+      gui::CrystalConfig pyr;
+      pyr.type = gui::CrystalType::kPyramid;
+      pyr.prism_h.sync_group = 3;
+      pyr.upper_h.sync_group = 4;  // != prism_h: a positional mapping swaps these two
+      pyr.lower_h.sync_group = 3;
+      for (int i = 0; i < 6; ++i) {
+        pyr.face_distance[i].sync_group = 6 - i;
+      }
+      gui::EntryCard extra;
+      extra.crystal_id = static_cast<int>(gui::g_state.crystals.size());
+      extra.proportion = 50.0f;
+      gui::g_state.crystals.push_back(pyr);
+      gui::g_state.layers[0].entries.push_back(extra);
+
+      // Key names are asserted against the emitted document, not just round-trip stability: a
+      // round-trip is self-consistent even if the GUI writes keys core cannot read (the third
+      // mirror table's failure mode — there is no compile-time link between the three copies).
+      const auto doc = nlohmann::json::parse(gui::SerializeGuiStateJson(gui::g_state));
+      // Presence first: without it a serializer that emits nothing fails by throwing out of
+      // operator[] instead of reporting which expectation broke.
+      IM_CHECK(doc["layers"][0]["entries"][0]["crystal"]["shape"].contains("sync_group"));
+      IM_CHECK(doc["layers"][0]["entries"][1]["crystal"]["shape"].contains("sync_group"));
+      const auto& prism_sg = doc["layers"][0]["entries"][0]["crystal"]["shape"]["sync_group"];
+      IM_CHECK_EQ(prism_sg["height"].get<int>(), 5);
+      IM_CHECK_EQ(prism_sg["face_distance"][2].get<int>(), 1);
+      IM_CHECK(!prism_sg.contains("prism_h"));  // inapplicable to this type, as for the scalars
+      const auto& pyr_sg = doc["layers"][0]["entries"][1]["crystal"]["shape"]["sync_group"];
+      IM_CHECK_EQ(pyr_sg["prism_h"].get<int>(), 3);
+      IM_CHECK_EQ(pyr_sg["upper_h"].get<int>(), 4);
+      IM_CHECK_EQ(pyr_sg["lower_h"].get<int>(), 3);
+      IM_CHECK_EQ(pyr_sg["face_distance"][0].get<int>(), 6);
+      IM_CHECK(!pyr_sg.contains("height"));
+
+      const char* tmp_path = "/tmp/lumice_sync_group_roundtrip.lmc";
+      IM_CHECK(gui::SaveLmcFile(tmp_path, gui::g_state, gui::g_preview, false));
+      gui::DoNew();
+      std::vector<unsigned char> tex_data;
+      int tex_w = 0;
+      int tex_h = 0;
+      IM_CHECK(gui::LoadLmcFile(tmp_path, gui::g_state, tex_data, tex_w, tex_h));
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
+      const auto& loaded_prism = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[0]);
+      IM_CHECK_EQ(loaded_prism.height.sync_group, 5);
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(loaded_prism.face_distance[i].sync_group, (i % 2 == 0) ? 1 : 2);
+      }
+      const auto& loaded_pyr = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[1]);
+      IM_CHECK_EQ(loaded_pyr.prism_h.sync_group, 3);
+      IM_CHECK_EQ(loaded_pyr.upper_h.sync_group, 4);
+      IM_CHECK_EQ(loaded_pyr.lower_h.sync_group, 3);
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(loaded_pyr.face_distance[i].sync_group, 6 - i);
+      }
+
+      std::remove(tmp_path);
+    };
+  }
+
+  // AC2, the other half: an all-independent crystal must emit NO "sync_group" key, so every .lmc
+  // written before v4.13 keeps its exact wire form. Paired with a red/green flip — asserting only
+  // absence would pass just as happily on a serializer that never writes the key at all.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_absent_when_all_independent");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      auto& cr = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[0]);
+      cr.type = gui::CrystalType::kPrism;
+      const auto shape_of = [](const std::string& doc_str) {
+        return nlohmann::json::parse(doc_str)["layers"][0]["entries"][0]["crystal"]["shape"];
+      };
+      IM_CHECK(!shape_of(gui::SerializeGuiStateJson(gui::g_state)).contains("sync_group"));
+
+      cr.face_distance[3].sync_group = 1;
+      IM_CHECK(shape_of(gui::SerializeGuiStateJson(gui::g_state)).contains("sync_group"));
+    };
+  }
+
+  // AC3: the preview's change detector sees a grouping change. CrystalParamHash gates the mesh
+  // re-upload, so a hash blind to sync_group leaves the previous crystal on screen — which reads
+  // as "the feature does not work" rather than as a stale cache. Both directions are checked: a
+  // hash that ignored the field would fail the first, one that hashed uninitialized memory the
+  // second.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "sync_group_changes_param_hash");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      gui::CrystalConfig base;
+      base.type = gui::CrystalType::kPrism;
+      for (int i = 0; i < 6; ++i) {
+        base.face_distance[i] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.0f, 0.1f };
+      }
+
+      gui::CrystalConfig same = base;
+      IM_CHECK_EQ(gui::CrystalParamHash(base), gui::CrystalParamHash(same));
+
+      // Every slot individually: a hash built from a partial field list would pass on some and
+      // fail on others, and "which field is invisible to the preview" is not a guess worth making.
+      for (int slot = 0; slot < LUMICE_SHAPE_SCALAR_COUNT; ++slot) {
+        gui::CrystalConfig grouped = base;
+        gui::ShapeScalarAt(grouped, slot).sync_group = 1;
+        IM_CHECK_NE(gui::CrystalParamHash(base), gui::CrystalParamHash(grouped));
+      }
     };
   }
 

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4073,6 +4073,16 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       std::string name_baseline = gui::CrystalOf(gui::g_state, entry).name;
       gui::CrystalType type_baseline = gui::CrystalOf(gui::g_state, entry).type;
 
+      // Step 1b: declare sync groups (404.3). There is no control for them yet — 404.4 adds the
+      // column — so they are injected straight into the entry, from where the modal copies them
+      // into its edit buffer like any other shape state. Both a scalar and face slots, because
+      // Reset All clears them not by naming them but by assigning whole ShapeDist values; a
+      // future rewrite that switched to per-component assignment would leave exactly these
+      // behind, and nothing else in the suite would notice.
+      gui::CrystalOf(gui::g_state, entry).height.sync_group = 3;
+      gui::CrystalOf(gui::g_state, entry).face_distance[2].sync_group = 1;
+      gui::CrystalOf(gui::g_state, entry).face_distance[4].sync_group = 1;
+
       // Step 2: open modal again, modify height to another non-default (2.0),
       // click Reset All, then OK to commit the reset.
       ctx->ItemClick("**/Edit##cr");
@@ -4094,6 +4104,12 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).lower_alpha, defaults.lower_alpha);
       for (int i = 0; i < 6; ++i) {
         IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).face_distance[i], defaults.face_distance[i]);
+      }
+      // Sync groups cleared too (404.3). Spelled out rather than left to ShapeDist::operator==
+      // above so the intent is visible at the assertion, not inferred from a comparison operator.
+      IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).height.sync_group, 0);
+      for (int i = 0; i < 6; ++i) {
+        IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).face_distance[i].sync_group, 0);
       }
 
       // Step 4: assert name/type/axis preserved (Reset All must not touch them).

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4463,6 +4463,63 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_modal/sync_group_cross_range_converges — grouping scalars whose sliders have DIFFERENT
+  // ranges is permitted (the design deliberately runs no dimensional-commensurability check), and
+  // Height [0.01, 100] with a face distance [0, 2] is the case where that shows. What the group
+  // then settles on is the tighter bound: a value propagated into the face row is clamped by that
+  // row's own slider, and the clamp propagates straight back out.
+  //
+  // The property worth pinning is not the number 2.0 — it is that the loop TERMINATES. Propagation
+  // is triggered by "this row's value changed", and a clamp is a change, so a value that no member
+  // can hold is fed back and forth between rows. Measured: one frame to converge, stable after.
+  // An implementation that ping-ponged (or clamped asymmetrically) would leave the modal visibly
+  // twitching and this test red.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_cross_range_converges");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+      crystal().type = gui::CrystalType::kPrism;
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Height##modal_cr");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      // Both start at the shared default 1.0, which is inside both ranges — nothing to clamp yet.
+      IM_CHECK_EQ(crystal().height.center, 1.0f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
+
+      // 50 is legal for Height and far outside the face range.
+      ctx->ItemInputValue("**/##Height##modal_cr_input", 50.0f);
+      ctx->Yield(1);
+      // Settled after a SINGLE frame, on the face row's maximum, with both members agreeing.
+      IM_CHECK_EQ(crystal().face_distance[0].center, 2.0f);
+      IM_CHECK_EQ(crystal().height.center, 2.0f);
+      // ...and it stays there: no oscillation between the two clamps over the following frames.
+      ctx->Yield(8);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 2.0f);
+      IM_CHECK_EQ(crystal().height.center, 2.0f);
+
+      ctx->ItemClose("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
   // p2_modal/sync_column_layout_budget — AC5, as a measurement rather than a look at the modal.
   // The Sync column is FIXED width and Value is the only stretch column, so every pixel Sync takes
   // comes out of the slider. Two things could go wrong and neither is visible in a state assertion:

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4178,7 +4178,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
-      ctx->ItemClick("**/Face Distance##modal");  // default-collapsed section
+      ctx->ItemOpen("**/Face Distance##modal");  // default-collapsed section
       ctx->Yield(2);
 
       // Face 5 (face_distance[2]) starts a group of its own. "+ New group" allocates id 1 here —
@@ -4234,7 +4234,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
       IM_CHECK_EQ(crystal().face_distance[0].sync_group, 0);
 
-      ctx->ItemClick("**/Face Distance##modal");  // restore the default-collapsed state for later tests
+      ctx->ItemClose("**/Face Distance##modal");  // restore the default-collapsed state for later tests
       ctx->Yield(2);
       ctx->ItemClick("**/Close##edit_modal");
       ctx->Yield(2);
@@ -4256,7 +4256,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
 
       // Build a two-member group with a non-default value, so "value unchanged on leave" is a claim
@@ -4291,7 +4291,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(crystal().face_distance[0].center, 0.5f);
       IM_CHECK_EQ(crystal().face_distance[1].center, 1.75f);
 
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
       ctx->ItemClick("**/Close##edit_modal");
       ctx->Yield(2);
@@ -4318,7 +4318,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
 
       // Regroup inside the buffer: a third row joins group 2, and one of its members leaves.
@@ -4333,7 +4333,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       // Staged mode: none of that reached the entry yet.
       IM_CHECK(gui::CrystalOf(gui::g_state, entry) == baseline);
 
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
       ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
       ctx->Yield(3);
@@ -4411,31 +4411,42 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
         return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
       };
       crystal().type = gui::CrystalType::kPyramid;
+      // The group is seeded with two members that DISAGREE — the only configuration in which
+      // "which member is the leader" is observable at all. A group built by clicking has equal
+      // members by construction, and a snapshot from either end of it looks identical. (A
+      // hand-authored config reaching the GUI in exactly this state is normal: canonicalization
+      // belongs to core's from_json, on commit, not to the GUI.)
+      // upper_h is slot 1, lower_h slot 3, and upper_h is drawn BELOW both of the other two.
       crystal().upper_h = gui::ShapeDist{ gui::ShapeDistType::kUniform, 0.4f, 0.08f };
+      crystal().upper_h.sync_group = 1;
+      crystal().lower_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.9f, 0.0f };
+      crystal().lower_h.sync_group = 1;
       crystal().prism_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 3.0f, 0.0f };
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
 
-      // Upper H (slot 1) forms the group first, then Prism H (slot 2) — drawn ABOVE it — joins.
-      ctx->ItemClick("**/##sync_Upper H##modal_cr");
-      ctx->Yield(2);
-      ctx->ItemClick("**/###sync_new");
-      ctx->Yield(2);
+      // Prism H (slot 2, drawn FIRST of the three) joins: it must take upper_h's distribution
+      // (slot 1), not lower_h's (slot 3). Row order says lower_h is further away; slot order is
+      // what decides.
       ctx->ItemClick("**/##sync_Prism H##modal_cr");
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_group_1");
       ctx->Yield(2);
-      // Prism H took Upper H's distribution, not the other way round: the leader is the lower SLOT,
-      // even though it is the lower ROW.
+      IM_CHECK_EQ(crystal().prism_h.sync_group, 1);
       IM_CHECK_EQ(crystal().prism_h.center, 0.4f);
       IM_CHECK_EQ(crystal().prism_h.type, gui::ShapeDistType::kUniform);
       IM_CHECK_EQ(crystal().prism_h.spread, 0.08f);
-      IM_CHECK_EQ(crystal().upper_h.center, 0.4f);  // the leader itself is not disturbed
+      // Joining reads the group, it does not write it: the two seeded members are untouched, and
+      // still disagreeing.
+      IM_CHECK_EQ(crystal().upper_h.center, 0.4f);
+      IM_CHECK_EQ(crystal().lower_h.center, 0.9f);
 
-      // A face slot joining the same group also snapshots from Upper H — every face slot (4..9) is
-      // above the three H slots in the index space, so no face can ever be the leader here.
-      ctx->ItemClick("**/Face Distance##modal");
+      // A face slot joining the same group also snapshots from upper_h — every face slot (4..9) is
+      // above all three H slots in the index space, so no face can ever be the leader here, and the
+      // disagreeing lower_h is still sitting there to be picked by a search that scanned the other
+      // way.
+      ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
       ctx->ItemClick("**/##sync_Face 3##modal_fd");
       ctx->Yield(2);
@@ -4444,7 +4455,7 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(crystal().face_distance[0].center, 0.4f);
       IM_CHECK_EQ(crystal().face_distance[0].type, gui::ShapeDistType::kUniform);
 
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
       ctx->ItemClick("**/Close##edit_modal");
       ctx->Yield(2);
@@ -4453,10 +4464,15 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
   }
 
   // p2_modal/sync_group_reselect_current_is_noop — re-picking the group a row is already in must
-  // not re-snapshot it. Cheap, and it guards the one branch in the popup that is easy to drop
-  // ("if (dist.sync_group != group)"): without it, re-selecting overwrites the row from the leader,
-  // which for the LEADER itself is harmless and for anyone else silently discards an edit in
-  // progress. Registered rather than left as a "budget permitting" note in the plan.
+  // not re-snapshot it, i.e. the popup's "if (dist.sync_group != group)" guard is load-bearing.
+  //
+  // The starting state is a group whose two members hold DIFFERENT distributions. That is not
+  // contrived: the GUI passes hand-authored sync_group values through verbatim and never
+  // normalizes them (core's from_json owns that, on commit), so a config file can perfectly well
+  // declare a group over rows that disagree — and it is the only state in which "re-select does
+  // nothing" and "re-select snapshots from the leader" are distinguishable at all. Building the
+  // group by clicking instead would leave its members already equal, and the test would pass just
+  // as happily with the guard deleted.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_reselect_current_is_noop");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -4466,36 +4482,41 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       auto crystal = []() -> gui::CrystalConfig& {
         return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
       };
+      // Face 3 (leader, lowest slot) and Face 4, same group, deliberately disagreeing.
+      crystal().face_distance[0] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.6f, 0.3f };
+      crystal().face_distance[0].sync_group = 1;
+      crystal().face_distance[1] = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.9f, 0.0f };
+      crystal().face_distance[1].sync_group = 1;
+      const gui::ShapeDist leader_before = crystal().face_distance[0];
+      const gui::ShapeDist member_before = crystal().face_distance[1];
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
 
-      ctx->ItemClick("**/##sync_Face 3##modal_fd");
-      ctx->Yield(2);
-      ctx->ItemClick("**/###sync_new");
-      ctx->Yield(2);
-      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 1.6f);
-      ctx->Yield(2);
+      // Re-pick the group Face 4 is already in: nothing may move, on either row.
       ctx->ItemClick("**/##sync_Face 4##modal_fd");
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_group_1");
       ctx->Yield(2);
+      IM_CHECK(crystal().face_distance[1] == member_before);
+      IM_CHECK(crystal().face_distance[0] == leader_before);
 
-      // Face 4 is in group 1 with the leader's 1.6. Give it a value of its own (which propagates,
-      // as AC2 covers), then re-pick group 1 on it: nothing may move.
-      ctx->ItemInputValue("**/##Face 4##modal_fd_input", 0.9f);
+      // Positive control on the same row: picking a DIFFERENT group does snapshot. Without it, a
+      // widget that ignored every popup click would pass the assertions above.
+      ctx->ItemClick("**/##sync_Face 5##modal_fd");
       ctx->Yield(2);
-      const gui::ShapeDist before = crystal().face_distance[1];
+      ctx->ItemClick("**/###sync_new");  // group 2, seeded from Face 5's own value
+      ctx->Yield(2);
       ctx->ItemClick("**/##sync_Face 4##modal_fd");
       ctx->Yield(2);
-      ctx->ItemClick("**/###sync_group_1");
+      ctx->ItemClick("**/###sync_group_2");
       ctx->Yield(2);
-      IM_CHECK(crystal().face_distance[1] == before);
-      IM_CHECK_EQ(crystal().face_distance[0].center, 0.9f);
+      IM_CHECK_EQ(crystal().face_distance[1].sync_group, 2);
+      IM_CHECK_EQ(crystal().face_distance[1].center, crystal().face_distance[2].center);
 
-      ctx->ItemClick("**/Face Distance##modal");
+      ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
       ctx->ItemClick("**/Close##edit_modal");
       ctx->Yield(2);

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4,9 +4,10 @@
 #include <fstream>
 #include <thread>
 
-#include "IconsFontAwesome6.h"  // ICON_FA_* selectors used to match new icon-prefixed button labels
-#include "gui/file_io.hpp"      // DeserializeFromJson / BuildExportJsonOrWarn (hand-authored-config walkthroughs)
-#include "gui/log_sink.hpp"     // ImGuiLogSink (for log_panel_above_left_panel test sink injection)
+#include "IconsFontAwesome6.h"      // ICON_FA_* selectors used to match new icon-prefixed button labels
+#include "gui/crystal_preview.hpp"  // BuildCrystalMeshData (core-side sync-group leader oracle)
+#include "gui/file_io.hpp"          // DeserializeFromJson / BuildExportJsonOrWarn (hand-authored-config walkthroughs)
+#include "gui/log_sink.hpp"         // ImGuiLogSink (for log_panel_above_left_panel test sink injection)
 // imgui_internal.h is generally an anti-pattern, but z-order assertions need
 // direct ImGuiContext::Windows access. The relied-on semantics
 // (BringWindowToDisplayFront splices to g.Windows back; creation with
@@ -4396,25 +4397,28 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_modal/sync_group_leader_is_lowest_syncable_slot — the leader rule, checked across the two
+  // p2_modal/sync_group_leader_is_lowest_visible_slot — the leader rule, checked across the two
   // ways "lowest slot index" can disagree with what a naive search finds. lumice.h defines the
-  // group's owner as its lowest-indexed applicable member; the GUI snapshots from that same slot
-  // (restricted to the slots it lets the user sync), so what the user sees on join is the value core
-  // will draw with. Two disagreements are exercised, one per group:
+  // group's owner as its lowest-indexed applicable member, and core evaluates that over every slot
+  // the crystal type has (crystal_config.cpp kApplicablePrism / kApplicablePyramid). The GUI
+  // snapshots from that same slot, over that same set, so what the user sees on join is the value
+  // core will draw with. Two disagreements are exercised, one per group:
   //   group 1 — slot order vs ROW order: Upper H is slot 1, Lower H slot 3, and Upper H is drawn
   //             BELOW Prism H. A search following the visual order, or CrystalConfig's field order,
   //             lands on the wrong one.
   //   group 2 — slot order vs SYNCABLE order: Prism H (slot 2) is the group's lowest member outright,
-  //             but it is not syncable (no commensurable partner — it has no Sync control at all), so
-  //             the leader must be the lowest slot the user can actually reach. A leader search still
-  //             scoped by IsShapeScalarVisible elects the unreachable Prism H and hands out 0.75.
+  //             and it has no Sync control (no commensurable partner to offer the user). It is the
+  //             leader all the same. Electing the lowest slot the user can REACH instead — the
+  //             narrower, affordance-driven set — hands out face_distance[1]'s 1.5 while core draws
+  //             with 0.75, so the table would show a distribution the simulation overwrites on
+  //             commit. What a row cannot do is join a group; being in one is not the GUI's call.
   // Both groups are seeded with members that DISAGREE — the only configuration in which "which member
   // is the leader" is observable at all. A group built by clicking has equal members by construction,
   // and a snapshot from either end of it looks identical. (A hand-authored config reaching the GUI in
   // exactly this state is normal: canonicalization belongs to core's from_json, on commit, not to the
-  // GUI — and group 2 is precisely a grouping the GUI itself can no longer build.)
+  // GUI — and group 2 is precisely a grouping the GUI itself cannot build.)
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_is_lowest_syncable_slot");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_is_lowest_visible_slot");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       gui::g_state.modal_immediate_mode = true;
@@ -4427,13 +4431,13 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       crystal().upper_h.sync_group = 1;  // slot 1 — group 1's leader
       crystal().lower_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.9f, 0.0f };
       crystal().lower_h.sync_group = 1;  // slot 3 — the foil for group 1
-      // Prism H: slot 2, non-syncable, and group 2's lowest member by index. Its value is inside the
-      // face slider's [0, 2] range on purpose, so a wrong leader shows up as the wrong NUMBER rather
-      // than as a clamp artifact that could be explained away.
+      // Prism H: slot 2, no Sync control, and group 2's lowest member by index — hence its leader.
+      // Its value is inside the face slider's [0, 2] range on purpose, so a wrong leader shows up as
+      // the wrong NUMBER rather than as a clamp artifact that could be explained away.
       crystal().prism_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.75f, 0.0f };
       crystal().prism_h.sync_group = 2;
       crystal().face_distance[1] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.5f, 0.3f };
-      crystal().face_distance[1].sync_group = 2;  // slot 5 — group 2's lowest SYNCABLE member
+      crystal().face_distance[1].sync_group = 2;  // slot 5 — the foil: lowest slot the user can reach
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
@@ -4453,23 +4457,25 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(crystal().face_distance[0].type, gui::ShapeDistType::kUniform);
       IM_CHECK_EQ(crystal().face_distance[0].spread, 0.08f);
 
-      // Face 5 (slot 6) joins group 2: the leader is face_distance[1] (slot 5), NOT the lower-indexed
-      // but unsyncable prism_h (slot 2).
+      // Face 5 (slot 6) joins group 2: the leader is prism_h (slot 2), NOT the higher-indexed
+      // face_distance[1] (slot 5) that happens to be the lowest member carrying a Sync control.
+      // 0.75 vs 1.5 is the whole point — this is the value core hands the simulation, so it is the
+      // value the joining row must take, whether or not the row it came from is editable from here.
       ctx->ItemClick("**/##sync_Face 5##modal_fd");
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_group_2");
       ctx->Yield(2);
       IM_CHECK_EQ(crystal().face_distance[2].sync_group, 2);
-      IM_CHECK_EQ(crystal().face_distance[2].center, 1.5f);
-      IM_CHECK_EQ(crystal().face_distance[2].type, gui::ShapeDistType::kUniform);
-      IM_CHECK_EQ(crystal().face_distance[2].spread, 0.3f);
+      IM_CHECK_EQ(crystal().face_distance[2].center, 0.75f);
+      IM_CHECK_EQ(crystal().face_distance[2].type, gui::ShapeDistType::kNoRandom);
+      IM_CHECK_EQ(crystal().face_distance[2].spread, 0.0f);
 
       // Joining reads the group, it does not write it: every seeded member is untouched, and the two
       // groups are still internally disagreeing.
       IM_CHECK_EQ(crystal().upper_h.center, 0.4f);
       IM_CHECK_EQ(crystal().lower_h.center, 0.9f);
       IM_CHECK_EQ(crystal().prism_h.center, 0.75f);
-      IM_CHECK_EQ(crystal().prism_h.sync_group, 2);  // dormant, not cleared
+      IM_CHECK_EQ(crystal().prism_h.sync_group, 2);  // still a member, and still the leader
       IM_CHECK_EQ(crystal().face_distance[1].center, 1.5f);
 
       ctx->ItemClose("**/Face Distance##modal");
@@ -4480,16 +4486,21 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_modal/sync_group_unsyncable_member_is_inert — AC2. A hand-authored config MAY group a scalar
-  // the GUI offers no Sync control for (lumice.h runs no commensurability check, and the GUI is not a
-  // second authority on what is legal). Every consequence of that is checked in one walkthrough,
-  // because the failure mode is a HALF-applied predicate: a swatch hidden while the membership list,
-  // the leader search or the propagation still counted the row would leave the user staring at a
-  // group they cannot reach, or at a value that moves for no visible reason.
+  // p2_modal/sync_group_unsyncable_member_is_a_full_member — a hand-authored config MAY group a
+  // scalar the GUI offers no Sync control for (lumice.h runs no commensurability check, and the GUI
+  // is not a second authority on what is legal). Once such a group exists, core treats that scalar as
+  // an ordinary member — it is applicable, so NormalizeSyncGroups elects it and writes over the rest
+  // of the group from it — and the GUI reports and propagates it the same way. The missing Sync
+  // control means one thing only: the user cannot make this row join a group from here.
+  //
+  // Every consequence is checked in one walkthrough, because the failure mode is a HALF-applied
+  // predicate: hiding the swatch is the affordance, and if the membership list, the leader search or
+  // the propagation followed it, the table would report a distribution core overwrites on commit —
+  // the row silently reverting after the user edited it.
   //
   // The config groups prism `height` with `face_distance[0]` — the exact shape the owner named.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_unsyncable_member_is_inert");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_unsyncable_member_is_a_full_member");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(2);
@@ -4544,34 +4555,43 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(ctx->ItemExists("**/##Height##modal_cr_input"));
       IM_CHECK(ctx->ItemExists("**/##sync_Face 3##modal_fd"));
 
-      // (2) The membership list names only rows the user can go and find. The popup item's visible
-      // label carries the list, so this reads what is actually on screen rather than re-deriving it.
+      // (2) The membership list names the group's real members, Height included. It describes the
+      // group the user is about to join, and Height is the member whose value that group carries —
+      // omitting it would understate what joining costs. The popup item's visible label carries the
+      // list, so this reads what is actually on screen rather than re-deriving it. Both names fit
+      // inside ImGuiTestItemInfo::DebugLabel's 32-char buffer, which is why the config has exactly
+      // two members.
       ctx->ItemClick("**/##sync_Face 3##modal_fd");
       ctx->Yield(2);
       const ImGuiTestItemInfo group_item = ctx->ItemInfo("**/###sync_group_1");
       IM_CHECK_NE(group_item.ID, (ImGuiID)0);
-      fprintf(stderr, "[sync_inert] group 1 popup label = '%s'\n", group_item.DebugLabel);
+      fprintf(stderr, "[sync_full_member] group 1 popup label = '%s'\n", group_item.DebugLabel);
       IM_CHECK(strstr(group_item.DebugLabel, "Face 3") != nullptr);  // the list is really being read
-      IM_CHECK(strstr(group_item.DebugLabel, "Height") == nullptr);  // ...and Height is not in it
+      IM_CHECK(strstr(group_item.DebugLabel, "Height") != nullptr);  // ...and Height is in it
       // Re-selecting the group the row is already in is a documented no-op, so this only dismisses
       // the popup (see sync_group_reselect_current_is_noop).
       ctx->ItemClick("**/###sync_group_1");
       ctx->Yield(2);
       IM_CHECK_EQ(crystal().face_distance[0].sync_group, 1);
 
-      // (3) Editing across the pair moves neither row into the other, in EITHER direction. The
-      // face→height direction is the destination-side gate (Height is not a propagation target); the
-      // height→face direction is the source-side gate (a row with no swatch must not be a group
-      // writer either, or the face value would jump with nothing on screen to explain it).
-      const float height_before = crystal().height.center;
+      // (3) An edit to either row moves the other, in BOTH directions — the group is written whole.
+      // face→height is the destination-side scope (core normalizes Height too, so leaving it behind
+      // would only mean core rewrites the face on commit); height→face is the source-side scope (the
+      // row has no swatch, but it is the group's leader, and an edit to the leader is precisely the
+      // edit the whole group must follow). The Param-name tint on both rows is what makes the paired
+      // movement attributable on screen.
+      //
+      // Both values sit inside BOTH sliders' ranges — Height's [0.01, 100] and a face distance's
+      // [0, 2] — so nothing here is a clamp. Cross-range clamping has its own test
+      // (sync_group_cross_range_converges) and does not belong in this one.
       ctx->ItemInputValue("**/##Face 3##modal_fd_input", 0.75f);
       ctx->Yield(2);
       IM_CHECK_EQ(crystal().face_distance[0].center, 0.75f);
-      IM_CHECK_EQ(crystal().height.center, height_before);
-      ctx->ItemInputValue("**/##Height##modal_cr_input", 3.0f);
+      IM_CHECK_EQ(crystal().height.center, 0.75f);
+      ctx->ItemInputValue("**/##Height##modal_cr_input", 1.8f);
       ctx->Yield(2);
-      IM_CHECK_EQ(crystal().height.center, 3.0f);
-      IM_CHECK_EQ(crystal().face_distance[0].center, 0.75f);
+      IM_CHECK_EQ(crystal().height.center, 1.8f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.8f);
 
       ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
@@ -4590,6 +4610,139 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       const auto& rc = gui::CrystalOf(reloaded, reloaded.layers[0].entries[0]);
       IM_CHECK_EQ(rc.height.sync_group, rc.face_distance[0].sync_group);
       IM_CHECK_NE(rc.height.sync_group, 0);
+    };
+  }
+
+  // p2_modal/sync_group_leader_agrees_with_core_mesh_oracle — the mechanism that pins "the GUI's
+  // leader IS core's leader", as opposed to a comment asking the next person to keep them in step.
+  //
+  // The GUI's leader rule and core's are two implementations of one sentence in lumice.h. Nothing
+  // structural forces them together, and they HAVE drifted apart once: a GUI-side affordance
+  // narrowing (some rows get no Sync control) leaked into the leader search, so for a hand-authored
+  // group the table showed, and handed out on join, a distribution core discarded on commit. A test
+  // that hardcodes the expected leader cannot catch the recurrence in general — it freezes today's
+  // GUI-side belief, and if core's rule is what moves, the frozen literal moves with the GUI and the
+  // test stays green while the two diverge.
+  //
+  // So the expected value is not written down here. It is measured, from core, at run time:
+  // BuildCrystalMeshData goes through the public LUMICE_GetCrystalMesh, whose param->JSON->param
+  // round trip runs the real PrepareSyncGroups (canonicalize + leader-normalize) before sampling
+  // geometry. Feed it the disagreeing group and it returns the mesh core would actually draw; compare
+  // that against one control mesh per candidate leader — each the same crystal with the group
+  // flattened to that candidate's value — and exactly one matches. That match names core's leader
+  // without reading a single line of GUI code. The GUI then has to agree with it.
+  //
+  // Consequences, which are the point:
+  //   - core changes its leader rule (kApplicable* / the NormalizeSyncGroupsImpl scan) → the matching
+  //     control changes → the GUI, unchanged, disagrees → red.
+  //   - the GUI's mirror side goes back to scoping the leader search by the affordance predicate
+  //     (this bug, recurring) → it hands out 0.75 where the oracle says 1.0 → red.
+  // What this deliberately does NOT catch is the affordance predicate simply excluding one more row.
+  // That is not a silent hazard any more but a no-op: the mirror side no longer reads that predicate
+  // at all, which is the decoupling this test exists on top of, not a gap in it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_agrees_with_core_mesh_oracle");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+
+      // The owner's reproduction, verbatim: prism height (slot 0, no Sync control) grouped with
+      // face_distance[0] (slot 4), the two disagreeing. Only a hand-authored config can produce this
+      // state, and it is the only state in which "who is the leader" is observable at all.
+      constexpr float kHeightValue = 1.0f;
+      constexpr float kFaceValue = 0.75f;
+      crystal().type = gui::CrystalType::kPrism;
+      crystal().height = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, kHeightValue, 0.0f };
+      crystal().height.sync_group = 1;
+      crystal().face_distance[0] = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, kFaceValue, 0.0f };
+      crystal().face_distance[0].sync_group = 1;
+
+      // --- The oracle: ask core, through the public mesh API, which member it drew with. ---
+      auto build = [](const gui::CrystalConfig& cr, LUMICE_CrystalMesh* out) {
+        // kNoRandom throughout, so the seed selects nothing and the draw is deterministic; passing
+        // the same literal every time keeps that explicit rather than incidental.
+        return lumice::gui::BuildCrystalMeshData(cr, lumice::gui::kPreviewFixedSampleSeed, out);
+      };
+      auto same_mesh = [](const LUMICE_CrystalMesh& a, const LUMICE_CrystalMesh& b) {
+        return a.vertex_count == b.vertex_count && a.edge_count == b.edge_count &&
+               a.triangle_count == b.triangle_count &&
+               std::memcmp(a.vertices, b.vertices, sizeof(float) * a.vertex_count * 3) == 0 &&
+               std::memcmp(a.edges, b.edges, sizeof(int) * a.edge_count * 2) == 0 &&
+               std::memcmp(a.triangles, b.triangles, sizeof(int) * a.triangle_count * 3) == 0;
+      };
+
+      // Candidate controls: the same crystal with the group already flattened onto one candidate,
+      // and no groups left for core to normalize. Leader-normalization writes the leader's
+      // distribution over every member, so core's output for the grouped config must equal exactly
+      // one of these.
+      gui::CrystalConfig flat_height = crystal();
+      flat_height.height.center = kHeightValue;
+      flat_height.face_distance[0].center = kHeightValue;
+      flat_height.height.sync_group = 0;
+      flat_height.face_distance[0].sync_group = 0;
+
+      gui::CrystalConfig flat_face = flat_height;
+      flat_face.height.center = kFaceValue;
+      flat_face.face_distance[0].center = kFaceValue;
+
+      LUMICE_CrystalMesh mesh_core{};
+      LUMICE_CrystalMesh mesh_flat_height{};
+      LUMICE_CrystalMesh mesh_flat_face{};
+      IM_CHECK(build(crystal(), &mesh_core));
+      IM_CHECK(build(flat_height, &mesh_flat_height));
+      IM_CHECK(build(flat_face, &mesh_flat_face));
+
+      const bool core_chose_height = same_mesh(mesh_core, mesh_flat_height);
+      const bool core_chose_face = same_mesh(mesh_core, mesh_flat_face);
+      // Exactly one. Both true would mean the mesh cannot tell the two candidates apart and the
+      // oracle proves nothing; both false would mean core picked something neither control models,
+      // and reading a leader value out of it would be an invention.
+      fprintf(stderr, "[sync_oracle] core_chose_height=%d core_chose_face=%d\n", (int)core_chose_height,
+              (int)core_chose_face);
+      IM_CHECK(core_chose_height != core_chose_face);
+      const float core_leader_value = core_chose_height ? kHeightValue : kFaceValue;
+
+      // --- The GUI must hand out that same value. ---
+      // Face 5 (slot 6) joining group 1 snapshots from whatever the GUI thinks the leader is, so the
+      // value that lands in the row IS the GUI's answer, read through a real click rather than by
+      // calling the predicate directly.
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 5##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[2].sync_group, 1);
+      IM_CHECK_EQ(crystal().face_distance[2].center, core_leader_value);
+
+      // AC2, the other half: with the GUI writing the whole group, an edit leaves every member equal,
+      // so core's normalize finds nothing to override — no silent rewrite of the row the user just
+      // typed into, and no leader-override warning on commit. Checked the same way, against core:
+      // after the edit the grouped config's mesh must equal the mesh of the same values carrying no
+      // groups at all, which can only hold if normalization changed nothing.
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 1.25f);
+      ctx->Yield(2);
+      gui::CrystalConfig after_edit_ungrouped = crystal();
+      for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+        gui::ShapeScalarAt(after_edit_ungrouped, s).sync_group = 0;
+      }
+      LUMICE_CrystalMesh mesh_after_edit{};
+      LUMICE_CrystalMesh mesh_after_edit_ungrouped{};
+      IM_CHECK(build(crystal(), &mesh_after_edit));
+      IM_CHECK(build(after_edit_ungrouped, &mesh_after_edit_ungrouped));
+      IM_CHECK(same_mesh(mesh_after_edit, mesh_after_edit_ungrouped));
+
+      ctx->ItemClose("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
     };
   }
 

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4633,8 +4633,8 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
   // without reading a single line of GUI code. The GUI then has to agree with it.
   //
   // Consequences, which are the point:
-  //   - core changes its leader rule (kApplicable* / the NormalizeSyncGroupsImpl scan) → the matching
-  //     control changes → the GUI, unchanged, disagrees → red.
+  //   - core changes its leader rule (its slot-applicability map / the NormalizeSyncGroupsImpl scan)
+  //     → the matching control changes → the GUI, unchanged, disagrees → red.
   //   - the GUI's mirror side goes back to scoping the leader search by the affordance predicate
   //     (this bug, recurring) → it hands out 0.75 where the oracle says 1.0 → red.
   // What this deliberately does NOT catch is the affordance predicate simply excluding one more row.

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4733,6 +4733,98 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_modal/shape_table_fixed_columns_fit_text — the other half of the width budget. Each of the
+  // four fixed columns is sized by TEXT, not by its control: Param by its longest row label
+  // ("Prism H" / "Upper A"), Sync and Rand by their own 4-character headers (the swatch and the
+  // checkbox are both one frame tall and far narrower than that). Their declared widths were
+  // tightened to where the text is what fits last, and both clipping modes are SILENT — ImGui
+  // ellipsizes a header and hard-clips a row label without complaint — so nothing else notices.
+  //
+  // The criterion is ImGui's own layout bookkeeping, never a pixel constant: ContentMaxXHeadersIdeal
+  // is where a header's text WOULD end if nothing clipped it, ContentMaxXUnfrozen is the same for the
+  // row cells, and WorkMaxX is the column's content region. Comparing those three is font- and
+  // DPI-adaptive by construction: a platform whose glyphs render wider fails here instead of shipping
+  // a clipped table (pin the relation, never the number). Both layouts are exercised, since the fixed
+  // columns keep their declared width in each while everything around them moves; and both tables
+  // (params + Face Distance) are checked, since only one has a header row and only the other has the
+  // "Face N" labels.
+  //
+  // Measured margins at the widths this task settled on (identical in both layouts — the fixed
+  // columns do not move): Param 52 vs 49 needed by "Prism H", Sync/Rand 29 vs 28 needed by their
+  // headers, Spread 60 vs 60 (its input is SetNextItemWidth(-FLT_MIN), so it fills the cell exactly
+  // by construction and 0 slack is the correct value, not a near miss). Those are tight on purpose,
+  // and they are not platform-fragile: font_init.hpp uses AddFontDefault(), i.e. the embedded
+  // fixed-width ProggyClean at 13 px, so every one of these strings is exactly 7 px per character on
+  // every platform.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "shape_table_fixed_columns_fit_text");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      // Pyramid: the type with the widest Param labels ("Prism H", "Upper A", "Lower A").
+      gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].type = gui::CrystalType::kPyramid;
+
+      // pass 0 = horizontal (kEditModalMinWidth 820), pass 1 = vertical (kEditModalMinWidthVertical 420).
+      for (int pass = 0; pass < 2; ++pass) {
+        const bool vertical = pass == 1;
+        // Same flag-FLIP dance as sync_column_layout_budget: the width floor is only applied on the
+        // frame RenderEditModals observes the change.
+        gui::g_state.modal_layout_vertical = !vertical;
+        ctx->Yield(2);
+        ctx->ItemClick("**/Edit##cr");
+        ctx->Yield(4);
+        gui::g_state.modal_layout_vertical = vertical;
+        ctx->Yield(6);
+        ctx->ItemOpen("**/Face Distance##modal");
+        ctx->Yield(4);
+
+        ImGuiWindow* win = ctx->GetWindowByRef("Edit Entry");
+        IM_CHECK(win != nullptr);
+        IM_CHECK_EQ(win->Size.x, vertical ? 420.0f : 820.0f);
+
+        // Both shape tables, found by their column signature rather than by an id we would have to
+        // reproduce through the child-window stack.
+        ImGuiContext& g = *ImGui::GetCurrentContext();
+        int tables_checked = 0;
+        for (int n = 0; n < g.Tables.GetMapSize(); ++n) {
+          ImGuiTable* table = g.Tables.TryGetMapData(n);
+          if (table == nullptr || table->ColumnsCount != gui::kShapeTableColumnCount ||
+              table->LastFrameActive < g.FrameCount - 1) {
+            continue;
+          }
+          const char* col0 = ImGui::TableGetColumnName(table, 0);
+          if (col0 == nullptr || strcmp(col0, "Param") != 0) {
+            continue;  // some other 5-column table
+          }
+          ++tables_checked;
+          for (int c = 0; c < table->ColumnsCount; ++c) {
+            const ImGuiTableColumn& column = table->Columns[c];
+            const char* name = ImGui::TableGetColumnName(table, c);
+            if (strcmp(name, "Value") == 0) {
+              continue;  // the stretch column absorbs the slack; it is the others that are budgeted
+            }
+            // Widest thing this column would draw if nothing clipped it: its header text, or its
+            // cells' content, whichever reaches further right.
+            const float ideal = ImMax(column.ContentMaxXHeadersIdeal, column.ContentMaxXUnfrozen);
+            fprintf(stderr, "[col_fit] %-6s layout=%-10s table#%d width=%.1f needs=%.1f slack=%.1f\n", name,
+                    vertical ? "vertical" : "horizontal", tables_checked, column.WidthGiven, ideal - column.WorkMinX,
+                    column.WorkMaxX - ideal);
+            IM_CHECK_LE(ideal, column.WorkMaxX);
+          }
+        }
+        IM_CHECK_EQ(tables_checked, 2);  // params + Face Distance; a miss must fail, not silently skip
+
+        ctx->ItemClose("**/Face Distance##modal");
+        ctx->Yield(2);
+        ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+        ctx->Yield(2);
+      }
+      // Hand the modal back to later tests in the default horizontal form.
+      gui::g_state.modal_layout_vertical = false;
+      ctx->Yield(2);
+    };
+  }
+
   // p2_modal/sync_group_reselect_current_is_noop — re-picking the group a row is already in must
   // not re-snapshot it, i.e. the popup's "if (dist.sync_group != group)" guard is load-bearing.
   //

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4696,10 +4696,14 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       fprintf(stderr, "[sync_layout] vertical modal=%.0f slider_w=%.1f input_right=%.1f swatch=(%.1fx%.1f)\n",
               win->Size.x, slider_w, input.RectFull.Max.x, swatch.RectFull.GetWidth(), swatch.RectFull.GetHeight());
       IM_CHECK_GT(slider_w, 40.0f);
-      // The input sits to the slider's right and must end before the Rand column starts — i.e. the
-      // pair fits the cell instead of spilling into the next one.
+      // The input sits to the slider's right and must end before the NEXT column's content starts —
+      // i.e. the pair fits the cell instead of spilling into the neighbour. That neighbour is the
+      // Sync column (the order is Param | Value | Sync | Rand | Spread), so the swatch is what this
+      // has to clear; the Rand checkbox is checked too, as the ordering of the three is itself part
+      // of the claim and a silent column-order regression would otherwise still pass.
       const auto rand_check = ctx->ItemInfo("**/##rnd_Face 3##modal_fd");
-      IM_CHECK_LT(input.RectFull.Max.x, rand_check.RectFull.Min.x);
+      IM_CHECK_LT(input.RectFull.Max.x, swatch.RectFull.Min.x);
+      IM_CHECK_LT(swatch.RectFull.Max.x, rand_check.RectFull.Min.x);
       // The swatch is square and exactly one frame tall, so it cannot be what drives row height.
       IM_CHECK_EQ(swatch.RectFull.GetWidth(), swatch.RectFull.GetHeight());
       IM_CHECK_LE(swatch.RectFull.GetHeight(), ImGui::GetFrameHeight());

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4463,6 +4463,79 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_modal/sync_column_layout_budget — AC5, as a measurement rather than a look at the modal.
+  // The Sync column is FIXED width and Value is the only stretch column, so every pixel Sync takes
+  // comes out of the slider. Two things could go wrong and neither is visible in a state assertion:
+  // the slider hitting PrepareSliderLayout's 40 px floor (below which it stops shrinking and starts
+  // overflowing its cell instead), and the taller-content case needing a scrollbar in the modal's
+  // fixed-height content pane. Both are checked in the worst case the modal supports: the narrow
+  // vertical layout, a Pyramid (three H rows + two wedge rows), with Face Distance expanded.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_column_layout_budget");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].type = gui::CrystalType::kPyramid;
+
+      // The 420 px vertical width is only reached on the frame RenderEditModals observes the
+      // layout flag FLIP; without the flip the window keeps whatever width AlwaysAutoResize last
+      // converged to (see test_gui_modal_layout.cpp for the same dance and why).
+      gui::g_state.modal_layout_vertical = false;
+      ctx->Yield(2);
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      gui::g_state.modal_layout_vertical = true;
+      ctx->Yield(6);
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(4);
+
+      ImGuiWindow* win = ctx->GetWindowByRef("Edit Entry");
+      IM_CHECK(win != nullptr);
+      IM_CHECK_EQ(win->Size.x, 420.0f);  // the narrow layout really is what is being measured
+
+      // Value column: the slider must still be laid out by the formula, not clamped by the floor.
+      // PrepareSliderLayout returns max(avail - kInputWidth - spacing, 40); a return of exactly 40
+      // means the cell is too narrow for the [slider][input] pair and the input is overflowing.
+      const auto slider = ctx->ItemInfo("**/##Face 3##modal_fd_slider");
+      const auto input = ctx->ItemInfo("**/##Face 3##modal_fd_input");
+      const auto swatch = ctx->ItemInfo("**/##sync_Face 3##modal_fd");
+      const float slider_w = slider.RectFull.GetWidth();
+      fprintf(stderr, "[sync_layout] vertical modal=%.0f slider_w=%.1f input_right=%.1f swatch=(%.1fx%.1f)\n",
+              win->Size.x, slider_w, input.RectFull.Max.x, swatch.RectFull.GetWidth(), swatch.RectFull.GetHeight());
+      IM_CHECK_GT(slider_w, 40.0f);
+      // The input sits to the slider's right and must end before the Rand column starts — i.e. the
+      // pair fits the cell instead of spilling into the next one.
+      const auto rand_check = ctx->ItemInfo("**/##rnd_Face 3##modal_fd");
+      IM_CHECK_LT(input.RectFull.Max.x, rand_check.RectFull.Min.x);
+      // The swatch is square and exactly one frame tall, so it cannot be what drives row height.
+      IM_CHECK_EQ(swatch.RectFull.GetWidth(), swatch.RectFull.GetHeight());
+      IM_CHECK_LE(swatch.RectFull.GetHeight(), ImGui::GetFrameHeight());
+
+      // No scrollbar in the modal's fixed-height content pane with everything expanded. The pane is
+      // a BeginChild of the modal; find it by walking ImGui's window list rather than guessing its
+      // auto-generated child name.
+      ImGuiContext& g = *ImGui::GetCurrentContext();
+      bool found_pane = false;
+      for (ImGuiWindow* w : g.Windows) {
+        if (w->ParentWindow == win && w->WasActive && strstr(w->Name, "modal_bottom_pane") != nullptr) {
+          found_pane = true;
+          fprintf(stderr, "[sync_layout] pane '%s' scroll_max_y=%.1f\n", w->Name, w->ScrollMax.y);
+          IM_CHECK_EQ(w->ScrollMax.y, 0.0f);  // content fits: nothing to scroll
+        }
+      }
+      IM_CHECK(found_pane);  // a renamed pane must fail loudly, not silently skip the check
+
+      // Restore the layout flag BEFORE closing, so the modal (and the widths ImGui has cached for
+      // it) is handed back to later tests in the default horizontal form.
+      ctx->ItemClose("**/Face Distance##modal");
+      ctx->Yield(2);
+      gui::g_state.modal_layout_vertical = false;
+      ctx->Yield(4);
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+    };
+  }
+
   // p2_modal/sync_group_reselect_current_is_noop — re-picking the group a row is already in must
   // not re-snapshot it, i.e. the popup's "if (dist.sync_group != group)" guard is load-bearing.
   //

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4400,7 +4400,8 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
   // p2_modal/sync_group_leader_is_lowest_visible_slot — the leader rule, checked across the two
   // ways "lowest slot index" can disagree with what a naive search finds. lumice.h defines the
   // group's owner as its lowest-indexed applicable member, and core evaluates that over every slot
-  // the crystal type has (crystal_config.cpp kApplicablePrism / kApplicablePyramid). The GUI
+  // the crystal type has (the slot table in crystal_config.cpp, which the GUI queries through
+  // LUMICE_IsShapeScalarApplicable rather than mirroring). The GUI
   // snapshots from that same slot, over that same set, so what the user sees on join is the value
   // core will draw with. Two disagreements are exercised, one per group:
   //   group 1 — slot order vs ROW order: Upper H is slot 1, Lower H slot 3, and Upper H is drawn

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -4154,6 +4154,355 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // ============ Sync column: shape-scalar sync groups, driven through the UI ============
+  // These drive the real widget (swatch button → popup Selectable), not the underlying helpers:
+  // the whole point of this column is that a user can build a grouping by clicking, and a test
+  // that called a helper directly would keep passing if the popup stopped being reachable.
+  //
+  // Widget ids, all stable by construction: the swatch is "##sync_<row label>" with the group
+  // number DRAWN on it rather than being part of the label, and the popup items are anchored with
+  // "###sync_none" / "###sync_group_N" / "###sync_new" so the membership text they display can
+  // change without moving the id out from under these paths.
+
+  // p2_modal/sync_group_join_snapshots_and_propagates — AC2, both halves. Joining a group snaps the
+  // row to the group's value; editing any member afterwards writes through to the whole group.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_join_snapshots_and_propagates");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;  // commit the edit buffer to g_state every frame
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Face Distance##modal");  // default-collapsed section
+      ctx->Yield(2);
+
+      // Face 5 (face_distance[2]) starts a group of its own. "+ New group" allocates id 1 here —
+      // nothing else in this crystal is grouped.
+      ctx->ItemClick("**/##sync_Face 5##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[2].sync_group, 1);
+      // A brand-new group has no other member, so joining it must NOT disturb the row's own value.
+      IM_CHECK_EQ(crystal().face_distance[2].center, 1.0f);
+
+      // Give the group a distinctive value + randomization, so the snapshot below is checked on all
+      // three fields rather than on a center that happened to already match.
+      ctx->ItemClick("**/##rnd_Face 5##modal_fd");  // → Uniform, spread = 0.2 × center
+      ctx->Yield(2);
+      ctx->ItemInputValue("**/##Face 5##modal_fd_input", 1.5f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[2].center, 1.5f);
+      IM_CHECK_EQ(crystal().face_distance[2].type, gui::ShapeDistType::kUniform);
+      const float leader_spread = crystal().face_distance[2].spread;
+      IM_CHECK(leader_spread > 0.0f);
+
+      // Face 7 (face_distance[4]) joins the SAME group by picking it out of the popup. The item is
+      // addressed by its "###sync_group_1" anchor; what the user reads is "1  (Face 5)".
+      IM_CHECK_EQ(crystal().face_distance[4].center, 1.0f);  // differs from the leader pre-join
+      ctx->ItemClick("**/##sync_Face 7##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+
+      // Snapshot: all three fields now equal the leader's, immediately and visibly.
+      IM_CHECK_EQ(crystal().face_distance[4].sync_group, 1);
+      IM_CHECK_EQ(crystal().face_distance[4].center, 1.5f);
+      IM_CHECK_EQ(crystal().face_distance[4].type, gui::ShapeDistType::kUniform);
+      IM_CHECK_EQ(crystal().face_distance[4].spread, leader_spread);
+
+      // Propagation: editing the leader row again moves the subordinate with it.
+      ctx->ItemInputValue("**/##Face 5##modal_fd_input", 0.75f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[2].center, 0.75f);
+      IM_CHECK_EQ(crystal().face_distance[4].center, 0.75f);
+
+      // ...and so does editing the SUBORDINATE row: a subordinate stays editable and writes through
+      // to the whole group (the owner picked this over greying subordinates out).
+      ctx->ItemInputValue("**/##Face 7##modal_fd_input", 1.25f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[4].center, 1.25f);
+      IM_CHECK_EQ(crystal().face_distance[2].center, 1.25f);
+
+      // An ungrouped row is untouched by any of it — propagation is scoped to the group, not to
+      // "every face row".
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
+      IM_CHECK_EQ(crystal().face_distance[0].sync_group, 0);
+
+      ctx->ItemClick("**/Face Distance##modal");  // restore the default-collapsed state for later tests
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
+  // p2_modal/sync_group_leave_keeps_value — AC3. Selecting None leaves the group without restoring
+  // the row's pre-join value (no shadow state is kept) and without touching the group it left.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leave_keeps_value");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+
+      // Build a two-member group with a non-default value, so "value unchanged on leave" is a claim
+      // about a value the group actually imposed.
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 1.75f);
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 4##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[1].sync_group, 1);
+      IM_CHECK_EQ(crystal().face_distance[1].center, 1.75f);
+
+      // Leave: independent afterwards, and holding the value the group gave it — NOT the 1.0 it
+      // had before joining.
+      ctx->ItemClick("**/##sync_Face 4##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_none");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[1].sync_group, 0);
+      IM_CHECK_EQ(crystal().face_distance[1].center, 1.75f);
+      // The row it left is unaffected, both in membership and in value.
+      IM_CHECK_EQ(crystal().face_distance[0].sync_group, 1);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.75f);
+      // And it no longer follows the group: editing the ex-leader leaves it where it is.
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 0.5f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.5f);
+      IM_CHECK_EQ(crystal().face_distance[1].center, 1.75f);
+
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
+  // p2_modal/sync_group_cancel_keeps_entry — AC4. Grouping is edit-buffer state like every other
+  // shape field: Cancel discards it. Compared against a baseline captured just before the modal was
+  // opened, not against "the defaults", so the test cannot pass by the entry being reset instead of
+  // preserved.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_cancel_keeps_entry");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();  // leaves modal_immediate_mode false: OK/Cancel atomicity is what is under test
+      ctx->Yield(2);
+      auto& entry = gui::g_state.layers[0].entries[0];
+
+      // Pre-existing grouping on the entry, so Cancel has to preserve a non-trivial value rather
+      // than just "no groups".
+      gui::CrystalOf(gui::g_state, entry).face_distance[0].sync_group = 2;
+      gui::CrystalOf(gui::g_state, entry).face_distance[1].sync_group = 2;
+      const gui::CrystalConfig baseline = gui::CrystalOf(gui::g_state, entry);
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+
+      // Regroup inside the buffer: a third row joins group 2, and one of its members leaves.
+      ctx->ItemClick("**/##sync_Face 6##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_2");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_none");
+      ctx->Yield(2);
+      // Staged mode: none of that reached the entry yet.
+      IM_CHECK(gui::CrystalOf(gui::g_state, entry) == baseline);
+
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(3);
+
+      // Whole-crystal comparison (ShapeDist::operator== includes sync_group), plus the two group
+      // ids spelled out so a failure names the field instead of just "the crystal differs".
+      IM_CHECK(gui::CrystalOf(gui::g_state, entry) == baseline);
+      IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).face_distance[3].sync_group, 0);
+      IM_CHECK_EQ(gui::CrystalOf(gui::g_state, entry).face_distance[0].sync_group, 2);
+    };
+  }
+
+  // p2_modal/sync_group_dormant_across_type_switch — the cross-type visibility assumption, made
+  // checkable. The widget only ever sees the scalars the current crystal type draws, so a group id
+  // sitting on the other type's scalar must survive a type switch untouched and must not appear in
+  // the popup's membership lists. This is D1 ("no commensurability check") implemented as the
+  // smallest possible GUI behavior; a later "tidy-up" that cleared such ids would silently change it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_dormant_across_type_switch");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+      // height is prism-only; give it a group, then edit as a pyramid.
+      crystal().height.sync_group = 4;
+      crystal().type = gui::CrystalType::kPrism;
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Pyramid##modal");  // height's row disappears; the three H rows appear
+      ctx->Yield(3);
+
+      // Group the pyramid's Upper H. "+ New group" must not hand out 4 — the dormant prism group
+      // still holds it, and reusing it would silently merge the two on a switch back.
+      ctx->ItemClick("**/##sync_Upper H##modal_cr");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().upper_h.sync_group, 5);
+      // SLOT-ORDER TRAP guard: it is upper_h that moved, not prism_h (slot 1 vs slot 2, the reverse
+      // of the rows' visual order). A positional slot mapping fails exactly here.
+      IM_CHECK_EQ(crystal().prism_h.sync_group, 0);
+      IM_CHECK_EQ(crystal().lower_h.sync_group, 0);
+      // The dormant prism group is untouched by any of it.
+      IM_CHECK_EQ(crystal().height.sync_group, 4);
+
+      // Switch back: the prism grouping is still there, exactly as it was.
+      ctx->ItemClick("**/Prism##modal");
+      ctx->Yield(3);
+      IM_CHECK_EQ(crystal().height.sync_group, 4);
+      IM_CHECK_EQ(crystal().upper_h.sync_group, 5);
+
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
+  // p2_modal/sync_group_leader_is_lowest_slot — the leader rule, checked across the slot classes
+  // where "lowest slot index" and "row order on screen" disagree. lumice.h defines the group's
+  // owner as its lowest-indexed applicable member; the GUI snapshots from that same slot, so what
+  // the user sees on join is the value core will draw with. Upper H (slot 1) is BELOW Prism H
+  // (slot 2) in the index space while being drawn second, and both are below every face slot — so
+  // a leader search that followed the visual order, or the struct's field order, lands elsewhere.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_is_lowest_slot");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+      crystal().type = gui::CrystalType::kPyramid;
+      crystal().upper_h = gui::ShapeDist{ gui::ShapeDistType::kUniform, 0.4f, 0.08f };
+      crystal().prism_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 3.0f, 0.0f };
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+
+      // Upper H (slot 1) forms the group first, then Prism H (slot 2) — drawn ABOVE it — joins.
+      ctx->ItemClick("**/##sync_Upper H##modal_cr");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Prism H##modal_cr");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      // Prism H took Upper H's distribution, not the other way round: the leader is the lower SLOT,
+      // even though it is the lower ROW.
+      IM_CHECK_EQ(crystal().prism_h.center, 0.4f);
+      IM_CHECK_EQ(crystal().prism_h.type, gui::ShapeDistType::kUniform);
+      IM_CHECK_EQ(crystal().prism_h.spread, 0.08f);
+      IM_CHECK_EQ(crystal().upper_h.center, 0.4f);  // the leader itself is not disturbed
+
+      // A face slot joining the same group also snapshots from Upper H — every face slot (4..9) is
+      // above the three H slots in the index space, so no face can ever be the leader here.
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.4f);
+      IM_CHECK_EQ(crystal().face_distance[0].type, gui::ShapeDistType::kUniform);
+
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
+  // p2_modal/sync_group_reselect_current_is_noop — re-picking the group a row is already in must
+  // not re-snapshot it. Cheap, and it guards the one branch in the popup that is easy to drop
+  // ("if (dist.sync_group != group)"): without it, re-selecting overwrites the row from the leader,
+  // which for the LEADER itself is harmless and for anyone else silently discards an edit in
+  // progress. Registered rather than left as a "budget permitting" note in the plan.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_reselect_current_is_noop");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_new");
+      ctx->Yield(2);
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 1.6f);
+      ctx->Yield(2);
+      ctx->ItemClick("**/##sync_Face 4##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+
+      // Face 4 is in group 1 with the leader's 1.6. Give it a value of its own (which propagates,
+      // as AC2 covers), then re-pick group 1 on it: nothing may move.
+      ctx->ItemInputValue("**/##Face 4##modal_fd_input", 0.9f);
+      ctx->Yield(2);
+      const gui::ShapeDist before = crystal().face_distance[1];
+      ctx->ItemClick("**/##sync_Face 4##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      IM_CHECK(crystal().face_distance[1] == before);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.9f);
+
+      ctx->ItemClick("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+    };
+  }
+
   // p2_modal/spectrum_modal_reset_resets_to_preset_seed — inject a non-default custom
   // spectrum baseline, open the modal, click Reset, OK to commit; verify the committed
   // custom_spectrum matches the uniform 9-point 400–720nm/weight=1.0 preset seed

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 
 #include "IconsFontAwesome6.h"  // ICON_FA_* selectors used to match new icon-prefixed button labels
+#include "gui/file_io.hpp"      // DeserializeFromJson / BuildExportJsonOrWarn (hand-authored-config walkthroughs)
 #include "gui/log_sink.hpp"     // ImGuiLogSink (for log_panel_above_left_panel test sink injection)
 // imgui_internal.h is generally an anti-pattern, but z-order assertions need
 // direct ImGuiContext::Windows access. The relied-on semantics
@@ -4395,14 +4396,25 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // p2_modal/sync_group_leader_is_lowest_slot — the leader rule, checked across the slot classes
-  // where "lowest slot index" and "row order on screen" disagree. lumice.h defines the group's
-  // owner as its lowest-indexed applicable member; the GUI snapshots from that same slot, so what
-  // the user sees on join is the value core will draw with. Upper H (slot 1) is BELOW Prism H
-  // (slot 2) in the index space while being drawn second, and both are below every face slot — so
-  // a leader search that followed the visual order, or the struct's field order, lands elsewhere.
+  // p2_modal/sync_group_leader_is_lowest_syncable_slot — the leader rule, checked across the two
+  // ways "lowest slot index" can disagree with what a naive search finds. lumice.h defines the
+  // group's owner as its lowest-indexed applicable member; the GUI snapshots from that same slot
+  // (restricted to the slots it lets the user sync), so what the user sees on join is the value core
+  // will draw with. Two disagreements are exercised, one per group:
+  //   group 1 — slot order vs ROW order: Upper H is slot 1, Lower H slot 3, and Upper H is drawn
+  //             BELOW Prism H. A search following the visual order, or CrystalConfig's field order,
+  //             lands on the wrong one.
+  //   group 2 — slot order vs SYNCABLE order: Prism H (slot 2) is the group's lowest member outright,
+  //             but it is not syncable (no commensurable partner — it has no Sync control at all), so
+  //             the leader must be the lowest slot the user can actually reach. A leader search still
+  //             scoped by IsShapeScalarVisible elects the unreachable Prism H and hands out 0.75.
+  // Both groups are seeded with members that DISAGREE — the only configuration in which "which member
+  // is the leader" is observable at all. A group built by clicking has equal members by construction,
+  // and a snapshot from either end of it looks identical. (A hand-authored config reaching the GUI in
+  // exactly this state is normal: canonicalization belongs to core's from_json, on commit, not to the
+  // GUI — and group 2 is precisely a grouping the GUI itself can no longer build.)
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_is_lowest_slot");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_leader_is_lowest_syncable_slot");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       gui::g_state.modal_immediate_mode = true;
@@ -4411,49 +4423,54 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
         return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
       };
       crystal().type = gui::CrystalType::kPyramid;
-      // The group is seeded with two members that DISAGREE — the only configuration in which
-      // "which member is the leader" is observable at all. A group built by clicking has equal
-      // members by construction, and a snapshot from either end of it looks identical. (A
-      // hand-authored config reaching the GUI in exactly this state is normal: canonicalization
-      // belongs to core's from_json, on commit, not to the GUI.)
-      // upper_h is slot 1, lower_h slot 3, and upper_h is drawn BELOW both of the other two.
       crystal().upper_h = gui::ShapeDist{ gui::ShapeDistType::kUniform, 0.4f, 0.08f };
-      crystal().upper_h.sync_group = 1;
+      crystal().upper_h.sync_group = 1;  // slot 1 — group 1's leader
       crystal().lower_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.9f, 0.0f };
-      crystal().lower_h.sync_group = 1;
-      crystal().prism_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 3.0f, 0.0f };
+      crystal().lower_h.sync_group = 1;  // slot 3 — the foil for group 1
+      // Prism H: slot 2, non-syncable, and group 2's lowest member by index. Its value is inside the
+      // face slider's [0, 2] range on purpose, so a wrong leader shows up as the wrong NUMBER rather
+      // than as a clamp artifact that could be explained away.
+      crystal().prism_h = gui::ShapeDist{ gui::ShapeDistType::kNoRandom, 0.75f, 0.0f };
+      crystal().prism_h.sync_group = 2;
+      crystal().face_distance[1] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.5f, 0.3f };
+      crystal().face_distance[1].sync_group = 2;  // slot 5 — group 2's lowest SYNCABLE member
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
-
-      // Prism H (slot 2, drawn FIRST of the three) joins: it must take upper_h's distribution
-      // (slot 1), not lower_h's (slot 3). Row order says lower_h is further away; slot order is
-      // what decides.
-      ctx->ItemClick("**/##sync_Prism H##modal_cr");
-      ctx->Yield(2);
-      ctx->ItemClick("**/###sync_group_1");
-      ctx->Yield(2);
-      IM_CHECK_EQ(crystal().prism_h.sync_group, 1);
-      IM_CHECK_EQ(crystal().prism_h.center, 0.4f);
-      IM_CHECK_EQ(crystal().prism_h.type, gui::ShapeDistType::kUniform);
-      IM_CHECK_EQ(crystal().prism_h.spread, 0.08f);
-      // Joining reads the group, it does not write it: the two seeded members are untouched, and
-      // still disagreeing.
-      IM_CHECK_EQ(crystal().upper_h.center, 0.4f);
-      IM_CHECK_EQ(crystal().lower_h.center, 0.9f);
-
-      // A face slot joining the same group also snapshots from upper_h — every face slot (4..9) is
-      // above all three H slots in the index space, so no face can ever be the leader here, and the
-      // disagreeing lower_h is still sitting there to be picked by a search that scanned the other
-      // way.
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
+
+      // Face 3 (slot 4) joins group 1: it must take upper_h's distribution (slot 1), not lower_h's
+      // (slot 3). Every face slot is above all three H slots in the index space, so no face can be
+      // the leader here, and the disagreeing lower_h is sitting there to be picked by a search that
+      // scanned the other way.
       ctx->ItemClick("**/##sync_Face 3##modal_fd");
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_group_1");
       ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[0].sync_group, 1);
       IM_CHECK_EQ(crystal().face_distance[0].center, 0.4f);
       IM_CHECK_EQ(crystal().face_distance[0].type, gui::ShapeDistType::kUniform);
+      IM_CHECK_EQ(crystal().face_distance[0].spread, 0.08f);
+
+      // Face 5 (slot 6) joins group 2: the leader is face_distance[1] (slot 5), NOT the lower-indexed
+      // but unsyncable prism_h (slot 2).
+      ctx->ItemClick("**/##sync_Face 5##modal_fd");
+      ctx->Yield(2);
+      ctx->ItemClick("**/###sync_group_2");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[2].sync_group, 2);
+      IM_CHECK_EQ(crystal().face_distance[2].center, 1.5f);
+      IM_CHECK_EQ(crystal().face_distance[2].type, gui::ShapeDistType::kUniform);
+      IM_CHECK_EQ(crystal().face_distance[2].spread, 0.3f);
+
+      // Joining reads the group, it does not write it: every seeded member is untouched, and the two
+      // groups are still internally disagreeing.
+      IM_CHECK_EQ(crystal().upper_h.center, 0.4f);
+      IM_CHECK_EQ(crystal().lower_h.center, 0.9f);
+      IM_CHECK_EQ(crystal().prism_h.center, 0.75f);
+      IM_CHECK_EQ(crystal().prism_h.sync_group, 2);  // dormant, not cleared
+      IM_CHECK_EQ(crystal().face_distance[1].center, 1.5f);
 
       ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);
@@ -4463,17 +4480,135 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // p2_modal/sync_group_unsyncable_member_is_inert — AC2. A hand-authored config MAY group a scalar
+  // the GUI offers no Sync control for (lumice.h runs no commensurability check, and the GUI is not a
+  // second authority on what is legal). Every consequence of that is checked in one walkthrough,
+  // because the failure mode is a HALF-applied predicate: a swatch hidden while the membership list,
+  // the leader search or the propagation still counted the row would leave the user staring at a
+  // group they cannot reach, or at a value that moves for no visible reason.
+  //
+  // The config groups prism `height` with `face_distance[0]` — the exact shape the owner named.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_unsyncable_member_is_inert");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      // Same core-JSON shape as import_export/sync_group_imports_from_core_json, loaded into the live
+      // state so the modal can be driven over it. Exactly two members so the popup's membership label
+      // stays inside ImGuiTestItemInfo::DebugLabel's 32-char buffer and the string checks below are
+      // not reading a truncation.
+      const std::string core_json = R"({
+        "crystal": [
+          {"id": 1, "type": "prism",
+           "shape": {"height": 1.0,
+                     "face_distance": [1,1,1,1,1,1],
+                     "sync_group": {"height": 1, "face_distance": [1,0,0,0,0,0]}}}
+        ],
+        "scene": {
+          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "ray_num": 1000,
+          "max_hits": 8,
+          "scattering": [
+            {"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0}]}
+          ]
+        }
+      })";
+      // DeserializeFromJson assigns a fresh GuiState (file_io.cpp `state = GuiState{}`), so it
+      // resets the modal's two display-tier flags to their STRUCT defaults — not to whatever the
+      // harness had them at. modal_layout_vertical in particular defaults to true, and the harness
+      // never recomputes it without a window resize, so an import silently hands the following
+      // clicks a vertical modal whose bottom button row is off-screen. Both flags are therefore set
+      // AFTER the import, not before.
+      const bool layout_vertical_before = gui::g_state.modal_layout_vertical;
+      IM_CHECK(gui::DeserializeFromJson(core_json, gui::g_state));
+      gui::g_state.modal_layout_vertical = layout_vertical_before;
+      gui::g_state.modal_immediate_mode = true;
+      ctx->Yield(2);
+      auto crystal = []() -> gui::CrystalConfig& {
+        return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
+      };
+      // The import kept the grouping verbatim — the premise of everything below.
+      IM_CHECK_EQ(crystal().type, gui::CrystalType::kPrism);
+      IM_CHECK_EQ(crystal().height.sync_group, 1);
+      IM_CHECK_EQ(crystal().face_distance[0].sync_group, 1);
+
+      ctx->ItemClick("**/Edit##cr");
+      ctx->Yield(4);
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(2);
+
+      // (1) No Sync control on the Height row. Two positive controls so a false pass is impossible:
+      // the row itself is still there and editable, and a row that IS syncable still has its swatch.
+      IM_CHECK(!ctx->ItemExists("**/##sync_Height##modal_cr"));
+      IM_CHECK(ctx->ItemExists("**/##Height##modal_cr_input"));
+      IM_CHECK(ctx->ItemExists("**/##sync_Face 3##modal_fd"));
+
+      // (2) The membership list names only rows the user can go and find. The popup item's visible
+      // label carries the list, so this reads what is actually on screen rather than re-deriving it.
+      ctx->ItemClick("**/##sync_Face 3##modal_fd");
+      ctx->Yield(2);
+      const ImGuiTestItemInfo group_item = ctx->ItemInfo("**/###sync_group_1");
+      IM_CHECK_NE(group_item.ID, (ImGuiID)0);
+      fprintf(stderr, "[sync_inert] group 1 popup label = '%s'\n", group_item.DebugLabel);
+      IM_CHECK(strstr(group_item.DebugLabel, "Face 3") != nullptr);  // the list is really being read
+      IM_CHECK(strstr(group_item.DebugLabel, "Height") == nullptr);  // ...and Height is not in it
+      // Re-selecting the group the row is already in is a documented no-op, so this only dismisses
+      // the popup (see sync_group_reselect_current_is_noop).
+      ctx->ItemClick("**/###sync_group_1");
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[0].sync_group, 1);
+
+      // (3) Editing across the pair moves neither row into the other, in EITHER direction. The
+      // face→height direction is the destination-side gate (Height is not a propagation target); the
+      // height→face direction is the source-side gate (a row with no swatch must not be a group
+      // writer either, or the face value would jump with nothing on screen to explain it).
+      const float height_before = crystal().height.center;
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 0.75f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.75f);
+      IM_CHECK_EQ(crystal().height.center, height_before);
+      ctx->ItemInputValue("**/##Height##modal_cr_input", 3.0f);
+      ctx->Yield(2);
+      IM_CHECK_EQ(crystal().height.center, 3.0f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.75f);
+
+      ctx->ItemClose("**/Face Distance##modal");
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = false;
+
+      // (4) The group id was never the GUI's to clean up: it survives the whole walkthrough in state
+      // AND through the production export path, checked by reading it back rather than by matching
+      // substrings against a JSON dump.
+      IM_CHECK_EQ(crystal().height.sync_group, 1);
+      std::string exported;
+      IM_CHECK(gui::BuildExportJsonOrWarn(gui::g_state, &exported, nullptr));
+      gui::GuiState reloaded = gui::InitDefaultState();
+      IM_CHECK(gui::DeserializeFromJson(exported, reloaded));
+      const auto& rc = gui::CrystalOf(reloaded, reloaded.layers[0].entries[0]);
+      IM_CHECK_EQ(rc.height.sync_group, rc.face_distance[0].sync_group);
+      IM_CHECK_NE(rc.height.sync_group, 0);
+    };
+  }
+
   // p2_modal/sync_group_cross_range_converges — grouping scalars whose sliders have DIFFERENT
   // ranges is permitted (the design deliberately runs no dimensional-commensurability check), and
-  // Height [0.01, 100] with a face distance [0, 2] is the case where that shows. What the group
-  // then settles on is the tighter bound: a value propagated into the face row is clamped by that
-  // row's own slider, and the clamp propagates straight back out.
+  // Upper H [0, 1] with a face distance [0, 2] is the case where that shows. What the group then
+  // settles on is the tighter bound: a value propagated into the Upper H row is clamped by that row's
+  // own slider, and the clamp propagates straight back out.
   //
-  // The property worth pinning is not the number 2.0 — it is that the loop TERMINATES. Propagation
+  // The property worth pinning is not the number 1.0 — it is that the loop TERMINATES. Propagation
   // is triggered by "this row's value changed", and a clamp is a change, so a value that no member
   // can hold is fed back and forth between rows. Measured: one frame to converge, stable after.
   // An implementation that ping-ponged (or clamped asymmetrically) would leave the modal visibly
   // twitching and this test red.
+  //
+  // The edited row is the WIDE one (Face 3) and the clamping row is drawn ABOVE it, so the clamp is
+  // applied on the frame after the edit rather than later in the same frame — the direction that
+  // actually requires a second pass through the table, and the one a "converges immediately because
+  // the rows happen to be in the right order" implementation would fail.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_modal", "sync_group_cross_range_converges");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -4483,13 +4618,13 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       auto crystal = []() -> gui::CrystalConfig& {
         return gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id];
       };
-      crystal().type = gui::CrystalType::kPrism;
+      crystal().type = gui::CrystalType::kPyramid;
 
       ctx->ItemClick("**/Edit##cr");
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
-      ctx->ItemClick("**/##sync_Height##modal_cr");
+      ctx->ItemClick("**/##sync_Upper H##modal_cr");
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_new");
       ctx->Yield(2);
@@ -4497,20 +4632,21 @@ void RegisterP2InteractionModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       ctx->ItemClick("**/###sync_group_1");
       ctx->Yield(2);
-      // Both start at the shared default 1.0, which is inside both ranges — nothing to clamp yet.
-      IM_CHECK_EQ(crystal().height.center, 1.0f);
-      IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
+      // Face 3 snapshotted from its group's only other member, Upper H (default 0.2), which is inside
+      // both ranges — nothing to clamp yet.
+      IM_CHECK_EQ(crystal().upper_h.center, 0.2f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 0.2f);
 
-      // 50 is legal for Height and far outside the face range.
-      ctx->ItemInputValue("**/##Height##modal_cr_input", 50.0f);
-      ctx->Yield(1);
-      // Settled after a SINGLE frame, on the face row's maximum, with both members agreeing.
-      IM_CHECK_EQ(crystal().face_distance[0].center, 2.0f);
-      IM_CHECK_EQ(crystal().height.center, 2.0f);
+      // 2.0 is legal for a face distance and outside Upper H's [0, 1].
+      ctx->ItemInputValue("**/##Face 3##modal_fd_input", 2.0f);
+      ctx->Yield(2);
+      // Settled on the Upper H row's maximum, with both members agreeing.
+      IM_CHECK_EQ(crystal().upper_h.center, 1.0f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
       // ...and it stays there: no oscillation between the two clamps over the following frames.
       ctx->Yield(8);
-      IM_CHECK_EQ(crystal().face_distance[0].center, 2.0f);
-      IM_CHECK_EQ(crystal().height.center, 2.0f);
+      IM_CHECK_EQ(crystal().upper_h.center, 1.0f);
+      IM_CHECK_EQ(crystal().face_distance[0].center, 1.0f);
 
       ctx->ItemClose("**/Face Distance##modal");
       ctx->Yield(2);

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -107,7 +107,7 @@
       }
     },
     "modal_layout": {
-      "generated_at": "2026-07-27T03:14:14",
+      "generated_at": "2026-07-27T09:02:33",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -107,36 +107,36 @@
       }
     },
     "modal_layout": {
-      "generated_at": "2026-07-25T17:19:12",
+      "generated_at": "2026-07-27T03:14:14",
       "n_ref_runs": 10,
-      "n_calib_runs": 60,
+      "n_calib_runs": 10,
       "scenes": {
         "crystal_prism": {
           "psnr_mean": null,
           "psnr_std": null,
-          "identical_runs": 60,
-          "n_samples": 60,
+          "identical_runs": 10,
+          "n_samples": 10,
           "threshold": 40.0
         },
         "crystal_pyramid": {
           "psnr_mean": null,
           "psnr_std": null,
-          "identical_runs": 60,
-          "n_samples": 60,
+          "identical_runs": 10,
+          "n_samples": 10,
           "threshold": 40.0
         },
         "filter_ee": {
           "psnr_mean": null,
           "psnr_std": null,
-          "identical_runs": 60,
-          "n_samples": 60,
+          "identical_runs": 10,
+          "n_samples": 10,
           "threshold": 40.0
         },
         "filter_raypath": {
           "psnr_mean": null,
           "psnr_std": null,
-          "identical_runs": 60,
-          "n_samples": 60,
+          "identical_runs": 10,
+          "n_samples": 10,
           "threshold": 40.0
         }
       }

--- a/test/gui/references/modal_layout_crystal_prism.png
+++ b/test/gui/references/modal_layout_crystal_prism.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8cc3972173498db6d75f574a6a7dbb326967eca2a559722af3a0f47b4867db8
-size 19198
+oid sha256:72d68eb6078d824738e54087eb10b9868f6f03563cc43adb1da4fcc9f6e1691b
+size 19363

--- a/test/gui/references/modal_layout_crystal_prism.png
+++ b/test/gui/references/modal_layout_crystal_prism.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72d68eb6078d824738e54087eb10b9868f6f03563cc43adb1da4fcc9f6e1691b
-size 19363
+oid sha256:163f6f09ab8ecf7a64c1e48b826a0434f6f0479334be56f3fa4baebba1c8abec
+size 19235

--- a/test/gui/references/modal_layout_crystal_pyramid.png
+++ b/test/gui/references/modal_layout_crystal_pyramid.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2090fc60fbef6d2a84920732e3130bd9acd2975931ce8ee0325ff1f3c8b3d273
-size 25230
+oid sha256:a13ba3ff9f0f493608453a831e116a881e741fa0fd30013b3f400fff433c725b
+size 25388

--- a/test/gui/references/modal_layout_crystal_pyramid.png
+++ b/test/gui/references/modal_layout_crystal_pyramid.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48356564e1f2f23ceda23ff1ab75f479beb5dfd12bfb5c467ccc106838a94a49
-size 24137
+oid sha256:2090fc60fbef6d2a84920732e3130bd9acd2975931ce8ee0325ff1f3c8b3d273
+size 25230

--- a/test/unit-correctness/config/test_crystal_sync_group.cpp
+++ b/test/unit-correctness/config/test_crystal_sync_group.cpp
@@ -208,10 +208,12 @@ TEST(ShapeScalarSyncGroupNormalize, AgreeingMembersProduceNoWarning) {
 }
 
 TEST(ShapeScalarSyncGroupNormalize, LeaderIsTheLowestApplicableSlotNotTheLowestDeclared) {
-  // On a pyramid, `height` is inapplicable and dropped by rule 1, so upper_h
-  // becomes the group's leader. Had Normalize run before Canonicalize, the
-  // about-to-be-dropped height slot would have donated its distribution to
-  // everyone — this pins the ordering of the two passes.
+  // On a pyramid, `height` is inapplicable, so upper_h — not the numerically
+  // lower height slot — leads the group. The exclusion is structural: leader
+  // election scans the slot map, and a slot this type does not have is a nullptr
+  // there. It is NOT a consequence of canonicalization having zeroed the slot
+  // first; see NormalizeAloneExcludesInapplicableSlotWithoutCanonicalizeFirst,
+  // which reaches the same leader with only the normalize pass run.
   ns::PyramidCrystalParam p;
   p.h_pyr_u_ = Gauss(0.3f, 0.05f);
   p.h_pyr_l_ = Uniform(9.0f, 9.0f);
@@ -220,6 +222,28 @@ TEST(ShapeScalarSyncGroupNormalize, LeaderIsTheLowestApplicableSlotNotTheLowestD
 
   ns::PrepareSyncGroups(p);
   EXPECT_TRUE(p.h_pyr_l_ == Gauss(0.3f, 0.05f)) << "upper_h leads the group; lower_h must adopt its distribution";
+}
+
+TEST(ShapeScalarSyncGroupNormalize, NormalizeAloneExcludesInapplicableSlotWithoutCanonicalizeFirst) {
+  // NormalizeSyncGroups carries no ordering precondition — this runs it with
+  // CanonicalizeSyncGroups deliberately NOT called, on the very configuration
+  // the old doc comment claimed would misfire: a pyramid whose group also names
+  // `height`, a slot pyramids do not have.
+  ns::PyramidCrystalParam p;
+  p.h_pyr_u_ = Gauss(0.3f, 0.05f);
+  p.h_pyr_l_ = Uniform(9.0f, 9.0f);
+  p.sync_group_[ns::kShapeScalarHeight] = 4;  // inapplicable to a pyramid, and still declared
+  p.sync_group_[ns::kShapeScalarUpperH] = 4;
+  p.sync_group_[ns::kShapeScalarLowerH] = 4;
+
+  ns::NormalizeSyncGroups(p);
+
+  EXPECT_TRUE(p.h_pyr_l_ == Gauss(0.3f, 0.05f))
+      << "upper_h must still lead: the height slot names no field on a pyramid, so it can donate nothing";
+  // Guards the premise of this test rather than its conclusion: had anything
+  // canonicalized `p` along the way, this slot would read 0 and the case above
+  // would no longer be the un-canonicalized one it claims to cover.
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarHeight], 4) << "NormalizeSyncGroups must not rewrite group numbers at all";
 }
 
 // ==================================================================================================

--- a/test/unit-correctness/config/test_crystal_sync_group.cpp
+++ b/test/unit-correctness/config/test_crystal_sync_group.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
+#include <variant>
 
 #include "config/config_compare.hpp"
 #include "config/crystal_config.hpp"
@@ -313,6 +314,32 @@ TEST(ShapeScalarSyncGroupJson, SerializationDoesNotMutateTheSourceParam) {
   const auto emitted = out.at("sync_group").at("face_distance").get<std::vector<int>>();
   const std::vector<int> expected = { 1, 2, 1, 2, 1, 2 };
   EXPECT_EQ(emitted, expected);
+}
+
+TEST(ShapeScalarSyncGroupJson, ReachableFromTheDocumentedConfigFilePosition) {
+  // The schema position users write is `crystal[].shape.sync_group`, one level
+  // above the shape object the tests above feed directly. This pins that the key
+  // survives CrystalConfig's own from_json rather than only the param's.
+  nlohmann::json shape = PrismShapeJson();
+  shape["sync_group"] = { { "face_distance", nlohmann::json::array({ 1, 2, 1, 2, 1, 2 }) } };
+  const nlohmann::json crystal = {
+    { "id", 1 },
+    { "type", "prism" },
+    { "shape", shape },
+    { "axis",
+      { { "zenith", { { "type", "uniform" }, { "mean", 90 }, { "std", 360 } } },
+        { "azimuth", { { "type", "uniform" }, { "mean", 0 }, { "std", 360 } } } } },
+  };
+
+  const auto config = crystal.get<ns::CrystalConfig>();
+  ASSERT_TRUE(std::holds_alternative<ns::PrismCrystalParam>(config.param_));
+  const auto& p = std::get<ns::PrismCrystalParam>(config.param_);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace0], 1);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace1], 2);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace2], 1);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace3], 2);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace4], 1);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace5], 2);
 }
 
 TEST(ShapeScalarSyncGroupJson, ParsingIntoAReusedParamClearsStaleGroups) {

--- a/test/unit-correctness/config/test_crystal_sync_group.cpp
+++ b/test/unit-correctness/config/test_crystal_sync_group.cpp
@@ -1,0 +1,331 @@
+#include <spdlog/sinks/ostream_sink.h>
+
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+
+#include "config/config_compare.hpp"
+#include "config/crystal_config.hpp"
+#include "core/math.hpp"
+#include "gtest/gtest.h"
+#include "util/logger.hpp"
+
+// Shape-scalar sync groups, config side: canonical form, leader normalization,
+// JSON codec and the equality predicate that drives re-simulation.
+
+namespace {
+
+namespace ns = lumice;
+
+// Captures everything the global logger emits for the lifetime of the object.
+// RAII rather than a manual remove_sink at the end of each test, because
+// GetSharedSink() is a process-wide singleton: an ASSERT_* returning early with
+// the sink still attached would leave later tests in this binary writing into a
+// destroyed ostringstream.
+class LogCapture {
+ public:
+  LogCapture() : sink_(std::make_shared<spdlog::sinks::ostream_sink_mt>(oss_)) { ns::GetSharedSink()->add_sink(sink_); }
+
+  ~LogCapture() { ns::GetSharedSink()->remove_sink(sink_); }
+
+  LogCapture(const LogCapture&) = delete;
+  LogCapture& operator=(const LogCapture&) = delete;
+
+  std::string Text() const { return oss_.str(); }
+
+ private:
+  std::ostringstream oss_;
+  std::shared_ptr<spdlog::sinks::ostream_sink_mt> sink_;
+};
+
+ns::Distribution Gauss(float mean, float std) {
+  return ns::Distribution{ ns::DistributionType::kGaussian, mean, std };
+}
+
+ns::Distribution Uniform(float center, float spread) {
+  return ns::Distribution{ ns::DistributionType::kUniform, center, spread };
+}
+
+// A shape JSON with randomized height and faces, matching the wire form
+// Distribution::to_json emits for a non-kNoRandom distribution.
+nlohmann::json PrismShapeJson() {
+  return nlohmann::json{
+    { "height", { { "type", "gauss" }, { "mean", 1.0 }, { "std", 0.2 } } },
+    { "face_distance", nlohmann::json::array({
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                           { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.4 } },
+                       }) },
+  };
+}
+
+nlohmann::json PyramidShapeJson() {
+  nlohmann::json j = PrismShapeJson();
+  j.erase("height");
+  j["prism_h"] = { { "type", "uniform" }, { "mean", 1.0 }, { "std", 0.3 } };
+  j["upper_h"] = { { "type", "gauss" }, { "mean", 0.3 }, { "std", 0.05 } };
+  j["lower_h"] = { { "type", "gauss" }, { "mean", 0.3 }, { "std", 0.05 } };
+  return j;
+}
+
+// ==================================================================================================
+// AC3 — canonical form, one test per rule.
+
+TEST(ShapeScalarSyncGroupCanonical, InapplicableSlotIsZeroedWithoutDissolvingTheGroup) {
+  ns::PrismCrystalParam p;
+  // upper_h does not exist on a prism, but faces 0 and 2 form a real group. Only
+  // the inapplicable slot may be dropped — a rule 1 that also took the surviving
+  // group down with it would pass a weaker single-assertion test.
+  p.sync_group_[ns::kShapeScalarUpperH] = 5;
+  p.sync_group_[ns::kShapeScalarFace0] = 5;
+  p.sync_group_[ns::kShapeScalarFace2] = 5;
+  ns::CanonicalizeSyncGroups(p);
+
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarUpperH], 0) << "a prism has no upper_h; that declaration is not a membership";
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace0], 1);
+  EXPECT_EQ(p.sync_group_[ns::kShapeScalarFace2], 1);
+
+  // Mirror case on a pyramid: it is `height` that does not exist there.
+  ns::PyramidCrystalParam q;
+  q.sync_group_[ns::kShapeScalarHeight] = 3;
+  q.sync_group_[ns::kShapeScalarUpperH] = 3;
+  q.sync_group_[ns::kShapeScalarLowerH] = 3;
+  ns::CanonicalizeSyncGroups(q);
+
+  EXPECT_EQ(q.sync_group_[ns::kShapeScalarHeight], 0);
+  EXPECT_EQ(q.sync_group_[ns::kShapeScalarUpperH], 1);
+  EXPECT_EQ(q.sync_group_[ns::kShapeScalarLowerH], 1);
+}
+
+TEST(ShapeScalarSyncGroupCanonical, SingletonGroupCollapsesToIndependent) {
+  ns::PrismCrystalParam p;
+  p.sync_group_[ns::kShapeScalarHeight] = 1;
+  ns::CanonicalizeSyncGroups(p);
+
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(p.sync_group_[i], 0) << "slot " << i << ": a group of one is independence";
+  }
+  // And therefore indistinguishable from a default-constructed param.
+  EXPECT_TRUE(p == ns::PrismCrystalParam{});
+}
+
+TEST(ShapeScalarSyncGroupCanonical, SamePartitionDifferentNumberingIsOneCanonicalForm) {
+  ns::PrismCrystalParam a;
+  ns::PrismCrystalParam b;
+  const int a_faces[6] = { 2, 1, 2, 1, 2, 1 };
+  const int b_faces[6] = { 1, 2, 1, 2, 1, 2 };
+  for (int i = 0; i < 6; i++) {
+    a.sync_group_[ns::kShapeScalarFace0 + i] = a_faces[i];
+    b.sync_group_[ns::kShapeScalarFace0 + i] = b_faces[i];
+  }
+
+  // Equality must hold WITHOUT the caller canonicalizing first — that is the
+  // whole point, since operator== is the re-simulation trigger.
+  EXPECT_TRUE(a == b) << "two spellings of the same partition must not trigger a re-run";
+
+  ns::PrismCrystalParam ca = a;
+  ns::PrismCrystalParam cb = b;
+  ns::CanonicalizeSyncGroups(ca);
+  ns::CanonicalizeSyncGroups(cb);
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(ca.sync_group_[ns::kShapeScalarFace0 + i], b_faces[i])
+        << "canonical numbering follows first appearance in ShapeScalar order, slot " << i;
+    EXPECT_EQ(cb.sync_group_[ns::kShapeScalarFace0 + i], b_faces[i]);
+  }
+}
+
+TEST(ShapeScalarSyncGroupCanonical, DifferentPartitionsStillCompareUnequal) {
+  // Guards against writing the canonicalize-then-compare as a tautology: if
+  // Canonicalize zeroed everything, or operator== ignored sync_group_ entirely,
+  // the test above would still pass and this one would not.
+  ns::PrismCrystalParam grouped;
+  for (int i = 0; i < 6; i++) {
+    grouped.sync_group_[ns::kShapeScalarFace0 + i] = (i % 2 == 0) ? 1 : 2;
+  }
+  EXPECT_FALSE(grouped == ns::PrismCrystalParam{}) << "an alternating C3 partition is not the all-independent param";
+
+  // Same member count, different partition: {0,1,2}+{3,4,5} vs {0,2,4}+{1,3,5}.
+  ns::PrismCrystalParam blocked;
+  for (int i = 0; i < 6; i++) {
+    blocked.sync_group_[ns::kShapeScalarFace0 + i] = (i < 3) ? 1 : 2;
+  }
+  EXPECT_FALSE(grouped == blocked);
+
+  ns::PyramidCrystalParam pa;
+  ns::PyramidCrystalParam pb;
+  pa.sync_group_[ns::kShapeScalarUpperH] = 1;
+  pa.sync_group_[ns::kShapeScalarLowerH] = 1;
+  EXPECT_FALSE(pa == pb);
+}
+
+// ==================================================================================================
+// AC5 — leader normalization is visible, in both directions.
+
+TEST(ShapeScalarSyncGroupNormalize, DivergentMemberIsOverriddenWithAWarning) {
+  ns::PrismCrystalParam p;
+  p.d_[0] = Uniform(1.0f, 1.0f);
+  p.d_[2] = Gauss(1.0f, 1.0f);  // Same group, different distribution.
+  p.sync_group_[ns::kShapeScalarFace0] = 1;
+  p.sync_group_[ns::kShapeScalarFace2] = 1;
+
+  std::string log_text;
+  {
+    LogCapture capture;
+    ns::PrepareSyncGroups(p);
+    log_text = capture.Text();
+  }
+
+  EXPECT_NE(log_text.find("sync group"), std::string::npos)
+      << "overriding a member's distribution must not be silent; captured log was: " << log_text;
+  // Overridden, not rejected: the group ends up with one distribution, the
+  // leader's (face 0, the lower ShapeScalar index and thus the one that draws).
+  EXPECT_TRUE(p.d_[0] == p.d_[2]);
+  EXPECT_TRUE(p.d_[0] == Uniform(1.0f, 1.0f));
+}
+
+TEST(ShapeScalarSyncGroupNormalize, AgreeingMembersProduceNoWarning) {
+  ns::PrismCrystalParam p;
+  p.d_[0] = Uniform(1.0f, 1.0f);
+  p.d_[2] = Uniform(1.0f, 1.0f);
+  p.sync_group_[ns::kShapeScalarFace0] = 1;
+  p.sync_group_[ns::kShapeScalarFace2] = 1;
+
+  std::string log_text;
+  {
+    LogCapture capture;
+    ns::PrepareSyncGroups(p);
+    log_text = capture.Text();
+  }
+
+  EXPECT_EQ(log_text.find("sync group"), std::string::npos)
+      << "a consistent config must stay quiet; captured log was: " << log_text;
+  EXPECT_TRUE(p.d_[0] == p.d_[2]);
+}
+
+TEST(ShapeScalarSyncGroupNormalize, LeaderIsTheLowestApplicableSlotNotTheLowestDeclared) {
+  // On a pyramid, `height` is inapplicable and dropped by rule 1, so upper_h
+  // becomes the group's leader. Had Normalize run before Canonicalize, the
+  // about-to-be-dropped height slot would have donated its distribution to
+  // everyone — this pins the ordering of the two passes.
+  ns::PyramidCrystalParam p;
+  p.h_pyr_u_ = Gauss(0.3f, 0.05f);
+  p.h_pyr_l_ = Uniform(9.0f, 9.0f);
+  p.sync_group_[ns::kShapeScalarUpperH] = 4;
+  p.sync_group_[ns::kShapeScalarLowerH] = 4;
+
+  ns::PrepareSyncGroups(p);
+  EXPECT_TRUE(p.h_pyr_l_ == Gauss(0.3f, 0.05f)) << "upper_h leads the group; lower_h must adopt its distribution";
+}
+
+// ==================================================================================================
+// AC4 — JSON codec.
+
+TEST(ShapeScalarSyncGroupJson, PrismRoundTripIsStable) {
+  nlohmann::json j = PrismShapeJson();
+  j["sync_group"] = { { "face_distance", nlohmann::json::array({ 1, 2, 1, 2, 1, 2 }) } };
+
+  const auto first = j.get<ns::PrismCrystalParam>();
+  nlohmann::json round_tripped;
+  ns::to_json(round_tripped, first);
+  const auto second = round_tripped.get<ns::PrismCrystalParam>();
+
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(first.sync_group_[i], second.sync_group_[i]) << "slot " << i;
+  }
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarFace0], 1);
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarFace1], 2);
+  EXPECT_TRUE(first == second);
+}
+
+TEST(ShapeScalarSyncGroupJson, PyramidRoundTripCoversTheNamedHeightKeys) {
+  nlohmann::json j = PyramidShapeJson();
+  j["sync_group"] = {
+    { "upper_h", 3 },
+    { "lower_h", 3 },
+    { "face_distance", nlohmann::json::array({ 1, 2, 1, 2, 1, 2 }) },
+  };
+
+  const auto first = j.get<ns::PyramidCrystalParam>();
+  // Canonical renumbering follows ShapeScalar order, where the pyramidal heights
+  // precede the faces: the height pair becomes group 1.
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarUpperH], 1);
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarLowerH], 1);
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarFace0], 2);
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarFace1], 3);
+  EXPECT_EQ(first.sync_group_[ns::kShapeScalarPrismH], 0);
+
+  nlohmann::json round_tripped;
+  ns::to_json(round_tripped, first);
+  const auto second = round_tripped.get<ns::PyramidCrystalParam>();
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(first.sync_group_[i], second.sync_group_[i]) << "slot " << i;
+  }
+  EXPECT_TRUE(first == second);
+}
+
+TEST(ShapeScalarSyncGroupJson, ConfigWithoutTheKeyParsesAsFullyIndependent) {
+  const auto prism = PrismShapeJson().get<ns::PrismCrystalParam>();
+  const auto pyramid = PyramidShapeJson().get<ns::PyramidCrystalParam>();
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(prism.sync_group_[i], 0) << "slot " << i;
+    EXPECT_EQ(pyramid.sync_group_[i], 0) << "slot " << i;
+  }
+}
+
+TEST(ShapeScalarSyncGroupJson, FullyIndependentParamEmitsNoSyncGroupKey) {
+  nlohmann::json prism_out;
+  ns::to_json(prism_out, ns::PrismCrystalParam{});
+  EXPECT_FALSE(prism_out.contains("sync_group")) << "existing configs must serialize exactly as before";
+
+  nlohmann::json pyramid_out;
+  ns::to_json(pyramid_out, ns::PyramidCrystalParam{});
+  EXPECT_FALSE(pyramid_out.contains("sync_group"));
+
+  // A param whose only declaration is a singleton (or an inapplicable slot) is
+  // semantically independent, so it must not resurrect the key either.
+  ns::PrismCrystalParam singleton;
+  singleton.sync_group_[ns::kShapeScalarFace3] = 7;
+  singleton.sync_group_[ns::kShapeScalarUpperH] = 8;
+  nlohmann::json singleton_out;
+  ns::to_json(singleton_out, singleton);
+  EXPECT_FALSE(singleton_out.contains("sync_group"));
+}
+
+TEST(ShapeScalarSyncGroupJson, SerializationDoesNotMutateTheSourceParam) {
+  ns::PrismCrystalParam p;
+  for (int i = 0; i < 6; i++) {
+    p.sync_group_[ns::kShapeScalarFace0 + i] = (i % 2 == 0) ? 9 : 4;
+  }
+  const ns::PrismCrystalParam before = p;
+
+  nlohmann::json out;
+  ns::to_json(out, p);
+
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(p.sync_group_[i], before.sync_group_[i])
+        << "to_json canonicalizes a copy, never its argument, slot " << i;
+  }
+  // The emitted numbering is canonical even though the source's is not.
+  const auto emitted = out.at("sync_group").at("face_distance").get<std::vector<int>>();
+  const std::vector<int> expected = { 1, 2, 1, 2, 1, 2 };
+  EXPECT_EQ(emitted, expected);
+}
+
+TEST(ShapeScalarSyncGroupJson, ParsingIntoAReusedParamClearsStaleGroups) {
+  ns::PrismCrystalParam p;
+  p.sync_group_[ns::kShapeScalarFace0] = 1;
+  p.sync_group_[ns::kShapeScalarFace2] = 1;
+
+  // Same object, now fed a config that declares nothing — matching how `d_` is
+  // reset before parsing rather than merged into.
+  ns::from_json(PrismShapeJson(), p);
+  for (int i = 0; i < ns::kShapeScalarCount; i++) {
+    EXPECT_EQ(p.sync_group_[i], 0) << "slot " << i;
+  }
+}
+
+}  // namespace

--- a/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
+++ b/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
@@ -1,0 +1,321 @@
+#include <cmath>
+#include <cstring>
+
+#include "config/crystal_config.hpp"
+#include "core/crystal.hpp"
+#include "core/math.hpp"
+#include "core/trace_ops.hpp"
+#include "gtest/gtest.h"
+
+// Shape-scalar sync groups, core sampling side.
+//
+// The suite's first job is a hard compatibility gate: declaring no sync group
+// must leave the RNG stream byte-identical to what MakeCrystal produced before
+// sync groups existed. The kPrism*/kPyramid* golden arrays below were captured
+// from that pre-change implementation (temporary hex-float dump inside
+// CrystalMaker, one rng instance, 20 consecutive MakeCrystal calls), so they are
+// an external oracle rather than a transcription of the new code's own behavior.
+// If they ever need regenerating, that is a red flag, not a chore: every seeded
+// reference in the repo (golden / parity / e2e) moves with this stream.
+
+namespace {
+
+namespace ns = lumice;
+
+constexpr int kGoldenDraws = 20;
+
+// Prism golden: rng seed 20260726, h_ = Gaussian(1.0, 0.3), all six
+// face_distance = Uniform(center 1.0, spread 0.6), sync_group_ all zero.
+constexpr uint32_t kPrismGoldenSeed = 20260726u;
+
+constexpr float kPrismGoldenH[kGoldenDraws] = {
+  0x1.a13438p-1f, 0x1.39f4c2p-1f, 0x1.24d3e2p-1f, 0x1.748ad4p-1f, 0x1.c446fap-1f, 0x1.0deacap+0f, 0x1.8fd5ep-1f,
+  0x1.b1c74p+0f,  0x1.84aa8cp-1f, 0x1.558e3ep-1f, 0x1.354ba2p-1f, 0x1.873076p-1f, 0x1.01221ap-1f, 0x1.2f66b8p+0f,
+  0x1.7a0706p-1f, 0x1.992eeap+0f, 0x1.fa15f6p-2f, 0x1.d9bffcp-1f, 0x1.501b9p-1f,  0x1.bbba1ap-1f,
+};
+constexpr float kPrismGoldenD[kGoldenDraws][6] = {
+  { 0x1.baab4p-1f, 0x1.168e16p+0f, 0x1.d08ap-1f, 0x1.4871fap+0f, 0x1.3e0ba4p+0f, 0x1.32e02cp+0f },
+  { 0x1.7b4f8p-1f, 0x1.fe6176p-1f, 0x1.9bf48ep-1f, 0x1.148a0ep+0f, 0x1.6a2718p-1f, 0x1.c623e8p-1f },
+  { 0x1.2cbdf6p+0f, 0x1.2df93cp+0f, 0x1.372e78p+0f, 0x1.0936ccp+0f, 0x1.39aa72p+0f, 0x1.6d2fe6p-1f },
+  { 0x1.0eb29ap+0f, 0x1.093b6p+0f, 0x1.0c32e6p+0f, 0x1.37b9ecp+0f, 0x1.36b908p+0f, 0x1.96854cp-1f },
+  { 0x1.3dcb94p+0f, 0x1.673de2p-1f, 0x1.3eea96p+0f, 0x1.28f61cp+0f, 0x1.b25016p-1f, 0x1.c93b7ep-1f },
+  { 0x1.e0fac2p-1f, 0x1.2949f2p+0f, 0x1.1ffdd4p+0f, 0x1.397fe4p+0f, 0x1.94118p-1f, 0x1.cdcc5ep-1f },
+  { 0x1.9479a2p-1f, 0x1.b89218p-1f, 0x1.1b34bcp+0f, 0x1.21dc06p+0f, 0x1.0d74bcp+0f, 0x1.099feap+0f },
+  { 0x1.19271ap+0f, 0x1.e33a4ep-1f, 0x1.1afdb8p+0f, 0x1.1cf0c2p+0f, 0x1.412f1p+0f, 0x1.2e6c52p+0f },
+  { 0x1.0de706p+0f, 0x1.38eb18p+0f, 0x1.bd1b74p-1f, 0x1.07eb0ap+0f, 0x1.2d0a9cp+0f, 0x1.c3f55ep-1f },
+  { 0x1.1bf264p+0f, 0x1.2f14c8p+0f, 0x1.32adb8p+0f, 0x1.3b773ep+0f, 0x1.1c1d7ap+0f, 0x1.427252p+0f },
+  { 0x1.45401cp+0f, 0x1.a4984ep-1f, 0x1.42f59p+0f, 0x1.e5b6b2p-1f, 0x1.0ed59ap+0f, 0x1.26cf34p+0f },
+  { 0x1.88d9d8p-1f, 0x1.3155fcp+0f, 0x1.c73324p-1f, 0x1.f08432p-1f, 0x1.3ac3aep+0f, 0x1.d6ee94p-1f },
+  { 0x1.f0da26p-1f, 0x1.0259e4p+0f, 0x1.fbbf2ep-1f, 0x1.cd3404p-1f, 0x1.4acb46p+0f, 0x1.d6059p-1f },
+  { 0x1.49b702p+0f, 0x1.66a51ap-1f, 0x1.9b6a44p-1f, 0x1.e6f32p-1f, 0x1.2875eep+0f, 0x1.a4844ap-1f },
+  { 0x1.49e9acp+0f, 0x1.d9ee96p-1f, 0x1.2d758ep+0f, 0x1.1a9b04p+0f, 0x1.a4d6f2p-1f, 0x1.17e6fep+0f },
+  { 0x1.1e24ap+0f, 0x1.ea83e4p-1f, 0x1.6f1c26p-1f, 0x1.0604f8p+0f, 0x1.3a3578p+0f, 0x1.30f41p+0f },
+  { 0x1.fec928p-1f, 0x1.8e5e74p-1f, 0x1.c773b4p-1f, 0x1.ef983ap-1f, 0x1.94658p-1f, 0x1.88760cp-1f },
+  { 0x1.0fdc5ep+0f, 0x1.80544cp-1f, 0x1.97a49cp-1f, 0x1.257b3cp+0f, 0x1.bb6bc4p-1f, 0x1.2e5fb8p+0f },
+  { 0x1.2864e8p+0f, 0x1.433df6p+0f, 0x1.ce2f64p-1f, 0x1.f0d9a8p-1f, 0x1.cf4f7cp-1f, 0x1.2adfd8p+0f },
+  { 0x1.11d8a4p+0f, 0x1.0506d2p+0f, 0x1.21f06cp+0f, 0x1.a33a82p-1f, 0x1.93754p-1f, 0x1.153592p+0f },
+};
+
+// Pyramid golden: rng seed 20260727, h_pyr_u_ = Gaussian(0.3, 0.1),
+// h_prs_ = Uniform(center 1.0, spread 0.4), h_pyr_l_ = Laplacian(0.3, 0.1) —
+// three deliberately different distribution types, so a mixed-up draw order
+// between the three heights cannot pass unnoticed. All six face_distance =
+// Gaussian(1.0, 0.5), sync_group_ all zero.
+constexpr uint32_t kPyramidGoldenSeed = 20260727u;
+
+constexpr float kPyramidGoldenH1[kGoldenDraws] = {
+  0x1.764b88p-2f, 0x1.85ee1ep-2f, 0x1.8dcc86p-3f, 0x1.8d6cd8p-2f, 0x1.862c92p-2f, 0x1.bccc7cp-2f, 0x1.fd17f2p-3f,
+  0x1.3c7eaap-3f, 0x1.893176p-4f, 0x1.f00f8cp-3f, 0x1.0498d4p-2f, 0x1.a73358p-2f, 0x1.ca30eep-2f, 0x1.2c1962p-2f,
+  0x1.35e4a4p-2f, 0x1.fb92b6p-3f, 0x1.359ab6p-2f, 0x1.34c628p-2f, 0x1.881ddcp-2f, 0x1.45e57ap-2f,
+};
+constexpr float kPyramidGoldenH2[kGoldenDraws] = {
+  0x1.1f995ap+0f, 0x1.cbaa3cp-1f, 0x1.1c552cp+0f, 0x1.1aae94p+0f, 0x1.05e6dep+0f, 0x1.1c2648p+0f, 0x1.02a6aap+0f,
+  0x1.25893ap+0f, 0x1.2d012p+0f,  0x1.26db9p+0f,  0x1.12bb64p+0f, 0x1.a78cdp-1f,  0x1.9dfe0ep-1f, 0x1.11eac6p+0f,
+  0x1.097a04p+0f, 0x1.19b9d2p+0f, 0x1.f2b008p-1f, 0x1.c4c67cp-1f, 0x1.ab68f2p-1f, 0x1.2bdb4ap+0f,
+};
+constexpr float kPyramidGoldenH3[kGoldenDraws] = {
+  0x1.aaed8ep-2f, 0x1.e81ap-4f,   0x1.258016p-2f, 0x1.490ddep-2f, 0x1.2f71e6p-2f, 0x1.d33a5cp-3f, 0x1.3a1654p-2f,
+  0x1.7ece8p-2f,  0x1.25678p-2f,  0x1.718ce4p-2f, 0x1.833d48p-3f, 0x1.382d64p-2f, 0x1.d0ee5cp-2f, 0x1.0ef692p-3f,
+  0x1.431cdcp-4f, 0x1.2eb044p-2f, 0x1.6303cp-2f,  0x1.e6b0d6p-4f, 0x1.2acd68p-2f, 0x1.ed6e32p-3f,
+};
+constexpr float kPyramidGoldenD[kGoldenDraws][6] = {
+  { 0x1.77b53p+0f, 0x1.cad678p-2f, 0x1.53d0f8p-1f, 0x1.f37f5p-2f, 0x1.14429p+1f, 0x1.a089eep-1f },
+  { 0x1.48d38p-6f, 0x1.ee3578p-1f, 0x1.65ef64p+0f, 0x1.a08d74p-1f, 0x1.6f6ad2p-1f, 0x1.139276p+0f },
+  { 0x1.d62dap-2f, 0x1.d65be4p-1f, 0x1.ac5834p-2f, 0x1.25633ep-1f, 0x1.7c9316p+0f, 0x1.23d864p-1f },
+  { 0x1.28d99cp+0f, 0x1.14aa22p+0f, 0x1.b549dap-1f, 0x1.ea8e84p-2f, 0x1.5d1c7ep-1f, -0x1.60eacp-5f },
+  { 0x1.2585e4p-2f, 0x1.e1dbecp-1f, 0x1.dcb7cp-1f, 0x1.a8b88p+0f, 0x1.5b0cf4p+0f, 0x1.00e098p-2f },
+  { 0x1.61c2eep-1f, 0x1.05197cp+0f, 0x1.4aa888p-1f, 0x1.b0e758p-1f, 0x1.b2d7ecp-2f, 0x1.22678cp-1f },
+  { 0x1.7b0bp+0f, 0x1.5d48ep+0f, 0x1.25d24p-2f, 0x1.a0108cp-2f, 0x1.443d86p+0f, 0x1.10b9fcp+0f },
+  { 0x1.ccdefap+0f, 0x1.f9ecccp-1f, 0x1.3ef062p+1f, 0x1.f1a694p-1f, 0x1.99e0f6p+0f, 0x1.246cecp+1f },
+  { 0x1.4b3aacp+0f, 0x1.2958e6p+0f, 0x1.b1e866p-1f, 0x1.06f37ep+0f, 0x1.77aa4p-1f, 0x1.536a88p+1f },
+  { 0x1.0e5c2ep+0f, 0x1.474bf4p+0f, 0x1.555696p+0f, 0x1.956e76p-1f, 0x1.f14ac8p+0f, 0x1.eb6654p-1f },
+  { 0x1.2405f2p-1f, 0x1.91859ep+0f, 0x1.49589ap+0f, 0x1.9e3c62p-1f, 0x1.db26dcp+0f, 0x1.7605ccp+0f },
+  { 0x1.8278ep+0f, 0x1.131f22p+1f, 0x1.1fa8cp+0f, 0x1.427faep+0f, 0x1.3db826p+0f, 0x1.0b5ffp-2f },
+  { 0x1.01d42cp-1f, 0x1.5dd4dep-1f, 0x1.492a9cp+0f, 0x1.8647d4p-1f, 0x1.0a6636p+0f, 0x1.2a0618p+0f },
+  { 0x1.5790e8p-1f, 0x1.b58cfcp-1f, 0x1.ed8696p-1f, 0x1.57e4cp-1f, 0x1.0f66a6p+0f, 0x1.c73d4cp-1f },
+  { 0x1.80e57p+0f, 0x1.2862ep-1f, 0x1.0f8e5ep+1f, 0x1.7e8d58p-2f, 0x1.7a023cp-1f, 0x1.2eeb62p+0f },
+  { 0x1.38af62p-1f, 0x1.855638p+0f, 0x1.0881c6p-1f, 0x1.625268p-1f, 0x1.638412p+0f, 0x1.57064ap+0f },
+  { 0x1.2b869ep+0f, 0x1.0f2646p+0f, 0x1.4a598p-1f, 0x1.031cep+0f, 0x1.cd4998p+0f, 0x1.fdc336p+0f },
+  { 0x1.0584c8p-1f, 0x1.89a9dp+0f, 0x1.13448ep+0f, 0x1.516788p-2f, 0x1.07c95p+0f, 0x1.69c4f6p+0f },
+  { 0x1.08b95p-1f, 0x1.064a02p+1f, 0x1.6c7e5p+0f, 0x1.d5842ep-1f, 0x1.06741p+0f, 0x1.73fc64p+0f },
+  { 0x1.af4544p-2f, 0x1.c15a4p+0f, 0x1.4d0fc8p+0f, 0x1.fba91p-2f, 0x1.205d4cp-1f, 0x1.952238p+0f },
+};
+
+ns::PrismCrystalParam GoldenPrismParam() {
+  ns::PrismCrystalParam p;
+  p.h_ = ns::Distribution{ ns::DistributionType::kGaussian, 1.0f, 0.3f };
+  for (auto& d : p.d_) {
+    d = ns::Distribution{ ns::DistributionType::kUniform, 1.0f, 0.6f };
+  }
+  return p;
+}
+
+ns::PyramidCrystalParam GoldenPyramidParam() {
+  ns::PyramidCrystalParam p;
+  p.h_pyr_u_ = ns::Distribution{ ns::DistributionType::kGaussian, 0.3f, 0.1f };
+  p.h_prs_ = ns::Distribution{ ns::DistributionType::kUniform, 1.0f, 0.4f };
+  p.h_pyr_l_ = ns::Distribution{ ns::DistributionType::kLaplacian, 0.3f, 0.1f };
+  for (auto& d : p.d_) {
+    d = ns::Distribution{ ns::DistributionType::kGaussian, 1.0f, 0.5f };
+  }
+  return p;
+}
+
+bool CfGeomBytesEqual(const ns::CrystalGeom& a, const ns::CrystalGeom& b) {
+  return std::memcmp(&a, &b, sizeof(ns::CrystalGeom)) == 0;
+}
+
+// ==================================================================================================
+// AC1 — no sync declaration must not perturb the RNG stream, value for value.
+
+TEST(ShapeScalarSyncGroupSampling, PrismNoSyncMatchesPreChangeGolden) {
+  const ns::PrismCrystalParam p = GoldenPrismParam();
+  ns::RandomNumberGenerator rng(kPrismGoldenSeed);
+
+  // One rng instance, consumed continuously across the draws — exactly the
+  // lifecycle the golden was captured under. Rebuilding it per draw would reset
+  // the stream and make every row identical.
+  for (int draw = 0; draw < kGoldenDraws; draw++) {
+    float dist[6]{};
+    const float h = ns::SamplePrismShapeScalars(rng, p, dist);
+    ASSERT_EQ(h, kPrismGoldenH[draw]) << "prism height diverged at draw " << draw;
+    for (int i = 0; i < 6; i++) {
+      ASSERT_EQ(dist[i], kPrismGoldenD[draw][i]) << "prism face_distance[" << i << "] diverged at draw " << draw;
+    }
+  }
+}
+
+TEST(ShapeScalarSyncGroupSampling, PyramidNoSyncMatchesPreChangeGolden) {
+  const ns::PyramidCrystalParam p = GoldenPyramidParam();
+  ns::RandomNumberGenerator rng(kPyramidGoldenSeed);
+
+  for (int draw = 0; draw < kGoldenDraws; draw++) {
+    float h1 = 0.f;
+    float h2 = 0.f;
+    float h3 = 0.f;
+    float dist[6]{};
+    ns::SamplePyramidShapeScalars(rng, p, h1, h2, h3, dist);
+    // h1/h2/h3 are upper / prism / lower — the draw order, not the declaration
+    // order of PyramidCrystalParam.
+    ASSERT_EQ(h1, kPyramidGoldenH1[draw]) << "pyramid upper_h diverged at draw " << draw;
+    ASSERT_EQ(h2, kPyramidGoldenH2[draw]) << "pyramid prism_h diverged at draw " << draw;
+    ASSERT_EQ(h3, kPyramidGoldenH3[draw]) << "pyramid lower_h diverged at draw " << draw;
+    for (int i = 0; i < 6; i++) {
+      ASSERT_EQ(dist[i], kPyramidGoldenD[draw][i]) << "pyramid face_distance[" << i << "] diverged at draw " << draw;
+    }
+  }
+}
+
+// The two tests above pin the extracted sampler against the golden. These two
+// pin the *full MakeCrystal pipeline* against the same golden, so a divergence
+// between "what the sampler draws" and "what MakeCrystal actually builds a
+// crystal from" cannot hide: MakeCrystal is the entry point all three backends
+// use, the sampler is only its first half.
+TEST(ShapeScalarSyncGroupSampling, PrismMakeCrystalAgreesWithGoldenGeometry) {
+  const ns::PrismCrystalParam p = GoldenPrismParam();
+  ns::RandomNumberGenerator rng(kPrismGoldenSeed);
+
+  for (int draw = 0; draw < kGoldenDraws; draw++) {
+    const ns::Crystal from_pipeline = ns::MakeCrystal(rng, ns::CrystalParam{ p });
+    float golden_dist[6]{};
+    std::memcpy(golden_dist, kPrismGoldenD[draw], sizeof(golden_dist));
+    const ns::Crystal from_golden = ns::Crystal::CreatePrism(kPrismGoldenH[draw], golden_dist);
+    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_golden.CfGeom()))
+        << "MakeCrystal geometry differs from the golden scalars' geometry at draw " << draw;
+  }
+}
+
+TEST(ShapeScalarSyncGroupSampling, PyramidMakeCrystalAgreesWithGoldenGeometry) {
+  const ns::PyramidCrystalParam p = GoldenPyramidParam();
+  ns::RandomNumberGenerator rng(kPyramidGoldenSeed);
+
+  for (int draw = 0; draw < kGoldenDraws; draw++) {
+    const ns::Crystal from_pipeline = ns::MakeCrystal(rng, ns::CrystalParam{ p });
+    float golden_dist[6]{};
+    std::memcpy(golden_dist, kPyramidGoldenD[draw], sizeof(golden_dist));
+    const ns::Crystal from_golden =
+        ns::Crystal::CreatePyramid(p.wedge_angle_u_, p.wedge_angle_l_, kPyramidGoldenH1[draw], kPyramidGoldenH2[draw],
+                                   kPyramidGoldenH3[draw], golden_dist);
+    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_golden.CfGeom()))
+        << "MakeCrystal geometry differs from the golden scalars' geometry at draw " << draw;
+  }
+}
+
+// ==================================================================================================
+// AC2 — members of one group share one value and one draw.
+
+TEST(ShapeScalarSyncGroupSampling, PrismGroupSharesOneValueAndOneDraw) {
+  constexpr uint32_t kSeed = 4242u;
+  // Group {FACE_0, FACE_2, FACE_4}: the C3 case, one of two alternating groups.
+  // Group members carry the same distribution (this test exercises the sampler,
+  // not NormalizeSyncGroups); the independent slots carry a very different one so
+  // a wrong draw order shows up as a wrong magnitude, not just a wrong bit.
+  const ns::Distribution grouped{ ns::DistributionType::kUniform, 0.0f, 2.0f };
+  const ns::Distribution loner{ ns::DistributionType::kGaussian, 50.0f, 1.0f };
+
+  ns::PrismCrystalParam p;
+  p.h_ = loner;
+  p.d_[0] = p.d_[2] = p.d_[4] = grouped;
+  p.d_[1] = p.d_[3] = p.d_[5] = loner;
+  p.sync_group_[ns::kShapeScalarFace0] = 1;
+  p.sync_group_[ns::kShapeScalarFace2] = 1;
+  p.sync_group_[ns::kShapeScalarFace4] = 1;
+
+  ns::RandomNumberGenerator rng(kSeed);
+  ns::RandomNumberGenerator ref(kSeed);
+
+  // Two consecutive draws: the group cache must be per-crystal, so draw 1 has to
+  // re-draw the group rather than reuse draw 0's value.
+  for (int draw = 0; draw < 2; draw++) {
+    // Hand-replayed expected stream: h, d0, d1, d3, d5 — five draws, in this
+    // order. d2 and d4 consume nothing and reuse d0.
+    const float exp_h = std::abs(ref.Get(p.h_));
+    const float exp_d0 = ref.Get(p.d_[0]);
+    const float exp_d1 = ref.Get(p.d_[1]);
+    const float exp_d3 = ref.Get(p.d_[3]);
+    const float exp_d5 = ref.Get(p.d_[5]);
+
+    float dist[6]{};
+    const float h = ns::SamplePrismShapeScalars(rng, p, dist);
+
+    ASSERT_EQ(h, exp_h) << "draw " << draw;
+    ASSERT_EQ(dist[0], exp_d0) << "draw " << draw;
+    ASSERT_EQ(dist[1], exp_d1) << "draw " << draw;
+    ASSERT_EQ(dist[2], exp_d0) << "grouped face 2 must reuse face 0's value bit-for-bit, draw " << draw;
+    ASSERT_EQ(dist[3], exp_d3) << "draw " << draw;
+    ASSERT_EQ(dist[4], exp_d0) << "grouped face 4 must reuse face 0's value bit-for-bit, draw " << draw;
+    ASSERT_EQ(dist[5], exp_d5) << "draw " << draw;
+  }
+
+  // The two streams are still in lockstep, which is the actual draw-count
+  // assertion: the sampler consumed exactly the 5 draws replayed above per
+  // crystal. Had the grouped slots each drawn (7 per crystal), rng would be 4
+  // draws ahead of ref and this would fail.
+  ASSERT_EQ(rng.GetUniform(), ref.GetUniform()) << "grouped sampling consumed a different number of RNG draws";
+}
+
+TEST(ShapeScalarSyncGroupSampling, PyramidTwoGroupsAlternateIndependently) {
+  constexpr uint32_t kSeed = 909u;
+  // Full C3 habit: {FACE_0, FACE_2, FACE_4} and {FACE_1, FACE_3, FACE_5} each
+  // sync, so the hexagon is (a, b, a, b, a, b) — a single checkbox-style "sync
+  // all" could never express this.
+  ns::PyramidCrystalParam p = GoldenPyramidParam();
+  p.sync_group_[ns::kShapeScalarFace0] = 1;
+  p.sync_group_[ns::kShapeScalarFace2] = 1;
+  p.sync_group_[ns::kShapeScalarFace4] = 1;
+  p.sync_group_[ns::kShapeScalarFace1] = 2;
+  p.sync_group_[ns::kShapeScalarFace3] = 2;
+  p.sync_group_[ns::kShapeScalarFace5] = 2;
+  // Upper and lower pyramidal heights sync too (the symmetric-pyramid case).
+  p.sync_group_[ns::kShapeScalarUpperH] = 3;
+  p.sync_group_[ns::kShapeScalarLowerH] = 3;
+  p.h_pyr_l_ = p.h_pyr_u_;
+
+  ns::RandomNumberGenerator rng(kSeed);
+  for (int draw = 0; draw < 8; draw++) {
+    float h1 = 0.f;
+    float h2 = 0.f;
+    float h3 = 0.f;
+    float dist[6]{};
+    ns::SamplePyramidShapeScalars(rng, p, h1, h2, h3, dist);
+    ASSERT_EQ(dist[0], dist[2]) << "draw " << draw;
+    ASSERT_EQ(dist[0], dist[4]) << "draw " << draw;
+    ASSERT_EQ(dist[1], dist[3]) << "draw " << draw;
+    ASSERT_EQ(dist[1], dist[5]) << "draw " << draw;
+    ASSERT_EQ(h1, h3) << "upper/lower pyramidal heights share a group, draw " << draw;
+    // Distinct groups must not collapse onto each other — a cache keyed on
+    // "any non-zero group" instead of the group id would make these equal.
+    ASSERT_NE(dist[0], dist[1]) << "the two face groups must draw independently, draw " << draw;
+  }
+}
+
+// ==================================================================================================
+// A group spanning a height and a face distance shares the raw draw; the
+// height member folds it with std::abs at its own use site.
+
+TEST(ShapeScalarSyncGroupSampling, MixedHeightFaceGroupSharesRawDrawAndFoldsHeightOnly) {
+  ns::PrismCrystalParam p;
+  // Centered well below zero with a tight spread, so the shared draw is
+  // negative with overwhelming probability — that is what makes the abs()
+  // asymmetry observable at all.
+  p.h_ = ns::Distribution{ ns::DistributionType::kGaussian, -1.0f, 0.01f };
+  p.d_[1] = p.h_;
+  for (int i = 0; i < 6; i++) {
+    if (i != 1) {
+      p.d_[i] = ns::Distribution{ ns::DistributionType::kNoRandom, 1.0f, 0.0f };
+    }
+  }
+  p.sync_group_[ns::kShapeScalarHeight] = 1;
+  p.sync_group_[ns::kShapeScalarFace1] = 1;
+
+  ns::RandomNumberGenerator rng(31337u);
+  for (int draw = 0; draw < 8; draw++) {
+    float dist[6]{};
+    const float h = ns::SamplePrismShapeScalars(rng, p, dist);
+    ASSERT_LT(dist[1], 0.f) << "fixture precondition: the shared draw must be negative, draw " << draw;
+    ASSERT_EQ(h, std::abs(dist[1])) << "height must be the absolute value of the group's shared raw draw, draw "
+                                    << draw;
+  }
+}
+
+}  // namespace

--- a/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
+++ b/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
@@ -11,95 +11,45 @@
 //
 // The suite's first job is a hard compatibility gate: declaring no sync group
 // must leave the RNG stream byte-identical to what MakeCrystal produced before
-// sync groups existed. The kPrism*/kPyramid* golden arrays below were captured
-// from that pre-change implementation (temporary hex-float dump inside
-// CrystalMaker, one rng instance, 20 consecutive MakeCrystal calls), so they are
-// an external oracle rather than a transcription of the new code's own behavior.
-// If they ever need regenerating, that is a red flag, not a chore: every seeded
-// reference in the repo (golden / parity / e2e) moves with this stream.
+// sync groups existed. That gate is written as a CONTRACT REPLAY, not as a table
+// of captured values: a second RandomNumberGenerator on the same seed is driven
+// by hand, in the order the contract fixes (prism h_ then d[0..5]; pyramid
+// h_pyr_u_, h_prs_, h_pyr_l_, then d[0..5] — the draw order, not the declaration
+// order), and the two streams are compared value for value. Both run on the same
+// standard library inside the same binary, so the comparison is bit-exact on
+// every platform; and because the reference is written from the contract rather
+// than transcribed from the sampler, reordering a draw or adding/dropping one
+// still desynchronizes the streams and fails.
+//
+// An earlier form of this gate hard-coded hex-float sample values captured on a
+// single machine. Only std::mt19937 is portable by specification; the adaptors
+// on top of it (normal_distribution, uniform_real_distribution) are
+// implementation defined, and normal_distribution's polar method caches a second
+// value, so even the NUMBER of engine outputs it consumes varies. Such a table
+// can therefore only ever hold on the standard library it was captured on. Same
+// defect family as the platform-dependent pyramid oracle retired in
+// doc/numerical-robustness.md §8, and the same resolution: align on the
+// contract, retire the absolute oracle.
 
 namespace {
 
 namespace ns = lumice;
 
-constexpr int kGoldenDraws = 20;
+// Consecutive draws replayed per test — one rng instance consumed continuously,
+// so the sampler's per-crystal state (the sync-group cache) is exercised across
+// crystals rather than only on a fresh sampler.
+constexpr int kContractReplayDraws = 20;
 
-// Prism golden: rng seed 20260726, h_ = Gaussian(1.0, 0.3), all six
+// Prism fixture: rng seed 20260726, h_ = Gaussian(1.0, 0.3), all six
 // face_distance = Uniform(center 1.0, spread 0.6), sync_group_ all zero.
 constexpr uint32_t kPrismGoldenSeed = 20260726u;
 
-constexpr float kPrismGoldenH[kGoldenDraws] = {
-  0x1.a13438p-1f, 0x1.39f4c2p-1f, 0x1.24d3e2p-1f, 0x1.748ad4p-1f, 0x1.c446fap-1f, 0x1.0deacap+0f, 0x1.8fd5ep-1f,
-  0x1.b1c74p+0f,  0x1.84aa8cp-1f, 0x1.558e3ep-1f, 0x1.354ba2p-1f, 0x1.873076p-1f, 0x1.01221ap-1f, 0x1.2f66b8p+0f,
-  0x1.7a0706p-1f, 0x1.992eeap+0f, 0x1.fa15f6p-2f, 0x1.d9bffcp-1f, 0x1.501b9p-1f,  0x1.bbba1ap-1f,
-};
-constexpr float kPrismGoldenD[kGoldenDraws][6] = {
-  { 0x1.baab4p-1f, 0x1.168e16p+0f, 0x1.d08ap-1f, 0x1.4871fap+0f, 0x1.3e0ba4p+0f, 0x1.32e02cp+0f },
-  { 0x1.7b4f8p-1f, 0x1.fe6176p-1f, 0x1.9bf48ep-1f, 0x1.148a0ep+0f, 0x1.6a2718p-1f, 0x1.c623e8p-1f },
-  { 0x1.2cbdf6p+0f, 0x1.2df93cp+0f, 0x1.372e78p+0f, 0x1.0936ccp+0f, 0x1.39aa72p+0f, 0x1.6d2fe6p-1f },
-  { 0x1.0eb29ap+0f, 0x1.093b6p+0f, 0x1.0c32e6p+0f, 0x1.37b9ecp+0f, 0x1.36b908p+0f, 0x1.96854cp-1f },
-  { 0x1.3dcb94p+0f, 0x1.673de2p-1f, 0x1.3eea96p+0f, 0x1.28f61cp+0f, 0x1.b25016p-1f, 0x1.c93b7ep-1f },
-  { 0x1.e0fac2p-1f, 0x1.2949f2p+0f, 0x1.1ffdd4p+0f, 0x1.397fe4p+0f, 0x1.94118p-1f, 0x1.cdcc5ep-1f },
-  { 0x1.9479a2p-1f, 0x1.b89218p-1f, 0x1.1b34bcp+0f, 0x1.21dc06p+0f, 0x1.0d74bcp+0f, 0x1.099feap+0f },
-  { 0x1.19271ap+0f, 0x1.e33a4ep-1f, 0x1.1afdb8p+0f, 0x1.1cf0c2p+0f, 0x1.412f1p+0f, 0x1.2e6c52p+0f },
-  { 0x1.0de706p+0f, 0x1.38eb18p+0f, 0x1.bd1b74p-1f, 0x1.07eb0ap+0f, 0x1.2d0a9cp+0f, 0x1.c3f55ep-1f },
-  { 0x1.1bf264p+0f, 0x1.2f14c8p+0f, 0x1.32adb8p+0f, 0x1.3b773ep+0f, 0x1.1c1d7ap+0f, 0x1.427252p+0f },
-  { 0x1.45401cp+0f, 0x1.a4984ep-1f, 0x1.42f59p+0f, 0x1.e5b6b2p-1f, 0x1.0ed59ap+0f, 0x1.26cf34p+0f },
-  { 0x1.88d9d8p-1f, 0x1.3155fcp+0f, 0x1.c73324p-1f, 0x1.f08432p-1f, 0x1.3ac3aep+0f, 0x1.d6ee94p-1f },
-  { 0x1.f0da26p-1f, 0x1.0259e4p+0f, 0x1.fbbf2ep-1f, 0x1.cd3404p-1f, 0x1.4acb46p+0f, 0x1.d6059p-1f },
-  { 0x1.49b702p+0f, 0x1.66a51ap-1f, 0x1.9b6a44p-1f, 0x1.e6f32p-1f, 0x1.2875eep+0f, 0x1.a4844ap-1f },
-  { 0x1.49e9acp+0f, 0x1.d9ee96p-1f, 0x1.2d758ep+0f, 0x1.1a9b04p+0f, 0x1.a4d6f2p-1f, 0x1.17e6fep+0f },
-  { 0x1.1e24ap+0f, 0x1.ea83e4p-1f, 0x1.6f1c26p-1f, 0x1.0604f8p+0f, 0x1.3a3578p+0f, 0x1.30f41p+0f },
-  { 0x1.fec928p-1f, 0x1.8e5e74p-1f, 0x1.c773b4p-1f, 0x1.ef983ap-1f, 0x1.94658p-1f, 0x1.88760cp-1f },
-  { 0x1.0fdc5ep+0f, 0x1.80544cp-1f, 0x1.97a49cp-1f, 0x1.257b3cp+0f, 0x1.bb6bc4p-1f, 0x1.2e5fb8p+0f },
-  { 0x1.2864e8p+0f, 0x1.433df6p+0f, 0x1.ce2f64p-1f, 0x1.f0d9a8p-1f, 0x1.cf4f7cp-1f, 0x1.2adfd8p+0f },
-  { 0x1.11d8a4p+0f, 0x1.0506d2p+0f, 0x1.21f06cp+0f, 0x1.a33a82p-1f, 0x1.93754p-1f, 0x1.153592p+0f },
-};
-
-// Pyramid golden: rng seed 20260727, h_pyr_u_ = Gaussian(0.3, 0.1),
+// Pyramid fixture: rng seed 20260727, h_pyr_u_ = Gaussian(0.3, 0.1),
 // h_prs_ = Uniform(center 1.0, spread 0.4), h_pyr_l_ = Laplacian(0.3, 0.1) —
 // three deliberately different distribution types, so a mixed-up draw order
 // between the three heights cannot pass unnoticed. All six face_distance =
 // Gaussian(1.0, 0.5), sync_group_ all zero.
 constexpr uint32_t kPyramidGoldenSeed = 20260727u;
-
-constexpr float kPyramidGoldenH1[kGoldenDraws] = {
-  0x1.764b88p-2f, 0x1.85ee1ep-2f, 0x1.8dcc86p-3f, 0x1.8d6cd8p-2f, 0x1.862c92p-2f, 0x1.bccc7cp-2f, 0x1.fd17f2p-3f,
-  0x1.3c7eaap-3f, 0x1.893176p-4f, 0x1.f00f8cp-3f, 0x1.0498d4p-2f, 0x1.a73358p-2f, 0x1.ca30eep-2f, 0x1.2c1962p-2f,
-  0x1.35e4a4p-2f, 0x1.fb92b6p-3f, 0x1.359ab6p-2f, 0x1.34c628p-2f, 0x1.881ddcp-2f, 0x1.45e57ap-2f,
-};
-constexpr float kPyramidGoldenH2[kGoldenDraws] = {
-  0x1.1f995ap+0f, 0x1.cbaa3cp-1f, 0x1.1c552cp+0f, 0x1.1aae94p+0f, 0x1.05e6dep+0f, 0x1.1c2648p+0f, 0x1.02a6aap+0f,
-  0x1.25893ap+0f, 0x1.2d012p+0f,  0x1.26db9p+0f,  0x1.12bb64p+0f, 0x1.a78cdp-1f,  0x1.9dfe0ep-1f, 0x1.11eac6p+0f,
-  0x1.097a04p+0f, 0x1.19b9d2p+0f, 0x1.f2b008p-1f, 0x1.c4c67cp-1f, 0x1.ab68f2p-1f, 0x1.2bdb4ap+0f,
-};
-constexpr float kPyramidGoldenH3[kGoldenDraws] = {
-  0x1.aaed8ep-2f, 0x1.e81ap-4f,   0x1.258016p-2f, 0x1.490ddep-2f, 0x1.2f71e6p-2f, 0x1.d33a5cp-3f, 0x1.3a1654p-2f,
-  0x1.7ece8p-2f,  0x1.25678p-2f,  0x1.718ce4p-2f, 0x1.833d48p-3f, 0x1.382d64p-2f, 0x1.d0ee5cp-2f, 0x1.0ef692p-3f,
-  0x1.431cdcp-4f, 0x1.2eb044p-2f, 0x1.6303cp-2f,  0x1.e6b0d6p-4f, 0x1.2acd68p-2f, 0x1.ed6e32p-3f,
-};
-constexpr float kPyramidGoldenD[kGoldenDraws][6] = {
-  { 0x1.77b53p+0f, 0x1.cad678p-2f, 0x1.53d0f8p-1f, 0x1.f37f5p-2f, 0x1.14429p+1f, 0x1.a089eep-1f },
-  { 0x1.48d38p-6f, 0x1.ee3578p-1f, 0x1.65ef64p+0f, 0x1.a08d74p-1f, 0x1.6f6ad2p-1f, 0x1.139276p+0f },
-  { 0x1.d62dap-2f, 0x1.d65be4p-1f, 0x1.ac5834p-2f, 0x1.25633ep-1f, 0x1.7c9316p+0f, 0x1.23d864p-1f },
-  { 0x1.28d99cp+0f, 0x1.14aa22p+0f, 0x1.b549dap-1f, 0x1.ea8e84p-2f, 0x1.5d1c7ep-1f, -0x1.60eacp-5f },
-  { 0x1.2585e4p-2f, 0x1.e1dbecp-1f, 0x1.dcb7cp-1f, 0x1.a8b88p+0f, 0x1.5b0cf4p+0f, 0x1.00e098p-2f },
-  { 0x1.61c2eep-1f, 0x1.05197cp+0f, 0x1.4aa888p-1f, 0x1.b0e758p-1f, 0x1.b2d7ecp-2f, 0x1.22678cp-1f },
-  { 0x1.7b0bp+0f, 0x1.5d48ep+0f, 0x1.25d24p-2f, 0x1.a0108cp-2f, 0x1.443d86p+0f, 0x1.10b9fcp+0f },
-  { 0x1.ccdefap+0f, 0x1.f9ecccp-1f, 0x1.3ef062p+1f, 0x1.f1a694p-1f, 0x1.99e0f6p+0f, 0x1.246cecp+1f },
-  { 0x1.4b3aacp+0f, 0x1.2958e6p+0f, 0x1.b1e866p-1f, 0x1.06f37ep+0f, 0x1.77aa4p-1f, 0x1.536a88p+1f },
-  { 0x1.0e5c2ep+0f, 0x1.474bf4p+0f, 0x1.555696p+0f, 0x1.956e76p-1f, 0x1.f14ac8p+0f, 0x1.eb6654p-1f },
-  { 0x1.2405f2p-1f, 0x1.91859ep+0f, 0x1.49589ap+0f, 0x1.9e3c62p-1f, 0x1.db26dcp+0f, 0x1.7605ccp+0f },
-  { 0x1.8278ep+0f, 0x1.131f22p+1f, 0x1.1fa8cp+0f, 0x1.427faep+0f, 0x1.3db826p+0f, 0x1.0b5ffp-2f },
-  { 0x1.01d42cp-1f, 0x1.5dd4dep-1f, 0x1.492a9cp+0f, 0x1.8647d4p-1f, 0x1.0a6636p+0f, 0x1.2a0618p+0f },
-  { 0x1.5790e8p-1f, 0x1.b58cfcp-1f, 0x1.ed8696p-1f, 0x1.57e4cp-1f, 0x1.0f66a6p+0f, 0x1.c73d4cp-1f },
-  { 0x1.80e57p+0f, 0x1.2862ep-1f, 0x1.0f8e5ep+1f, 0x1.7e8d58p-2f, 0x1.7a023cp-1f, 0x1.2eeb62p+0f },
-  { 0x1.38af62p-1f, 0x1.855638p+0f, 0x1.0881c6p-1f, 0x1.625268p-1f, 0x1.638412p+0f, 0x1.57064ap+0f },
-  { 0x1.2b869ep+0f, 0x1.0f2646p+0f, 0x1.4a598p-1f, 0x1.031cep+0f, 0x1.cd4998p+0f, 0x1.fdc336p+0f },
-  { 0x1.0584c8p-1f, 0x1.89a9dp+0f, 0x1.13448ep+0f, 0x1.516788p-2f, 0x1.07c95p+0f, 0x1.69c4f6p+0f },
-  { 0x1.08b95p-1f, 0x1.064a02p+1f, 0x1.6c7e5p+0f, 0x1.d5842ep-1f, 0x1.06741p+0f, 0x1.73fc64p+0f },
-  { 0x1.af4544p-2f, 0x1.c15a4p+0f, 0x1.4d0fc8p+0f, 0x1.fba91p-2f, 0x1.205d4cp-1f, 0x1.952238p+0f },
-};
 
 ns::PrismCrystalParam GoldenPrismParam() {
   ns::PrismCrystalParam p;
@@ -128,76 +78,114 @@ bool CfGeomBytesEqual(const ns::CrystalGeom& a, const ns::CrystalGeom& b) {
 // ==================================================================================================
 // AC1 — no sync declaration must not perturb the RNG stream, value for value.
 
-TEST(ShapeScalarSyncGroupSampling, PrismNoSyncMatchesPreChangeGolden) {
+TEST(ShapeScalarSyncGroupSampling, PrismNoSyncMatchesContractOrder) {
   const ns::PrismCrystalParam p = GoldenPrismParam();
   ns::RandomNumberGenerator rng(kPrismGoldenSeed);
+  ns::RandomNumberGenerator ref(kPrismGoldenSeed);
 
-  // One rng instance, consumed continuously across the draws — exactly the
-  // lifecycle the golden was captured under. Rebuilding it per draw would reset
-  // the stream and make every row identical.
-  for (int draw = 0; draw < kGoldenDraws; draw++) {
+  // One rng instance each, consumed continuously across the draws — the
+  // lifecycle MakeCrystal runs under. Rebuilding them per draw would reset both
+  // streams and make every row identical.
+  for (int draw = 0; draw < kContractReplayDraws; draw++) {
+    // Hand-replayed contract stream: h_, then d[0..5] — seven draws in this
+    // order. std::abs folds the height only, matching the fold site inside
+    // SamplePrismShapeScalars; face_distance stays signed.
+    const float exp_h = std::abs(ref.Get(p.h_));
+    float exp_dist[6]{};
+    for (int i = 0; i < 6; i++) {
+      exp_dist[i] = ref.Get(p.d_[i]);
+    }
+
     float dist[6]{};
     const float h = ns::SamplePrismShapeScalars(rng, p, dist);
-    ASSERT_EQ(h, kPrismGoldenH[draw]) << "prism height diverged at draw " << draw;
+    ASSERT_EQ(h, exp_h) << "prism height diverged at draw " << draw;
     for (int i = 0; i < 6; i++) {
-      ASSERT_EQ(dist[i], kPrismGoldenD[draw][i]) << "prism face_distance[" << i << "] diverged at draw " << draw;
+      ASSERT_EQ(dist[i], exp_dist[i]) << "prism face_distance[" << i << "] diverged at draw " << draw;
     }
   }
+
+  // Both streams must still sit at the same position: a sampler that drew an
+  // extra value (or one fewer) somewhere could in principle still have matched
+  // every assertion above only if the surplus draw came last, which this catches.
+  ASSERT_EQ(rng.GetUniform(), ref.GetUniform()) << "prism sampling consumed a different number of RNG draws";
 }
 
-TEST(ShapeScalarSyncGroupSampling, PyramidNoSyncMatchesPreChangeGolden) {
+TEST(ShapeScalarSyncGroupSampling, PyramidNoSyncMatchesContractOrder) {
   const ns::PyramidCrystalParam p = GoldenPyramidParam();
   ns::RandomNumberGenerator rng(kPyramidGoldenSeed);
+  ns::RandomNumberGenerator ref(kPyramidGoldenSeed);
 
-  for (int draw = 0; draw < kGoldenDraws; draw++) {
+  for (int draw = 0; draw < kContractReplayDraws; draw++) {
+    // Contract stream: upper, prism, lower height, then d[0..5] — the draw
+    // order, not the declaration order of PyramidCrystalParam. All three
+    // heights fold with std::abs, the face distances do not.
+    const float exp_h1 = std::abs(ref.Get(p.h_pyr_u_));
+    const float exp_h2 = std::abs(ref.Get(p.h_prs_));
+    const float exp_h3 = std::abs(ref.Get(p.h_pyr_l_));
+    float exp_dist[6]{};
+    for (int i = 0; i < 6; i++) {
+      exp_dist[i] = ref.Get(p.d_[i]);
+    }
+
     float h1 = 0.f;
     float h2 = 0.f;
     float h3 = 0.f;
     float dist[6]{};
     ns::SamplePyramidShapeScalars(rng, p, h1, h2, h3, dist);
-    // h1/h2/h3 are upper / prism / lower — the draw order, not the declaration
-    // order of PyramidCrystalParam.
-    ASSERT_EQ(h1, kPyramidGoldenH1[draw]) << "pyramid upper_h diverged at draw " << draw;
-    ASSERT_EQ(h2, kPyramidGoldenH2[draw]) << "pyramid prism_h diverged at draw " << draw;
-    ASSERT_EQ(h3, kPyramidGoldenH3[draw]) << "pyramid lower_h diverged at draw " << draw;
+    ASSERT_EQ(h1, exp_h1) << "pyramid upper_h diverged at draw " << draw;
+    ASSERT_EQ(h2, exp_h2) << "pyramid prism_h diverged at draw " << draw;
+    ASSERT_EQ(h3, exp_h3) << "pyramid lower_h diverged at draw " << draw;
     for (int i = 0; i < 6; i++) {
-      ASSERT_EQ(dist[i], kPyramidGoldenD[draw][i]) << "pyramid face_distance[" << i << "] diverged at draw " << draw;
+      ASSERT_EQ(dist[i], exp_dist[i]) << "pyramid face_distance[" << i << "] diverged at draw " << draw;
     }
   }
+
+  ASSERT_EQ(rng.GetUniform(), ref.GetUniform()) << "pyramid sampling consumed a different number of RNG draws";
 }
 
-// The two tests above pin the extracted sampler against the golden. These two
-// pin the *full MakeCrystal pipeline* against the same golden, so a divergence
+// The two tests above pin the extracted sampler against the contract. These two
+// pin the *full MakeCrystal pipeline* against the same contract, so a divergence
 // between "what the sampler draws" and "what MakeCrystal actually builds a
 // crystal from" cannot hide: MakeCrystal is the entry point all three backends
 // use, the sampler is only its first half.
-TEST(ShapeScalarSyncGroupSampling, PrismMakeCrystalAgreesWithGoldenGeometry) {
+TEST(ShapeScalarSyncGroupSampling, PrismMakeCrystalAgreesWithContractGeometry) {
   const ns::PrismCrystalParam p = GoldenPrismParam();
   ns::RandomNumberGenerator rng(kPrismGoldenSeed);
+  ns::RandomNumberGenerator ref(kPrismGoldenSeed);
 
-  for (int draw = 0; draw < kGoldenDraws; draw++) {
+  for (int draw = 0; draw < kContractReplayDraws; draw++) {
+    const float ref_h = std::abs(ref.Get(p.h_));
+    float ref_dist[6]{};
+    for (int i = 0; i < 6; i++) {
+      ref_dist[i] = ref.Get(p.d_[i]);
+    }
+
     const ns::Crystal from_pipeline = ns::MakeCrystal(rng, ns::CrystalParam{ p });
-    float golden_dist[6]{};
-    std::memcpy(golden_dist, kPrismGoldenD[draw], sizeof(golden_dist));
-    const ns::Crystal from_golden = ns::Crystal::CreatePrism(kPrismGoldenH[draw], golden_dist);
-    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_golden.CfGeom()))
-        << "MakeCrystal geometry differs from the golden scalars' geometry at draw " << draw;
+    const ns::Crystal from_contract = ns::Crystal::CreatePrism(ref_h, ref_dist);
+    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_contract.CfGeom()))
+        << "MakeCrystal geometry differs from the contract-order scalars' geometry at draw " << draw;
   }
 }
 
-TEST(ShapeScalarSyncGroupSampling, PyramidMakeCrystalAgreesWithGoldenGeometry) {
+TEST(ShapeScalarSyncGroupSampling, PyramidMakeCrystalAgreesWithContractGeometry) {
   const ns::PyramidCrystalParam p = GoldenPyramidParam();
   ns::RandomNumberGenerator rng(kPyramidGoldenSeed);
+  ns::RandomNumberGenerator ref(kPyramidGoldenSeed);
 
-  for (int draw = 0; draw < kGoldenDraws; draw++) {
+  for (int draw = 0; draw < kContractReplayDraws; draw++) {
+    const float ref_h1 = std::abs(ref.Get(p.h_pyr_u_));
+    const float ref_h2 = std::abs(ref.Get(p.h_prs_));
+    const float ref_h3 = std::abs(ref.Get(p.h_pyr_l_));
+    float ref_dist[6]{};
+    for (int i = 0; i < 6; i++) {
+      ref_dist[i] = ref.Get(p.d_[i]);
+    }
+
     const ns::Crystal from_pipeline = ns::MakeCrystal(rng, ns::CrystalParam{ p });
-    float golden_dist[6]{};
-    std::memcpy(golden_dist, kPyramidGoldenD[draw], sizeof(golden_dist));
-    const ns::Crystal from_golden =
-        ns::Crystal::CreatePyramid(p.wedge_angle_u_, p.wedge_angle_l_, kPyramidGoldenH1[draw], kPyramidGoldenH2[draw],
-                                   kPyramidGoldenH3[draw], golden_dist);
-    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_golden.CfGeom()))
-        << "MakeCrystal geometry differs from the golden scalars' geometry at draw " << draw;
+    const ns::Crystal from_contract =
+        ns::Crystal::CreatePyramid(p.wedge_angle_u_, p.wedge_angle_l_, ref_h1, ref_h2, ref_h3, ref_dist);
+    EXPECT_TRUE(CfGeomBytesEqual(from_pipeline.CfGeom(), from_contract.CfGeom()))
+        << "MakeCrystal geometry differs from the contract-order scalars' geometry at draw " << draw;
   }
 }
 

--- a/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
+++ b/test/unit-correctness/core/test_crystal_sync_group_sampling.cpp
@@ -104,9 +104,10 @@ TEST(ShapeScalarSyncGroupSampling, PrismNoSyncMatchesContractOrder) {
     }
   }
 
-  // Both streams must still sit at the same position: a sampler that drew an
-  // extra value (or one fewer) somewhere could in principle still have matched
-  // every assertion above only if the surplus draw came last, which this catches.
+  // Both streams must still sit at the same position. A miscount anywhere in the
+  // middle already shows up as a value mismatch on the next draw, but one that
+  // lands after the LAST replayed crystal's final draw would pass every
+  // assertion above; this is the only thing that catches it.
   ASSERT_EQ(rng.GetUniform(), ref.GetUniform()) << "prism sampling consumed a different number of RNG draws";
 }
 
@@ -140,6 +141,7 @@ TEST(ShapeScalarSyncGroupSampling, PyramidNoSyncMatchesContractOrder) {
     }
   }
 
+  // Same trailing-miscount guard as the prism case above.
   ASSERT_EQ(rng.GetUniform(), ref.GetUniform()) << "pyramid sampling consumed a different number of RNG draws";
 }
 

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -3,10 +3,12 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <set>
@@ -15,7 +17,8 @@
 #include <thread>
 #include <vector>
 
-#include "config/filter_config.hpp"         // core FilterConfig + to_json, for emit isomorphism cross-check
+#include "config/crystal_config.hpp"  // core PrismCrystalParam + from_json, the sync-group canonical-form authority
+#include "config/filter_config.hpp"   // core FilterConfig + to_json, for emit isomorphism cross-check
 #include "config/raypath_color_config.hpp"  // core RaypathColorConfig + to_json, for color-class isomorphism
 #include "core/crystal.hpp"
 #include "core/def.hpp"
@@ -2412,6 +2415,261 @@ TEST(DistributionRoundTrip, CommitsToRealServer) {
 
   LUMICE_StopServer(server);
   LUMICE_DestroyServer(server);
+}
+
+// =====================================================================================
+// v4.13 shape-scalar sync groups: LUMICE_CrystalParam.sync_group[] across the C API.
+//
+// The struct field is the whole point of this surface: core has expressed sync groups since
+// v4.12, but with no slot here every declaration made through a config file / the GUI / a python
+// caller was dropped in translation — core received all-zero and nothing warned. So the tests
+// below deliberately cover BOTH halves: the C API's own verbatim round-trip (this layer must not
+// invent semantics), and what core actually does with the JSON this layer emits (the layer must
+// not emit a key core cannot read — the exact failure mode this task exists to close).
+// =====================================================================================
+
+namespace {
+
+// Signed plane offset (centroid · unit normal) of every prism face (face numbers 3..8) in `mesh`,
+// in face_number order. Deliberately measured off the geometry rather than assuming a
+// face_number <-> face_distance[i] mapping, so the assertions below stay true statements about
+// "same-group faces sit at the same distance" no matter how the two are ordered internally.
+std::vector<float> PrismFacePlaneOffsets(const LUMICE_CrystalMesh& mesh) {
+  std::vector<float> offsets(6, std::numeric_limits<float>::quiet_NaN());
+  for (int fi = 0; fi < mesh.face_count; ++fi) {
+    const int fn = mesh.face_numbers_by_face[fi];
+    if (fn < 3 || fn > 8) {
+      continue;  // basal / pyramidal
+    }
+    const int offset = mesh.face_vtx_offsets[fi];
+    const int count = mesh.face_vtx_counts[fi];
+    if (count <= 0) {
+      continue;
+    }
+    float c[3] = { 0.0f, 0.0f, 0.0f };
+    for (int k = 0; k < count; ++k) {
+      const float* p = mesh.vertices + mesh.face_vtx_pool[offset + k] * 3;
+      c[0] += p[0];
+      c[1] += p[1];
+      c[2] += p[2];
+    }
+    const float* n = mesh.face_normals + fi * 3;
+    offsets[fn - 3] = (c[0] * n[0] + c[1] * n[1] + c[2] * n[2]) / static_cast<float>(count);
+  }
+  return offsets;
+}
+
+// Number of distinct values in `v` under `tol`. Used to phrase "the three C3-equivalent faces
+// collapsed onto one distance" without naming which faces those are.
+size_t CountDistinct(const std::vector<float>& v, float tol) {
+  std::vector<float> uniq;
+  for (float x : v) {
+    if (std::none_of(uniq.begin(), uniq.end(), [&](float u) { return std::fabs(u - x) <= tol; })) {
+      uniq.push_back(x);
+    }
+  }
+  return uniq.size();
+}
+
+void ExpectSyncGroupEq(const LUMICE_CrystalParam& out, const LUMICE_CrystalParam& in) {
+  for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; ++i) {
+    EXPECT_EQ(out.sync_group[i], in.sync_group[i]) << "sync_group slot " << i;
+  }
+}
+
+}  // namespace
+
+// AC1 form (a): six prism faces in two C3-symmetric groups — the motivating case.
+TEST(SyncGroupRoundTrip, PrismFacesOnly) {
+  LUMICE_CrystalParam cr = MakePrismParam(1.0f);
+  cr.id = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_0] = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_2] = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_4] = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_1] = 2;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_3] = 2;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_5] = 2;
+  ExpectSyncGroupEq(RoundTripCrystal(cr), cr);
+}
+
+// AC1 form (b): the pyramid arm, grouping two of the three height scalars. Also guards the
+// index-order trap — UPPER_H is slot 1 and PRISM_H slot 2, the reverse of this struct's field
+// declaration order, so a translation written by field position instead of by name lands on the
+// wrong keys and this test goes red.
+TEST(SyncGroupRoundTrip, PyramidHeightsOnly) {
+  LUMICE_CrystalParam cr = MakePyramidParam(1.0f, 0.5f, 0.5f);
+  cr.id = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_UPPER_H] = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_LOWER_H] = 1;
+  ExpectSyncGroupEq(RoundTripCrystal(cr), cr);
+}
+
+// AC1 form (c): a group spanning two different scalar KINDS (a height and a face distance).
+// Mixing dimensions is deliberately permitted — the mechanism shares a draw, it does not claim
+// the members are commensurable — so the translation must not quietly drop the cross-kind edge.
+TEST(SyncGroupRoundTrip, MixedHeightAndFace) {
+  LUMICE_CrystalParam cr = MakePrismParam(1.0f);
+  cr.id = 1;
+  cr.height = LUMICE_Distribution{ LUMICE_DIST_GAUSS, 1.0f, 0.1f };
+  cr.face_distance[0] = LUMICE_Distribution{ LUMICE_DIST_GAUSS, 1.0f, 0.1f };
+  cr.sync_group[LUMICE_SHAPE_SCALAR_HEIGHT] = 1;
+  cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_0] = 1;
+  const auto out = RoundTripCrystal(cr);
+  ExpectSyncGroupEq(out, cr);
+  // Both members' distributions survive the trip too (this layer translates; it does not
+  // leader-normalize — that happens once, in core).
+  EXPECT_EQ(out.height.type, LUMICE_DIST_GAUSS);
+  EXPECT_FLOAT_EQ(out.height.center, 1.0f);
+  EXPECT_FLOAT_EQ(out.height.spread, 0.1f);
+  EXPECT_EQ(out.face_distance[0].type, LUMICE_DIST_GAUSS);
+  EXPECT_FLOAT_EQ(out.face_distance[0].center, 1.0f);
+  EXPECT_FLOAT_EQ(out.face_distance[0].spread, 0.1f);
+}
+
+// AC2: a zero-initialized param stays all-independent through the round trip.
+TEST(SyncGroupRoundTrip, ZeroInitStaysIndependent) {
+  LUMICE_CrystalParam cr = MakePrismParam(1.0f);  // built from LUMICE_CrystalParam{}
+  cr.id = 1;
+  const auto out = RoundTripCrystal(cr);
+  for (int i = 0; i < LUMICE_SHAPE_SCALAR_COUNT; ++i) {
+    EXPECT_EQ(out.sync_group[i], 0) << "sync_group slot " << i;
+  }
+}
+
+// AC2, the stronger half: "all independent" must not merely round-trip, it must leave the wire
+// form untouched — no `sync_group` key at all — so every pre-v4.13 config serializes byte for
+// byte as it did before. The second half is the green counterpart: the key DOES appear once
+// something is actually synced, so the first assertion cannot pass by never emitting anything.
+TEST(SyncGroupWireForm, KeyOmittedWhenAllIndependent) {
+  ConfigScratch cfg{};
+  ConfigScratchGuard cfg_guard(cfg);
+  cfg.crystal_count = 1;
+  cfg.crystals[0] = MakePrismParam(1.0f);
+  cfg.crystals[0].id = 1;
+  EXPECT_EQ(ScratchToJson(cfg).find("sync_group"), std::string::npos);
+
+  cfg.crystals[0].sync_group[LUMICE_SHAPE_SCALAR_FACE_0] = 1;
+  cfg.crystals[0].sync_group[LUMICE_SHAPE_SCALAR_FACE_3] = 1;
+  EXPECT_NE(ScratchToJson(cfg).find("sync_group"), std::string::npos);
+}
+
+// AC3: the preview path. LUMICE_GetCrystalMesh needs no change of its own — it already routes
+// through CrystalShapeToJson -> core from_json -> MakeCrystal — so teaching that translation
+// about sync_group is enough for the mesh to honor grouping. Asserted white-box on the geometry
+// (same-group faces sit at the same plane offset), not by eye.
+TEST(SyncGroupPreview, GroupedFacesShareDistance) {
+  // Control: two faces declared at DIFFERENT distances and NOT synced -> the mesh shows two
+  // distinct prism-face offsets. Without this the grouped case below could pass on a mesh that
+  // ignores face_distance entirely.
+  LUMICE_CrystalParam ungrouped = MakePrismParam(1.0f);
+  ungrouped.id = 1;
+  ungrouped.face_distance[2] = DetDist(1.5f);
+  LUMICE_CrystalMesh mesh{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&ungrouped, /*sample_seed=*/7, &mesh), LUMICE_OK);
+  const auto ungrouped_offsets = PrismFacePlaneOffsets(mesh);
+  EXPECT_EQ(CountDistinct(ungrouped_offsets, 1e-5f), 2u);
+
+  // Same two scalars, now in one group. The leader is the lower ShapeScalar index (FACE_0, the
+  // 1.0), so BOTH land on the leader's value: all six faces collapse onto the single distance
+  // the ungrouped mesh showed five of. This distinguishes "leader wins" from "some member wins".
+  LUMICE_CrystalParam grouped = ungrouped;
+  grouped.sync_group[LUMICE_SHAPE_SCALAR_FACE_0] = 1;
+  grouped.sync_group[LUMICE_SHAPE_SCALAR_FACE_2] = 1;
+  LUMICE_CrystalMesh grouped_mesh{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&grouped, /*sample_seed=*/7, &grouped_mesh), LUMICE_OK);
+  const auto grouped_offsets = PrismFacePlaneOffsets(grouped_mesh);
+  ASSERT_EQ(CountDistinct(grouped_offsets, 1e-5f), 1u);
+
+  // ...and that single distance is the leader's, i.e. the one five of the ungrouped faces had.
+  LUMICE_CrystalParam all_leader = MakePrismParam(1.0f);  // all six at the leader's 1.0
+  all_leader.id = 1;
+  LUMICE_CrystalMesh leader_mesh{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&all_leader, /*sample_seed=*/7, &leader_mesh), LUMICE_OK);
+  const auto leader_offsets = PrismFacePlaneOffsets(leader_mesh);
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(grouped_offsets[i], leader_offsets[i], 1e-5f) << "prism face " << (i + 3);
+  }
+}
+
+// AC3, the payload case: with RANDOMIZED face distances, a C3 grouping must make the sampled
+// mesh itself C3-symmetric — three faces on one drawn distance, three on another. This is what
+// a shared draw buys that leader normalization alone cannot; the control shows six independent
+// draws produce six distinct distances.
+TEST(SyncGroupPreview, C3GroupingCollapsesRandomDrawsToTwo) {
+  LUMICE_CrystalParam cr = MakePrismParam(1.0f);
+  cr.id = 1;
+  for (auto& fd : cr.face_distance) {
+    fd = LUMICE_Distribution{ LUMICE_DIST_GAUSS, 1.0f, 0.1f };
+  }
+
+  LUMICE_CrystalMesh independent_mesh{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&cr, /*sample_seed=*/12345, &independent_mesh), LUMICE_OK);
+  EXPECT_EQ(CountDistinct(PrismFacePlaneOffsets(independent_mesh), 1e-5f), 6u);
+
+  for (int i = 0; i < 6; ++i) {
+    cr.sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = (i % 2 == 0) ? 1 : 2;
+  }
+  LUMICE_CrystalMesh c3_mesh{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&cr, /*sample_seed=*/12345, &c3_mesh), LUMICE_OK);
+  const auto c3_offsets = PrismFacePlaneOffsets(c3_mesh);
+  ASSERT_EQ(CountDistinct(c3_offsets, 1e-5f), 2u);
+  EXPECT_NEAR(c3_offsets[0], c3_offsets[2], 1e-5f);
+  EXPECT_NEAR(c3_offsets[2], c3_offsets[4], 1e-5f);
+  EXPECT_NEAR(c3_offsets[1], c3_offsets[3], 1e-5f);
+  EXPECT_NEAR(c3_offsets[3], c3_offsets[5], 1e-5f);
+}
+
+// AC4: group ids are labels for a partition, not values. Two spellings of the SAME partition must
+// reach core as the same canonical form. Consumed through core's own from_json — the single
+// authority on what "canonical" means — rather than re-deriving the rule here.
+TEST(SyncGroupCanonicalForm, EquivalentPartitionsCollapse) {
+  LUMICE_CrystalParam canonical = MakePrismParam(1.0f);
+  canonical.id = 1;
+  LUMICE_CrystalParam relabeled = canonical;
+  for (int i = 0; i < 6; ++i) {
+    canonical.sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = (i % 2 == 0) ? 1 : 2;
+    relabeled.sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = (i % 2 == 0) ? 2 : 1;
+  }
+
+  const auto a = CrystalShapeToJson(canonical).at("shape").get<lumice::PrismCrystalParam>();
+  const auto b = CrystalShapeToJson(relabeled).at("shape").get<lumice::PrismCrystalParam>();
+
+  // Guard first: both must actually carry groups. Without this the equality below would also be
+  // satisfied by the pre-v4.13 bug — a key core never reads, both sides silently all-zero.
+  bool any_grouped = false;
+  for (int i = 0; i < lumice::kShapeScalarCount; ++i) {
+    any_grouped = any_grouped || a.sync_group_[i] != 0;
+  }
+  ASSERT_TRUE(any_grouped) << "core received no sync group at all — C API key name drift?";
+
+  for (int i = 0; i < lumice::kShapeScalarCount; ++i) {
+    EXPECT_EQ(a.sync_group_[i], b.sync_group_[i]) << "sync_group_ slot " << i;
+  }
+}
+
+// AC4 at the level a user can observe: the two spellings sample the same crystal. Randomized
+// distributions make this a statement about the RNG draw sequence, not just about stored ids.
+TEST(SyncGroupCanonicalForm, EquivalentPartitionsSampleIdenticalMesh) {
+  LUMICE_CrystalParam canonical = MakePrismParam(1.0f);
+  canonical.id = 1;
+  for (auto& fd : canonical.face_distance) {
+    fd = LUMICE_Distribution{ LUMICE_DIST_GAUSS, 1.0f, 0.1f };
+  }
+  LUMICE_CrystalParam relabeled = canonical;
+  for (int i = 0; i < 6; ++i) {
+    canonical.sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = (i % 2 == 0) ? 1 : 2;
+    relabeled.sync_group[LUMICE_SHAPE_SCALAR_FACE_0 + i] = (i % 2 == 0) ? 2 : 1;
+  }
+
+  LUMICE_CrystalMesh mesh_a{};
+  LUMICE_CrystalMesh mesh_b{};
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&canonical, /*sample_seed=*/999, &mesh_a), LUMICE_OK);
+  ASSERT_EQ(LUMICE_GetCrystalMesh(&relabeled, /*sample_seed=*/999, &mesh_b), LUMICE_OK);
+  ASSERT_EQ(mesh_a.vertex_count, mesh_b.vertex_count);
+  ASSERT_GT(mesh_a.vertex_count, 0);
+  for (int i = 0; i < mesh_a.vertex_count * 3; ++i) {
+    EXPECT_FLOAT_EQ(mesh_a.vertices[i], mesh_b.vertices[i]) << "vertex component " << i;
+  }
 }
 
 // Parse cross-check against core from_json (source of truth): parsing a filter JSON via

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1514,6 +1514,78 @@ TEST(IsLegalFaceApi, PyramidIllegalFaces) {
 }
 
 // ============================================================
+// LUMICE_IsShapeScalarApplicable / LUMICE_ShapeScalarSyncKeyName
+// ============================================================
+
+TEST(ShapeScalarApplicableApi, PrismOwnsHeightAndTheSixFaces) {
+  EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_HEIGHT), 0);
+  for (int s = LUMICE_SHAPE_SCALAR_FACE_0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PRISM, s), 0) << "slot=" << s;
+  }
+  // The three stacked pyramid heights are not fields a prism has at all.
+  EXPECT_EQ(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_UPPER_H), 0);
+  EXPECT_EQ(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_PRISM_H), 0);
+  EXPECT_EQ(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_LOWER_H), 0);
+}
+
+TEST(ShapeScalarApplicableApi, PyramidOwnsThreeHeightsAndTheSixFaces) {
+  EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_UPPER_H), 0);
+  EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_PRISM_H), 0);
+  EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_LOWER_H), 0);
+  for (int s = LUMICE_SHAPE_SCALAR_FACE_0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+    EXPECT_NE(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, s), 0) << "slot=" << s;
+  }
+  EXPECT_EQ(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_HEIGHT), 0);
+}
+
+TEST(ShapeScalarApplicableApi, OutOfRangeSlotsAnswerFalseRatherThanTrapping) {
+  for (auto kind : { LUMICE_CRYSTAL_PRISM, LUMICE_CRYSTAL_PYRAMID }) {
+    EXPECT_EQ(LUMICE_IsShapeScalarApplicable(kind, -1), 0);
+    EXPECT_EQ(LUMICE_IsShapeScalarApplicable(kind, LUMICE_SHAPE_SCALAR_COUNT), 0);
+    EXPECT_EQ(LUMICE_IsShapeScalarApplicable(kind, 12345), 0);
+  }
+}
+
+TEST(ShapeScalarSyncKeyNameApi, NamesEveryApplicableSlot) {
+  EXPECT_STREQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_HEIGHT), "height");
+  EXPECT_STREQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_UPPER_H), "upper_h");
+  EXPECT_STREQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_PRISM_H), "prism_h");
+  EXPECT_STREQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_LOWER_H), "lower_h");
+  // All six faces share one key — its wire value is a 6-element array.
+  for (auto kind : { LUMICE_CRYSTAL_PRISM, LUMICE_CRYSTAL_PYRAMID }) {
+    for (int s = LUMICE_SHAPE_SCALAR_FACE_0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+      EXPECT_STREQ(LUMICE_ShapeScalarSyncKeyName(kind, s), "face_distance") << "slot=" << s;
+    }
+  }
+}
+
+TEST(ShapeScalarSyncKeyNameApi, InapplicableAndOutOfRangeSlotsAnswerNull) {
+  EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_UPPER_H), nullptr);
+  EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_PRISM_H), nullptr);
+  EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PRISM, LUMICE_SHAPE_SCALAR_LOWER_H), nullptr);
+  EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_HEIGHT), nullptr);
+  for (auto kind : { LUMICE_CRYSTAL_PRISM, LUMICE_CRYSTAL_PYRAMID }) {
+    EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(kind, -1), nullptr);
+    EXPECT_EQ(LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_COUNT), nullptr);
+  }
+}
+
+// The two queries answer the same question about the same slot, so they must never disagree:
+// a slot that applies must be nameable, and a slot that does not must have no name. This is the
+// assertion that keeps the "unreachable" nullptr branch inside ShapeScalarSyncKeyName unreachable
+// — a slot added to the applicability map but not to the key table would land there, and would
+// otherwise show up only as a JSON field that silently goes missing.
+TEST(ShapeScalarSyncKeyNameApi, AgreesWithApplicabilityOnEverySlot) {
+  for (auto kind : { LUMICE_CRYSTAL_PRISM, LUMICE_CRYSTAL_PYRAMID }) {
+    for (int s = 0; s < LUMICE_SHAPE_SCALAR_COUNT; ++s) {
+      const bool applicable = LUMICE_IsShapeScalarApplicable(kind, s) != 0;
+      const char* key = LUMICE_ShapeScalarSyncKeyName(kind, s);
+      EXPECT_EQ(applicable, key != nullptr) << "kind=" << kind << " slot=" << s;
+    }
+  }
+}
+
+// ============================================================
 // LUMICE_ValidateRaypathText
 // ============================================================
 


### PR DESCRIPTION
## 背景

内测用户反馈：希望 face distance 随机化时能让若干面**保持 sync**——一旦 sync，它们采用**同一个抽样值**，从而在随机化下保持严格对称性。典型场景：面 3/5/7 与 4/6/8 各自成组 = 严格 C3（三方晶体）习性。

讨论中把作用域泛化为**任意可随机形状标量**（`height` / `prism_h` / `upper_h` / `lower_h` / `face_distance[0..5]`）——除 6 个面外，`upper_h ↔ lower_h`（对称棱锥）是当场就成立的第二个真实用例。

## 为什么单个 checkbox 不够

只 sync `{3,5,7}` 而 `{4,6,8}` 各自独立，得到的**不是**三重对称。C3 要求两个组各自成组、取两个不同值（a,b,a,b,a,b）。最低表达要求是**划分（partition）**，不是布尔标志。

## 实现

- **核心**：`ShapeScalar` 枚举（顺序刻意 = RNG 抽取顺序，使「组 leader」= 「组内最先被抽到者」无需第二套定义）+ `sync_group_[]` 平行数组（`0 = 独立`）；`CrystalMaker` 组内首次抽样、之后复用不消费 RNG。
- **规范形**（不适用槽位归零 / 单例组归零 / 按抽取序首次出现重编号）：不是装饰性的——`config_compare.hpp::operator==` 是**重新仿真的触发判据**，非规范形会让语义空操作触发全量重跑。
- **C API v4.13 BREAKING**：`LUMICE_CrystalParam` 末尾追加 `sync_group[LUMICE_SHAPE_SCALAR_COUNT]`；零初始化等价于 v4.12 行为。
- **GUI**：形状参数表新增 `Sync` 列——组号画在色块内（前注意分组感知 + 色觉可达），点击弹 popup（`None` / 已有组带成员清单 / `+ New group`）。无删除项、无改色项：组不是对象而是等价关系，最后一个成员离开即消失；颜色是等价关系的*渲染*，从组号查固定调色板派生、**永不存储**。

## 兼容性

- **RNG 流逐字节兼容**：无 sync 声明时抽取次数与顺序不变（改动前抓取真实抽样值作外部 golden，改动后逐值 `ASSERT_EQ`）。
- **旧配置零改动**：`sync_group` 为可选键，缺省 = 全独立；全独立时不写出该键。
- **三后端零改动**：形状抽样只在 host 侧 `MakeCrystal`，从不过 device 线（`git diff --name-only` 机械确认无 `.cu`/`.mm`/`.metal`）。

## 验证

集成后分支上重跑（非逐 task 结果汇总）：

| 项 | 结果 |
|----|------|
| `build.sh -gtj release` | ctest **5/5**；gui_test **482/482** + **6/6**（本 PR 净增 14 例） |
| `pytest -v`（CI 口径 fast e2e） | **127 passed / 31 skipped**（skip 全为 CUDA） |
| `check_policies.py` / `check_new_refs.py --range` / `format.sh --check` | 全部 exit 0 |

`modal_layout` 参考图已按 full-suite 口径重拍（Phase A+B）。

## 已知边界（有意保留）

- **不做量纲可通约性校验**：可以把 `Height` 和 `Face N` 放进同一组——共享值仍是合法几何，只是物理上无意义。代价是跨量程分组会因 slider clamp 反向传播震荡**一帧**后稳定（实测后续 8 帧不振荡不发散），已固化为常驻回归 `sync_group_cross_range_converges`。
- **跨类组的 abs 差异**：高度类标量仍取 `|v|`、face distance 取 `v`（负 d 合法），故跨类同组时两者差一个绝对值。文档已写明。
- **face distance 随机化只平移面、不旋转法向**，故 sync **不产生新的光晕角度**；它买到的是习性保真度（严格对称的晶体族），以及对面对同组时消掉几何合法性拒绝。

🤖 Generated with [Claude Code](https://claude.com/claude-code)