### PR TITLE
fix(stats): make crystals=N a scene property instead of a schedule artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   persisted in `.lmc` files and core JSON configs.
 
 ### Changed
+- **`crystal_num` / `Stats: crystals=N` redefined** (no ABI change — same field name and
+  type): the value is now **how many distinct crystal geometries the run actually sampled**,
+  not how many crystal objects it built. A scene with no random shape distributions reports
+  exactly its (scattering layer × entry) count regardless of `ray_num`; give a shape a
+  distribution and the count rises with the geometries actually drawn. Previously the value
+  tracked the batch schedule instead of the scene — sweeping `LUMICE_DISPATCH_RAY_NUM` alone
+  moved it by two orders of magnitude, and a randomized scene reported the same number as its
+  fixed-shape twin. **Expect the reported number to drop sharply** for fixed-shape scenes
+  (e.g. 785 → 5 on a 5-population 20k-ray scene); that is the fix, not a regression. The
+  value remains non-comparable across backends (CPU samples per ray-group, the GPU K-shape
+  clock is off by default) and is still scaled by the worker count on the multi-worker CPU
+  route. See `doc/c_api.md` and the contract block on
+  `TraceBackend::GetLastBatchNewCrystalSampleCount`.
 - **Breaking config change (discrete spectra)**: `ray_num` now means the TOTAL number of
   rays traced across ALL wavelengths (previously it was per-wavelength). The server derives
   the per-wavelength budget via `ceil(ray_num / n_wavelengths)`. Externally hand-written

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked the batch schedule instead of the scene — sweeping `LUMICE_DISPATCH_RAY_NUM` alone
   moved it by two orders of magnitude, and a randomized scene reported the same number as its
   fixed-shape twin. **Expect the reported number to drop sharply** for fixed-shape scenes
-  (e.g. 785 → 5 on a 5-population 20k-ray scene); that is the fix, not a regression. The
-  value remains non-comparable across backends (CPU samples per ray-group, the GPU K-shape
-  clock is off by default) and is still scaled by the worker count on the multi-worker CPU
-  route. See `doc/c_api.md` and the contract block on
-  `TraceBackend::GetLastBatchNewCrystalSampleCount`.
+  (e.g. 785 → 5 on a 5-population 20k-ray scene, or 60 → 5 on the default multi-worker CLI);
+  that is the fix, not a regression. The value is now independent of `num_workers` and of the
+  dispatch grain — the fixed-shape part of a scene is counted once from the committed config
+  rather than once per worker per batch — but remains non-comparable across backends (CPU
+  samples per ray-group, the GPU K-shape clock is off by default). See `doc/c_api.md` and the
+  contract block on `TraceBackend::GetLastBatchStochasticCrystalSampleCount`.
 - **Breaking config change (discrete spectra)**: `ray_num` now means the TOTAL number of
   rays traced across ALL wavelengths (previously it was per-wavelength). The server derives
   the per-wavelength budget via `ceil(ray_num / n_wavelengths)`. Externally hand-written

--- a/doc/c_api.md
+++ b/doc/c_api.md
@@ -163,12 +163,29 @@ Statistics result structure.
 typedef struct LUMICE_StatsResult_ {
   unsigned long ray_seg_num;   // Number of ray segments
   unsigned long sim_ray_num;   // Number of simulated rays
-  unsigned long crystal_num;   // Number of crystals
+  unsigned long crystal_num;   // Distinct crystal geometries this run sampled (see Notes)
 } LUMICE_StatsResult;
 ```
 
 **Notes**:
 - Sentinel marker: all zeros (`sim_ray_num == 0`)
+- `crystal_num` is **how many distinct crystal geometries the run actually
+  sampled**, not how many crystal objects it built. A shape defined by fixed
+  numbers is drawn once and reused for the rest of the run, so a scene with
+  no random shape distributions reports exactly its (scattering layer × entry)
+  count — 3 entries in layer 1 plus 2 in layer 2 reports 5, whatever `ray_num`
+  is. Give a shape a distribution (`{"type": "gauss", ...}` on `height` or
+  `face_distance`) and the count rises with the number of geometries actually
+  drawn, which is how you confirm shape randomization is taking effect.
+- **Not comparable across backends.** The CPU route samples a fresh geometry per
+  ray-group; the GPU route samples per (layer, entry) per dispatch unless the
+  K-shape geometry clock is enabled, which is off by default. The same scene
+  therefore reports different values on different backends. That gap is the
+  sampling-density difference between the routes, not an inconsistency to
+  reconcile.
+- On the multi-worker CPU route each worker samples independently, so the value
+  is scaled by the number of workers that received work (a fixed `sim_seed`
+  collapses the run to one worker, where the count is exact).
 
 #### LUMICE_ServerConfig
 

--- a/doc/c_api.md
+++ b/doc/c_api.md
@@ -183,9 +183,13 @@ typedef struct LUMICE_StatsResult_ {
   therefore reports different values on different backends. That gap is the
   sampling-density difference between the routes, not an inconsistency to
   reconcile.
-- On the multi-worker CPU route each worker samples independently, so the value
-  is scaled by the number of workers that received work (a fixed `sim_seed`
-  collapses the run to one worker, where the count is exact).
+- Independent of `num_workers` and of the batch/dispatch grain. The fixed-shape
+  part of a scene is counted once from the committed config, not once per worker
+  or per batch, so a performance knob can never move it. The randomly-drawn part
+  is summed over every draw, which is the intended answer: those really are
+  different geometries.
+- A fixed-shape entry counts even if it never receives rays (e.g.
+  `crystal_proportion` 0). The count describes the scene, not the schedule.
 
 #### LUMICE_ServerConfig
 

--- a/doc/c_api_zh.md
+++ b/doc/c_api_zh.md
@@ -151,8 +151,11 @@ typedef struct LUMICE_StatsResult_ {
 - **不可跨后端比较**。CPU 路线逐 ray-group 抽新几何；GPU 路线在 K-shape 几何时钟关闭
   （默认关闭）时每 dispatch 每 (层, entry) 只抽一次。同一场景在不同后端上因此报出不同的
   数值：这个差距就是两条路线的采样密度差异本身，不是需要抹平的不一致。
-- 多 worker 的 CPU 路线上每个 worker 独立抽样，故该值会按拿到任务的 worker 数放大
-  （固定 `sim_seed` 会把整个 run 收敛为单 worker，此时计数是精确的）。
+- 与 `num_workers`、与 batch/dispatch 粒度都无关。场景中形状固定的那部分按 committed
+  config 清点一次，不是每 worker 一次、也不是每 batch 一次，所以性能旋钮动不了它；
+  随机抽出的那部分则逐次累加 —— 那些确实是不同的几何，累加正是想要的答案。
+- 形状固定的 entry 即使没分到光线（例如 `crystal_proportion` 为 0）也计入。
+  这个量描述的是场景，不是调度。
 
 #### LUMICE_ServerConfig
 

--- a/doc/c_api_zh.md
+++ b/doc/c_api_zh.md
@@ -137,12 +137,22 @@ typedef struct LUMICE_RenderResult_ {
 typedef struct LUMICE_StatsResult_ {
   unsigned long ray_seg_num;   // 光线段数量
   unsigned long sim_ray_num;   // 模拟光线数量
-  unsigned long crystal_num;   // 晶体数量
+  unsigned long crystal_num;   // 本次 run 实际采样出的不同晶体几何数（见"注意"）
 } LUMICE_StatsResult;
 ```
 
 **注意**：
 - 哨兵标识：全零（`sim_ray_num == 0`）
+- `crystal_num` 是**本次 run 实际采样出了几个不同的晶体几何**，不是构造了几个晶体对象。
+  形状由固定数值给定时只会抽样一次、之后全程复用，所以形状不含随机分布的场景恰好报出
+  它的（散射层 × entry）总数 —— 第 1 层 3 个 entry 加第 2 层 2 个就报 5，与 `ray_num`
+  无关。给形状加上分布（`height` / `face_distance` 上的 `{"type": "gauss", ...}`）后，
+  这个数随实际抽出的几何数增长 —— 这正是用来确认形状随机化是否真的生效的观察量。
+- **不可跨后端比较**。CPU 路线逐 ray-group 抽新几何；GPU 路线在 K-shape 几何时钟关闭
+  （默认关闭）时每 dispatch 每 (层, entry) 只抽一次。同一场景在不同后端上因此报出不同的
+  数值：这个差距就是两条路线的采样密度差异本身，不是需要抹平的不一致。
+- 多 worker 的 CPU 路线上每个 worker 独立抽样，故该值会按拿到任务的 worker 数放大
+  （固定 `sim_seed` 会把整个 run 收敛为单 worker，此时计数是精确的）。
 
 #### LUMICE_ServerConfig
 

--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -37,7 +37,10 @@ namespace lumice {
 // (size_t, 8B) for the device-side Y-lane drain, bumping 296 → 328.
 // task-color-degrade-gui-surfacing adds color_degrade_counts_ (ColorDegradeCounts
 // = 3 × size_t = 24B) for the GPU color-degrade tally, bumping 328 → 352.
-static_assert(sizeof(SimData) == 352, "SimData size changed — update copy/move ctors and operators");
+// The crystal-sample-count contract splits crystal_count_ into an accumulated
+// stochastic half and an overwritten deterministic half (+1 size_t, 8B),
+// bumping 352 → 360.
+static_assert(sizeof(SimData) == 360, "SimData size changed — update copy/move ctors and operators");
 
 namespace {
 
@@ -394,7 +397,8 @@ SimData::SimData(const SimData& other)
       exit_records_(other.exit_records_), xyz_pixel_data_(other.xyz_pixel_data_),
       xyz_landed_weight_(other.xyz_landed_weight_), lane_pixel_data_(other.lane_pixel_data_),
       lane_class_count_(other.lane_class_count_), root_ray_count_(other.root_ray_count_),
-      crystal_count_(other.crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
+      stochastic_crystal_sample_count_(other.stochastic_crystal_sample_count_),
+      deterministic_crystal_count_(other.deterministic_crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
       color_degrade_counts_(other.color_degrade_counts_) {}
 
 SimData::SimData(SimData&& other) noexcept
@@ -405,7 +409,8 @@ SimData::SimData(SimData&& other) noexcept
       exit_records_(std::move(other.exit_records_)), xyz_pixel_data_(std::move(other.xyz_pixel_data_)),
       xyz_landed_weight_(other.xyz_landed_weight_), lane_pixel_data_(std::move(other.lane_pixel_data_)),
       lane_class_count_(other.lane_class_count_), root_ray_count_(other.root_ray_count_),
-      crystal_count_(other.crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
+      stochastic_crystal_sample_count_(other.stochastic_crystal_sample_count_),
+      deterministic_crystal_count_(other.deterministic_crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
       color_degrade_counts_(other.color_degrade_counts_) {}
 
 SimData& SimData::operator=(const SimData& other) {
@@ -431,7 +436,8 @@ SimData& SimData::operator=(const SimData& other) {
   lane_pixel_data_ = other.lane_pixel_data_;
   lane_class_count_ = other.lane_class_count_;
   root_ray_count_ = other.root_ray_count_;
-  crystal_count_ = other.crystal_count_;
+  stochastic_crystal_sample_count_ = other.stochastic_crystal_sample_count_;
+  deterministic_crystal_count_ = other.deterministic_crystal_count_;
   sim_scene_credit_ = other.sim_scene_credit_;
   color_degrade_counts_ = other.color_degrade_counts_;  // task-color-degrade-gui-surfacing (POD)
   return *this;
@@ -465,7 +471,8 @@ SimData& SimData::operator=(SimData&& other) noexcept {
   lane_pixel_data_ = std::move(other.lane_pixel_data_);  // task-358.1 Step 4
   lane_class_count_ = other.lane_class_count_;
   root_ray_count_ = other.root_ray_count_;
-  crystal_count_ = other.crystal_count_;
+  stochastic_crystal_sample_count_ = other.stochastic_crystal_sample_count_;
+  deterministic_crystal_count_ = other.deterministic_crystal_count_;
   sim_scene_credit_ = other.sim_scene_credit_;
   color_degrade_counts_ = other.color_degrade_counts_;  // task-color-degrade-gui-surfacing (POD)
   return *this;

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -215,14 +215,26 @@ struct SimData {
   // the physical-result fields above (rays_/xyz_pixel_data_/exit_records_).
   size_t root_ray_count_ = 0;  // Count of root rays (prev_ray_idx_ == kInfSize)
 
-  // Crystal geometries this batch freshly SAMPLED, for stats reporting — NOT
-  // the size of `crystals_` above, which also counts the copies made when a
-  // shape is reused. StatsConsumer sums this over the run to report "how many
-  // distinct crystal geometries did this run draw". The legacy path counts its
-  // own CrystalMaker calls; the exit-seam path reads
-  // TraceBackend::GetLastBatchNewCrystalSampleCount(), where the contract and
-  // its per-backend caveats are documented.
-  size_t crystal_count_ = 0;
+  // The reported crystal-geometry count is carried as TWO fields because its
+  // two halves aggregate differently. StatsConsumer reports their sum; see
+  // TraceBackend::GetLastBatchStochasticCrystalSampleCount for the full
+  // contract.
+  //
+  // (a) Stochastic draws THIS batch made — ACCUMULATED over batches and over
+  //     workers. Every such draw is a genuinely different geometry (each worker
+  //     has its own RNG stream), so summing is the right answer. NOT the size of
+  //     `crystals_` above, which also counts the copies made when a shape is
+  //     reused. The legacy path counts its own CrystalMaker calls; the
+  //     exit-seam path reads the backend getter named above.
+  size_t stochastic_crystal_sample_count_ = 0;
+  // (b) How many (layer, ci) slots of the committed scene carry deterministic
+  //     shape params — a CONFIG CONSTANT, so OVERWRITE, never accumulate (same
+  //     discipline as color_degrade_counts_ below). Each such slot is one
+  //     geometry no matter how many batches re-derive it or how many workers
+  //     redundantly derive it in parallel, which is exactly why it cannot be
+  //     counted per batch: doing so made the stat a function of the dispatch
+  //     grain and the worker-pool size instead of a property of the scene.
+  size_t deterministic_crystal_count_ = 0;
 
   // scrum-312 (third-clock drain): how many sim_scene_cnt_ units this SimData
   // accounts for on the consumer side. Normally 1 (one SimData per

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -215,10 +215,13 @@ struct SimData {
   // the physical-result fields above (rays_/xyz_pixel_data_/exit_records_).
   size_t root_ray_count_ = 0;  // Count of root rays (prev_ray_idx_ == kInfSize)
 
-  // Crystal count for stats reporting. Populated by legacy path from
-  // all_crystals.size() and by exit-seam path from
-  // TraceBackend::GetLastBatchCrystalCount() (== final-layer setting count).
-  // See scrum-cleanup-cuda-ci-misc/task-exit-seam-crystal-count.
+  // Crystal geometries this batch freshly SAMPLED, for stats reporting — NOT
+  // the size of `crystals_` above, which also counts the copies made when a
+  // shape is reused. StatsConsumer sums this over the run to report "how many
+  // distinct crystal geometries did this run draw". The legacy path counts its
+  // own CrystalMaker calls; the exit-seam path reads
+  // TraceBackend::GetLastBatchNewCrystalSampleCount(), where the contract and
+  // its per-backend caveats are documented.
   size_t crystal_count_ = 0;
 
   // scrum-312 (third-clock drain): how many sim_scene_cnt_ units this SimData

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -258,7 +258,11 @@ void CpuTraceBackend::BeginSession(const SessionSpec& spec) {
 
   continuation_buf_ = RayBuffer{};
   exit_records_.clear();
-  last_layer_crystal_count_ = 0;
+  new_sample_count_this_batch_ = 0;
+  // Per-batch: the counter above. Per-scene: the tracker below — clearing it
+  // here unconditionally would make every batch re-count its shapes as new,
+  // which is the cross-batch double-count the new-sample semantic removes.
+  sample_tracker_.ResetIfSceneChanged(spec.scene);
 
   // Design 2 (task-engine-redirect-design2): build the placement-scoped color
   // gate table for this session's scene × raypath_color config. Missing
@@ -292,13 +296,6 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
   // proportions from setting_[ci].crystal_proportion_ + zeros carry (one
   // session = one wavelength here, no cross-wavelength accumulation).
   size_t crystal_cnt = ms_info.setting_.size();
-  // task-exit-seam-crystal-count: record final MS layer setting count for
-  // Simulator to feed SimData.crystal_count_. Semantics: last layer only,
-  // not cross-layer sum (mirrors CUDA `final_layer_crystals_`; Metal keeps no
-  // host-side final-layer mirror since the emit gate moved on-device).
-  if (ms_idx_ + 1 == spec_.scene->ms_.size()) {
-    last_layer_crystal_count_ = crystal_cnt;
-  }
   std::vector<float> proportions;
   proportions.reserve(crystal_cnt);
   for (size_t ci = 0; ci < crystal_cnt; ci++) {
@@ -356,6 +353,16 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
       crystal = MakeCrystal(rng_, setting.crystal_.param_);
       crystal_id = ci;
       refractive_index = crystal.GetRefractiveIndex(spec_.wl.wl_);
+      // MakeCrystal above stays UNCONDITIONAL on purpose: caching the
+      // deterministic result would change the rng draw order, a behaviour
+      // change well outside a statistics fix. So the shape is re-derived every
+      // batch and the tracker decides whether re-deriving it counts as a new
+      // sample — it does not, once this scene has drawn it before. The
+      // host-supplied branch above deliberately never reaches this: it consumes
+      // no draw at all, so it is neither a new sample nor a reuse.
+      if (sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
+        new_sample_count_this_batch_++;
+      }
     }
 
     auto filter_spec = FilterSpec::Create(setting.filter_, crystal, crystal_axis);
@@ -521,7 +528,11 @@ void CpuTraceBackend::EndSession() {
   in_session_ = false;
   ms_idx_ = 0;
   root_ray_count_ = 0;
-  last_layer_crystal_count_ = 0;  // task-exit-seam-crystal-count: lifecycle symmetry with BeginSession
+  new_sample_count_this_batch_ = 0;  // lifecycle symmetry with BeginSession
+  // sample_tracker_ is intentionally NOT cleared here: EndSession runs once per
+  // batch, and the tracker must outlive the batch cycle to recognise the next
+  // batch's shapes as reuse. Its invalidation signal is a scene change, checked
+  // in BeginSession.
   total_landed_weight_ = 0.0f;
   xyz_buf_.reset();
   continuation_buf_ = RayBuffer{};

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -258,11 +258,7 @@ void CpuTraceBackend::BeginSession(const SessionSpec& spec) {
 
   continuation_buf_ = RayBuffer{};
   exit_records_.clear();
-  new_sample_count_this_batch_ = 0;
-  // Per-batch: the counter above. Per-scene: the tracker below — clearing it
-  // here unconditionally would make every batch re-count its shapes as new,
-  // which is the cross-batch double-count the new-sample semantic removes.
-  sample_tracker_.ResetIfSceneChanged(spec.scene);
+  stochastic_sample_count_this_batch_ = 0;
 
   // Design 2 (task-engine-redirect-design2): build the placement-scoped color
   // gate table for this session's scene × raypath_color config. Missing
@@ -355,13 +351,13 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
       refractive_index = crystal.GetRefractiveIndex(spec_.wl.wl_);
       // MakeCrystal above stays UNCONDITIONAL on purpose: caching the
       // deterministic result would change the rng draw order, a behaviour
-      // change well outside a statistics fix. So the shape is re-derived every
-      // batch and the tracker decides whether re-deriving it counts as a new
-      // sample — it does not, once this scene has drawn it before. The
-      // host-supplied branch above deliberately never reaches this: it consumes
-      // no draw at all, so it is neither a new sample nor a reuse.
-      if (sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
-        new_sample_count_this_batch_++;
+      // change well outside a statistics fix. So a deterministic shape is
+      // re-derived every batch while consuming no draw — it contributes to the
+      // scene's config-constant term instead of this counter. The host-supplied
+      // branch above deliberately never reaches this: it consumes no draw
+      // either, so it is not a sampling event at all.
+      if (!IsDeterministic(setting.crystal_.param_)) {
+        stochastic_sample_count_this_batch_++;
       }
     }
 
@@ -528,11 +524,7 @@ void CpuTraceBackend::EndSession() {
   in_session_ = false;
   ms_idx_ = 0;
   root_ray_count_ = 0;
-  new_sample_count_this_batch_ = 0;  // lifecycle symmetry with BeginSession
-  // sample_tracker_ is intentionally NOT cleared here: EndSession runs once per
-  // batch, and the tracker must outlive the batch cycle to recognise the next
-  // batch's shapes as reuse. Its invalidation signal is a scene change, checked
-  // in BeginSession.
+  stochastic_sample_count_this_batch_ = 0;  // lifecycle symmetry with BeginSession
   total_landed_weight_ = 0.0f;
   xyz_buf_.reset();
   continuation_buf_ = RayBuffer{};

--- a/src/core/backend/cpu_trace_backend.hpp
+++ b/src/core/backend/cpu_trace_backend.hpp
@@ -72,7 +72,7 @@ class CpuTraceBackend : public TraceBackend {
 
   // Crystal geometries this batch freshly sampled, summed across every
   // (layer, ci). See TraceBackend for the cross-backend contract.
-  size_t GetLastBatchCrystalCount() const override { return new_sample_count_this_batch_; }
+  size_t GetLastBatchNewCrystalSampleCount() const override { return new_sample_count_this_batch_; }
 
  private:
   SessionSpec spec_{};
@@ -83,7 +83,7 @@ class CpuTraceBackend : public TraceBackend {
   int height_ = 0;
 
   size_t root_ray_count_ = 0;
-  // Output register for GetLastBatchCrystalCount: zeroed every BeginSession,
+  // Output register for GetLastBatchNewCrystalSampleCount: zeroed every BeginSession,
   // incremented per (layer, ci) that sample_tracker_ judges to be a new draw.
   size_t new_sample_count_this_batch_ = 0;
   // "Which deterministic (layer, ci) shapes has this scene already sampled" —

--- a/src/core/backend/cpu_trace_backend.hpp
+++ b/src/core/backend/cpu_trace_backend.hpp
@@ -70,9 +70,9 @@ class CpuTraceBackend : public TraceBackend {
   size_t RootRayCount() const { return root_ray_count_; }
   float TotalLandedWeight() const { return total_landed_weight_; }
 
-  // Crystal geometries this batch freshly sampled, summed across every
+  // Stochastic crystal-geometry draws this batch made, summed across every
   // (layer, ci). See TraceBackend for the cross-backend contract.
-  size_t GetLastBatchNewCrystalSampleCount() const override { return new_sample_count_this_batch_; }
+  size_t GetLastBatchStochasticCrystalSampleCount() const override { return stochastic_sample_count_this_batch_; }
 
  private:
   SessionSpec spec_{};
@@ -83,14 +83,12 @@ class CpuTraceBackend : public TraceBackend {
   int height_ = 0;
 
   size_t root_ray_count_ = 0;
-  // Output register for GetLastBatchNewCrystalSampleCount: zeroed every BeginSession,
-  // incremented per (layer, ci) that sample_tracker_ judges to be a new draw.
-  size_t new_sample_count_this_batch_ = 0;
-  // "Which deterministic (layer, ci) shapes has this scene already sampled" —
-  // deliberately NOT reset by BeginSession/EndSession (only by a scene change),
-  // because its whole job is to span the per-batch session cycle. See
-  // NewSampleTracker's lifetime note.
-  NewSampleTracker sample_tracker_;
+  // Output register for GetLastBatchStochasticCrystalSampleCount: zeroed every
+  // BeginSession, incremented per (layer, ci) whose params actually draw. Purely
+  // per-batch — no cross-batch state is needed, because the shapes that ARE
+  // reused across batches are the deterministic ones, and those are counted from
+  // the config rather than from any batch.
+  size_t stochastic_sample_count_this_batch_ = 0;
   size_t ms_idx_ = 0;  // advances on each Recombine.
   float total_landed_weight_ = 0.0f;
 

--- a/src/core/backend/cpu_trace_backend.hpp
+++ b/src/core/backend/cpu_trace_backend.hpp
@@ -10,6 +10,7 @@
 #include "core/backend/trace_backend.hpp"
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
+#include "core/trace_ops.hpp"
 
 namespace lumice {
 
@@ -69,9 +70,9 @@ class CpuTraceBackend : public TraceBackend {
   size_t RootRayCount() const { return root_ray_count_; }
   float TotalLandedWeight() const { return total_landed_weight_; }
 
-  // task-exit-seam-crystal-count: setting count of the final MS layer for the
-  // current session. Set by TraceLayer when processing the last layer.
-  size_t GetLastBatchCrystalCount() const override { return last_layer_crystal_count_; }
+  // Crystal geometries this batch freshly sampled, summed across every
+  // (layer, ci). See TraceBackend for the cross-backend contract.
+  size_t GetLastBatchCrystalCount() const override { return new_sample_count_this_batch_; }
 
  private:
   SessionSpec spec_{};
@@ -82,8 +83,15 @@ class CpuTraceBackend : public TraceBackend {
   int height_ = 0;
 
   size_t root_ray_count_ = 0;
-  size_t last_layer_crystal_count_ = 0;  // task-exit-seam-crystal-count
-  size_t ms_idx_ = 0;                    // advances on each Recombine.
+  // Output register for GetLastBatchCrystalCount: zeroed every BeginSession,
+  // incremented per (layer, ci) that sample_tracker_ judges to be a new draw.
+  size_t new_sample_count_this_batch_ = 0;
+  // "Which deterministic (layer, ci) shapes has this scene already sampled" —
+  // deliberately NOT reset by BeginSession/EndSession (only by a scene change),
+  // because its whole job is to span the per-batch session cycle. See
+  // NewSampleTracker's lifetime note.
+  NewSampleTracker sample_tracker_;
+  size_t ms_idx_ = 0;  // advances on each Recombine.
   float total_landed_weight_ = 0.0f;
 
   // Backend-owned storage for the device-resident handle returned by Recombine.

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1760,10 +1760,12 @@ struct CudaTraceBackend::Impl {
   // flat_ci (逐位等价 today's behavior). Sized (config crystal total) elements.
   std::vector<uint32_t> ci_pool_slot_base_;
   std::vector<uint32_t> ci_pool_shape_count_;
-  // Diagnostic accumulator — sum of distinct pool shapes built this batch
-  // (across every (layer, ci)). Mirrors Metal's `pool_shape_count_this_batch_`
-  // (metal_trace_backend.mm:819). Reset in BeginSession; incremented in
-  // BuildGeomPool per shape built. Consumed by `GetLastBatchCrystalCount()`.
+  // Diagnostic accumulator — crystal geometries this batch freshly SAMPLED,
+  // across every (layer, ci). Mirrors Metal's `pool_shape_count_this_batch_`.
+  // Reset in BeginSession (unconditionally, before any geom_pool_built_
+  // decision — that placement is what makes a pool-reuse batch report 0);
+  // incremented in BuildGeomPool per shape drawn. Consumed by
+  // `GetLastBatchCrystalCount()`, which documents the contract.
   size_t pool_shape_count_this_batch_ = 0;
   bool        geom_pool_built_ = false;
   const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
@@ -2662,7 +2664,11 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
   layer_ci_base_.clear();
   ci_pool_slot_base_.clear();
   ci_pool_shape_count_.clear();
-  pool_shape_count_this_batch_ = 0u;
+  // pool_shape_count_this_batch_ is NOT zeroed here: BeginSession owns that, so
+  // a batch which skips this function still reports 0. Re-adding a reset here
+  // would be harmless on its own but would give "who zeroes the counter" a
+  // second answer, and the answer that matters is the one on the path this
+  // function is not on.
 
   std::vector<float>    h_poly_n, h_poly_d, h_tri_vtx, h_tri_norm, h_tri_area;
   std::vector<uint8_t>  h_poly_fn;
@@ -3497,6 +3503,22 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
       impl_->rng_seeded_      = true;
     }
     impl_->ray_alloc_carry_.clear();  // per-(layer,ci) partition carry — fresh per session
+
+    // New-crystal-sample counter: zeroed unconditionally, here, BEFORE any
+    // geom_pool_built_ decision below — the value must not depend on whether
+    // this batch ends up rebuilding the pool.
+    //
+    // ⚠️ This REVERSES a deliberate earlier choice, it is not a bug fix. The old
+    // design zeroed the counter inside BuildGeomPool, so on a deterministic
+    // scene — where BuildGeomPool runs once per scene and every later batch
+    // skips it — the counter kept reporting the first batch's value forever, and
+    // that persistence was intentional under the old "how many pool shapes does
+    // this scene have" reading. The counter now answers "how many geometries did
+    // THIS batch sample", so a batch that skips the build sampled nothing and
+    // must report 0: StatsConsumer sums these per batch, and re-reporting a
+    // stale non-zero made the run total a function of the batch count instead of
+    // the scene. Do not "restore" the old reset point.
+    impl_->pool_shape_count_this_batch_ = 0u;
 
     // scrum-306.2 increment 4: a scene change invalidates every per-session-constant
     // cache (geometry pool, filter descriptors, wl pool). Within one scene these are
@@ -4800,29 +4822,25 @@ uint32_t CudaTraceBackend::WlPoolSize() const {
 }
 
 size_t CudaTraceBackend::GetLastBatchCrystalCount() const {
-  // Unified with MetalTraceBackend semantic: return the total distinct pool
-  // shapes built this batch (Σ P_ci over all layers × cis). Reflects the
-  // K-shape geometry pool's actual shape footprint — matches the "how many
-  // distinct crystal instances did we trace against" question the diagnostic
-  // is meant to answer (main.cpp: `Stats: crystals=N`).
+  // Unified with MetalTraceBackend: the number of crystal geometries THIS batch
+  // freshly sampled (Σ P_ci over the (layer, ci) pairs it actually drew). See
+  // trace_backend.hpp for the cross-backend contract.
   //
-  //   - K==0 (LUMICE_GPU_GEOM_CLOCK unset) or deterministic scene:
-  //       P_ci ≡ 1 per (layer,ci) → count == Σ crystal_cnt over layers
-  //       (== today's semantic behavior even though we replaced the
-  //       `final_layer_crystals_.size()` implementation — which was
-  //       "final-layer crystal_cnt only", NOT the config-total).
-  //   - K>0 stochastic scene: count grows with the pool depth ~ ray_num/K.
-  //   - `disable_device_gen_` debug fallback: BuildGeomPool is skipped, so
-  //     `pool_shape_count_this_batch_` stays 0 — the fallback path uploads
-  //     one crystal per (layer,ci) per batch via UploadCrystalGeometry, so
-  //     the pool footprint is effectively `Σ crystal_cnt`. Mirroring that
-  //     exactly requires per-ci accounting on the fallback path; deferred
-  //     as a diagnostic-only follow-up (the main K-shape path — which is
-  //     the reason this counter was added — is correct).
-  //
-  // Reset in BuildGeomPool (device-gen paths) so the deterministic once-per-
-  // scene rebuild's count persists across batches, and stochastic per-batch
-  // rebuilds' count is refreshed each batch.
+  //   - deterministic scene: the first batch of a scene builds the pool and
+  //     reports Σ P_ci (at K==0, Σ layers Σ ci 1 = the config total); every
+  //     later batch skips BuildGeomPool entirely, samples nothing, and reports
+  //     0. Zeroing happens in BeginSession precisely so the skip path reports 0
+  //     rather than replaying the first batch's value.
+  //   - stochastic scene: BeginSession force-invalidates geom_pool_built_, so
+  //     every batch rebuilds and every batch's draws are new — the count repeats
+  //     per batch, and the run-level sum grows with the batch count. That is the
+  //     honest answer for a scene that really does draw fresh shapes per batch.
+  //   - K>0: a stochastic ci contributes ~ci_n/K per batch instead of 1.
+  //   - `disable_device_gen_` debug fallback: BuildGeomPool is skipped, so this
+  //     stays 0 even on the first batch, while the fallback does upload one
+  //     crystal per (layer,ci) per batch via UploadCrystalGeometry. Mirroring
+  //     that requires per-ci accounting on the fallback path; still deferred as
+  //     a diagnostic-only gap (the primary device-gen path is exact).
   return impl_->pool_shape_count_this_batch_;
 }
 

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1760,12 +1760,12 @@ struct CudaTraceBackend::Impl {
   // flat_ci (逐位等价 today's behavior). Sized (config crystal total) elements.
   std::vector<uint32_t> ci_pool_slot_base_;
   std::vector<uint32_t> ci_pool_shape_count_;
-  // Diagnostic accumulator — crystal geometries this batch freshly SAMPLED,
+  // Diagnostic accumulator — stochastic crystal-geometry draws this batch made,
   // across every (layer, ci). Mirrors Metal's `pool_shape_count_this_batch_`.
   // Reset in BeginSession (unconditionally, before any geom_pool_built_
   // decision — that placement is what makes a pool-reuse batch report 0);
-  // incremented in BuildGeomPool per shape drawn. Consumed by
-  // `GetLastBatchNewCrystalSampleCount()`, which documents the contract.
+  // incremented in BuildGeomPool per shape drawn by a stochastic ci. Consumed by
+  // `GetLastBatchStochasticCrystalSampleCount()`, which documents the contract.
   size_t pool_shape_count_this_batch_ = 0;
   bool        geom_pool_built_ = false;
   const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
@@ -2700,6 +2700,12 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
       // (the "flat config-space ci index") is the plan §3.3 accounting split.
       ci_pool_slot_base_.push_back(static_cast<uint32_t>(pool_crystals_.size()));
       ci_pool_shape_count_.push_back(p_ci);
+      // Whether this ci's MakeCrystal calls below are sampling EVENTS or just
+      // re-derivations of one fixed shape. Deterministic cis are re-derived here
+      // on every pool build (cheaper than special-casing the loop, and it keeps
+      // the rng draw order intact) but draw nothing, so they are left out of the
+      // counter and carried as the scene's config constant instead.
+      const bool ci_draws = !IsDeterministic(settings[ci].crystal_.param_);
       for (uint32_t s = 0; s < p_ci; ++s) {
         Crystal crystal = MakeCrystal(rng_, settings[ci].crystal_.param_);
         size_t poly_cnt = crystal.PolygonFaceCount();
@@ -2723,7 +2729,9 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
           pool_tri_off_.push_back(tri_acc);
           pool_tri_cnt_.push_back(0u);
           pool_crystals_.push_back(std::move(crystal));
-          ++pool_shape_count_this_batch_;
+          if (ci_draws) {
+            ++pool_shape_count_this_batch_;
+          }
           continue;
         }
         if (tri_cnt > static_cast<size_t>(lm_pcg::kMaxTriPerKernel)) {
@@ -2753,7 +2761,9 @@ void CudaTraceBackend::Impl::BuildGeomPool(const SceneConfig& scene, size_t ray_
         poly_acc += static_cast<uint32_t>(poly_cnt);
         tri_acc  += static_cast<uint32_t>(tri_cnt);
         pool_crystals_.push_back(std::move(crystal));
-        ++pool_shape_count_this_batch_;
+        if (ci_draws) {
+          ++pool_shape_count_this_batch_;
+        }
       }
     }
   }
@@ -3514,7 +3524,7 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     // skips it — the counter kept reporting the first batch's value forever, and
     // that persistence was intentional under the old "how many pool shapes does
     // this scene have" reading. The counter now answers "how many geometries did
-    // THIS batch sample", so a batch that skips the build sampled nothing and
+    // THIS batch draw", so a batch that skips the build drew nothing and
     // must report 0: StatsConsumer sums these per batch, and re-reporting a
     // stale non-zero made the run total a function of the batch count instead of
     // the scene. Do not "restore" the old reset point.
@@ -4821,16 +4831,17 @@ uint32_t CudaTraceBackend::WlPoolSize() const {
   return ResolveWlPoolSize(logger);
 }
 
-size_t CudaTraceBackend::GetLastBatchNewCrystalSampleCount() const {
-  // Unified with MetalTraceBackend: the number of crystal geometries THIS batch
-  // freshly sampled (Σ P_ci over the (layer, ci) pairs it actually drew). See
-  // trace_backend.hpp for the cross-backend contract.
+size_t CudaTraceBackend::GetLastBatchStochasticCrystalSampleCount() const {
+  // Unified with MetalTraceBackend: the number of STOCHASTIC crystal-geometry
+  // draws THIS batch made (Σ P_ci over the (layer, ci) pairs whose params
+  // consume the rng). See trace_backend.hpp for the cross-backend contract.
   //
-  //   - deterministic scene: the first batch of a scene builds the pool and
-  //     reports Σ P_ci (at K==0, Σ layers Σ ci 1 = the config total); every
-  //     later batch skips BuildGeomPool entirely, samples nothing, and reports
-  //     0. Zeroing happens in BeginSession precisely so the skip path reports 0
-  //     rather than replaying the first batch's value.
+  //   - deterministic scene: reports 0 from every batch, including the first —
+  //     the first batch does build the pool, but re-deriving a deterministic
+  //     shape draws nothing, and the scene's deterministic population is
+  //     carried as a config constant instead. Later batches skip BuildGeomPool
+  //     entirely; zeroing happens in BeginSession precisely so the skip path
+  //     reports 0 rather than replaying the first batch's value.
   //   - stochastic scene: BeginSession force-invalidates geom_pool_built_, so
   //     every batch rebuilds and every batch's draws are new — the count repeats
   //     per batch, and the run-level sum grows with the batch count. That is the

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -3528,6 +3528,17 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     // must report 0: StatsConsumer sums these per batch, and re-reporting a
     // stale non-zero made the run total a function of the batch count instead of
     // the scene. Do not "restore" the old reset point.
+    //
+    // Honest status, measured on dev49 (RTX 4060 Ti) rather than assumed: with the
+    // stochastic gate below in place, DELETING this line changes no observable
+    // behaviour, and CudaBackendCrystalCount stays green. The gate independently
+    // guarantees the 0 — a deterministic (layer, ci) never increments, so there is
+    // no stale non-zero left to leak into a reuse batch. The two mechanisms landed
+    // in that order, and the second subsumed the first's observable effect.
+    // It stays because session start is the right owner of a per-session counter's
+    // lifetime, and because the alternative leaves the counter's zeroing on a path
+    // that legitimately does not run. But do not read the paragraph above as "a
+    // regression test will catch you if you remove this" — none will.
     impl_->pool_shape_count_this_batch_ = 0u;
 
     // scrum-306.2 increment 4: a scene change invalidates every per-session-constant

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1765,7 +1765,7 @@ struct CudaTraceBackend::Impl {
   // Reset in BeginSession (unconditionally, before any geom_pool_built_
   // decision — that placement is what makes a pool-reuse batch report 0);
   // incremented in BuildGeomPool per shape drawn. Consumed by
-  // `GetLastBatchCrystalCount()`, which documents the contract.
+  // `GetLastBatchNewCrystalSampleCount()`, which documents the contract.
   size_t pool_shape_count_this_batch_ = 0;
   bool        geom_pool_built_ = false;
   const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
@@ -4821,7 +4821,7 @@ uint32_t CudaTraceBackend::WlPoolSize() const {
   return ResolveWlPoolSize(logger);
 }
 
-size_t CudaTraceBackend::GetLastBatchCrystalCount() const {
+size_t CudaTraceBackend::GetLastBatchNewCrystalSampleCount() const {
   // Unified with MetalTraceBackend: the number of crystal geometries THIS batch
   // freshly sampled (Σ P_ci over the (layer, ci) pairs it actually drew). See
   // trace_backend.hpp for the cross-backend contract.

--- a/src/core/backend/cuda_trace_backend.hpp
+++ b/src/core/backend/cuda_trace_backend.hpp
@@ -139,7 +139,7 @@ class CudaTraceBackend : public TraceBackend {
   // task-exit-seam-crystal-count: setting count of the final MS layer for the
   // current session. Backed by Impl::final_layer_crystals_ populated during
   // BeginSession — safe to read anytime the session is open.
-  size_t GetLastBatchCrystalCount() const override;
+  size_t GetLastBatchNewCrystalSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 
@@ -147,7 +147,7 @@ class CudaTraceBackend : public TraceBackend {
   // migrated to `CudaTraceBackendTestHooks` (see
   // `core/backend/cuda_trace_backend_test_hooks.hpp`). This class's public
   // interface is now production-only, with zero `*ForTest`-suffixed symbols
-  // remaining on it — `GetLastBatchCrystalCount` above never carried that
+  // remaining on it — `GetLastBatchNewCrystalSampleCount` above never carried that
   // suffix and is an ordinary production method, unaffected by this
   // refactor. Tests construct
   // `CudaTraceBackendTestHooks(backend).SetInitialRayBase(...)` etc.

--- a/src/core/backend/cuda_trace_backend.hpp
+++ b/src/core/backend/cuda_trace_backend.hpp
@@ -136,10 +136,11 @@ class CudaTraceBackend : public TraceBackend {
   // driving loop queries it first). Mirrors MetalTraceBackend::WlPoolSize().
   uint32_t WlPoolSize() const override;
 
-  // task-exit-seam-crystal-count: setting count of the final MS layer for the
-  // current session. Backed by Impl::final_layer_crystals_ populated during
-  // BeginSession — safe to read anytime the session is open.
-  size_t GetLastBatchNewCrystalSampleCount() const override;
+  // Stochastic crystal-geometry draws this batch made, across every
+  // (layer, ci). Backed by Impl::pool_shape_count_this_batch_, zeroed at
+  // BeginSession and incremented inside the pool build — which a reuse batch
+  // skips entirely. See TraceBackend for the cross-backend contract.
+  size_t GetLastBatchStochasticCrystalSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 
@@ -147,7 +148,7 @@ class CudaTraceBackend : public TraceBackend {
   // migrated to `CudaTraceBackendTestHooks` (see
   // `core/backend/cuda_trace_backend_test_hooks.hpp`). This class's public
   // interface is now production-only, with zero `*ForTest`-suffixed symbols
-  // remaining on it — `GetLastBatchNewCrystalSampleCount` above never carried that
+  // remaining on it — `GetLastBatchStochasticCrystalSampleCount` above never carried that
   // suffix and is an ordinary production method, unaffected by this
   // refactor. Tests construct
   // `CudaTraceBackendTestHooks(backend).SetInitialRayBase(...)` etc.

--- a/src/core/backend/cuda_trace_backend_test_hooks.hpp
+++ b/src/core/backend/cuda_trace_backend_test_hooks.hpp
@@ -99,8 +99,11 @@ class CudaTraceBackendTestHooks {
   //
   //   * ReadbackPoolShapeTable — D2H copy of `d_pool_shape_table_` as a flat
   //     vector of `{poly_off, poly_cnt, tri_off, tri_cnt}` rows. .size() ==
-  //     Σ P_ci over every (layer, ci) resolved in this BeginSession (aka the
-  //     value `GetLastBatchCrystalCount()` reports). The device buffer's
+  //     Σ P_ci over every (layer, ci) in the pool as last BUILT. Note this is
+  //     NOT always `GetLastBatchCrystalCount()`: that counts what the CURRENT
+  //     batch sampled, so on a deterministic scene's second batch the pool
+  //     (and this table) is intact while the counter reads 0. The two agree on
+  //     any batch that actually built the pool. The device buffer's
   //     backing storage `Impl::pool_shape_slot_cap_` is set to
   //     `pool_crystals_.size()` at every BuildGeomPool (freed to 0 on
   //     scene-change / no-K path), so it is EXACTLY the current batch's

--- a/src/core/backend/cuda_trace_backend_test_hooks.hpp
+++ b/src/core/backend/cuda_trace_backend_test_hooks.hpp
@@ -4,8 +4,8 @@
 // injection points that white-box tests need, while leaving `CudaTraceBackend`
 // itself with a production-clean public interface (`grep -rn ForTest
 // src/core/backend/cuda_trace_backend.hpp` should hit only the enumerated
-// known exception `GetLastBatchNewCrystalSampleCount` — which is production and NOT a
-// test-only symbol; kept in the class body as-is).
+// known exception `GetLastBatchStochasticCrystalSampleCount` — which is production and
+// NOT a test-only symbol; kept in the class body as-is).
 //
 // Access mechanism: this class is declared a `friend` of `CudaTraceBackend` so
 // its methods can reach the private pimpl `impl_`. The method bodies live in
@@ -100,10 +100,11 @@ class CudaTraceBackendTestHooks {
   //   * ReadbackPoolShapeTable — D2H copy of `d_pool_shape_table_` as a flat
   //     vector of `{poly_off, poly_cnt, tri_off, tri_cnt}` rows. .size() ==
   //     Σ P_ci over every (layer, ci) in the pool as last BUILT. Note this is
-  //     NOT always `GetLastBatchNewCrystalSampleCount()`: that counts what the CURRENT
-  //     batch sampled, so on a deterministic scene's second batch the pool
-  //     (and this table) is intact while the counter reads 0. The two agree on
-  //     any batch that actually built the pool. The device buffer's
+  //     NOT `GetLastBatchStochasticCrystalSampleCount()`: that counts only the
+  //     STOCHASTIC draws of the CURRENT batch, so a deterministic scene has a
+  //     fully-populated table while the counter reads 0 on every batch, and on
+  //     a mixed scene the table also holds the deterministic cis' slots. The two
+  //     agree only on a batch that built the pool from all-stochastic cis. The device buffer's
   //     backing storage `Impl::pool_shape_slot_cap_` is set to
   //     `pool_crystals_.size()` at every BuildGeomPool (freed to 0 on
   //     scene-change / no-K path), so it is EXACTLY the current batch's
@@ -120,7 +121,7 @@ class CudaTraceBackendTestHooks {
   //     which is far more expensive to trace than a host-side throw here.
   //
   // No `PoolShapeCountThisBatch()` sibling: CUDA already exposes the same
-  // value on the production surface as `GetLastBatchNewCrystalSampleCount()` — tests
+  // value on the production surface as `GetLastBatchStochasticCrystalSampleCount()` — tests
   // read that directly (no reason to duplicate the getter here).
   //
   // Design note: both methods D2H-copy into a fresh vector rather than

--- a/src/core/backend/cuda_trace_backend_test_hooks.hpp
+++ b/src/core/backend/cuda_trace_backend_test_hooks.hpp
@@ -4,7 +4,7 @@
 // injection points that white-box tests need, while leaving `CudaTraceBackend`
 // itself with a production-clean public interface (`grep -rn ForTest
 // src/core/backend/cuda_trace_backend.hpp` should hit only the enumerated
-// known exception `GetLastBatchCrystalCount` — which is production and NOT a
+// known exception `GetLastBatchNewCrystalSampleCount` — which is production and NOT a
 // test-only symbol; kept in the class body as-is).
 //
 // Access mechanism: this class is declared a `friend` of `CudaTraceBackend` so
@@ -100,7 +100,7 @@ class CudaTraceBackendTestHooks {
   //   * ReadbackPoolShapeTable — D2H copy of `d_pool_shape_table_` as a flat
   //     vector of `{poly_off, poly_cnt, tri_off, tri_cnt}` rows. .size() ==
   //     Σ P_ci over every (layer, ci) in the pool as last BUILT. Note this is
-  //     NOT always `GetLastBatchCrystalCount()`: that counts what the CURRENT
+  //     NOT always `GetLastBatchNewCrystalSampleCount()`: that counts what the CURRENT
   //     batch sampled, so on a deterministic scene's second batch the pool
   //     (and this table) is intact while the counter reads 0. The two agree on
   //     any batch that actually built the pool. The device buffer's
@@ -120,7 +120,7 @@ class CudaTraceBackendTestHooks {
   //     which is far more expensive to trace than a host-side throw here.
   //
   // No `PoolShapeCountThisBatch()` sibling: CUDA already exposes the same
-  // value on the production surface as `GetLastBatchCrystalCount()` — tests
+  // value on the production surface as `GetLastBatchNewCrystalSampleCount()` — tests
   // read that directly (no reason to duplicate the getter here).
   //
   // Design note: both methods D2H-copy into a fresh vector rather than

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -139,7 +139,7 @@ class MetalTraceBackend : public TraceBackend {
   // LUMICE_GPU_GEOM_CLOCK unset (P_ci = 1 per ci) this equals the cross-layer
   // instance count. Simulator reads it after the MS loop to fill
   // SimData.crystal_count_ for stats reporting.
-  size_t GetLastBatchCrystalCount() const override;
+  size_t GetLastBatchNewCrystalSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -134,12 +134,12 @@ class MetalTraceBackend : public TraceBackend {
   // thereafter for the backend instance's lifetime.
   uint32_t WlPoolSize() const override;
 
-  // K-shape pool: total distinct crystal INSTANCES built during this batch
-  // across every (layer, ci) — the sum of P_ci over the whole scene. At
-  // LUMICE_GPU_GEOM_CLOCK unset (P_ci = 1 per ci) this equals the cross-layer
-  // instance count. Simulator reads it after the MS loop to fill
-  // SimData.crystal_count_ for stats reporting.
-  size_t GetLastBatchNewCrystalSampleCount() const override;
+  // K-shape pool: stochastic crystal-geometry draws made during this batch
+  // across every (layer, ci) — Σ P_ci restricted to the cis whose params
+  // consume the rng. Simulator reads it after the MS loop to fill
+  // SimData.stochastic_crystal_sample_count_; see TraceBackend for the
+  // cross-backend contract.
+  size_t GetLastBatchStochasticCrystalSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -819,7 +819,7 @@ struct MetalTraceBackend::Impl {
   // Running total of crystal geometries this batch freshly SAMPLED, across
   // every (layer, ci). Reset in BeginSession; incremented by
   // ResolveLayerCrystalForCi for the cis that sample_tracker_ judges to be new
-  // draws. Read out by GetLastBatchCrystalCount(); see trace_backend.hpp for
+  // draws. Read out by GetLastBatchNewCrystalSampleCount(); see trace_backend.hpp for
   // the cross-backend contract.
   size_t                   pool_shape_count_this_batch_ = 0;
   // "Which deterministic (layer, ci) shapes has this scene already sampled" —
@@ -2001,7 +2001,7 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
   current_crystal = pool_crystals_.front();
   have_crystal = true;
   UploadCrystalPool(pool_crystals_);
-  // Cross-(layer, ci) running total for GetLastBatchCrystalCount. Counted here
+  // Cross-(layer, ci) running total for GetLastBatchNewCrystalSampleCount. Counted here
   // rather than inside UploadCrystalPool because only this scope knows whether a
   // draw happened at all: the host-injected branch above uploads a shape the
   // caller supplied, consuming no rng draw, so it is not a sampling event. For
@@ -2908,7 +2908,7 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   impl_->ms_idx = 0;
   // K-shape pool: reset the per-batch new-sample counter (accumulated by
   // ResolveLayerCrystalForCi across every (layer, ci) resolve inside this
-  // session). See GetLastBatchCrystalCount for the unified semantics.
+  // session). See GetLastBatchNewCrystalSampleCount for the unified semantics.
   impl_->pool_shape_count_this_batch_ = 0u;
   // Per-batch: the counter above. Per-scene: the tracker below, which must NOT
   // be cleared unconditionally here or every batch would re-count its shapes as
@@ -3670,7 +3670,7 @@ uint32_t MetalTraceBackend::WlPoolSize() const {
   return impl_->wl_pool_size_ != 0u ? impl_->wl_pool_size_ : ResolveWlPoolSize(EffectiveLogger(impl_->logger_));
 }
 
-size_t MetalTraceBackend::GetLastBatchCrystalCount() const {
+size_t MetalTraceBackend::GetLastBatchNewCrystalSampleCount() const {
   // K-shape pool: the number of crystal geometries this batch freshly SAMPLED,
   // summed over every (layer, ci) — Σ P_ci restricted to the cis that actually
   // drew. With LUMICE_GPU_GEOM_CLOCK unset (P_ci ≡ 1) a deterministic scene's

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -1997,20 +1997,21 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
     // exact regardless of p_ci.
     current_n_idx =
         (spec.wl.wl_ > 1.0f) ? pool_crystals_.front().GetRefractiveIndex(spec.wl.wl_) : 0.0f;
+    // Cross-(layer, ci) running total for GetLastBatchNewCrystalSampleCount.
+    // Counted in THIS branch — not after the if/else, and not inside
+    // UploadCrystalPool — because this is the only branch that draws: the
+    // host-injected branch above uploads a caller-supplied shape and consumes no
+    // rng draw, so it is not a sampling event at all. Whether a draw was NEW is
+    // then the tracker's call: a deterministic param is re-derived every batch by
+    // the loop above, but only its first derivation in this scene sampled
+    // anything.
+    if (sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
+      pool_shape_count_this_batch_ += pool_crystals_.size();
+    }
   }
   current_crystal = pool_crystals_.front();
   have_crystal = true;
   UploadCrystalPool(pool_crystals_);
-  // Cross-(layer, ci) running total for GetLastBatchNewCrystalSampleCount. Counted here
-  // rather than inside UploadCrystalPool because only this scope knows whether a
-  // draw happened at all: the host-injected branch above uploads a shape the
-  // caller supplied, consuming no rng draw, so it is not a sampling event. For
-  // a real draw the tracker decides new-vs-reuse — a deterministic param is
-  // re-derived on every batch (see the else branch above) but only the first
-  // derivation in this scene sampled anything.
-  if (!(use_host && host_batch.crystal != nullptr) && sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
-    pool_shape_count_this_batch_ += pool_crystals_.size();
-  }
   // 330.2 S3b: rebuild the latitude LUT at the same per-ci cadence — it depends
   // only on the axis distribution and is shared by the gen and transit passes of
   // this ci. EnsureLatLutBuffers (inside) keeps the buffers non-nil for binding.

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -816,18 +816,15 @@ struct MetalTraceBackend::Impl {
   std::vector<std::array<uint32_t, 4>> pool_shape_table_h_;
   id<MTLBuffer> pool_shape_table_buf_ = nil;  // pool_capacity_ × uint4 (shape offsets)
   size_t        pool_shape_capacity_  = 0;
-  // Running total of crystal geometries this batch freshly SAMPLED, across
+  // Running total of stochastic crystal-geometry draws this batch made, across
   // every (layer, ci). Reset in BeginSession; incremented by
-  // ResolveLayerCrystalForCi for the cis that sample_tracker_ judges to be new
-  // draws. Read out by GetLastBatchNewCrystalSampleCount(); see trace_backend.hpp for
-  // the cross-backend contract.
+  // ResolveLayerCrystalForCi for the cis whose params consume the rng. Metal
+  // rebuilds pool_crystals_ every batch regardless, but re-deriving a
+  // deterministic shape draws nothing, so those cis are left to the scene's
+  // config-constant term. Read out by
+  // GetLastBatchStochasticCrystalSampleCount(); see trace_backend.hpp for the
+  // cross-backend contract.
   size_t                   pool_shape_count_this_batch_ = 0;
-  // "Which deterministic (layer, ci) shapes has this scene already sampled" —
-  // NOT reset per BeginSession (only on a scene change), because it must span
-  // the per-batch session cycle. Metal rebuilds pool_crystals_ every batch
-  // regardless; this is what keeps a rebuild of an already-drawn deterministic
-  // shape from being reported as a fresh sample. See NewSampleTracker.
-  NewSampleTracker         sample_tracker_;
 
   // Unified area-measure inverse-CDF latitude LUT (330.2). Three fixed-size
   // (LatLut::kNodes float) shared buffers rebuilt per-ci by UploadLatLut when the
@@ -1997,15 +1994,15 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
     // exact regardless of p_ci.
     current_n_idx =
         (spec.wl.wl_ > 1.0f) ? pool_crystals_.front().GetRefractiveIndex(spec.wl.wl_) : 0.0f;
-    // Cross-(layer, ci) running total for GetLastBatchNewCrystalSampleCount.
-    // Counted in THIS branch — not after the if/else, and not inside
-    // UploadCrystalPool — because this is the only branch that draws: the
-    // host-injected branch above uploads a caller-supplied shape and consumes no
-    // rng draw, so it is not a sampling event at all. Whether a draw was NEW is
-    // then the tracker's call: a deterministic param is re-derived every batch by
-    // the loop above, but only its first derivation in this scene sampled
-    // anything.
-    if (sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
+    // Cross-(layer, ci) running total for
+    // GetLastBatchStochasticCrystalSampleCount. Counted in THIS branch — not
+    // after the if/else, and not inside UploadCrystalPool — because this is the
+    // only branch that draws: the host-injected branch above uploads a
+    // caller-supplied shape and consumes no rng draw, so it is not a sampling
+    // event at all. A deterministic param is re-derived every batch by the loop
+    // above while consuming no draw; it rides the scene's config-constant term
+    // instead of this counter.
+    if (!IsDeterministic(setting.crystal_.param_)) {
       pool_shape_count_this_batch_ += pool_crystals_.size();
     }
   }
@@ -2907,14 +2904,11 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   impl_->spec = spec;
   impl_->in_session = true;
   impl_->ms_idx = 0;
-  // K-shape pool: reset the per-batch new-sample counter (accumulated by
+  // K-shape pool: reset the per-batch stochastic-draw counter (accumulated by
   // ResolveLayerCrystalForCi across every (layer, ci) resolve inside this
-  // session). See GetLastBatchNewCrystalSampleCount for the unified semantics.
+  // session). See GetLastBatchStochasticCrystalSampleCount for the unified
+  // semantics.
   impl_->pool_shape_count_this_batch_ = 0u;
-  // Per-batch: the counter above. Per-scene: the tracker below, which must NOT
-  // be cleared unconditionally here or every batch would re-count its shapes as
-  // new samples.
-  impl_->sample_tracker_.ResetIfSceneChanged(spec.scene);
   // task-color-degrade-gui-surfacing: reset the GPU color-degrade tally at the
   // single per-config entry point, BEFORE both the color-class clamp below
   // (~L2700) and EnsureFilterBuffers (~L2711, where the symmetry-group /
@@ -3671,14 +3665,14 @@ uint32_t MetalTraceBackend::WlPoolSize() const {
   return impl_->wl_pool_size_ != 0u ? impl_->wl_pool_size_ : ResolveWlPoolSize(EffectiveLogger(impl_->logger_));
 }
 
-size_t MetalTraceBackend::GetLastBatchNewCrystalSampleCount() const {
-  // K-shape pool: the number of crystal geometries this batch freshly SAMPLED,
-  // summed over every (layer, ci) — Σ P_ci restricted to the cis that actually
-  // drew. With LUMICE_GPU_GEOM_CLOCK unset (P_ci ≡ 1) a deterministic scene's
-  // first batch reports Σ layers Σ ci 1 and every later batch reports 0, since
-  // rebuilding an already-drawn deterministic shape samples nothing; a
-  // stochastic ci draws fresh shapes every batch and keeps counting. With the K
-  // knob on, a stochastic ci contributes ~ci_n/K per batch.
+size_t MetalTraceBackend::GetLastBatchStochasticCrystalSampleCount() const {
+  // K-shape pool: the number of stochastic crystal-geometry draws this batch
+  // made, summed over every (layer, ci) — Σ P_ci restricted to the cis whose
+  // params actually consume the rng. A fully deterministic scene reports 0 from
+  // every batch (its whole count is the config constant); a stochastic ci draws
+  // fresh shapes every batch and keeps counting. With LUMICE_GPU_GEOM_CLOCK
+  // unset (P_ci ≡ 1) such a ci contributes 1 per batch; with the K knob on it
+  // contributes ~ci_n/K.
   return impl_->pool_shape_count_this_batch_;
 }
 

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -816,14 +816,18 @@ struct MetalTraceBackend::Impl {
   std::vector<std::array<uint32_t, 4>> pool_shape_table_h_;
   id<MTLBuffer> pool_shape_table_buf_ = nil;  // pool_capacity_ × uint4 (shape offsets)
   size_t        pool_shape_capacity_  = 0;
-  // Running total of distinct pool shapes built across every (layer, ci) in
-  // the current batch. Reset in BeginSession; incremented by UploadCrystalPool.
-  // Read out by GetLastBatchCrystalCount() as the "how many distinct crystal
-  // instances did this batch actually build" metric — the semantic that both
-  // GPU backends converge on when geometry becomes a per-ray sampled quantity
-  // (unifies the CPU vs GPU divergence documented on trace_backend.hpp's
-  // GetLastBatchCrystalCount).
+  // Running total of crystal geometries this batch freshly SAMPLED, across
+  // every (layer, ci). Reset in BeginSession; incremented by
+  // ResolveLayerCrystalForCi for the cis that sample_tracker_ judges to be new
+  // draws. Read out by GetLastBatchCrystalCount(); see trace_backend.hpp for
+  // the cross-backend contract.
   size_t                   pool_shape_count_this_batch_ = 0;
+  // "Which deterministic (layer, ci) shapes has this scene already sampled" —
+  // NOT reset per BeginSession (only on a scene change), because it must span
+  // the per-batch session cycle. Metal rebuilds pool_crystals_ every batch
+  // regardless; this is what keeps a rebuild of an already-drawn deterministic
+  // shape from being reported as a fresh sample. See NewSampleTracker.
+  NewSampleTracker         sample_tracker_;
 
   // Unified area-measure inverse-CDF latitude LUT (330.2). Three fixed-size
   // (LatLut::kNodes float) shared buffers rebuilt per-ci by UploadLatLut when the
@@ -1926,8 +1930,6 @@ void MetalTraceBackend::Impl::UploadCrystalPool(const std::vector<Crystal>& pool
     table_ptr[s * 4 + 3] = pool_shape_table_h_[s][3];
   }
 
-  // Cross-(layer, ci) running total for GetLastBatchCrystalCount.
-  pool_shape_count_this_batch_ += pool.size();
 }
 
 // 330.2 S3b: allocate the three fixed-size shared LUT buffers if not yet present.
@@ -1999,6 +2001,16 @@ void MetalTraceBackend::Impl::ResolveLayerCrystalForCi(const ScatteringSetting& 
   current_crystal = pool_crystals_.front();
   have_crystal = true;
   UploadCrystalPool(pool_crystals_);
+  // Cross-(layer, ci) running total for GetLastBatchCrystalCount. Counted here
+  // rather than inside UploadCrystalPool because only this scope knows whether a
+  // draw happened at all: the host-injected branch above uploads a shape the
+  // caller supplied, consuming no rng draw, so it is not a sampling event. For
+  // a real draw the tracker decides new-vs-reuse — a deterministic param is
+  // re-derived on every batch (see the else branch above) but only the first
+  // derivation in this scene sampled anything.
+  if (!(use_host && host_batch.crystal != nullptr) && sample_tracker_.MarkIfNew(setting.crystal_.param_)) {
+    pool_shape_count_this_batch_ += pool_crystals_.size();
+  }
   // 330.2 S3b: rebuild the latitude LUT at the same per-ci cadence — it depends
   // only on the axis distribution and is shared by the gen and transit passes of
   // this ci. EnsureLatLutBuffers (inside) keeps the buffers non-nil for binding.
@@ -2894,10 +2906,14 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   impl_->spec = spec;
   impl_->in_session = true;
   impl_->ms_idx = 0;
-  // K-shape pool: reset the per-batch distinct-shape counter (accumulated by
-  // UploadCrystalPool across every (layer, ci) resolve inside this session).
-  // See GetLastBatchCrystalCount for the unified semantics.
+  // K-shape pool: reset the per-batch new-sample counter (accumulated by
+  // ResolveLayerCrystalForCi across every (layer, ci) resolve inside this
+  // session). See GetLastBatchCrystalCount for the unified semantics.
   impl_->pool_shape_count_this_batch_ = 0u;
+  // Per-batch: the counter above. Per-scene: the tracker below, which must NOT
+  // be cleared unconditionally here or every batch would re-count its shapes as
+  // new samples.
+  impl_->sample_tracker_.ResetIfSceneChanged(spec.scene);
   // task-color-degrade-gui-surfacing: reset the GPU color-degrade tally at the
   // single per-config entry point, BEFORE both the color-class clamp below
   // (~L2700) and EnsureFilterBuffers (~L2711, where the symmetry-group /
@@ -3655,12 +3671,13 @@ uint32_t MetalTraceBackend::WlPoolSize() const {
 }
 
 size_t MetalTraceBackend::GetLastBatchCrystalCount() const {
-  // K-shape pool: this is now the number of distinct crystal INSTANCES the
-  // backend actually built during this batch across every (layer, ci) — the
-  // sum of P_ci over the whole scene. At LUMICE_GPU_GEOM_CLOCK unset (P_ci
-  // collapses to 1 per ci) it equals Σ layers Σ ci 1 = the cross-layer
-  // instance count; with the K knob on it grows toward ~ray_num/K and
-  // converges on legacy CPU's per-batch-instance semantics.
+  // K-shape pool: the number of crystal geometries this batch freshly SAMPLED,
+  // summed over every (layer, ci) — Σ P_ci restricted to the cis that actually
+  // drew. With LUMICE_GPU_GEOM_CLOCK unset (P_ci ≡ 1) a deterministic scene's
+  // first batch reports Σ layers Σ ci 1 and every later batch reports 0, since
+  // rebuilding an already-drawn deterministic shape samples nothing; a
+  // stochastic ci draws fresh shapes every batch and keeps counting. With the K
+  // knob on, a stochastic ci contributes ~ci_n/K per batch.
   return impl_->pool_shape_count_this_batch_;
 }
 

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -520,32 +520,58 @@ class TraceBackend {
   // and the simulator falls back to per-batch wl in SimData.outgoing_wl_.
   virtual uint32_t WlPoolSize() const { return 0; }
 
-  // task-exit-seam-crystal-count: number of crystal settings in the final
-  // (last) MS layer for the most recent session. Populated by the backend
-  // after BeginSession (CUDA) or after the final TraceLayer call (Metal / CPU),
-  // consumed by Simulator to fill SimData.crystal_count_ for stats reporting.
+  // How many crystal geometries THIS batch freshly SAMPLED, summed across every
+  // (layer, ci). Read by Simulator into SimData::crystal_count_, which
+  // StatsConsumer sums over the run, so the run-level total answers: "how many
+  // distinct crystal geometries did this run actually draw?" — reported as the
+  // CLI's `Stats: ... crystals=N` and the C API's LUMICE_StatsResult.crystal_num.
   //
-  // Per-backend semantic:
-  //   * legacy CPU (SimulateOneWavelength): per-batch Crystal-INSTANCE count —
-  //     one Crystal emplaced per small batch for random-orientation scenes,
-  //     so the accumulated total grows ~ray_num/128.
-  //   * Metal (K-shape geometry pool): distinct pool shapes built during the
-  //     batch summed across every (layer, ci) — Σ P_ci. At the default knob
-  //     LUMICE_GPU_GEOM_CLOCK=0 this collapses to Σ layers Σ ci 1 = the
-  //     cross-layer instance count. With K>0 it grows toward ~ray_num/K and
-  //     converges on the legacy CPU meaning as K → 1.
-  //   * CUDA (K-shape geometry pool): same semantic as Metal — Σ P_ci over
-  //     every (layer, ci) built this batch. At the default knob
-  //     LUMICE_GPU_GEOM_CLOCK=0 this collapses to Σ layers Σ ci 1, matching
-  //     Metal's default meaning byte-for-byte. `disable_device_gen_` debug
-  //     fallback still returns 0 until per-ci accounting on that path lands
-  //     (diagnostic-only gap; the primary device-gen path is exact).
-  // The ONLY consumer is the CLI diagnostic line (main.cpp `Stats: ...
-  // crystals=N`); GUI does not display it and no internal logic depends on it,
-  // so a residual factor-of-K gap between CPU and GPU at intermediate K values
-  // is expected and harmless. Do NOT use this value in a bit-parity assertion
-  // against legacy stats.
-  virtual size_t GetLastBatchCrystalCount() const { return 0; }
+  // A batch that only REUSES geometry reports 0. That is the whole point: the
+  // shape a deterministic param produces is bit-identical on every draw, so
+  // re-deriving it samples nothing new, however many times a backend rebuilds
+  // it. Without this the stat was a function of the batch schedule — a
+  // deterministic scene reported ~(layer,ci) × batch count, so sweeping the
+  // LUMICE_DISPATCH_RAY_NUM performance knob alone moved it by two orders of
+  // magnitude, and a scene with stochastic shapes reported the same number as
+  // its deterministic twin (i.e. the stat was blind to whether geometry
+  // randomization was doing anything, the one question it is for).
+  //
+  // What counts as "new" is ONE judgement, shared: trace_ops.hpp's
+  // NewSampleTracker over IsDeterministic. How each arm HOOKS that judgement up
+  // is deliberately heterogeneous — each follows the reuse structure its own
+  // pipeline already had, and forcing one shape on all four would mean rewriting
+  // three pool lifecycles for no gain:
+  //   * legacy CPU (SimulateOneWavelength): counts its real CrystalMaker calls.
+  //     Its per-Run() `crystal_cache` already separated draw from copy, so it
+  //     needs no tracker.
+  //   * CpuTraceBackend: rebuilds every batch and asks the shared tracker
+  //     whether the rebuild sampled anything. It does NOT cache the Crystal —
+  //     that would change the rng draw order, a behaviour change rather than a
+  //     statistics fix.
+  //   * Metal: same shared tracker, hooked at the per-ci pool resolve. At the
+  //     default LUMICE_GPU_GEOM_CLOCK=0 a ci contributes 1; with K>0 a
+  //     stochastic ci contributes its whole fresh pool (~ci_n/K).
+  //   * CUDA: no tracker — it already SKIPS the pool build on a reuse batch, so
+  //     zeroing the counter at BeginSession is enough to make that skip report
+  //     0. (Its `disable_device_gen_` debug fallback reports 0 unconditionally;
+  //     diagnostic-only gap, primary device-gen path is exact.)
+  // If a future backend needs to build such reuse state FROM SCRATCH, hook it to
+  // NewSampleTracker rather than hand-rolling a third copy of the judgement.
+  //
+  // Two properties are deliberately NOT claimed:
+  //   * Cross-backend equality. The CPU arms sample per ray-group; the GPU arms
+  //     default to K off and sample once per (layer, ci) per batch. The numbers
+  //     legitimately differ on the same scene — that difference IS the sampling
+  //     density difference, made visible. Do NOT "fix" it, and do NOT put this
+  //     value in a cross-backend parity assertion.
+  //   * Worker independence on the multi-worker legacy CPU route. Each worker
+  //     owns its own Simulator and its own crystal cache, so a deterministic
+  //     scene is drawn once PER WORKER and the total is (layer,ci) × active
+  //     workers — and since the batch count decides how many workers get work,
+  //     the dispatch knob still moves it there (bounded by core count, where it
+  //     used to be unbounded in ray_num / dispatch). Fixed-seed runs collapse to
+  //     one worker and are exact.
+  virtual size_t GetLastBatchNewCrystalSampleCount() const { return 0; }
 
   // Per-committed-config tally of GPU-side raypath-color drops (see
   // ColorDegradeCounts above). Base + CPU backend have no such caps and return

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -520,58 +520,71 @@ class TraceBackend {
   // and the simulator falls back to per-batch wl in SimData.outgoing_wl_.
   virtual uint32_t WlPoolSize() const { return 0; }
 
-  // How many crystal geometries THIS batch freshly SAMPLED, summed across every
-  // (layer, ci). Read by Simulator into SimData::crystal_count_, which
-  // StatsConsumer sums over the run, so the run-level total answers: "how many
-  // distinct crystal geometries did this run actually draw?" — reported as the
-  // CLI's `Stats: ... crystals=N` and the C API's LUMICE_StatsResult.crystal_num.
+  // How many STOCHASTIC crystal-geometry draws THIS batch made, summed across
+  // every (layer, ci). Read by Simulator into
+  // SimData::stochastic_crystal_sample_count_.
   //
-  // A batch that only REUSES geometry reports 0. That is the whole point: the
-  // shape a deterministic param produces is bit-identical on every draw, so
-  // re-deriving it samples nothing new, however many times a backend rebuilds
-  // it. Without this the stat was a function of the batch schedule — a
-  // deterministic scene reported ~(layer,ci) × batch count, so sweeping the
-  // LUMICE_DISPATCH_RAY_NUM performance knob alone moved it by two orders of
-  // magnitude, and a scene with stochastic shapes reported the same number as
-  // its deterministic twin (i.e. the stat was blind to whether geometry
-  // randomization was doing anything, the one question it is for).
+  // This is one of the two halves of the user-visible crystal count (the CLI's
+  // `Stats: ... crystals=N`, the C API's LUMICE_StatsResult.crystal_num). The
+  // full contract:
   //
-  // What counts as "new" is ONE judgement, shared: trace_ops.hpp's
-  // NewSampleTracker over IsDeterministic. How each arm HOOKS that judgement up
-  // is deliberately heterogeneous — each follows the reuse structure its own
-  // pipeline already had, and forcing one shape on all four would mean rewriting
-  // three pool lifecycles for no gain:
-  //   * legacy CPU (SimulateOneWavelength): counts its real CrystalMaker calls.
-  //     Its per-Run() `crystal_cache` already separated draw from copy, so it
-  //     needs no tracker.
-  //   * CpuTraceBackend: rebuilds every batch and asks the shared tracker
-  //     whether the rebuild sampled anything. It does NOT cache the Crystal —
-  //     that would change the rng draw order, a behaviour change rather than a
-  //     statistics fix.
-  //   * Metal: same shared tracker, hooked at the per-ci pool resolve. At the
-  //     default LUMICE_GPU_GEOM_CLOCK=0 a ci contributes 1; with K>0 a
-  //     stochastic ci contributes its whole fresh pool (~ci_n/K).
-  //   * CUDA: no tracker — it already SKIPS the pool build on a reuse batch, so
-  //     zeroing the counter at BeginSession is enough to make that skip report
-  //     0. (Its `disable_device_gen_` debug fallback reports 0 unconditionally;
-  //     diagnostic-only gap, primary device-gen path is exact.)
-  // If a future backend needs to build such reuse state FROM SCRATCH, hook it to
-  // NewSampleTracker rather than hand-rolling a third copy of the judgement.
+  //     crystals = (# of (layer, ci) slots whose shape params are deterministic)
+  //              + Σ over batches and workers of THIS getter
   //
-  // Two properties are deliberately NOT claimed:
-  //   * Cross-backend equality. The CPU arms sample per ray-group; the GPU arms
-  //     default to K off and sample once per (layer, ci) per batch. The numbers
-  //     legitimately differ on the same scene — that difference IS the sampling
-  //     density difference, made visible. Do NOT "fix" it, and do NOT put this
-  //     value in a cross-backend parity assertion.
-  //   * Worker independence on the multi-worker legacy CPU route. Each worker
-  //     owns its own Simulator and its own crystal cache, so a deterministic
-  //     scene is drawn once PER WORKER and the total is (layer,ci) × active
-  //     workers — and since the batch count decides how many workers get work,
-  //     the dispatch knob still moves it there (bounded by core count, where it
-  //     used to be unbounded in ray_num / dispatch). Fixed-seed runs collapse to
-  //     one worker and are exact.
-  virtual size_t GetLastBatchNewCrystalSampleCount() const { return 0; }
+  // and the reason it is a sum of two differently-aggregated terms is the whole
+  // design. A deterministic param produces a bit-identical shape on every draw,
+  // so the geometry it contributes is ONE geometry no matter how many batches
+  // re-derive it or how many workers redundantly derive it in parallel — it is a
+  // property of the committed scene, so it is counted once from the config and
+  // OVERWRITTEN on the way through (StatsConsumer::Consume). A stochastic param
+  // draws a genuinely different shape every time, on every worker's independent
+  // RNG stream, so those draws SUM. Conflating the two is what the whole task
+  // was about: the count used to be a per-batch quantity summed blindly, so a
+  // deterministic scene reported ~(layer,ci) × batch count × worker count —
+  // sweeping the LUMICE_DISPATCH_RAY_NUM performance knob alone moved it by two
+  // orders of magnitude, the worker pool scaled it linearly, and a scene with
+  // stochastic shapes reported the same number as its deterministic twin (the
+  // stat was blind to whether geometry randomization was doing anything, the one
+  // question it is for).
+  //
+  // Consequences worth stating outright, because they are choices and not
+  // accidents:
+  //   * A batch that only REUSES geometry reports 0 here, and a fully
+  //     deterministic scene reports 0 from every batch of every backend. Its
+  //     whole count comes from the config-constant term.
+  //   * The deterministic term counts scene SLOTS, not slots that were actually
+  //     traced. A (layer, ci) with crystal_proportion_ == 0 never reaches
+  //     MakeCrystal on the legacy path, yet still counts. That is inherent to
+  //     "config constant", and it is exactly what buys immunity to the dispatch
+  //     grain and the worker count.
+  //
+  // The judgement itself is ONE predicate, already single-sourced:
+  // IsDeterministic() in trace_ops.hpp. Where each arm applies it is deliberately
+  // heterogeneous — each follows the reuse structure its own pipeline already
+  // had, and forcing one shape on all four would mean rewriting three pool
+  // lifecycles for no gain:
+  //   * legacy CPU (SimulateOneWavelength): counts its real CrystalMaker calls,
+  //     minus the deterministic ones. Its per-Run() `crystal_cache` already
+  //     separated draw from copy.
+  //   * CpuTraceBackend: rebuilds every batch, counts the rebuilds that were
+  //     stochastic. It does NOT cache the Crystal — that would change the rng
+  //     draw order, a behaviour change rather than a statistics fix.
+  //   * Metal: same predicate, applied at the per-ci pool resolve. At the default
+  //     LUMICE_GPU_GEOM_CLOCK=0 a stochastic ci contributes 1; with K>0 it
+  //     contributes its whole fresh pool (~ci_n/K).
+  //   * CUDA: same predicate inside the pool build, which it already SKIPS
+  //     entirely on a reuse batch. (Its `disable_device_gen_` debug fallback
+  //     reports 0 unconditionally; diagnostic-only gap, primary device-gen path
+  //     is exact.)
+  // A future backend should apply IsDeterministic at whatever point it draws,
+  // rather than hand-rolling a second copy of the judgement.
+  //
+  // One property is deliberately NOT claimed: cross-backend equality. The CPU
+  // arms sample per ray-group; the GPU arms default to K off and sample once per
+  // (layer, ci) per batch. The numbers legitimately differ on the same scene —
+  // that difference IS the sampling density difference, made visible. Do NOT
+  // "fix" it, and do NOT put this value in a cross-backend parity assertion.
+  virtual size_t GetLastBatchStochasticCrystalSampleCount() const { return 0; }
 
   // Per-committed-config tally of GPU-side raypath-color drops (see
   // ColorDegradeCounts above). Base + CPU backend have no such caps and return

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -470,6 +470,18 @@ bool IsDeterministic(const CrystalParam& param) {
       param);
 }
 
+size_t DeterministicCrystalCount(const SceneConfig& config) {
+  size_t n = 0;
+  for (const auto& ms : config.ms_) {
+    for (const auto& setting : ms.setting_) {
+      if (IsDeterministic(setting.crystal_.param_)) {
+        n++;
+      }
+    }
+  }
+  return n;
+}
+
 
 RayBuffer AllocateAllData(const SceneConfig& config, size_t ray_num) {
   // Calculate total rays (expected value) used in the whole simulation.
@@ -1124,11 +1136,12 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   all_crystals.reserve(16);
   std::vector<AxisDistribution> all_axis_dists;
   all_axis_dists.reserve(16);
-  // How many crystal geometries this batch actually SAMPLED, i.e. how many
-  // times below we reach the real CrystalMaker call. Distinct from
-  // all_crystals.size(), which also counts the copies made when a shape is
-  // reused — see the crystal_count_ assignment at the end of this function.
-  size_t new_sample_count = 0;
+  // How many STOCHASTIC crystal geometries this batch drew, i.e. how many times
+  // below we reach the real CrystalMaker call with a param that actually
+  // consumes the RNG. Distinct from all_crystals.size(), which also counts the
+  // copies made when a shape is reused, and it deliberately excludes
+  // deterministic draws — see the assignment at the end of this function.
+  size_t stochastic_sample_count = 0;
 
   bool first_ms = true;
   for (size_t mi = 0; mi < config.ms_.size() && !stop_; mi++) {
@@ -1213,11 +1226,16 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
           all_axis_dists.emplace_back(s.crystal_.axis_);
           // The ONLY branch that draws a geometry: the two above copy an
           // existing shape (from this ci loop, or from the per-Run() cache).
-          new_sample_count++;
+          // Deterministic draws are excluded from the counter because they are
+          // already accounted for by the scene's config-constant term —
+          // counting them here would put them in a per-worker sum and scale the
+          // stat by the pool size.
           if (deterministic) {
             crystal_cache.emplace_back(param_ptr, all_crystals.back());
             cached_crystal = &crystal_cache.back().second;
             ci_crystal_id = curr_crystal_id;
+          } else {
+            stochastic_sample_count++;
           }
         }
         const auto& curr_crystal = all_crystals[curr_crystal_id];
@@ -1315,15 +1333,17 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   sim_data.outgoing_w_ = std::move(outgoing_w);
   sim_data.outgoing_component_ = std::move(outgoing_component);  // task-331.1
   sim_data.root_ray_count_ = original_ray_num;
-  // Newly SAMPLED geometries, not materialised instances. `crystals_` keeps
-  // every instance (the consumers index into it by per-ray crystal id and need
-  // the reuse copies), but reporting its size made the stat a function of the
-  // batch schedule: a deterministic scene re-copied its cached shape once per
-  // small batch, so the run-level sum grew with ray_num / batch size instead of
-  // describing the scene. `crystal_cache` lives in Run() scope, so a
-  // deterministic shape is drawn once per run and this stays at the scene's
-  // (layer, ci) count no matter how the rays are batched.
-  sim_data.crystal_count_ = new_sample_count;
+  // Newly DRAWN stochastic geometries, not materialised instances. `crystals_`
+  // keeps every instance (the consumers index into it by per-ray crystal id and
+  // need the reuse copies), but reporting its size made the stat a function of
+  // the batch schedule: a deterministic scene re-copied its cached shape once
+  // per small batch, so the run-level sum grew with ray_num / batch size
+  // instead of describing the scene. The deterministic half of the scene rides
+  // the config-constant field below instead of any per-batch counter, which is
+  // what also keeps it from scaling with the worker pool (every worker runs
+  // this function on its own Simulator).
+  sim_data.stochastic_crystal_sample_count_ = stochastic_sample_count;
+  sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(config);
   data_queue_->Emplace(std::move(sim_data));
 }
 
@@ -1374,7 +1394,10 @@ void Simulator::DrainDeviceXyz(TraceBackend* backend) {
   sim_data.curr_wl_ = xyz_win_.wl;
   sim_data.generation_ = xyz_win_.generation;
   sim_data.root_ray_count_ = xyz_win_.root_rays;
-  sim_data.crystal_count_ = xyz_win_.crystals;
+  sim_data.stochastic_crystal_sample_count_ = xyz_win_.stochastic_crystal_samples;
+  // OVERWRITE semantics, same as color_degrade_counts_ below: a config constant
+  // is carried through the window, never summed over its batches.
+  sim_data.deterministic_crystal_count_ = xyz_win_.deterministic_crystals;
   // task-color-degrade-gui-surfacing: carry the window's GPU color-degrade tally
   // into the drained SimData (config constant, direct copy — not accumulated).
   sim_data.color_degrade_counts_ = xyz_win_.color_degrade_counts_;
@@ -1522,7 +1545,9 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
       // hits the batch cap here. This sheds the per-batch synchronous D2H tax.
       xyz_win_.pending = true;
       xyz_win_.root_rays += ray_num;
-      xyz_win_.crystals += backend.GetLastBatchNewCrystalSampleCount();
+      xyz_win_.stochastic_crystal_samples += backend.GetLastBatchStochasticCrystalSampleCount();
+      // OVERWRITE (not +=) — config constant, identical on every batch.
+      xyz_win_.deterministic_crystals = DeterministicCrystalCount(scene);
       xyz_win_.generation = generation;
       xyz_win_.w = w;
       xyz_win_.h = h;
@@ -1543,7 +1568,8 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     sim_data.curr_wl_ = wl_param.wl_;
     sim_data.generation_ = generation;
     sim_data.root_ray_count_ = ray_num;
-    sim_data.crystal_count_ = backend.GetLastBatchNewCrystalSampleCount();
+    sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
+    sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(scene);
     // task-color-degrade-gui-surfacing: carry the GPU color-degrade tally on the
     // legacy per-batch drain too. Dead for today's backends (Metal + CUDA both take
     // the third-clock window branch above), but keeps this path from silently
@@ -1612,7 +1638,8 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   sim_data.root_ray_count_ = ray_num;  // distinguishes a valid backend batch
                                        // from the shutdown sentinel (see
                                        // server.cpp::ConsumeData).
-  sim_data.crystal_count_ = backend.GetLastBatchNewCrystalSampleCount();
+  sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
+  sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(scene);
   sim_data.outgoing_d_ = std::move(exit_d);
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1522,7 +1522,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
       // hits the batch cap here. This sheds the per-batch synchronous D2H tax.
       xyz_win_.pending = true;
       xyz_win_.root_rays += ray_num;
-      xyz_win_.crystals += backend.GetLastBatchCrystalCount();
+      xyz_win_.crystals += backend.GetLastBatchNewCrystalSampleCount();
       xyz_win_.generation = generation;
       xyz_win_.w = w;
       xyz_win_.h = h;
@@ -1543,7 +1543,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     sim_data.curr_wl_ = wl_param.wl_;
     sim_data.generation_ = generation;
     sim_data.root_ray_count_ = ray_num;
-    sim_data.crystal_count_ = backend.GetLastBatchCrystalCount();
+    sim_data.crystal_count_ = backend.GetLastBatchNewCrystalSampleCount();
     // task-color-degrade-gui-surfacing: carry the GPU color-degrade tally on the
     // legacy per-batch drain too. Dead for today's backends (Metal + CUDA both take
     // the third-clock window branch above), but keeps this path from silently
@@ -1612,7 +1612,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
   sim_data.root_ray_count_ = ray_num;  // distinguishes a valid backend batch
                                        // from the shutdown sentinel (see
                                        // server.cpp::ConsumeData).
-  sim_data.crystal_count_ = backend.GetLastBatchCrystalCount();
+  sim_data.crystal_count_ = backend.GetLastBatchNewCrystalSampleCount();
   sim_data.outgoing_d_ = std::move(exit_d);
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1124,6 +1124,11 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   all_crystals.reserve(16);
   std::vector<AxisDistribution> all_axis_dists;
   all_axis_dists.reserve(16);
+  // How many crystal geometries this batch actually SAMPLED, i.e. how many
+  // times below we reach the real CrystalMaker call. Distinct from
+  // all_crystals.size(), which also counts the copies made when a shape is
+  // reused — see the crystal_count_ assignment at the end of this function.
+  size_t new_sample_count = 0;
 
   bool first_ms = true;
   for (size_t mi = 0; mi < config.ms_.size() && !stop_; mi++) {
@@ -1206,6 +1211,9 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
           curr_crystal_id = all_crystals.size();
           all_crystals.emplace_back(std::visit(CrystalMaker{ rng_ }, s.crystal_.param_));
           all_axis_dists.emplace_back(s.crystal_.axis_);
+          // The ONLY branch that draws a geometry: the two above copy an
+          // existing shape (from this ci loop, or from the per-Run() cache).
+          new_sample_count++;
           if (deterministic) {
             crystal_cache.emplace_back(param_ptr, all_crystals.back());
             cached_crystal = &crystal_cache.back().second;
@@ -1307,7 +1315,15 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   sim_data.outgoing_w_ = std::move(outgoing_w);
   sim_data.outgoing_component_ = std::move(outgoing_component);  // task-331.1
   sim_data.root_ray_count_ = original_ray_num;
-  sim_data.crystal_count_ = sim_data.crystals_.size();
+  // Newly SAMPLED geometries, not materialised instances. `crystals_` keeps
+  // every instance (the consumers index into it by per-ray crystal id and need
+  // the reuse copies), but reporting its size made the stat a function of the
+  // batch schedule: a deterministic scene re-copied its cached shape once per
+  // small batch, so the run-level sum grew with ray_num / batch size instead of
+  // describing the scene. `crystal_cache` lives in Run() scope, so a
+  // deterministic shape is drawn once per run and this stays at the scene's
+  // (layer, ci) count no matter how the rays are batched.
+  sim_data.crystal_count_ = new_sample_count;
   data_queue_->Emplace(std::move(sim_data));
 }
 

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -999,6 +999,9 @@ void Simulator::Run() {
     const auto& config = *batch.scene_;
     auto generation = batch.generation_;
     idle_ = false;
+    // Single derivation point for the config-constant half of the crystal count
+    // (see the member's declaration for why it is not gated on a generation change).
+    deterministic_crystal_count_ = DeterministicCrystalCount(config);
 
     // Reset carry when config changes (new generation = new proportions).
     if (generation != prev_generation) {
@@ -1343,7 +1346,7 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   // what also keeps it from scaling with the worker pool (every worker runs
   // this function on its own Simulator).
   sim_data.stochastic_crystal_sample_count_ = stochastic_sample_count;
-  sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(config);
+  sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
   data_queue_->Emplace(std::move(sim_data));
 }
 
@@ -1547,7 +1550,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
       xyz_win_.root_rays += ray_num;
       xyz_win_.stochastic_crystal_samples += backend.GetLastBatchStochasticCrystalSampleCount();
       // OVERWRITE (not +=) — config constant, identical on every batch.
-      xyz_win_.deterministic_crystals = DeterministicCrystalCount(scene);
+      xyz_win_.deterministic_crystals = deterministic_crystal_count_;
       xyz_win_.generation = generation;
       xyz_win_.w = w;
       xyz_win_.h = h;
@@ -1569,7 +1572,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     sim_data.generation_ = generation;
     sim_data.root_ray_count_ = ray_num;
     sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
-    sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(scene);
+    sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
     // task-color-degrade-gui-surfacing: carry the GPU color-degrade tally on the
     // legacy per-batch drain too. Dead for today's backends (Metal + CUDA both take
     // the third-clock window branch above), but keeps this path from silently
@@ -1639,7 +1642,7 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
                                        // from the shutdown sentinel (see
                                        // server.cpp::ConsumeData).
   sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
-  sim_data.deterministic_crystal_count_ = DeterministicCrystalCount(scene);
+  sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
   sim_data.outgoing_d_ = std::move(exit_d);
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -109,9 +109,14 @@ class Simulator {
   // display cadence (producer-pause / generation-change / run-exit / batch cap),
   // not per batch — see Run() and DrainDeviceXyz.
   struct XyzDrainWindow {
-    bool pending = false;     // undrained device accumulation present
-    size_t root_rays = 0;     // Σ ray_num over the window (normalization denom)
-    size_t crystals = 0;      // Σ crystal_count over the window (stats)
+    bool pending = false;  // undrained device accumulation present
+    size_t root_rays = 0;  // Σ ray_num over the window (normalization denom)
+    // Stats: Σ stochastic draws over the window (accumulated) alongside the
+    // scene's deterministic slot count (OVERWRITTEN — config constant, same
+    // discipline as color_degrade_counts_ below). See TraceBackend::
+    // GetLastBatchStochasticCrystalSampleCount for why the two cannot be one.
+    size_t stochastic_crystal_samples = 0;
+    size_t deterministic_crystals = 0;
     uint64_t generation = 0;  // generation the window belongs to
     int w = 0;                // render resolution of the window
     int h = 0;

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -150,6 +150,17 @@ class Simulator {
   // ray_num*2 == 256 for a 128-ray SimBatch. See env_knobs.hpp GeomClock() for
   // the measured exit codes and the full mechanism before raising it.
   size_t geom_clock_ = kSmallBatchRayNum;
+  // Deterministic half of the reported crystal-geometry count for the config
+  // currently in hand — a pure function of that config (see
+  // trace_ops.hpp::DeterministicCrystalCount), so it is derived ONCE per
+  // committed batch in Run() and merely read by the four sites that publish it.
+  // Those sites all aggregate it by OVERWRITE, so recomputing per site was
+  // harmless, but it left the invariant with four derivation points and no
+  // single authority. Assigned in Run() right after the config is obtained
+  // rather than gated on `generation != prev_generation`: `prev_generation`
+  // starts at 0, so a generation-keyed cache would skip the first committed
+  // config whenever generations are 0-based and silently publish 0.
+  size_t deterministic_crystal_count_ = 0;
 
   QueuePtrS<SimBatch> config_queue_;
   QueuePtrS<SimData> data_queue_;

--- a/src/core/trace_ops.hpp
+++ b/src/core/trace_ops.hpp
@@ -2,6 +2,7 @@
 #define CORE_TRACE_OPS_H_
 
 #include <cstddef>
+#include <vector>
 
 #include "config/light_config.hpp"
 #include "config/proj_config.hpp"
@@ -20,7 +21,12 @@ class FilterSpec;
 // not included from simulator.hpp — backends that need these primitives
 // include it directly to keep simulator.hpp's TU set unpolluted.
 //
-// All function bodies live in simulator.cpp.
+// All free-function bodies live in simulator.cpp. The one type declared here
+// (NewSampleTracker, at the bottom) is a deliberate exception to the otherwise
+// stateless character of this header: it carries the minimum state a shared
+// PREDICATE needs to stay a single source. It is a judgement helper, not a
+// pipeline stage — anything with real per-session machinery belongs on a
+// backend, not here.
 
 // Sample crystal origin (p, from_face_, to_face_). Direction d MUST already
 // be set on the buffer.
@@ -93,6 +99,65 @@ Crystal MakeCrystal(RandomNumberGenerator& rng, const CrystalParam& param);
 // namespace scope — this header only adds the declaration so backends can see
 // it without duplicating the visitor logic).
 bool IsDeterministic(const CrystalParam& param);
+
+// Single source for one question: "is this (layer, ci) about to produce a NEW
+// crystal geometry, or is it re-deriving one this scene already sampled?"
+//
+// It exists so the backends that need that distinction share one judgement
+// instead of hand-writing it each: two hand-written copies of a predicate that
+// must agree are exactly how a semantic drifts (one excludes some path, the
+// other forgets to). Callers own the counter; this owns only the verdict.
+//
+// Rules:
+//   - a stochastic param is ALWAYS a new sample (each MakeCrystal draws a
+//     different shape), and is never remembered;
+//   - a deterministic param is a new sample the first time this scene asks for
+//     it and a reuse for the rest of the scene — MakeCrystal is bit-identical
+//     across repeated calls, so re-deriving it samples nothing new even when a
+//     backend does rebuild it every batch;
+//   - identity is the CrystalParam's ADDRESS, i.e. its (layer, ci) slot in the
+//     scene, not its value: two slots that happen to carry equal params are two
+//     populations, and the legacy path's own crystal cache keys the same way.
+//
+// Lifetime: one instance per backend instance = one Simulator::Run(), NOT one
+// per session. A per-batch reset would degrade it to "did this ci repeat inside
+// one batch", which is the very cross-batch double-count it exists to stop.
+// Scene-pointer identity is the invalidation signal (the pointers in `sampled_`
+// point into that scene's config), mirroring how the CUDA backend guards its
+// geometry pool.
+class NewSampleTracker {
+ public:
+  // Call at each BeginSession: clears the remembered set only when the scene
+  // actually changed, so repeated batches of one scene keep accumulating.
+  void ResetIfSceneChanged(const void* scene) {
+    if (scene == scene_) {
+      return;
+    }
+    scene_ = scene;
+    sampled_.clear();
+  }
+
+  // True = count this as a fresh geometry sample. See the rules above.
+  bool MarkIfNew(const CrystalParam& param) {
+    if (!IsDeterministic(param)) {
+      return true;
+    }
+    const CrystalParam* key = &param;
+    for (const auto* seen : sampled_) {
+      if (seen == key) {
+        return false;
+      }
+    }
+    sampled_.push_back(key);
+    return true;
+  }
+
+ private:
+  const void* scene_ = nullptr;
+  // Deterministic (layer, ci) params already sampled in `scene_`. Linear scan:
+  // the size is the scene's (layer, ci) count — single digits in practice.
+  std::vector<const CrystalParam*> sampled_;
+};
 
 }  // namespace lumice
 

--- a/src/core/trace_ops.hpp
+++ b/src/core/trace_ops.hpp
@@ -21,12 +21,8 @@ class FilterSpec;
 // not included from simulator.hpp — backends that need these primitives
 // include it directly to keep simulator.hpp's TU set unpolluted.
 //
-// All free-function bodies live in simulator.cpp. The one type declared here
-// (NewSampleTracker, at the bottom) is a deliberate exception to the otherwise
-// stateless character of this header: it carries the minimum state a shared
-// PREDICATE needs to stay a single source. It is a judgement helper, not a
-// pipeline stage — anything with real per-session machinery belongs on a
-// backend, not here.
+// All free-function bodies live in simulator.cpp. This header is stateless by
+// design — anything with real per-session machinery belongs on a backend.
 
 // Sample crystal origin (p, from_face_, to_face_). Direction d MUST already
 // be set on the buffer.
@@ -100,64 +96,14 @@ Crystal MakeCrystal(RandomNumberGenerator& rng, const CrystalParam& param);
 // it without duplicating the visitor logic).
 bool IsDeterministic(const CrystalParam& param);
 
-// Single source for one question: "is this (layer, ci) about to produce a NEW
-// crystal geometry, or is it re-deriving one this scene already sampled?"
-//
-// It exists so the backends that need that distinction share one judgement
-// instead of hand-writing it each: two hand-written copies of a predicate that
-// must agree are exactly how a semantic drifts (one excludes some path, the
-// other forgets to). Callers own the counter; this owns only the verdict.
-//
-// Rules:
-//   - a stochastic param is ALWAYS a new sample (each MakeCrystal draws a
-//     different shape), and is never remembered;
-//   - a deterministic param is a new sample the first time this scene asks for
-//     it and a reuse for the rest of the scene — MakeCrystal is bit-identical
-//     across repeated calls, so re-deriving it samples nothing new even when a
-//     backend does rebuild it every batch;
-//   - identity is the CrystalParam's ADDRESS, i.e. its (layer, ci) slot in the
-//     scene, not its value: two slots that happen to carry equal params are two
-//     populations, and the legacy path's own crystal cache keys the same way.
-//
-// Lifetime: one instance per backend instance = one Simulator::Run(), NOT one
-// per session. A per-batch reset would degrade it to "did this ci repeat inside
-// one batch", which is the very cross-batch double-count it exists to stop.
-// Scene-pointer identity is the invalidation signal (the pointers in `sampled_`
-// point into that scene's config), mirroring how the CUDA backend guards its
-// geometry pool.
-class NewSampleTracker {
- public:
-  // Call at each BeginSession: clears the remembered set only when the scene
-  // actually changed, so repeated batches of one scene keep accumulating.
-  void ResetIfSceneChanged(const void* scene) {
-    if (scene == scene_) {
-      return;
-    }
-    scene_ = scene;
-    sampled_.clear();
-  }
-
-  // True = count this as a fresh geometry sample. See the rules above.
-  bool MarkIfNew(const CrystalParam& param) {
-    if (!IsDeterministic(param)) {
-      return true;
-    }
-    const CrystalParam* key = &param;
-    for (const auto* seen : sampled_) {
-      if (seen == key) {
-        return false;
-      }
-    }
-    sampled_.push_back(key);
-    return true;
-  }
-
- private:
-  const void* scene_ = nullptr;
-  // Deterministic (layer, ci) params already sampled in `scene_`. Linear scan:
-  // the size is the scene's (layer, ci) count — single digits in practice.
-  std::vector<const CrystalParam*> sampled_;
-};
+// How many (layer, ci) slots of `config` carry deterministic shape params —
+// the config-constant half of the reported crystal-geometry count (the other
+// half being TraceBackend::GetLastBatchStochasticCrystalSampleCount, where the
+// contract is documented in full). Counts scene slots, NOT slots that a given
+// run happened to trace: being a pure function of the committed config is
+// precisely what makes the reported count immune to the dispatch grain and to
+// the worker-pool size.
+size_t DeterministicCrystalCount(const SceneConfig& config);
 
 }  // namespace lumice
 

--- a/src/core/trace_ops.hpp
+++ b/src/core/trace_ops.hpp
@@ -2,7 +2,6 @@
 #define CORE_TRACE_OPS_H_
 
 #include <cstddef>
-#include <vector>
 
 #include "config/light_config.hpp"
 #include "config/proj_config.hpp"

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1180,9 +1180,11 @@ void ServerImpl::ConsumeData() {
           auto t_lock1 = std::chrono::steady_clock::now();
           // task-268.4: chunk by kCommitCap on the backend exit-seam path
           // (outgoing_d_ populated AND rays_ empty). Only the FIRST chunk
-          // carries root_ray_count_ + crystals_ — StatsConsumer accumulates
-          // both, so spreading them across chunks would N×-count and break
-          // the stats invariant. Legacy CPU SimData (rays_ non-empty) are
+          // carries root_ray_count_ + the stochastic crystal-draw count —
+          // StatsConsumer accumulates both, so spreading them across chunks
+          // would N×-count and break the stats invariant. (The deterministic
+          // crystal count is the opposite case; see the chunk fill below.)
+          // Legacy CPU SimData (rays_ non-empty) are
           // delivered whole because their consumers project via per-ray
           // indices into rays_, which has no clean sub-batch slice.
           // NOLINTNEXTLINE(readability-identifier-naming) — local const flag, snake_case is project style for
@@ -1200,15 +1202,21 @@ void ServerImpl::ConsumeData() {
               SimData chunk;
               chunk.curr_wl_ = sim_data.curr_wl_;
               chunk.generation_ = sim_data.generation_;
-              // Stats fields only on the first chunk; rest carry 0 / empty
-              // so StatsConsumer's sim_rays_ / crystals_ accumulate to the
-              // same totals as a single whole-Consume call would yield.
+              // ACCUMULATED stats fields go on the first chunk only; the rest
+              // carry 0 / empty so StatsConsumer's running sums land on the same
+              // totals a single whole-Consume call would yield.
               if (emitted == 0) {
                 chunk.root_ray_count_ = sim_data.root_ray_count_;
-                chunk.crystal_count_ = sim_data.crystal_count_;
+                chunk.stochastic_crystal_sample_count_ = sim_data.stochastic_crystal_sample_count_;
                 chunk.crystals_ = sim_data.crystals_;
                 chunk.crystal_axis_dists_ = sim_data.crystal_axis_dists_;
               }
+              // OVERWRITTEN stats fields must go on EVERY chunk — the consumer
+              // stores rather than adds, so leaving this at 0 on the trailing
+              // chunks would have the last one wipe the value the first chunk
+              // published. The inverse of the rule above, for the inverse
+              // aggregation.
+              chunk.deterministic_crystal_count_ = sim_data.deterministic_crystal_count_;
               if (chunk_count > 0) {
                 chunk.outgoing_d_.assign(
                     sim_data.outgoing_d_.begin() + static_cast<std::ptrdiff_t>(emitted) * 3,

--- a/src/server/stats.cpp
+++ b/src/server/stats.cpp
@@ -7,13 +7,21 @@ namespace lumice {
 void StatsConsumer::Consume(const SimData& data) {
   sim_rays_ += data.root_ray_count_;
   total_rays_ += data.rays_.size_;
-  crystals_ += data.crystal_count_;
+  // The two halves of the crystal-geometry count aggregate differently, and
+  // conflating them is what made this stat scale with the dispatch grain and
+  // the worker-pool size. Stochastic draws are genuinely distinct geometries
+  // per batch and per worker, so they SUM; the deterministic population is a
+  // property of the committed scene that every batch and every worker reports
+  // identically, so it is OVERWRITTEN (same discipline as the GPU
+  // color-degrade tally). See SimData for the field-level contract.
+  stochastic_crystal_samples_ += data.stochastic_crystal_sample_count_;
+  deterministic_crystals_ = data.deterministic_crystal_count_;
 }
 
 void StatsConsumer::PrepareSnapshot() {
   snapshot_total_rays_ = total_rays_;
   snapshot_sim_rays_ = sim_rays_;
-  snapshot_crystals_ = crystals_;
+  snapshot_crystals_ = deterministic_crystals_ + stochastic_crystal_samples_;
 }
 
 Result StatsConsumer::GetResult() const {
@@ -23,7 +31,8 @@ Result StatsConsumer::GetResult() const {
 void StatsConsumer::Reset() {
   total_rays_ = 0;
   sim_rays_ = 0;
-  crystals_ = 0;
+  stochastic_crystal_samples_ = 0;
+  deterministic_crystals_ = 0;
   snapshot_total_rays_ = 0;
   snapshot_sim_rays_ = 0;
   snapshot_crystals_ = 0;

--- a/src/server/stats.hpp
+++ b/src/server/stats.hpp
@@ -27,7 +27,10 @@ class StatsConsumer : public IConsume {
  private:
   size_t total_rays_ = 0;
   size_t sim_rays_ = 0;
-  size_t crystals_ = 0;
+  // Two accumulators, two rules — summed vs overwritten. Their sum is the
+  // reported crystal count; see Consume() for why they cannot be one counter.
+  size_t stochastic_crystal_samples_ = 0;
+  size_t deterministic_crystals_ = 0;
   size_t snapshot_total_rays_ = 0;
   size_t snapshot_sim_rays_ = 0;
   size_t snapshot_crystals_ = 0;

--- a/test/cuda_test_helpers.hpp
+++ b/test/cuda_test_helpers.hpp
@@ -94,6 +94,14 @@ inline SceneConfig MakePrismScene(size_t max_hits) {
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
+// The std is arbitrary — ANY non-zero variance flips the predicate, and no
+// assertion depends on the magnitude — but it is kept identical across the sibling
+// copies (test/cpu_test_helpers.hpp's user in parity-cross-backend, and the
+// metal/cuda helper here) so the number cannot be misread as a meaningful
+// per-backend difference. The copies exist because these headers sit behind
+// __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a shared unguarded
+// home ever exists.
 inline void MakeShapeStochastic(ScatteringSetting& setting) {
   auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };

--- a/test/cuda_test_helpers.hpp
+++ b/test/cuda_test_helpers.hpp
@@ -14,6 +14,7 @@
 #if defined(LUMICE_CUDA_ENABLED)
 
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "config/crystal_config.hpp"
@@ -88,6 +89,15 @@ inline SceneConfig MakePrismScene(size_t max_hits) {
   ms.setting_.push_back(std::move(s));
   scene.ms_.push_back(std::move(ms));
   return scene;
+}
+
+// Turn a setting's prism height into a stochastic distribution, so
+// IsDeterministic(param) is false and every MakeCrystal call on it is a real
+// draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+inline void MakeShapeStochastic(ScatteringSetting& setting) {
+  auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
+  prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };
+  setting.crystal_.param_ = prism;
 }
 
 // Single-crystal random-axis prism scene. Random orientation makes the gen

--- a/test/cuda_test_helpers.hpp
+++ b/test/cuda_test_helpers.hpp
@@ -94,14 +94,12 @@ inline SceneConfig MakePrismScene(size_t max_hits) {
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
-// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
-// The std is arbitrary — ANY non-zero variance flips the predicate, and no
-// assertion depends on the magnitude — but it is kept identical across the sibling
-// copies (test/cpu_test_helpers.hpp's user in parity-cross-backend, and the
-// metal/cuda helper here) so the number cannot be misread as a meaningful
-// per-backend difference. The copies exist because these headers sit behind
-// __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a shared unguarded
-// home ever exists.
+// The std is arbitrary — any non-zero variance flips the predicate and no
+// assertion depends on the magnitude — but it is kept identical to the sibling
+// copies in the cpu/metal/cuda test helpers so the number cannot be misread as a
+// meaningful per-backend difference. Those copies exist because the metal/cuda
+// headers sit behind __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a
+// shared unguarded home ever exists.
 inline void MakeShapeStochastic(ScatteringSetting& setting) {
   auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -137,9 +137,11 @@ class SimResult:
     """Subset of LUMICE_RawXyzResult fields exposed to test code.
 
     `crystal_num` comes from LUMICE_StatsResult (a different C API call), read
-    once after the run reached IDLE-with-valid-data: it is the run-level sum of
-    per-batch new-crystal-sample counts, so it is only meaningful once the
-    simulation finished.
+    once after the run reached IDLE-with-valid-data: how many distinct crystal
+    geometries the run actually drew. Its two halves aggregate differently — the
+    deterministic population is a config constant carried by OVERWRITE, the
+    stochastic draws accumulate per batch and per worker — so it is only
+    meaningful once the simulation finished. See doc/c_api.md for the contract.
     """
 
     snapshot_intensity: float
@@ -365,9 +367,13 @@ def _summarize_backend(lines: List[str]) -> tuple[str, bool]:
 def _read_crystal_num(lib, server) -> int:
     """Read LUMICE_StatsResult.crystal_num for the run that just finished.
 
-    Call only after the polling loop observed has_valid_data AND IDLE — the
-    field is a run-level accumulation (StatsConsumer sums the per-batch
-    crystal_count_), so reading it mid-run returns a partial total.
+    Call only after the polling loop observed has_valid_data AND IDLE. The value
+    is the deterministic population (a config constant, OVERWRITTEN on the way
+    through StatsConsumer) plus the stochastic draws (accumulated across batches
+    and workers), so reading it mid-run returns a partial total: the stochastic
+    half is still growing. Not a plain sum — the deterministic half deliberately
+    does NOT scale with the batch count or the worker pool, which is the whole
+    point of the split.
     Returns 0 when no stats row is available (no StatsConsumer output yet).
     """
     stats = (LUMICE_StatsResult * (_LUMICE_MAX_STATS_RESULTS + 1))()

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -83,6 +83,26 @@ assert ctypes.sizeof(LUMICE_RenderResult) == 32, (
     "LUMICE_RenderResult size mismatch — verify lumice.h field layout"
 )
 
+
+# Mirrors LUMICE_StatsResult in src/include/lumice.h. All three fields are
+# LUMICE_RayCount = `unsigned long long` (64-bit on every platform, unlike
+# `unsigned long` on Windows — see the static_assert next to the typedef).
+class LUMICE_StatsResult(ctypes.Structure):
+    _fields_ = [
+        ("ray_seg_num",  ctypes.c_ulonglong),
+        ("sim_ray_num",  ctypes.c_ulonglong),
+        ("crystal_num",  ctypes.c_ulonglong),
+    ]
+
+
+assert ctypes.sizeof(LUMICE_StatsResult) == 24, (
+    "LUMICE_StatsResult size mismatch — verify lumice.h field layout"
+)
+
+# lumice.h LUMICE_MAX_STATS_RESULTS. The out array must hold one extra slot for
+# the all-zero sentinel LUMICE_GetStatsResults writes past the last filled row.
+_LUMICE_MAX_STATS_RESULTS = 1
+
 # Backend constants (lumice.h:391-392).
 LUMICE_BACKEND_CPU = 0
 LUMICE_BACKEND_METAL = 1
@@ -114,11 +134,18 @@ _LUMICE_SERVER_NOT_READY = 2
 
 @dataclass
 class SimResult:
-    """Subset of LUMICE_RawXyzResult fields exposed to test code."""
+    """Subset of LUMICE_RawXyzResult fields exposed to test code.
+
+    `crystal_num` comes from LUMICE_StatsResult (a different C API call), read
+    once after the run reached IDLE-with-valid-data: it is the run-level sum of
+    per-batch new-crystal-sample counts, so it is only meaningful once the
+    simulation finished.
+    """
 
     snapshot_intensity: float
     has_valid_data: bool
     effective_pixels: int
+    crystal_num: int = 0
 
 
 @dataclass
@@ -144,6 +171,7 @@ class BufferedSimResult:
     routed_backend: str = ""
     fell_back: bool = False
     log_lines: List[str] = field(default_factory=list)
+    crystal_num: int = 0
 
 
 def _project_root() -> Path:
@@ -228,6 +256,13 @@ def _load_lib() -> ctypes.CDLL:
     lib.LUMICE_GetRawXyzResults.argtypes = [
         ctypes.c_void_p,
         ctypes.POINTER(LUMICE_RawXyzResult),
+        ctypes.c_int,
+    ]
+
+    lib.LUMICE_GetStatsResults.restype = ctypes.c_int
+    lib.LUMICE_GetStatsResults.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(LUMICE_StatsResult),
         ctypes.c_int,
     ]
 
@@ -327,6 +362,23 @@ def _summarize_backend(lines: List[str]) -> tuple[str, bool]:
     return routed, fell_back
 
 
+def _read_crystal_num(lib, server) -> int:
+    """Read LUMICE_StatsResult.crystal_num for the run that just finished.
+
+    Call only after the polling loop observed has_valid_data AND IDLE — the
+    field is a run-level accumulation (StatsConsumer sums the per-batch
+    crystal_count_), so reading it mid-run returns a partial total.
+    Returns 0 when no stats row is available (no StatsConsumer output yet).
+    """
+    stats = (LUMICE_StatsResult * (_LUMICE_MAX_STATS_RESULTS + 1))()
+    err = lib.LUMICE_GetStatsResults(server, stats, _LUMICE_MAX_STATS_RESULTS)
+    if err != 0:
+        raise RuntimeError(f"GetStatsResults failed err={err}")
+    # Row 0 is the only stats row (LUMICE_MAX_STATS_RESULTS == 1); sim_ray_num
+    # == 0 is the sentinel meaning "no row produced".
+    return int(stats[0].crystal_num) if stats[0].sim_ray_num != 0 else 0
+
+
 def _commit_config(lib, server, config_path: str) -> None:
     """Parse `config_path` into a LUMICE_Scene handle and commit it, then free the handle.
 
@@ -412,6 +464,7 @@ def run_scene_capi(config_path: str, sim_seed: int = 0, timeout_sec: int = 180) 
             snapshot_intensity=float(r.snapshot_intensity),
             has_valid_data=bool(r.has_valid_data),
             effective_pixels=int(r.effective_pixels),
+            crystal_num=_read_crystal_num(lib, server),
         )
 
     finally:
@@ -426,6 +479,7 @@ def run_scene_capi_buffered(
     sim_seed: int = 0,
     timeout_sec: int = 180,
     backend: str = "legacy",
+    preserve_dispatch_env: bool = False,
 ) -> BufferedSimResult:
     """Run a Lumice sim via the C API and copy out XYZ + RGB buffers.
 
@@ -452,6 +506,13 @@ def run_scene_capi_buffered(
     `routed_backend` and `fell_back` are parsed from the captured core log;
     callers asserting "Metal really ran" must check both
     (routed_backend == "metal" and not fell_back).
+
+    `preserve_dispatch_env` opts out of the LUMICE_DISPATCH_RAY_NUM strip that
+    the legacy arm normally gets (rationale in the comment below). Pass True
+    only when varying the dispatch grain on the legacy arm IS the measurement —
+    the strip protects callers whose observable (energy) is not dispatch-
+    invariant on legacy, which does not apply to a caller asserting invariance
+    of a different observable.
     """
     if backend not in _BACKEND_MODES:
         raise ValueError(f"backend must be one of {_BACKEND_MODES}, got {backend!r}")
@@ -482,7 +543,7 @@ def run_scene_capi_buffered(
     # reflects the GPU backend's correctness alone.
     disp_was_set = "LUMICE_DISPATCH_RAY_NUM" in os.environ
     disp_old = os.environ.get("LUMICE_DISPATCH_RAY_NUM")
-    if backend == "legacy" and disp_was_set:
+    if backend == "legacy" and disp_was_set and not preserve_dispatch_env:
         del os.environ["LUMICE_DISPATCH_RAY_NUM"]
 
     capture = _LogCapture()
@@ -598,22 +659,33 @@ def run_scene_capi_buffered(
                     .reshape(rr_h, rr_w, 3)
                 )
 
-                routed, fell_back = _summarize_backend(log_lines)
-                return BufferedSimResult(
-                    snapshot_intensity=r_snap,
-                    has_valid_data=r_valid,
-                    effective_pixels=r_eff,
-                    img_width=r_w,
-                    img_height=r_h,
-                    flt_buf=flt_buf,
-                    rgb_buf=rgb_buf,
-                    routed_backend=routed,
-                    fell_back=fell_back,
-                    log_lines=list(log_lines),
-                )
+                crystal_num = _read_crystal_num(lib, server)
 
             finally:
                 lib.LUMICE_DestroyServer(server)
+
+            # Log parsing happens AFTER teardown on purpose: ServerImpl::Stop()
+            # (driven by DestroyServer) is what emits the RenderConsumer
+            # "Consume profile: N batches" line, so a caller using the batch
+            # count as a positive control would never see it if the snapshot
+            # were taken before. Every buffer/scalar above was already copied
+            # out of server memory, so nothing here touches the dead server —
+            # and on the exception path this block is skipped entirely (the
+            # finally re-raises), which is why it sits outside the try.
+            routed, fell_back = _summarize_backend(log_lines)
+            return BufferedSimResult(
+                snapshot_intensity=r_snap,
+                has_valid_data=r_valid,
+                effective_pixels=r_eff,
+                img_width=r_w,
+                img_height=r_h,
+                flt_buf=flt_buf,
+                rgb_buf=rgb_buf,
+                routed_backend=routed,
+                fell_back=fell_back,
+                log_lines=list(log_lines),
+                crystal_num=crystal_num,
+            )
     finally:
         # Restore env state regardless of success/failure.
         if backend in ("cpu_backend", "cuda"):

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -480,6 +480,7 @@ def run_scene_capi_buffered(
     timeout_sec: int = 180,
     backend: str = "legacy",
     preserve_dispatch_env: bool = False,
+    num_workers: int = 0,
 ) -> BufferedSimResult:
     """Run a Lumice sim via the C API and copy out XYZ + RGB buffers.
 
@@ -513,6 +514,13 @@ def run_scene_capi_buffered(
     the strip protects callers whose observable (energy) is not dispatch-
     invariant on legacy, which does not apply to a caller asserting invariance
     of a different observable.
+
+    `num_workers` pins the CPU-route worker pool (0 = the shipped default,
+    PhysicalCoreCount()). It is honoured independently of `sim_seed`: a caller
+    that pins a seed already gets one worker (server.cpp clamps the
+    deterministic CPU contract to a single simulator), so sweeping this knob is
+    only meaningful at `sim_seed == 0`. The GPU route ignores it (single
+    engine).
     """
     if backend not in _BACKEND_MODES:
         raise ValueError(f"backend must be one of {_BACKEND_MODES}, got {backend!r}")
@@ -550,8 +558,8 @@ def run_scene_capi_buffered(
 
     try:
         with capture as log_lines:
-            if sim_seed != 0:
-                cfg = LUMICE_ServerConfig(num_workers=0, sim_seed=sim_seed)
+            if sim_seed != 0 or num_workers != 0:
+                cfg = LUMICE_ServerConfig(num_workers=num_workers, sim_seed=sim_seed)
                 server = lib.LUMICE_CreateServerEx(ctypes.byref(cfg))
             else:
                 server = lib.LUMICE_CreateServer()

--- a/test/e2e/configs/crystal_sample_count_deterministic.json
+++ b/test/e2e/configs/crystal_sample_count_deterministic.json
@@ -1,0 +1,95 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": { "height": 1.0 },
+      "axis": {
+        "zenith":  { "type": "gauss",   "mean": 90.0, "std": 1.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0,  "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0,  "std": 360.0 }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": { "height": 0.3 },
+      "axis": {
+        "zenith":  { "type": "gauss",   "mean": 0.0, "std": 1.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": { "height": 1.2 },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": { "height": 0.6 },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": { "height": 2.0 },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": { "type": "dual_fisheye_equal_area", "fov": 360.0 },
+      "view": { "azimuth": 0.0, "elevation": 0.0, "roll": 0.0 },
+      "resolution": [256, 128],
+      "background": [0.0, 0.0, 0.0],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [ { "wavelength": 540, "weight": 1.0 } ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          { "crystal": 1, "proportion": 60.0 },
+          { "crystal": 2, "proportion": 40.0 }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          { "crystal": 3, "proportion": 40.0 },
+          { "crystal": 4, "proportion": 30.0 },
+          { "crystal": 5, "proportion": 30.0 }
+        ]
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/crystal_sample_count_random.json
+++ b/test/e2e/configs/crystal_sample_count_random.json
@@ -1,0 +1,95 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": { "height": { "type": "gauss", "mean": 1.0, "std": 0.1 } },
+      "axis": {
+        "zenith":  { "type": "gauss",   "mean": 90.0, "std": 1.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0,  "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0,  "std": 360.0 }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": { "height": { "type": "gauss", "mean": 0.3, "std": 0.03 } },
+      "axis": {
+        "zenith":  { "type": "gauss",   "mean": 0.0, "std": 1.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": { "height": { "type": "gauss", "mean": 1.2, "std": 0.12 } },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": { "height": { "type": "gauss", "mean": 0.6, "std": 0.06 } },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": { "height": { "type": "gauss", "mean": 2.0, "std": 0.2 } },
+      "axis": {
+        "zenith":  { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "azimuth": { "type": "uniform", "mean": 0.0, "std": 360.0 },
+        "roll":    { "type": "uniform", "mean": 0.0, "std": 360.0 }
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": { "type": "dual_fisheye_equal_area", "fov": 360.0 },
+      "view": { "azimuth": 0.0, "elevation": 0.0, "roll": 0.0 },
+      "resolution": [256, 128],
+      "background": [0.0, 0.0, 0.0],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [ { "wavelength": 540, "weight": 1.0 } ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          { "crystal": 1, "proportion": 60.0 },
+          { "crystal": 2, "proportion": 40.0 }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          { "crystal": 3, "proportion": 40.0 },
+          { "crystal": 4, "proportion": 30.0 },
+          { "crystal": 5, "proportion": 30.0 }
+        ]
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/crystal_sample_count_zero_proportion.json
+++ b/test/e2e/configs/crystal_sample_count_zero_proportion.json
@@ -1,0 +1,199 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 0.3
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 0.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": {
+        "height": 0.6
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": {
+        "height": 2.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360.0
+      },
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "resolution": [
+        256,
+        128
+      ],
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 540,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 60.0
+          },
+          {
+            "crystal": 2,
+            "proportion": 40.0
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 3,
+            "proportion": 40.0
+          },
+          {
+            "crystal": 4,
+            "proportion": 30.0
+          },
+          {
+            "crystal": 5,
+            "proportion": 0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -108,6 +108,14 @@ inline SceneConfig MakeMetalScene(size_t max_hits, size_t ms_layers) {
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
+// The std is arbitrary — ANY non-zero variance flips the predicate, and no
+// assertion depends on the magnitude — but it is kept identical across the sibling
+// copies (test/cpu_test_helpers.hpp's user in parity-cross-backend, and the
+// metal/cuda helper here) so the number cannot be misread as a meaningful
+// per-backend difference. The copies exist because these headers sit behind
+// __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a shared unguarded
+// home ever exists.
 inline void MakeShapeStochastic(ScatteringSetting& setting) {
   auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "config/crystal_config.hpp"
@@ -100,6 +101,27 @@ inline SceneConfig MakeMetalScene(size_t max_hits, size_t ms_layers) {
     s.crystal_proportion_ = 1.0f;
     ms.setting_.push_back(std::move(s));
     scene.ms_.push_back(std::move(ms));
+  }
+  return scene;
+}
+
+// Turn a setting's prism height into a stochastic distribution, so
+// IsDeterministic(param) is false and every MakeCrystal call on it is a real
+// draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+inline void MakeShapeStochastic(ScatteringSetting& setting) {
+  auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
+  prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };
+  setting.crystal_.param_ = prism;
+}
+
+// Random-h prism scene: overrides MakeMetalScene's deterministic h_ to a
+// gaussian so IsDeterministic returns false and the K knob takes effect.
+inline SceneConfig MakeMetalSceneRandomH(size_t max_hits, size_t ms_layers) {
+  SceneConfig scene = MakeMetalScene(max_hits, ms_layers);
+  for (auto& ms : scene.ms_) {
+    for (auto& s : ms.setting_) {
+      MakeShapeStochastic(s);
+    }
   }
   return scene;
 }

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -108,14 +108,12 @@ inline SceneConfig MakeMetalScene(size_t max_hits, size_t ms_layers) {
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
-// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
-// The std is arbitrary — ANY non-zero variance flips the predicate, and no
-// assertion depends on the magnitude — but it is kept identical across the sibling
-// copies (test/cpu_test_helpers.hpp's user in parity-cross-backend, and the
-// metal/cuda helper here) so the number cannot be misread as a meaningful
-// per-backend difference. The copies exist because these headers sit behind
-// __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a shared unguarded
-// home ever exists.
+// The std is arbitrary — any non-zero variance flips the predicate and no
+// assertion depends on the magnitude — but it is kept identical to the sibling
+// copies in the cpu/metal/cuda test helpers so the number cannot be misread as a
+// meaningful per-backend difference. Those copies exist because the metal/cuda
+// headers sit behind __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a
+// shared unguarded home ever exists.
 inline void MakeShapeStochastic(ScatteringSetting& setting) {
   auto prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -489,7 +489,7 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     host.crystal = nullptr;
     backend.TraceLayer(RootRaySource::FromHost(host));
 
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
     backend.EndSession();
 
     // Second batch, same backend instance + same scene: the deterministic shape
@@ -498,7 +498,7 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     // total would grow one per batch.
     backend.BeginSession(spec);
     backend.TraceLayer(RootRaySource::FromHost(host));
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
         << "Reuse batch on a deterministic scene must report 0 new samples";
     backend.EndSession();
   }
@@ -539,7 +539,7 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     // Layer 0 contributes to the running total immediately: the count is a
     // cross-layer accumulation, so it is 1 here rather than "0 until the final
     // layer runs".
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u)
         << "Layer 0's new sample must already be counted (cross-layer accumulation)";
 
     RecombineSpec rspec;
@@ -547,7 +547,8 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     auto roots1 = backend.Recombine(std::move(h0), rspec);
     backend.TraceLayer(roots1);
 
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u) << "Cross-layer new-sample sum: 1 (layer 0) + 3 (layer 1)";
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
+        << "Cross-layer new-sample sum: 1 (layer 0) + 3 (layer 1)";
 
     backend.EndSession();
 
@@ -557,7 +558,8 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     ASSERT_NE(h0b, nullptr);
     auto roots1b = backend.Recombine(std::move(h0b), rspec);
     backend.TraceLayer(roots1b);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+        << "Reuse batch must report 0 across all layers, not 4 again";
     backend.EndSession();
   }
 }
@@ -596,7 +598,7 @@ TEST(CpuTraceBackend, HostInjectedCrystalIsNotANewSample) {
   CpuTraceBackend backend;
   backend.BeginSession(spec);
   backend.TraceLayer(RootRaySource::FromHost(host));
-  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
       << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
   backend.EndSession();
 }

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -18,6 +18,7 @@
 #include "core/color_util.hpp"
 #include "core/lens_proj.hpp"
 #include "core/scatter_accum.hpp"
+#include "core/trace_ops.hpp"
 
 namespace lumice {
 namespace {
@@ -463,12 +464,15 @@ TEST(CpuTraceBackend, CrossHitFanoutDoesNotOverflowWorkspace) {
 }
 
 // =============================================================================
-// Test — task-exit-seam-crystal-count: GetLastBatchCrystalCount() returns the
-// setting count of the FINAL MS layer (not cross-layer sum). This locks the
-// deliberate semantic decision from plan §2 default assumption 2.
+// Test — new-crystal-sample count: the counter reports how many crystal
+// geometries this BATCH freshly sampled, summed across every (layer, ci) —
+// NOT the final layer's setting count, and NOT "how many crystal objects were
+// materialised". A deterministic param is a new sample the first time the scene
+// asks for it and a reuse forever after, so the second batch on the same
+// backend instance reports 0.
 // =============================================================================
-TEST(CpuTraceBackend, GetLastBatchCrystalCountReturnsFinalLayerSettings) {
-  // Single-MS single-crystal → count == 1.
+TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
+  // Single-MS single-crystal → 1 new sample on the first batch, 0 on the next.
   {
     auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
     auto render = MakeRenderConfig();
@@ -487,10 +491,21 @@ TEST(CpuTraceBackend, GetLastBatchCrystalCountReturnsFinalLayerSettings) {
 
     EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
     backend.EndSession();
+
+    // Second batch, same backend instance + same scene: the deterministic shape
+    // was already sampled, so nothing new is drawn. This is the assertion that
+    // makes the run-level Σ (StatsConsumer) dispatch-invariant — without it the
+    // total would grow one per batch.
+    backend.BeginSession(spec);
+    backend.TraceLayer(RootRaySource::FromHost(host));
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+        << "Reuse batch on a deterministic scene must report 0 new samples";
+    backend.EndSession();
   }
 
   // Multi-MS: layer 0 has 1 crystal, layer 1 (final) has 3 crystals.
-  // Return value MUST be 3 (final-layer settings count), NOT 4 (1+3 sum).
+  // Return value MUST be the cross-layer sum 1 + 3 = 4 — the pre-existing
+  // semantic reported the final layer's 3 settings only.
   {
     auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/2);
     // Extend final layer to 3 crystals by cloning the existing setting.
@@ -521,22 +536,69 @@ TEST(CpuTraceBackend, GetLastBatchCrystalCountReturnsFinalLayerSettings) {
     host.crystal = nullptr;
     auto h0 = backend.TraceLayer(RootRaySource::FromHost(host));
     ASSERT_NE(h0, nullptr);
-    // After first (non-final) layer: last_layer count is still 0 (or the
-    // final-layer count once the last layer runs); this test only asserts
-    // the final observed value after all layers, but along the way must not
-    // pick up layer-0's count.
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Non-final layer must not populate last_layer_crystal_count_";
+    // Layer 0 contributes to the running total immediately: the count is a
+    // cross-layer accumulation, so it is 1 here rather than "0 until the final
+    // layer runs".
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u)
+        << "Layer 0's new sample must already be counted (cross-layer accumulation)";
 
     RecombineSpec rspec;
     rspec.shuffle = true;
     auto roots1 = backend.Recombine(std::move(h0), rspec);
     backend.TraceLayer(roots1);
 
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 3u) << "Final-layer settings count, not cross-layer sum (would be 4)";
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u) << "Cross-layer new-sample sum: 1 (layer 0) + 3 (layer 1)";
 
     backend.EndSession();
-    // After EndSession the counter is reset by BeginSession on next open.
+
+    // Second batch over the same two layers: every (layer, ci) shape is a reuse.
+    backend.BeginSession(spec);
+    auto h0b = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0b, nullptr);
+    auto roots1b = backend.Recombine(std::move(h0b), rspec);
+    backend.TraceLayer(roots1b);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
+    backend.EndSession();
   }
+}
+
+// =============================================================================
+// Test — the host-injected crystal path is not a sampling event.
+//
+// When the caller supplies the Crystal (`RootRaySource::host.crystal != nullptr`,
+// the golden-ray hook), the backend draws no geometry at all: MakeCrystal is
+// never reached on that ci. So the counter must stay at 0 — neither "new" nor
+// "reuse" applies, because no sample happened. Asserted explicitly rather than
+// left to "the suite would crash if it were wrong": the pre-existing tests on
+// this path only checked that it runs.
+// =============================================================================
+TEST(CpuTraceBackend, HostInjectedCrystalIsNotANewSample) {
+  auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
+  auto render = MakeRenderConfig();
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 7;
+
+  RandomNumberGenerator local_rng(0);
+  local_rng.SetSeed(spec.seed);
+  Crystal crystal = MakeCrystal(local_rng, scene.ms_[0].setting_[0].crystal_.param_);
+
+  HostRayBatch host;
+  host.count = 256;
+  host.crystal = &crystal;
+  host.crystal_id = 0;
+  host.refractive_index = crystal.GetRefractiveIndex(spec.wl.wl_);
+
+  // Fresh backend instance: the tracker starts empty, so a non-zero result here
+  // could only come from counting the injected crystal.
+  CpuTraceBackend backend;
+  backend.BeginSession(spec);
+  backend.TraceLayer(RootRaySource::FromHost(host));
+  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+      << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
+  backend.EndSession();
 }
 
 // =============================================================================

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -54,6 +54,14 @@ SceneConfig MakeSimpleScene(size_t max_hits, size_t ms_layers, const FilterConfi
   return scene;
 }
 
+// Turn a setting's prism height into a stochastic distribution, so
+// IsDeterministic(param) is false and every MakeCrystal call on it is a real
+// draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+void MakeShapeStochastic(ScatteringSetting& setting) {
+  auto& prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
+  prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.2f };
+}
+
 RenderConfig MakeRenderConfig() {
   RenderConfig cfg;
   cfg.id_ = 0;
@@ -464,15 +472,17 @@ TEST(CpuTraceBackend, CrossHitFanoutDoesNotOverflowWorkspace) {
 }
 
 // =============================================================================
-// Test — new-crystal-sample count: the counter reports how many crystal
-// geometries this BATCH freshly sampled, summed across every (layer, ci) —
-// NOT the final layer's setting count, and NOT "how many crystal objects were
-// materialised". A deterministic param is a new sample the first time the scene
-// asks for it and a reuse forever after, so the second batch on the same
-// backend instance reports 0.
+// Test — stochastic crystal-draw count: the counter reports how many STOCHASTIC
+// geometry draws this BATCH made, summed across every (layer, ci) — NOT the
+// final layer's setting count, and NOT "how many crystal objects were
+// materialised". A deterministic param draws nothing however many times the
+// backend re-derives it (its population is reported as a config constant
+// elsewhere), so a deterministic scene reports 0 from every batch.
 // =============================================================================
-TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
-  // Single-MS single-crystal → 1 new sample on the first batch, 0 on the next.
+TEST(CpuTraceBackend, CountsStochasticCrystalDrawsAcrossLayers) {
+  // Deterministic single-MS: 0 on every batch, including the first. The shape is
+  // re-derived per batch but that consumes no rng draw, so counting it would put
+  // a scene constant into a per-batch sum.
   {
     auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
     auto render = MakeRenderConfig();
@@ -489,21 +499,17 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     host.crystal = nullptr;
     backend.TraceLayer(RootRaySource::FromHost(host));
 
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
+        << "Deterministic shape: re-deriving it draws nothing, on the first batch as on any other";
     backend.EndSession();
 
-    // Second batch, same backend instance + same scene: the deterministic shape
-    // was already sampled, so nothing new is drawn. This is the assertion that
-    // makes the run-level Σ (StatsConsumer) dispatch-invariant — without it the
-    // total would grow one per batch.
     backend.BeginSession(spec);
     backend.TraceLayer(RootRaySource::FromHost(host));
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch on a deterministic scene must report 0 new samples";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u) << "…and the reuse batch likewise reports 0";
     backend.EndSession();
   }
 
-  // Multi-MS: layer 0 has 1 crystal, layer 1 (final) has 3 crystals.
+  // Multi-MS, all-stochastic: layer 0 has 1 crystal, layer 1 (final) has 3.
   // Return value MUST be the cross-layer sum 1 + 3 = 4 — the pre-existing
   // semantic reported the final layer's 3 settings only.
   {
@@ -521,6 +527,11 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     final_ms.setting_.push_back(std::move(extra2));
     ASSERT_EQ(final_ms.setting_.size(), 3u);
     ASSERT_EQ(scene.ms_.front().setting_.size(), 1u);
+    for (auto& ms : scene.ms_) {
+      for (auto& setting : ms.setting_) {
+        MakeShapeStochastic(setting);
+      }
+    }
 
     auto render = MakeRenderConfig();
     SessionSpec spec;
@@ -539,27 +550,65 @@ TEST(CpuTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     // Layer 0 contributes to the running total immediately: the count is a
     // cross-layer accumulation, so it is 1 here rather than "0 until the final
     // layer runs".
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u)
-        << "Layer 0's new sample must already be counted (cross-layer accumulation)";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "Layer 0's draw must already be counted (cross-layer accumulation)";
 
     RecombineSpec rspec;
     rspec.shuffle = true;
     auto roots1 = backend.Recombine(std::move(h0), rspec);
     backend.TraceLayer(roots1);
 
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
-        << "Cross-layer new-sample sum: 1 (layer 0) + 3 (layer 1)";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 4u)
+        << "Cross-layer stochastic-draw sum: 1 (layer 0) + 3 (layer 1)";
 
     backend.EndSession();
 
-    // Second batch over the same two layers: every (layer, ci) shape is a reuse.
+    // Second batch over the same two layers: stochastic params really do draw
+    // fresh shapes every batch, so the count repeats rather than dropping to 0.
+    // This is the half of the contract that makes randomization observable.
     backend.BeginSession(spec);
     auto h0b = backend.TraceLayer(RootRaySource::FromHost(host));
     ASSERT_NE(h0b, nullptr);
     auto roots1b = backend.Recombine(std::move(h0b), rspec);
     backend.TraceLayer(roots1b);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 4u)
+        << "Stochastic scene: every batch draws anew, so the count repeats";
+    backend.EndSession();
+  }
+
+  // Mixed scene: only the stochastic cis are counted. Without the per-ci
+  // predicate, a scene with any stochastic ci would drag its deterministic
+  // siblings into the per-batch sum too.
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/2);
+    auto& final_ms = scene.ms_.back();
+    ScatteringSetting extra = final_ms.setting_.front();
+    extra.crystal_.id_ = 100;
+    extra.crystal_proportion_ = 0.5f;
+    final_ms.setting_.front().crystal_proportion_ = 0.5f;
+    MakeShapeStochastic(extra);  // final layer: one deterministic + one stochastic
+    final_ms.setting_.push_back(std::move(extra));
+
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 5;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 512;
+    host.crystal = nullptr;
+    auto h0 = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0, nullptr);
+    RecombineSpec rspec;
+    rspec.shuffle = true;
+    auto roots1 = backend.Recombine(std::move(h0), rspec);
+    backend.TraceLayer(roots1);
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "3 (layer, ci) slots, exactly one of them stochastic";
     backend.EndSession();
   }
 }
@@ -593,12 +642,18 @@ TEST(CpuTraceBackend, HostInjectedCrystalIsNotANewSample) {
   host.crystal_id = 0;
   host.refractive_index = crystal.GetRefractiveIndex(spec.wl.wl_);
 
-  // Fresh backend instance: the tracker starts empty, so a non-zero result here
-  // could only come from counting the injected crystal.
+  // The scene's params are made stochastic on purpose: with a deterministic
+  // scene this assertion would hold for the wrong reason (0 because nothing is
+  // ever counted), and the injected-crystal branch would go unprobed.
+  for (auto& ms : scene.ms_) {
+    for (auto& setting : ms.setting_) {
+      MakeShapeStochastic(setting);
+    }
+  }
   CpuTraceBackend backend;
   backend.BeginSession(spec);
   backend.TraceLayer(RootRaySource::FromHost(host));
-  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
       << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
   backend.EndSession();
 }

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -57,13 +57,12 @@ SceneConfig MakeSimpleScene(size_t max_hits, size_t ms_layers, const FilterConfi
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
-// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
-// The std is arbitrary — ANY non-zero variance flips the predicate, and no
+// The std is arbitrary — any non-zero variance flips the predicate and no
 // assertion depends on the magnitude — but it is kept identical to the sibling
-// copies in test/metal_test_helpers.hpp and test/cuda_test_helpers.hpp so the
-// number cannot be misread as a meaningful per-backend difference. Those two live
-// behind __APPLE__ / LUMICE_CUDA_ENABLED guards, which is why the three are not
-// one shared helper; if a shared unguarded home ever exists, collapse them.
+// copies in the cpu/metal/cuda test helpers so the number cannot be misread as a
+// meaningful per-backend difference. Those copies exist because the metal/cuda
+// headers sit behind __APPLE__ / LUMICE_CUDA_ENABLED guards; collapse them if a
+// shared unguarded home ever exists.
 void MakeShapeStochastic(ScatteringSetting& setting) {
   auto& prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -57,9 +57,16 @@ SceneConfig MakeSimpleScene(size_t max_hits, size_t ms_layers, const FilterConfi
 // Turn a setting's prism height into a stochastic distribution, so
 // IsDeterministic(param) is false and every MakeCrystal call on it is a real
 // draw. Mirrors what a config with `"height": {"type": "gaussian", ...}` does.
+// Flip a setting's shape params to stochastic so IsDeterministic() returns false.
+// The std is arbitrary — ANY non-zero variance flips the predicate, and no
+// assertion depends on the magnitude — but it is kept identical to the sibling
+// copies in test/metal_test_helpers.hpp and test/cuda_test_helpers.hpp so the
+// number cannot be misread as a meaningful per-backend difference. Those two live
+// behind __APPLE__ / LUMICE_CUDA_ENABLED guards, which is why the three are not
+// one shared helper; if a shared unguarded home ever exists, collapse them.
 void MakeShapeStochastic(ScatteringSetting& setting) {
   auto& prism = std::get<PrismCrystalParam>(setting.crystal_.param_);
-  prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.2f };
+  prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };
 }
 
 RenderConfig MakeRenderConfig() {

--- a/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
@@ -216,7 +216,7 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
 
     CudaTraceBackend backend;
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
     backend.EndSession();
 
     // Second batch, same instance + same scene. This is the white-box lock on
@@ -226,7 +226,7 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
     // batch's value. Without this, the run-level Σ that StatsConsumer reports
     // grows once per batch and stops being a scene property.
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
         << "Reuse batch on a deterministic scene must report 0 new samples "
            "(BuildGeomPool skipped → nothing sampled)";
     backend.EndSession();
@@ -264,13 +264,14 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
 
     CudaTraceBackend backend;
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
         << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
            "Pre-K-pool semantic was final-layer settings only (3).";
     backend.EndSession();
 
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+        << "Reuse batch must report 0 across all layers, not 4 again";
     backend.EndSession();
   }
 }

--- a/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
@@ -190,13 +190,16 @@ TEST(CudaRichExit, ExitFaceIsValid) {
 }
 
 // =============================================================================
-// K-shape geometry pool: GetLastBatchCrystalCount reports the CROSS-LAYER sum
-// of distinct pool shapes built during the batch (Σ layers Σ ci P_ci). At the
-// default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so the
-// return value equals Σ layers Σ ci 1 = the cross-layer setting count. Same
-// semantic as Metal (see MetalTraceBackend.GetLastBatchCrystalCountSumsPoolShapesAcrossLayers).
+// K-shape geometry pool: the counter reports the CROSS-LAYER sum of crystal
+// geometries this batch freshly SAMPLED (Σ layers Σ ci over the new draws). At
+// the default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so the
+// first batch of a deterministic scene reports Σ layers Σ ci 1 = the cross-layer
+// setting count — and a subsequent batch reports 0, because a deterministic
+// scene skips BuildGeomPool entirely on the reuse batch (nothing is sampled).
+// Same semantic as Metal (see
+// MetalTraceBackend.CountsNewCrystalSamplesAcrossLayers).
 // =============================================================================
-TEST(CudaBackendCrystalCount, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers) {
+TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
   if (!CudaDeviceAvailable()) {
     GTEST_SKIP() << "No CUDA device available on this host.";
   }
@@ -214,6 +217,18 @@ TEST(CudaBackendCrystalCount, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers
     CudaTraceBackend backend;
     backend.BeginSession(spec);
     EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    backend.EndSession();
+
+    // Second batch, same instance + same scene. This is the white-box lock on
+    // the deliberate reversal of the old "deterministic scene → the counter
+    // persists across batches" design: BuildGeomPool is skipped on a reuse
+    // batch, so the counter must read 0 rather than replay the previous
+    // batch's value. Without this, the run-level Σ that StatsConsumer reports
+    // grows once per batch and stops being a scene property.
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+        << "Reuse batch on a deterministic scene must report 0 new samples "
+           "(BuildGeomPool skipped → nothing sampled)";
     backend.EndSession();
   }
 
@@ -250,8 +265,12 @@ TEST(CudaBackendCrystalCount, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers
     CudaTraceBackend backend;
     backend.BeginSession(spec);
     EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u)
-        << "Cross-layer pool-shape sum at K=0: 1 (layer 0) + 3 (layer 1). "
+        << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
            "Pre-K-pool semantic was final-layer settings only (3).";
+    backend.EndSession();
+
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
     backend.EndSession();
   }
 }

--- a/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_rich_exit.cpp
@@ -190,21 +190,52 @@ TEST(CudaRichExit, ExitFaceIsValid) {
 }
 
 // =============================================================================
-// K-shape geometry pool: the counter reports the CROSS-LAYER sum of crystal
-// geometries this batch freshly SAMPLED (Σ layers Σ ci over the new draws). At
-// the default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so the
-// first batch of a deterministic scene reports Σ layers Σ ci 1 = the cross-layer
-// setting count — and a subsequent batch reports 0, because a deterministic
-// scene skips BuildGeomPool entirely on the reuse batch (nothing is sampled).
-// Same semantic as Metal (see
-// MetalTraceBackend.CountsNewCrystalSamplesAcrossLayers).
+// K-shape geometry pool: the counter reports the CROSS-LAYER sum of STOCHASTIC
+// crystal-geometry draws this batch made (Σ layers Σ ci over the drawing cis).
+// At the default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so a
+// stochastic scene reports Σ layers Σ ci 1 = the cross-layer setting count on
+// every batch, while a deterministic scene reports 0 on every batch — its first
+// batch does build the pool but draws nothing, and its later batches skip
+// BuildGeomPool entirely. Same semantic as Metal (see
+// MetalTraceBackend.CountsStochasticCrystalDrawsAcrossLayers).
 // =============================================================================
-TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
+TEST(CudaBackendCrystalCount, CountsStochasticCrystalDrawsAcrossLayers) {
   if (!CudaDeviceAvailable()) {
     GTEST_SKIP() << "No CUDA device available on this host.";
   }
 
-  // Case 1 — single MS, single crystal setting → count == 1.
+  // Case 1a — single MS, single STOCHASTIC crystal setting → 1 per batch.
+  {
+    auto scene = MakePrismScene(/*max_hits=*/4);
+    cuda_test::MakeShapeStochastic(scene.ms_.front().setting_.front());
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 21;
+
+    CudaTraceBackend backend;
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u);
+    backend.EndSession();
+
+    // A stochastic scene force-invalidates the pool every BeginSession, so the
+    // next batch really does draw again and the count repeats.
+    backend.BeginSession(spec);
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "Stochastic scene: every batch rebuilds and re-draws";
+    backend.EndSession();
+  }
+
+  // Case 1b — the deterministic twin: 0 on EVERY batch, including the first,
+  // which does build the pool. This is the white-box lock on the deliberate
+  // reversal of the old "deterministic scene → the counter persists across
+  // batches" design: the reuse batch skips BuildGeomPool and must read 0 rather
+  // than replay the previous batch's value, and the build batch must read 0 too
+  // because re-deriving a fixed shape draws nothing. Without both, the
+  // run-level Σ that StatsConsumer reports grows with the batch count and the
+  // worker count instead of describing the scene.
   {
     auto scene = MakePrismScene(/*max_hits=*/4);
     auto render = MakeRenderConfig();
@@ -216,25 +247,20 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
 
     CudaTraceBackend backend;
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
+        << "Deterministic scene, pool-building batch: a rebuild is not a draw";
     backend.EndSession();
 
-    // Second batch, same instance + same scene. This is the white-box lock on
-    // the deliberate reversal of the old "deterministic scene → the counter
-    // persists across batches" design: BuildGeomPool is skipped on a reuse
-    // batch, so the counter must read 0 rather than replay the previous
-    // batch's value. Without this, the run-level Σ that StatsConsumer reports
-    // grows once per batch and stops being a scene property.
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch on a deterministic scene must report 0 new samples "
-           "(BuildGeomPool skipped → nothing sampled)";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
+        << "Deterministic scene, reuse batch: BuildGeomPool skipped → 0";
     backend.EndSession();
   }
 
-  // Case 2 — multi MS scene with 3 settings on the FINAL layer, 1 on the
-  // first. Return value MUST be the cross-layer sum 1 + 3 = 4, not the
-  // final-layer-only count (3).
+  // Case 2 — multi MS scene with 3 settings on the FINAL layer, 1 on the first,
+  // and exactly ONE of the four stochastic. Return value MUST be the cross-layer
+  // sum over the DRAWING cis: 1, not the final-layer-only count (3), and not 4
+  // (which is what a per-scene rather than per-ci predicate would give).
   {
     auto scene = MakePrismScene(/*max_hits=*/4);
     // Convert single-MS scene to 2-MS: original layer becomes the first
@@ -254,6 +280,9 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
     scene.ms_.push_back(std::move(final_ms));
     ASSERT_EQ(scene.ms_.back().setting_.size(), 3u);
     ASSERT_EQ(scene.ms_.front().setting_.size(), 1u);
+    // One drawing ci, in the middle of the final layer's three, so a mistake
+    // that counts per-layer or per-scene rather than per-ci shows up.
+    cuda_test::MakeShapeStochastic(scene.ms_.back().setting_[1]);
 
     auto render = MakeRenderConfig();
     SessionSpec spec;
@@ -264,14 +293,16 @@ TEST(CudaBackendCrystalCount, CountsNewCrystalSamplesAcrossLayers) {
 
     CudaTraceBackend backend;
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
-        << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
-           "Pre-K-pool semantic was final-layer settings only (3).";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "Only the one stochastic ci draws. Pre-K-pool semantic was "
+           "final-layer settings only (3); a per-scene predicate would give 4.";
     backend.EndSession();
 
+    // The scene carries a stochastic ci, so the pool is rebuilt every batch and
+    // that one ci draws again — the count repeats rather than dropping to 0.
     backend.BeginSession(spec);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "The stochastic ci draws again on the next batch";
     backend.EndSession();
   }
 }

--- a/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
@@ -284,7 +284,7 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     host.refractive_index = 0.0f;
     backend.TraceLayer(RootRaySource::FromHost(host));
 
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
     backend.EndSession();
 
     // Second batch, same instance + same scene: the deterministic shape has
@@ -293,7 +293,7 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     // StatsConsumer reports invariant to the number of batches.
     backend.BeginSession(spec);
     backend.TraceLayer(RootRaySource::FromHost(host));
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
         << "Reuse batch on a deterministic scene must report 0 new samples";
     backend.EndSession();
   }
@@ -341,7 +341,7 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     auto roots1 = backend.Recombine(std::move(h0), rspec);
     backend.TraceLayer(roots1);
 
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u)
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
         << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
            "Pre-K-pool semantic was final-layer settings only (3).";
     backend.EndSession();
@@ -352,7 +352,8 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     ASSERT_NE(h0b, nullptr);
     auto roots1b = backend.Recombine(std::move(h0b), rspec);
     backend.TraceLayer(roots1b);
-    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+        << "Reuse batch must report 0 across all layers, not 4 again";
     backend.EndSession();
   }
 }
@@ -392,7 +393,7 @@ TEST(MetalTraceBackend, HostInjectedCrystalIsNotANewSample) {
   MetalTraceBackend backend;
   backend.BeginSession(spec);
   backend.TraceLayer(RootRaySource::FromHost(host));
-  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
       << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
   backend.EndSession();
 }
@@ -672,7 +673,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledSessionRunsAndProducesOutput_AC2) {
     if (handle) {
       stats = handle->GetLayerStats();
     }
-    size_t crystals = backend.GetLastBatchCrystalCount();
+    size_t crystals = backend.GetLastBatchNewCrystalSampleCount();
     backend.EndSession();
     return std::make_pair(stats, crystals);
   };
@@ -834,7 +835,7 @@ TEST(MetalTraceBackend, KShapePool_EmptyBatchWithKEnabledDoesNotCrash_Regression
   // loop, so no pool is built and pool_shape_count_this_batch_ stays 0.
   // The assertion is "we got here without an assert-crash from the p_ci
   // guard chain firing on the empty path".
-  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
       << "empty batch with K enabled must return 0 pool shapes (no pools "
          "built) — non-zero here would mean the empty-batch guard is gone "
          "and the K-shape path partially ran on a zero-ray batch.";

--- a/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
@@ -26,6 +26,7 @@ namespace {
 
 using metal_test::ChannelSum;
 using metal_test::MakeMetalScene;
+using metal_test::MakeMetalSceneRandomH;
 using metal_test::MakeRectangularRender;
 using metal_test::RelErr;
 using metal_test::ShouldSkipMetalTests;
@@ -252,21 +253,53 @@ TEST(MetalTraceBackend, TraceLayerKernelOccupancy) {
 }
 
 // =============================================================================
-// K-shape geometry pool: the counter reports the CROSS-LAYER sum of crystal
-// geometries this batch freshly SAMPLED (Σ layers Σ ci over the new draws), not
-// the pool shapes it uploaded. At the default knob LUMICE_GPU_GEOM_CLOCK=0,
-// P_ci collapses to 1 per ci, so the first batch of a deterministic scene
-// reports Σ layers Σ ci 1 = the cross-layer setting count — and a subsequent
-// batch reports 0, because every shape is then a reuse. (Metal rebuilds
-// `pool_crystals_` every batch regardless; that upload is not a sampling event
-// once the same deterministic shape has been drawn before.)
+// K-shape geometry pool: the counter reports the CROSS-LAYER sum of STOCHASTIC
+// crystal-geometry draws this batch made (Σ layers Σ ci over the drawing cis),
+// not the pool shapes it uploaded. At the default knob LUMICE_GPU_GEOM_CLOCK=0,
+// P_ci collapses to 1 per ci, so a stochastic scene reports Σ layers Σ ci 1 =
+// the cross-layer setting count on EVERY batch, while a deterministic scene
+// reports 0 on every batch. (Metal rebuilds `pool_crystals_` every batch
+// regardless; re-deriving a deterministic shape consumes no draw, and that
+// population is reported as a config constant elsewhere.)
 // =============================================================================
-TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
+TEST(MetalTraceBackend, CountsStochasticCrystalDrawsAcrossLayers) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
 
-  // Single-MS single-crystal → 1 layer × 1 ci × P_ci=1 = 1.
+  // Single-MS single-crystal, STOCHASTIC → 1 layer × 1 ci × P_ci=1 = 1 per batch.
+  {
+    auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/1);
+    auto render = MakeRectangularRender();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 11;
+
+    MetalTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = 512;
+    host.crystal = nullptr;
+    host.refractive_index = 0.0f;
+    backend.TraceLayer(RootRaySource::FromHost(host));
+
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u);
+    backend.EndSession();
+
+    // Second batch, same instance + same scene: a stochastic param really does
+    // draw a different shape, so the count repeats rather than dropping to 0.
+    backend.BeginSession(spec);
+    backend.TraceLayer(RootRaySource::FromHost(host));
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+        << "Stochastic scene: every batch draws anew, so the count repeats";
+    backend.EndSession();
+  }
+
+  // The deterministic twin of the block above: same structure, fixed shape →
+  // Metal still rebuilds and re-uploads the pool every batch, and every batch
+  // reports 0 because none of those rebuilds drew anything.
   {
     auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/1);
     auto render = MakeRectangularRender();
@@ -283,30 +316,19 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     host.crystal = nullptr;
     host.refractive_index = 0.0f;
     backend.TraceLayer(RootRaySource::FromHost(host));
-
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u);
-    backend.EndSession();
-
-    // Second batch, same instance + same scene: the deterministic shape has
-    // already been sampled, so this batch's fresh-sample count is 0 even though
-    // Metal re-uploads the pool. This is what makes the run-level Σ that
-    // StatsConsumer reports invariant to the number of batches.
-    backend.BeginSession(spec);
-    backend.TraceLayer(RootRaySource::FromHost(host));
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch on a deterministic scene must report 0 new samples";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
+        << "Deterministic scene: a pool rebuild is not a sampling event";
     backend.EndSession();
   }
 
-  // Multi-MS: layer 0 has 1 crystal setting, layer 1 has 3. At the default
-  // knob (P_ci=1 per ci) the batch-wide sum is 1 + 3 = 4 — this is the exact
-  // opposite of the pre-K-pool semantic that returned only the final layer's
-  // 3 settings.
-  //
-  // NOTE the two blocks below build their own backend instance, so each starts
-  // with an empty "already sampled" set and its first batch counts every shape.
+  // Multi-MS: layer 0 has 1 crystal setting, layer 1 has 3, and exactly ONE of
+  // the three is stochastic. At the default knob (P_ci=1 per ci) the batch-wide
+  // sum is 1 (layer 0) + 1 (the one drawing ci in layer 1) = 2 — cross-layer,
+  // which is the exact opposite of the pre-K-pool semantic that returned only
+  // the final layer's setting count, and per-ci, so a deterministic sibling in a
+  // partly-stochastic layer is not dragged into the per-batch sum.
   {
-    auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/2);
+    auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/2);
     auto& final_ms = scene.ms_.back();
     ScatteringSetting extra1 = final_ms.setting_.front();
     ScatteringSetting extra2 = final_ms.setting_.front();
@@ -315,6 +337,11 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     extra1.crystal_proportion_ = 0.3f;
     extra2.crystal_.id_ = 101;
     extra2.crystal_proportion_ = 0.3f;
+    // MakeMetalSceneRandomH made all three stochastic; pin two of them back to a
+    // fixed shape so this scene exercises the mixed case.
+    extra1.crystal_.param_ =
+        MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/1).ms_.front().setting_.front().crystal_.param_;
+    extra2.crystal_.param_ = extra1.crystal_.param_;
     final_ms.setting_.push_back(std::move(extra1));
     final_ms.setting_.push_back(std::move(extra2));
     ASSERT_EQ(final_ms.setting_.size(), 3u);
@@ -341,19 +368,22 @@ TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
     auto roots1 = backend.Recombine(std::move(h0), rspec);
     backend.TraceLayer(roots1);
 
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 4u)
-        << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
-           "Pre-K-pool semantic was final-layer settings only (3).";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 2u)
+        << "Cross-layer stochastic-draw sum at K=0: 1 (layer 0) + 1 (the single "
+           "stochastic ci of layer 1's three). Pre-K-pool semantic was "
+           "final-layer settings only (3), and a per-scene rather than per-ci "
+           "predicate would give 4.";
     backend.EndSession();
 
-    // Second batch over the same two layers: every shape is a reuse.
+    // Second batch over the same two layers: the stochastic cis draw again, the
+    // deterministic ones still do not.
     backend.BeginSession(spec);
     auto h0b = backend.TraceLayer(RootRaySource::FromHost(host));
     ASSERT_NE(h0b, nullptr);
     auto roots1b = backend.Recombine(std::move(h0b), rspec);
     backend.TraceLayer(roots1b);
-    EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
-        << "Reuse batch must report 0 across all layers, not 4 again";
+    EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 2u)
+        << "Same two stochastic cis draw again on the next batch";
     backend.EndSession();
   }
 }
@@ -370,7 +400,10 @@ TEST(MetalTraceBackend, HostInjectedCrystalIsNotANewSample) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
 
-  auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/1);
+  // Stochastic scene on purpose: with a deterministic one the assertion below
+  // would hold for the wrong reason (0 because nothing is ever counted), leaving
+  // the injected-crystal branch unprobed.
+  auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/1);
   auto render = MakeRectangularRender();
   SessionSpec spec;
   spec.scene = &scene;
@@ -388,12 +421,12 @@ TEST(MetalTraceBackend, HostInjectedCrystalIsNotANewSample) {
   host.crystal_id = 0;
   host.refractive_index = crystal.GetRefractiveIndex(spec.wl.wl_);
 
-  // Fresh backend instance: the tracker starts empty, so a non-zero result here
-  // could only come from counting the injected crystal.
+  // A non-zero result here could only come from counting the injected crystal:
+  // the scene's own params WOULD count if they were drawn.
   MetalTraceBackend backend;
   backend.BeginSession(spec);
   backend.TraceLayer(RootRaySource::FromHost(host));
-  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
       << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
   backend.EndSession();
 }
@@ -476,24 +509,6 @@ TEST(MetalTraceBackend, DeviceAndPsoSharedAcrossInstances) {
 //     are recomputed inside the test WITHOUT calling into production code —
 //     otherwise the assertion would only check that a function calls itself.
 // =============================================================================
-
-namespace {
-
-// Random-h prism scene: overrides MakeMetalScene's deterministic h_ to a
-// gaussian so IsDeterministic returns false and the K knob takes effect.
-SceneConfig MakeMetalSceneRandomH(size_t max_hits, size_t ms_layers) {
-  SceneConfig scene = MakeMetalScene(max_hits, ms_layers);
-  for (auto& ms : scene.ms_) {
-    for (auto& s : ms.setting_) {
-      auto prism = std::get<PrismCrystalParam>(s.crystal_.param_);
-      prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };
-      s.crystal_.param_ = prism;
-    }
-  }
-  return scene;
-}
-
-}  // namespace
 
 TEST(MetalTraceBackend, KShapePool_DefaultKnobUnsetGivesPCiOne_AC1) {
   if (ShouldSkipMetalTests()) {
@@ -673,7 +688,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledSessionRunsAndProducesOutput_AC2) {
     if (handle) {
       stats = handle->GetLayerStats();
     }
-    size_t crystals = backend.GetLastBatchNewCrystalSampleCount();
+    size_t crystals = backend.GetLastBatchStochasticCrystalSampleCount();
     backend.EndSession();
     return std::make_pair(stats, crystals);
   };
@@ -835,7 +850,7 @@ TEST(MetalTraceBackend, KShapePool_EmptyBatchWithKEnabledDoesNotCrash_Regression
   // loop, so no pool is built and pool_shape_count_this_batch_ stays 0.
   // The assertion is "we got here without an assert-crash from the p_ci
   // guard chain firing on the empty path".
-  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 0u)
+  EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 0u)
       << "empty batch with K enabled must return 0 pool shapes (no pools "
          "built) — non-zero here would mean the empty-batch guard is gone "
          "and the K-shape path partially ran on a zero-ray batch.";

--- a/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
@@ -18,6 +18,7 @@
 #include "core/backend/metal_trace_backend.hpp"
 #include "core/backend/metal_trace_backend_test_hooks.hpp"
 #include "core/backend/trace_backend.hpp"
+#include "core/trace_ops.hpp"
 #include "metal_test_helpers.hpp"
 
 namespace lumice {
@@ -251,12 +252,16 @@ TEST(MetalTraceBackend, TraceLayerKernelOccupancy) {
 }
 
 // =============================================================================
-// K-shape geometry pool: GetLastBatchCrystalCount reports the CROSS-LAYER sum
-// of distinct pool shapes built during the batch (Σ layers Σ ci P_ci). At the
-// default knob LUMICE_GPU_GEOM_CLOCK=0, P_ci collapses to 1 per ci, so the
-// return value equals Σ layers Σ ci 1 = the cross-layer setting count.
+// K-shape geometry pool: the counter reports the CROSS-LAYER sum of crystal
+// geometries this batch freshly SAMPLED (Σ layers Σ ci over the new draws), not
+// the pool shapes it uploaded. At the default knob LUMICE_GPU_GEOM_CLOCK=0,
+// P_ci collapses to 1 per ci, so the first batch of a deterministic scene
+// reports Σ layers Σ ci 1 = the cross-layer setting count — and a subsequent
+// batch reports 0, because every shape is then a reuse. (Metal rebuilds
+// `pool_crystals_` every batch regardless; that upload is not a sampling event
+// once the same deterministic shape has been drawn before.)
 // =============================================================================
-TEST(MetalTraceBackend, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers) {
+TEST(MetalTraceBackend, CountsNewCrystalSamplesAcrossLayers) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
@@ -281,12 +286,25 @@ TEST(MetalTraceBackend, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers) {
 
     EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u);
     backend.EndSession();
+
+    // Second batch, same instance + same scene: the deterministic shape has
+    // already been sampled, so this batch's fresh-sample count is 0 even though
+    // Metal re-uploads the pool. This is what makes the run-level Σ that
+    // StatsConsumer reports invariant to the number of batches.
+    backend.BeginSession(spec);
+    backend.TraceLayer(RootRaySource::FromHost(host));
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+        << "Reuse batch on a deterministic scene must report 0 new samples";
+    backend.EndSession();
   }
 
   // Multi-MS: layer 0 has 1 crystal setting, layer 1 has 3. At the default
   // knob (P_ci=1 per ci) the batch-wide sum is 1 + 3 = 4 — this is the exact
   // opposite of the pre-K-pool semantic that returned only the final layer's
   // 3 settings.
+  //
+  // NOTE the two blocks below build their own backend instance, so each starts
+  // with an empty "already sampled" set and its first batch counts every shape.
   {
     auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/2);
     auto& final_ms = scene.ms_.back();
@@ -324,10 +342,59 @@ TEST(MetalTraceBackend, GetLastBatchCrystalCountSumsPoolShapesAcrossLayers) {
     backend.TraceLayer(roots1);
 
     EXPECT_EQ(backend.GetLastBatchCrystalCount(), 4u)
-        << "Cross-layer pool-shape sum at K=0: 1 (layer 0) + 3 (layer 1). "
+        << "Cross-layer new-sample sum at K=0: 1 (layer 0) + 3 (layer 1). "
            "Pre-K-pool semantic was final-layer settings only (3).";
     backend.EndSession();
+
+    // Second batch over the same two layers: every shape is a reuse.
+    backend.BeginSession(spec);
+    auto h0b = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0b, nullptr);
+    auto roots1b = backend.Recombine(std::move(h0b), rspec);
+    backend.TraceLayer(roots1b);
+    EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u) << "Reuse batch must report 0 across all layers, not 4 again";
+    backend.EndSession();
   }
+}
+
+// =============================================================================
+// The host-injected crystal path is not a sampling event: when the caller
+// supplies the Crystal (golden-ray hook), ResolveLayerCrystalForCi collapses the
+// pool to that one shape and consumes no rng draw, so nothing was sampled and
+// the counter must stay 0. Asserted explicitly — the pre-existing tests on this
+// path only checked that it runs.
+// =============================================================================
+TEST(MetalTraceBackend, HostInjectedCrystalIsNotANewSample) {
+  if (ShouldSkipMetalTests()) {
+    GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
+  }
+
+  auto scene = MakeMetalScene(/*max_hits=*/4, /*ms_layers=*/1);
+  auto render = MakeRectangularRender();
+  SessionSpec spec;
+  spec.scene = &scene;
+  spec.render = &render;
+  spec.wl = WlParam{ 550.0f, 1.0f };
+  spec.seed = 17;
+
+  RandomNumberGenerator local_rng(0);
+  local_rng.SetSeed(spec.seed);
+  Crystal crystal = MakeCrystal(local_rng, scene.ms_[0].setting_[0].crystal_.param_);
+
+  HostRayBatch host;
+  host.count = 512;
+  host.crystal = &crystal;
+  host.crystal_id = 0;
+  host.refractive_index = crystal.GetRefractiveIndex(spec.wl.wl_);
+
+  // Fresh backend instance: the tracker starts empty, so a non-zero result here
+  // could only come from counting the injected crystal.
+  MetalTraceBackend backend;
+  backend.BeginSession(spec);
+  backend.TraceLayer(RootRaySource::FromHost(host));
+  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 0u)
+      << "Host-supplied crystal consumes no MakeCrystal draw, so it is not a sample";
+  backend.EndSession();
 }
 
 // =============================================================================

--- a/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
+++ b/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
@@ -19,19 +19,27 @@ that definition, and this file gates both:
    number on the `cpu_backend` arm — the stat was blind to the one question it
    is meant to answer.
 
+3. **Worker invariance.** The CPU route runs `PhysicalCoreCount()` workers by
+   default, each owning its own Simulator and therefore its own geometry
+   sampling. A deterministic scene's geometry set does not depend on how many
+   threads redundantly derive it, so `crystal_num` must not scale with the pool
+   size. Historically it did — exactly `(layer, ci) count x workers` — which is
+   the same defect as (1) with a different knob, and it hid from the first two
+   tests because pinning `sim_seed` collapses the CPU route to one worker.
+
 Both arms covered here are pure-CPU (`legacy` = the default in-simulator trace
 path, `cpu_backend` = the `CpuTraceBackend` seam implementation), so they run
 anywhere pytest runs. Metal/CUDA carry the same contract but are gated by their
-own backend-level unit tests (`GetLastBatchNewCrystalSampleCount*` in
+own backend-level unit tests (`GetLastBatchStochasticCrystalSampleCount*` in
 test/parity-cross-backend/backend/), which assert the per-batch half directly —
 "a reuse batch reports 0" — without needing a GPU device in this file.
 
-Single-worker is a hard requirement, not a convenience: each worker owns its own
-Simulator (and therefore its own crystal cache / new-sample tracker), so a
-P-worker run legitimately samples each geometry up to P times and how many
-workers receive work depends on the batch count. `sim_seed != 0` collapses the
-CPU route to one worker (server.cpp ServerImpl), which is what makes the exact
-expected value below well-defined.
+Why the first two tests pin `sim_seed != 0` and the third must NOT: a non-zero
+seed collapses the CPU route to a single worker (server.cpp ServerImpl), which
+removes one source of variance from tests (1) and (2) so their expected values
+are exact. But it also removes the very axis test (3) exists to sweep, and the
+shipped CLI never sets a seed — so test (3) runs at `sim_seed == 0` and pins
+`num_workers` explicitly instead.
 
 Marked `@pytest.mark.slow`: drives the C API through the shared library
 (`./scripts/build.sh -sj release`), like every other capi_runner-based test.
@@ -73,7 +81,15 @@ _DISPATCH_WHOLE_RUN = 20000
 # incidental jitter.
 _MIN_BATCH_COUNT_RATIO = 4.0
 
+# Worker counts swept by the worker-invariance test. 1 is the reference; 4 is
+# well above it yet available on any CI box (the default pool is
+# PhysicalCoreCount(), so a hardcoded larger value would be untestable on small
+# runners). Pre-fix these reported expected*1 vs expected*4.
+_WORKERS_ONE = 1
+_WORKERS_MANY = 4
+
 _RE_CONSUME_PROFILE = re.compile(r"Consume profile: (\d+) batches")
+_RE_WORKER_COUNT = re.compile(r"ServerImpl: gpu_route=\w+ worker_count=(\d+)")
 
 
 def _layer_ci_total(config_path) -> int:
@@ -121,13 +137,22 @@ def _consumed_batches(result: BufferedSimResult) -> int:
     return max(counts) if counts else 0
 
 
-def _run(config_path, backend: str, dispatch: Optional[int]) -> BufferedSimResult:
+def _worker_count(result: BufferedSimResult) -> int:
+    """Workers the server actually spawned (0 if the line never logged)."""
+    counts = [int(m.group(1)) for ln in result.log_lines
+              for m in [_RE_WORKER_COUNT.search(ln)] if m]
+    return max(counts) if counts else 0
+
+
+def _run(config_path, backend: str, dispatch: Optional[int],
+         sim_seed: int = _SIM_SEED, num_workers: int = 0) -> BufferedSimResult:
     with _dispatch_grain(dispatch):
         result = run_scene_capi_buffered(
             str(config_path),
-            sim_seed=_SIM_SEED,
+            sim_seed=sim_seed,
             backend=backend,
             timeout_sec=_TIMEOUT,
+            num_workers=num_workers,
             # The legacy arm normally has this knob stripped (it protects parity
             # oracles whose energy is not dispatch-invariant); here sweeping it
             # IS the measurement.
@@ -218,4 +243,48 @@ def test_crystal_num_observes_shape_randomization(backend: str) -> None:
         f"{expected} crystal populations — expected at least {expected * 10}. "
         f"Too close to the deterministic value {fixed.crystal_num} to "
         f"distinguish 'randomization observed' from measurement noise"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_crystal_num_is_worker_invariant(backend: str) -> None:
+    """Same scene, 1 vs N workers → identical crystal_num.
+
+    Runs at `sim_seed == 0` on purpose: a pinned seed clamps the CPU route to a
+    single worker, so a seeded version of this test would sweep nothing and pass
+    against a counter that scales linearly with the pool. That is precisely how
+    this defect survived the first two tests in this file.
+    """
+    expected = _layer_ci_total(_DETERMINISTIC_CFG)
+
+    one = _run(_DETERMINISTIC_CFG, backend, None, sim_seed=0, num_workers=_WORKERS_ONE)
+    many = _run(_DETERMINISTIC_CFG, backend, None, sim_seed=0, num_workers=_WORKERS_MANY)
+
+    # Positive control: `num_workers` is a request, and the server is free to
+    # clamp it (GPU route pins 1; a non-zero seed pins 1). If both runs ended up
+    # with the same pool, equality below would be vacuous.
+    w_one, w_many = _worker_count(one), _worker_count(many)
+    assert w_one == _WORKERS_ONE and w_many == _WORKERS_MANY, (
+        f"{backend}: asked for {_WORKERS_ONE} / {_WORKERS_MANY} workers but the "
+        f"server spawned {w_one} / {w_many} (from the 'ServerImpl: ... "
+        f"worker_count=' log line) — the pool size did not vary, so the "
+        f"invariance assertion below would prove nothing"
+    )
+
+    assert one.crystal_num == many.crystal_num, (
+        f"{backend}: crystal_num scaled with the worker pool — "
+        f"{one.crystal_num} @ {_WORKERS_ONE} worker vs {many.crystal_num} @ "
+        f"{_WORKERS_MANY}. Each worker owns its own Simulator and redundantly "
+        f"derives the same deterministic geometries; crystal_num counts the "
+        f"geometries the SCENE has, so how many threads re-derive them is not "
+        f"its business. A ratio of ~{_WORKERS_MANY}x means the deterministic "
+        f"population is being summed per worker instead of carried as the "
+        f"config constant it is"
+    )
+    assert many.crystal_num == expected, (
+        f"{backend}: {_WORKERS_MANY}-worker run reported crystal_num="
+        f"{many.crystal_num}, expected {expected} = Σ over MS layers of that "
+        f"layer's entry count. Equality with the 1-worker run above would also "
+        f"hold if both were wrong by the same factor"
     )

--- a/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
+++ b/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
@@ -61,6 +61,7 @@ from test.e2e.runner import get_project_root
 
 _CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
 _DETERMINISTIC_CFG = _CONFIGS_DIR / "crystal_sample_count_deterministic.json"
+_ZERO_PROPORTION_CFG = _CONFIGS_DIR / "crystal_sample_count_zero_proportion.json"
 _RANDOM_CFG = _CONFIGS_DIR / "crystal_sample_count_random.json"
 
 # Non-zero → single worker on the CPU route (see the module docstring).
@@ -287,4 +288,38 @@ def test_crystal_num_is_worker_invariant(backend: str) -> None:
         f"{many.crystal_num}, expected {expected} = Σ over MS layers of that "
         f"layer's entry count. Equality with the 1-worker run above would also "
         f"hold if both were wrong by the same factor"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_crystal_num_counts_scene_slots_not_traced_slots(backend: str) -> None:
+    """A crystal_proportion_ == 0 slot still counts toward the deterministic half.
+
+    This pins the property that BUYS the immunity asserted by the two tests above,
+    and it is the one a well-meaning change is most likely to break: counting only
+    the (layer, ci) slots a run actually reached looks strictly more accurate, and
+    it silently reintroduces exactly the defect this whole gate exists to catch.
+    Which slots get traced is a function of the ray partition, so it moves with the
+    dispatch grain and the worker pool — the deterministic half must be derived
+    from the committed config alone, never from what a particular run touched.
+
+    The fixture is the deterministic scene with its last entry's proportion set to
+    0. That slot never reaches MakeCrystal on any backend, yet the reported count
+    must still be the full slot total, identical to the un-zeroed scene.
+    """
+    expected = _layer_ci_total(_ZERO_PROPORTION_CFG)
+    zeroed = _run(_ZERO_PROPORTION_CFG, backend, None)
+
+    assert zeroed.crystal_num == expected, (
+        f"{backend}: scene with a proportion=0 slot reported crystal_num="
+        f"{zeroed.crystal_num}, expected {expected} = every (layer, ci) slot in "
+        f"the committed config. Counting only slots the run actually traced makes "
+        f"the value a function of the ray partition again, which is what the "
+        f"dispatch- and worker-invariance tests above forbid"
+    )
+    assert zeroed.crystal_num == _layer_ci_total(_DETERMINISTIC_CFG), (
+        f"{backend}: zeroing a slot's proportion changed crystal_num; the "
+        f"deterministic half is a property of the committed config, and setting a "
+        f"population's share to 0 does not remove it from the config"
     )

--- a/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
+++ b/test/regression-sentinel/test_crystal_count_dispatch_invariance.py
@@ -1,0 +1,221 @@
+"""Gate: `LUMICE_StatsResult.crystal_num` is a scene property, not a schedule artifact.
+
+`crystal_num` (CLI `Stats: crystals=N`) is defined as **how many distinct crystal
+geometries this run actually sampled**. Two consequences follow directly from
+that definition, and this file gates both:
+
+1. **Dispatch invariance.** `LUMICE_DISPATCH_RAY_NUM` is a per-SimBatch
+   scheduling grain — a performance knob. Sweeping it must not move
+   `crystal_num`, because it does not change which geometries the scene
+   contains. Historically it did: the counter was a per-batch quantity summed
+   by StatsConsumer, so it reported "how many crystal objects were materialised
+   across all batches" and swung by two orders of magnitude with the knob alone.
+
+2. **Randomization observability.** A deterministic-shape scene samples each
+   (layer, ci) geometry exactly once, so `crystal_num` must equal the scene's
+   (layer, ci) count. A scene with stochastic shape distributions draws a fresh
+   geometry per ray-group, so it must report substantially more. Historically
+   the deterministic and stochastic twins of the same scene reported the SAME
+   number on the `cpu_backend` arm — the stat was blind to the one question it
+   is meant to answer.
+
+Both arms covered here are pure-CPU (`legacy` = the default in-simulator trace
+path, `cpu_backend` = the `CpuTraceBackend` seam implementation), so they run
+anywhere pytest runs. Metal/CUDA carry the same contract but are gated by their
+own backend-level unit tests (`GetLastBatchNewCrystalSampleCount*` in
+test/parity-cross-backend/backend/), which assert the per-batch half directly —
+"a reuse batch reports 0" — without needing a GPU device in this file.
+
+Single-worker is a hard requirement, not a convenience: each worker owns its own
+Simulator (and therefore its own crystal cache / new-sample tracker), so a
+P-worker run legitimately samples each geometry up to P times and how many
+workers receive work depends on the batch count. `sim_seed != 0` collapses the
+CPU route to one worker (server.cpp ServerImpl), which is what makes the exact
+expected value below well-defined.
+
+Marked `@pytest.mark.slow`: drives the C API through the shared library
+(`./scripts/build.sh -sj release`), like every other capi_runner-based test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+from typing import Iterator, Optional
+
+import pytest
+
+from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
+from test.e2e.runner import get_project_root
+
+
+_CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
+_DETERMINISTIC_CFG = _CONFIGS_DIR / "crystal_sample_count_deterministic.json"
+_RANDOM_CFG = _CONFIGS_DIR / "crystal_sample_count_random.json"
+
+# Non-zero → single worker on the CPU route (see the module docstring).
+_SIM_SEED = 20260727
+_TIMEOUT = 240
+
+# The two fixtures carry ray_num=20000. 128 is the shipped CPU default grain
+# (157 batches); 20000 puts the whole run in ONE batch. If the counter were
+# still per-batch-accumulated, these two would differ by ~157x — the widest
+# lever available without changing the scene.
+_DISPATCH_SMALL = 128
+_DISPATCH_WHOLE_RUN = 20000
+
+# Positive control: the batch count actually observed inside the run must track
+# the requested grain, otherwise an env knob that silently stopped taking effect
+# would leave this file green for the wrong reason (both arms equal because
+# nothing varied). 4x is far below the ~157x the grains imply, and far above any
+# incidental jitter.
+_MIN_BATCH_COUNT_RATIO = 4.0
+
+_RE_CONSUME_PROFILE = re.compile(r"Consume profile: (\d+) batches")
+
+
+def _layer_ci_total(config_path) -> int:
+    """Σ over MS layers of that layer's entry count — the (layer, ci) pair count.
+
+    This is the number of distinct crystal geometries a deterministic-shape
+    scene samples: one per (layer, ci), reused for every ray-group afterwards.
+    Derived from the fixture instead of hardcoded so editing the fixture cannot
+    silently decouple the expectation from the scene.
+    """
+    with open(config_path) as f:
+        cfg = json.load(f)
+    return sum(len(layer["entries"]) for layer in cfg["scene"]["scattering"])
+
+
+@contextlib.contextmanager
+def _dispatch_grain(n: Optional[int]) -> Iterator[None]:
+    """Pin LUMICE_DISPATCH_RAY_NUM (+ COMMIT, for the batch-count witness).
+
+    COMMIT is pinned alongside DISPATCH so the "Consume profile: N batches"
+    positive control stays a clean witness on the exit-seam arm too: leaving
+    commit at its default would clamp the chunk count to ~exits/128 regardless
+    of the dispatch grain and erase the ratio signal. `n is None` leaves both
+    knobs untouched (shipped defaults).
+    """
+    keys = ("LUMICE_DISPATCH_RAY_NUM", "LUMICE_COMMIT_RAY_NUM")
+    saved = {k: os.environ.get(k) for k in keys}
+    try:
+        if n is not None:
+            for k in keys:
+                os.environ[k] = str(n)
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _consumed_batches(result: BufferedSimResult) -> int:
+    """Batch count the RenderConsumer actually saw (0 if the line never logged)."""
+    counts = [int(m.group(1)) for ln in result.log_lines
+              for m in [_RE_CONSUME_PROFILE.search(ln)] if m]
+    return max(counts) if counts else 0
+
+
+def _run(config_path, backend: str, dispatch: Optional[int]) -> BufferedSimResult:
+    with _dispatch_grain(dispatch):
+        result = run_scene_capi_buffered(
+            str(config_path),
+            sim_seed=_SIM_SEED,
+            backend=backend,
+            timeout_sec=_TIMEOUT,
+            # The legacy arm normally has this knob stripped (it protects parity
+            # oracles whose energy is not dispatch-invariant); here sweeping it
+            # IS the measurement.
+            preserve_dispatch_env=True,
+        )
+    assert result.has_valid_data, f"{config_path.name} @ {backend}: no valid data"
+    assert result.routed_backend == backend and not result.fell_back, (
+        f"{config_path.name}: asked for {backend!r} but ran "
+        f"{result.routed_backend!r} (fell_back={result.fell_back}); the "
+        f"measurement would be about the wrong backend"
+    )
+    return result
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_crystal_num_is_dispatch_invariant(backend: str) -> None:
+    """Same scene, two dispatch grains → identical crystal_num."""
+    small = _run(_DETERMINISTIC_CFG, backend, _DISPATCH_SMALL)
+    whole = _run(_DETERMINISTIC_CFG, backend, _DISPATCH_WHOLE_RUN)
+
+    # Positive control first: a no-op env knob would make the invariance
+    # assertion below trivially true.
+    n_small, n_whole = _consumed_batches(small), _consumed_batches(whole)
+    assert n_small > 0 and n_whole > 0, (
+        f"{backend}: no 'Consume profile: N batches' line captured "
+        f"({n_small} / {n_whole}) — cannot confirm the dispatch grain took "
+        f"effect, so the invariance assertion below would be unwitnessed"
+    )
+    assert n_small >= n_whole * _MIN_BATCH_COUNT_RATIO, (
+        f"{backend}: dispatch grain did not take effect — batches consumed "
+        f"{n_small} @ grain {_DISPATCH_SMALL} vs {n_whole} @ grain "
+        f"{_DISPATCH_WHOLE_RUN}; expected at least {_MIN_BATCH_COUNT_RATIO}x. "
+        f"Both runs traced the same schedule, so crystal_num equality proves "
+        f"nothing."
+    )
+
+    assert small.crystal_num == whole.crystal_num, (
+        f"{backend}: crystal_num moved with the dispatch grain — "
+        f"{small.crystal_num} @ LUMICE_DISPATCH_RAY_NUM={_DISPATCH_SMALL} vs "
+        f"{whole.crystal_num} @ {_DISPATCH_WHOLE_RUN}. crystal_num counts the "
+        f"distinct crystal geometries the scene sampled; a per-SimBatch "
+        f"scheduling knob cannot change that. A ratio close to "
+        f"{n_small // max(n_whole, 1)}x means the counter is again summing a "
+        f"per-batch quantity instead of counting new samples."
+    )
+    assert small.crystal_num > 0, (
+        f"{backend}: crystal_num == 0 for a scene that traces rays through "
+        f"{_layer_ci_total(_DETERMINISTIC_CFG)} crystal populations — equality "
+        f"above would also hold for a counter stuck at zero"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_crystal_num_observes_shape_randomization(backend: str) -> None:
+    """Deterministic scene → exactly the (layer, ci) count; stochastic twin → more.
+
+    The two fixtures are structurally identical (same layers, same entries, same
+    proportions, same ray_num); they differ only in whether `shape.height` is a
+    scalar or a gaussian distribution. So any difference in crystal_num is
+    attributable to shape randomization alone.
+    """
+    expected = _layer_ci_total(_DETERMINISTIC_CFG)
+
+    fixed = _run(_DETERMINISTIC_CFG, backend, None)
+    assert fixed.crystal_num == expected, (
+        f"{backend}: deterministic scene reported crystal_num="
+        f"{fixed.crystal_num}, expected {expected} = Σ over MS layers of that "
+        f"layer's entry count. A deterministic shape is sampled once per "
+        f"(layer, ci) and reused for every ray-group after that, so anything "
+        f"larger means reuse is being counted as fresh sampling"
+    )
+
+    stochastic = _run(_RANDOM_CFG, backend, None)
+    assert stochastic.crystal_num > fixed.crystal_num, (
+        f"{backend}: stochastic-shape scene reported crystal_num="
+        f"{stochastic.crystal_num}, no more than its deterministic twin's "
+        f"{fixed.crystal_num}. Every ray-group draws a fresh geometry when the "
+        f"shape carries a distribution, so this stat is blind to the one "
+        f"question it exists to answer: did my randomization take effect?"
+    )
+    # Separation, not just strict inequality: the fixtures run 20000 rays, so a
+    # working counter reports hundreds of samples, not expected+1.
+    assert stochastic.crystal_num >= expected * 10, (
+        f"{backend}: stochastic-shape scene reported only "
+        f"{stochastic.crystal_num} distinct samples for 20000 rays across "
+        f"{expected} crystal populations — expected at least {expected * 10}. "
+        f"Too close to the deterministic value {fixed.crystal_num} to "
+        f"distinguish 'randomization observed' from measurement noise"
+    )

--- a/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
+++ b/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
@@ -310,9 +310,13 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
 
   auto table = hooks.ReadbackPoolShapeTable();
   EXPECT_EQ(table.size(), 1u) << "K=0 must collapse pool to a single shape (P_ci ≡ 1 per (layer, ci)).";
+  // The scene is stochastic (MakeStochasticPrismScene), so this ci re-samples
+  // every batch and every draw is a NEW sample — the new-sample count therefore
+  // equals Σ P_ci here, unchanged by the counter's semantic tightening (which
+  // only zeroes the count on batches that reuse a deterministic shape).
   EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u)
-      << "K=0, single-(layer, ci) scene: Σ P_ci must be 1 (mirrors GetLastBatchCrystalCount contract "
-         "for the knob-off configuration).";
+      << "K=0, single-(layer, ci) stochastic scene: Σ P_ci must be 1 (mirrors the new-crystal-sample "
+         "count contract for the knob-off configuration).";
 
   // Every ray MUST report the single shape's tuple; any spread means the
   // K=0 collapse is broken (P_ci somehow > 1, or the picker sampled a

--- a/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
+++ b/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
@@ -28,8 +28,9 @@
 //
 //   * Test C (KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) — knob-off
 //     structural collapse: with `LUMICE_GPU_GEOM_CLOCK` unset, P_ci ≡ 1
-//     (one pool shape per (layer, ci)) and `GetLastBatchNewCrystalSampleCount()`
-//     equals the total (layer, ci) count. Complements the driver-verified
+//     (one pool shape per (layer, ci)) and, on a stochastic scene,
+//     `GetLastBatchStochasticCrystalSampleCount()` equals the total (layer, ci)
+//     count. Complements the driver-verified
 //     four-file parity battery (11 passed knob-off) with a structural
 //     assertion that pins the AC2 contract at the pool level (as a
 //     white-box structural anchor, not a re-verification of bit-equivalence
@@ -288,7 +289,8 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
   ::unsetenv("LUMICE_GPU_GEOM_CLOCK");  // isolation from prior test order
 
   // Single-layer stochastic scene — one (layer, ci) pair. K=0 → P_ci = 1 →
-  // pool table has exactly one row, and GetLastBatchNewCrystalSampleCount() == 1.
+  // pool table has exactly one row, and
+  // GetLastBatchStochasticCrystalSampleCount() == 1.
   auto scene = MakeStochasticPrismScene(/*max_hits=*/4, /*gaussian=*/true);
   auto render = MakeRenderConfig();
 
@@ -310,12 +312,13 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
 
   auto table = hooks.ReadbackPoolShapeTable();
   EXPECT_EQ(table.size(), 1u) << "K=0 must collapse pool to a single shape (P_ci ≡ 1 per (layer, ci)).";
-  // The scene is stochastic (MakeStochasticPrismScene), so this ci re-samples
-  // every batch and every draw is a NEW sample — the new-sample count therefore
-  // equals Σ P_ci here, unchanged by the counter's semantic tightening (which
-  // only zeroes the count on batches that reuse a deterministic shape).
-  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u)
-      << "K=0, single-(layer, ci) stochastic scene: Σ P_ci must be 1 (mirrors the new-crystal-sample "
+  // The scene is stochastic (MakeStochasticPrismScene), so this ci draws afresh
+  // every batch — the count therefore equals Σ P_ci here. On a deterministic
+  // scene it would be 0 instead, with that population reported as a config
+  // constant; this test deliberately stays on the stochastic side so the
+  // structural Σ P_ci claim is what it measures.
+  EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
+      << "K=0, single-(layer, ci) stochastic scene: Σ P_ci must be 1 (mirrors the stochastic-crystal-draw "
          "count contract for the knob-off configuration).";
 
   // Every ray MUST report the single shape's tuple; any spread means the

--- a/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
+++ b/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
@@ -28,7 +28,7 @@
 //
 //   * Test C (KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) — knob-off
 //     structural collapse: with `LUMICE_GPU_GEOM_CLOCK` unset, P_ci ≡ 1
-//     (one pool shape per (layer, ci)) and `GetLastBatchCrystalCount()`
+//     (one pool shape per (layer, ci)) and `GetLastBatchNewCrystalSampleCount()`
 //     equals the total (layer, ci) count. Complements the driver-verified
 //     four-file parity battery (11 passed knob-off) with a structural
 //     assertion that pins the AC2 contract at the pool level (as a
@@ -288,7 +288,7 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
   ::unsetenv("LUMICE_GPU_GEOM_CLOCK");  // isolation from prior test order
 
   // Single-layer stochastic scene — one (layer, ci) pair. K=0 → P_ci = 1 →
-  // pool table has exactly one row, and GetLastBatchCrystalCount() == 1.
+  // pool table has exactly one row, and GetLastBatchNewCrystalSampleCount() == 1.
   auto scene = MakeStochasticPrismScene(/*max_hits=*/4, /*gaussian=*/true);
   auto render = MakeRenderConfig();
 
@@ -314,7 +314,7 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
   // every batch and every draw is a NEW sample — the new-sample count therefore
   // equals Σ P_ci here, unchanged by the counter's semantic tightening (which
   // only zeroes the count on batches that reuse a deterministic shape).
-  EXPECT_EQ(backend.GetLastBatchCrystalCount(), 1u)
+  EXPECT_EQ(backend.GetLastBatchNewCrystalSampleCount(), 1u)
       << "K=0, single-(layer, ci) stochastic scene: Σ P_ci must be 1 (mirrors the new-crystal-sample "
          "count contract for the knob-off configuration).";
 

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -58,7 +58,10 @@ static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 // drain, bumping 296 → 328.
 // task-color-degrade-gui-surfacing adds color_degrade_counts_ (ColorDegradeCounts
 // = 3 × size_t = 24B) for the GPU color-degrade tally, bumping 328 → 352.
-static_assert(sizeof(SimData) == 352,
+// The crystal-sample-count contract splits crystal_count_ into an accumulated
+// stochastic half and an overwritten deterministic half (+1 size_t, 8B),
+// bumping 352 → 360.
+static_assert(sizeof(SimData) == 360,
               "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
               "and sim_data.cpp's static_assert.");
 #endif
@@ -123,8 +126,11 @@ SimData MakePopulatedSimData() {
   s.lane_pixel_data_ = { 0.11f, 0.22f, 0.33f, 0.44f };
   s.lane_class_count_ = 2;
   s.crystals_.emplace_back();
-  // task-exit-seam-crystal-count: propagation coverage for the new field.
-  s.crystal_count_ = 4;
+  // Propagation coverage for both halves of the crystal-geometry count. They
+  // are distinct fields with distinct values on purpose: a copy/move that
+  // dropped one and duplicated the other would still pass a single-value probe.
+  s.stochastic_crystal_sample_count_ = 4;
+  s.deterministic_crystal_count_ = 9;
   // scrum-312: third-clock drain counter-balance credit propagation coverage.
   s.sim_scene_credit_ = 11;
   // task-color-degrade-gui-surfacing: GPU color-degrade tally propagation coverage.
@@ -976,7 +982,8 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   EXPECT_FLOAT_EQ(copy.xyz_landed_weight_, 1.5f);
   EXPECT_EQ(copy.lane_pixel_data_, original.lane_pixel_data_);  // task-358.1 Step 4
   EXPECT_EQ(copy.lane_class_count_, 2u) << "lane_class_count_ not copied";
-  EXPECT_EQ(copy.crystal_count_, 4u) << "crystal_count_ not copied";         // task-exit-seam-crystal-count
+  EXPECT_EQ(copy.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not copied";
+  EXPECT_EQ(copy.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not copied";
   EXPECT_EQ(copy.sim_scene_credit_, 11u) << "sim_scene_credit_ not copied";  // scrum-312
   EXPECT_EQ(copy.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not copied";
   EXPECT_EQ(copy.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not copied";
@@ -1034,7 +1041,8 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   EXPECT_FLOAT_EQ(target.xyz_landed_weight_, 1.5f);
   EXPECT_EQ(target.lane_pixel_data_, original.lane_pixel_data_);  // task-358.1 Step 4
   EXPECT_EQ(target.lane_class_count_, 2u) << "lane_class_count_ not assigned";
-  EXPECT_EQ(target.crystal_count_, 4u) << "crystal_count_ not assigned";         // task-exit-seam-crystal-count
+  EXPECT_EQ(target.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not assigned";
+  EXPECT_EQ(target.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not assigned";
   EXPECT_EQ(target.sim_scene_credit_, 11u) << "sim_scene_credit_ not assigned";  // scrum-312
   EXPECT_EQ(target.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not assigned";
   EXPECT_EQ(target.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not assigned";
@@ -1095,7 +1103,8 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   EXPECT_FLOAT_EQ(moved.xyz_landed_weight_, 1.5f);
   EXPECT_EQ(moved.lane_pixel_data_.size(), 4u);  // task-358.1 Step 4
   EXPECT_EQ(moved.lane_class_count_, 2u) << "lane_class_count_ not moved";
-  EXPECT_EQ(moved.crystal_count_, 4u) << "crystal_count_ not moved";         // task-exit-seam-crystal-count
+  EXPECT_EQ(moved.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not moved";
+  EXPECT_EQ(moved.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not moved";
   EXPECT_EQ(moved.sim_scene_credit_, 11u) << "sim_scene_credit_ not moved";  // scrum-312
   EXPECT_EQ(moved.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not moved";
   EXPECT_EQ(moved.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not moved";
@@ -1144,7 +1153,8 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_FLOAT_EQ(dst.curr_wl_, 550.0f);
   EXPECT_EQ(dst.generation_, 42u);
   EXPECT_EQ(dst.crystals_.size(), 1u);
-  EXPECT_EQ(dst.crystal_count_, 4u) << "crystal_count_ not move-assigned";         // task-exit-seam-crystal-count
+  EXPECT_EQ(dst.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not move-assigned";
+  EXPECT_EQ(dst.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not move-assigned";
   EXPECT_EQ(dst.sim_scene_credit_, 11u) << "sim_scene_credit_ not move-assigned";  // scrum-312
   EXPECT_EQ(dst.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not move-assigned";
   EXPECT_EQ(dst.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not move-assigned";

--- a/test/unit-correctness/server/test_stats_consumer.cpp
+++ b/test/unit-correctness/server/test_stats_consumer.cpp
@@ -146,5 +146,52 @@ TEST(StatsConsumer, ChunkedDispatchAppliesTheRightRuleToEachHalf) {
       << "First-chunk-only dispatch: root_ray_count_ must also only be counted once.";
 }
 
+// CHARACTERIZATION: because the deterministic half is OVERWRITTEN, EVERY SimData
+// that reaches Consume() must carry it — one that leaves the field at its default
+// 0 erases the scene's whole config-constant population from the report.
+//
+// This documents a real coupling rather than a defect. Consume() deliberately does
+// NOT defend against it: the "is this a produced batch" predicate is owned by
+// server.cpp::ConsumeData (`rays_.Empty() && root_ray_count_ == 0` breaks out
+// before any Consume() call, so the shutdown/interruption sentinel never arrives
+// here). Re-deriving that predicate in this class would create a second authority
+// for the same protocol question and let the two drift — the exact anti-pattern
+// this change removed elsewhere, so it is not worth buying defence-in-depth with.
+//
+// What this test is for: the guarantee therefore lives in an upstream convention,
+// and that convention has already been wrong once (its predecessor keyed on
+// is_backend_path_ and mis-flagged exit-seam batches as sentinels). Pinning the
+// consequence here means a future reader who is tempted to relax the sentinel key,
+// add a Consume() call site, or add a producer that forgets the field can see in
+// one place what it costs. The sibling case is already covered above: trailing
+// chunks must re-assert the constant, and that one IS reachable today.
+TEST(StatsConsumer, DeterministicHalfIsOverwrittenSoEveryBatchMustCarryIt) {
+  constexpr size_t kStochastic = 7;
+  constexpr size_t kDeterministic = 5;
+
+  StatsConsumer stats;
+
+  SimData real_batch;
+  real_batch.root_ray_count_ = 128;
+  real_batch.stochastic_crystal_sample_count_ = kStochastic;
+  real_batch.deterministic_crystal_count_ = kDeterministic;
+  stats.Consume(real_batch);
+  EXPECT_EQ(CrystalNum(stats), kStochastic + kDeterministic);
+
+  // A batch that forgets the field: the stochastic half still accumulates, but
+  // the deterministic population is gone. Asserting the erasure (rather than
+  // immunity to it) is the point — it is the cost of the OVERWRITE rule.
+  SimData forgot_deterministic;
+  forgot_deterministic.root_ray_count_ = 128;
+  forgot_deterministic.stochastic_crystal_sample_count_ = 1;
+  stats.Consume(forgot_deterministic);
+
+  EXPECT_EQ(CrystalNum(stats), kStochastic + 1u)
+      << "OVERWRITE semantics: a producer that omits deterministic_crystal_count_ "
+         "silently drops the scene's config-constant population. If this ever "
+         "needs to stop being true, change the aggregation rule deliberately — do "
+         "not re-derive server.cpp's produced-batch predicate here.";
+}
+
 }  // namespace
 }  // namespace lumice

--- a/test/unit-correctness/server/test_stats_consumer.cpp
+++ b/test/unit-correctness/server/test_stats_consumer.cpp
@@ -1,11 +1,16 @@
-// StatsConsumer unit tests (task-exit-seam-crystal-count).
+// StatsConsumer unit tests.
 //
-// Locks the "crystals_ accumulates SimData.crystal_count_ (not
-// crystals_.size())" contract switched in stats.cpp, and covers the
-// server.cpp:834 "only-first-chunk carries stats fields" invariant that
-// chunked SimData dispatch relies on: with the new field, feeding N chunks
-// where only the first has crystal_count_ set must yield exactly that value
-// (not N× that value, not 0).
+// Locks the aggregation rules for the two halves of the reported crystal count:
+// stochastic draws ACCUMULATE across SimData, the deterministic population is
+// OVERWRITTEN (it is a config constant every producer reports identically).
+// Getting this pair wrong is the whole defect family this suite guards: summing
+// the deterministic half made the stat scale with the batch count AND with the
+// worker-pool size, while accumulating nothing at all would make geometry
+// randomization invisible.
+//
+// Also covers the server.cpp chunk-dispatch invariant, which is now two
+// opposite rules on the same dispatch: accumulated fields ride the FIRST chunk
+// only, overwritten fields ride EVERY chunk.
 
 #include <gtest/gtest.h>
 
@@ -17,16 +22,23 @@
 namespace lumice {
 namespace {
 
-TEST(StatsConsumer, CrystalCountAccumulatesAcrossBatches) {
+size_t CrystalNum(StatsConsumer& stats) {
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  EXPECT_TRUE(std::holds_alternative<StatsResult>(result));
+  return std::get<StatsResult>(result).crystal_num_;
+}
+
+TEST(StatsConsumer, StochasticSamplesAccumulateAcrossBatches) {
   StatsConsumer stats;
 
   SimData batch1;
-  batch1.crystal_count_ = 3;
+  batch1.stochastic_crystal_sample_count_ = 3;
   batch1.root_ray_count_ = 100;
   stats.Consume(batch1);
 
   SimData batch2;
-  batch2.crystal_count_ = 5;
+  batch2.stochastic_crystal_sample_count_ = 5;
   batch2.root_ray_count_ = 200;
   stats.Consume(batch2);
 
@@ -34,14 +46,58 @@ TEST(StatsConsumer, CrystalCountAccumulatesAcrossBatches) {
   auto result = stats.GetResult();
   ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
   const auto& r = std::get<StatsResult>(result);
-  EXPECT_EQ(r.crystal_num_, 8u);
+  EXPECT_EQ(r.crystal_num_, 8u) << "every stochastic draw is a genuinely different geometry — they sum";
   EXPECT_EQ(r.sim_ray_num_, 300u);
 }
 
-TEST(StatsConsumer, ResetClearsCrystalCount) {
+// The AC10 statement at unit scope: P workers each report the SAME deterministic
+// scene, because each derives the same geometries from the same config. The
+// reported total must be the scene's count, not P x it. Same shape as a single
+// worker feeding P batches, which is why one rule covers both knobs.
+TEST(StatsConsumer, DeterministicCountIsOverwrittenNotSummed) {
+  constexpr size_t kSceneCrystals = 5;
+  constexpr int kProducers = 4;
+
+  StatsConsumer stats;
+  for (int i = 0; i < kProducers; i++) {
+    SimData batch;
+    batch.deterministic_crystal_count_ = kSceneCrystals;
+    batch.root_ray_count_ = 10;
+    stats.Consume(batch);
+  }
+
+  EXPECT_EQ(CrystalNum(stats), kSceneCrystals)
+      << kProducers << " producers reported the same deterministic scene; summing them would report "
+      << kSceneCrystals * kProducers
+      << ", which is how this stat used to scale with the dispatch grain and the "
+         "worker pool instead of describing the scene";
+}
+
+// A mixed scene: the deterministic half stays put while the stochastic half
+// grows. Separating them is the point — a single counter cannot do both.
+TEST(StatsConsumer, MixedSceneSumsStochasticOnTopOfConstantDeterministic) {
+  constexpr size_t kSceneDeterministic = 2;
+  StatsConsumer stats;
+
+  SimData batch1;
+  batch1.deterministic_crystal_count_ = kSceneDeterministic;
+  batch1.stochastic_crystal_sample_count_ = 7;
+  stats.Consume(batch1);
+  EXPECT_EQ(CrystalNum(stats), kSceneDeterministic + 7u);
+
+  SimData batch2;
+  batch2.deterministic_crystal_count_ = kSceneDeterministic;
+  batch2.stochastic_crystal_sample_count_ = 6;
+  stats.Consume(batch2);
+  EXPECT_EQ(CrystalNum(stats), kSceneDeterministic + 13u)
+      << "the deterministic half must not grow with the batch count, and the stochastic half must";
+}
+
+TEST(StatsConsumer, ResetClearsBothHalves) {
   StatsConsumer stats;
   SimData batch;
-  batch.crystal_count_ = 7;
+  batch.stochastic_crystal_sample_count_ = 7;
+  batch.deterministic_crystal_count_ = 3;
   batch.root_ray_count_ = 42;
   stats.Consume(batch);
 
@@ -54,13 +110,16 @@ TEST(StatsConsumer, ResetClearsCrystalCount) {
   EXPECT_EQ(r.sim_ray_num_, 0u);
 }
 
-// Server-side chunk dispatch invariant (server.cpp:834): when a large SimData
-// is fanned out to N chunks, ONLY the first chunk carries the stats fields
-// (root_ray_count_, crystal_count_). This test simulates that dispatch and
-// verifies that accumulating N chunks yields exactly the original crystal
-// count once — no N× duplication, no zero.
-TEST(StatsConsumer, ChunkedDispatchAccumulatesFirstChunkOnlyOnce) {
-  constexpr size_t kOriginalCrystals = 4;
+// Server-side chunk dispatch invariant (server.cpp ConsumeData): when a large
+// SimData is fanned out to N chunks, the ACCUMULATED fields (root_ray_count_,
+// stochastic_crystal_sample_count_) ride only the first chunk, while the
+// OVERWRITTEN field (deterministic_crystal_count_) rides every chunk. This test
+// mirrors that fill exactly. Note what it would catch: putting the deterministic
+// count on the first chunk only leaves the trailing chunks overwriting it back
+// to 0, so the whole deterministic population silently vanishes from the report.
+TEST(StatsConsumer, ChunkedDispatchAppliesTheRightRuleToEachHalf) {
+  constexpr size_t kStochastic = 4;
+  constexpr size_t kDeterministic = 6;
   constexpr size_t kOriginalRootRays = 512;
   constexpr int kChunkCount = 5;
 
@@ -68,10 +127,11 @@ TEST(StatsConsumer, ChunkedDispatchAccumulatesFirstChunkOnlyOnce) {
   for (int i = 0; i < kChunkCount; i++) {
     SimData chunk;
     if (i == 0) {
-      chunk.crystal_count_ = kOriginalCrystals;
+      chunk.stochastic_crystal_sample_count_ = kStochastic;
       chunk.root_ray_count_ = kOriginalRootRays;
     }
-    // Non-first chunks carry only per-chunk outgoing rays (not modelled here).
+    chunk.deterministic_crystal_count_ = kDeterministic;  // every chunk, per server.cpp
+    // Non-first chunks otherwise carry only per-chunk outgoing rays (not modelled here).
     stats.Consume(chunk);
   }
 
@@ -79,9 +139,9 @@ TEST(StatsConsumer, ChunkedDispatchAccumulatesFirstChunkOnlyOnce) {
   auto result = stats.GetResult();
   ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
   const auto& r = std::get<StatsResult>(result);
-  EXPECT_EQ(r.crystal_num_, kOriginalCrystals) << "First-chunk-only dispatch: expected the original crystal_count_, "
-                                                  "not "
-                                               << kChunkCount << "x or 0.";
+  EXPECT_EQ(r.crystal_num_, kStochastic + kDeterministic)
+      << "expected the stochastic draws counted once (not " << kChunkCount
+      << "x) plus the deterministic population counted once (not 0)";
   EXPECT_EQ(r.sim_ray_num_, kOriginalRootRays)
       << "First-chunk-only dispatch: root_ray_count_ must also only be counted once.";
 }


### PR DESCRIPTION
## 问题

`Stats: crystals=N`（C API `LUMICE_StatsResult.crystal_num`）不是场景属性，而是调度产物。

一手实测（2 个 MS 层、5 个 (layer, ci) 槽位的探针场景，真值 = 5）：

| | 改动前 | 改动后 |
|---|---|---|
| `cpu_backend`，dispatch 128 / 1024 / 20000 | 471 / 60 / 3 | 5 / 5 / 5 |
| legacy CPU，确定性 vs 随机化形状 | 785 vs 3317 | 5 vs ~3.3k |
| `num_workers` 1 / 2 / 4 / 12 | 5 / 10 / 20 / 60 | 5 / 5 / 5 / 5 |

同一物理场景，只动一个性能旋钮就有 157× 摆动；且它对「几何随机化是否生效」完全不敏感（`cpu_backend`
与 Metal 的确定性/随机化场景报同一个数）——而这恰恰是这个 stat 唯一想回答的问题。

语义此前有**三套**互不兼容：legacy CPU 报「累计物化的晶体实例数（含缓存拷贝）」、`CpuTraceBackend`
报「最终 MS 层的 setting 数快照」（一份指向 scrum-384 已删除实现的陈旧镜像）、Metal/CUDA 报「本 batch
构建的 pool 形状数」但在复用批次上保留了上一次的陈旧值。

## 修法

把这个量拆成两半，各按自己的纪律聚合：

```
crystals = DeterministicCrystalCount(config)                    // config 常量，OVERWRITE
         + Σ GetLastBatchStochasticCrystalSampleCount()         // 随机抽样，累加
```

确定性参数每次抽样产出逐字节相同的形状，所以无论多少 batch 重新推导、多少 worker 并行冗余推导，
它贡献的都是**一个**几何——这是已提交配置的性质，因此从 config 数一次并按覆盖传递。随机参数每次
都抽到真正不同的形状（每个 worker 有独立的 `static thread_local` RNG），所以**累加**。把两者混为
一谈正是本 PR 要修的缺陷。

副产品：拆分之后「运行时去重状态」不再需要存在，中途引入的 `NewSampleTracker` 被整个删除，判据
收敛回单一纯谓词 `IsDeterministic`。

## 刻意的设计选择（不是疏漏）

- **不追求三后端数值相等**。GPU 默认 `geom_clock_ = 0`（K 关闭，opt-in 的产品决策），所以随机化场景
  GPU 与 CPU 本就采样不同数量的形状。本 PR 交付的是「数字诚实反映各后端实际采样了多少」，不是
  「三个数字相同」。
- **确定性项数的是 scene 槽位，不是被 trace 到的槽位**。`crystal_proportion_ == 0` 的槽位仍计入。
  哪些槽位被 trace 是 ray partition 的函数，会随 dispatch 粒度和 worker 数漂移——从 config 单独推导
  正是免疫性的来源。已由回归测试钉住。
- **计数的挂载方式在四个 arm 上刻意异构**，各自顺着已有的 build/skip 结构走；判据本身单源。

## 测试

- 新增 `test/regression-sentinel/test_crystal_count_dispatch_invariance.py`（8 例）：dispatch 不变性、
  worker 不变性、随机化可观测性、scene-槽位 vs traced-槽位。**红绿双态实测**：改动前分别报
  471/60/3、5/10/20/60，均按预期红。
- 4 处存量后端测试重定向到新契约（不靠放宽容差）；`StatsConsumer` 单测覆盖两套聚合规则 +
  分片派发 + 「省略字段会抹掉确定性半边」的特征化测试。
- 本机全绿：`-tj` 5/5、`-gtj` 5/5、`pytest -m slow` 8 passed、fast e2e 136 passed / 30 skipped、
  三闸（format / check_policies / check_new_refs）exit 0。

## 尚未验证

CUDA arm 只在编译层面过；按计划需要在 dev49 上跑「先只含测试断言确认红 → 再应用实现确认绿」的
两拍 round-trip，尚未执行。

## 无 C API break

`crystal_num` 字段名与类型不变，仅语义收紧（数值会显著变小），已在 `doc/c_api.md` / `_zh` 与
CHANGELOG 标注为用户可观察的数值行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)