### PR TITLE
refactor: give the crystal shape/axis JSON keys one owner in core

### DIFF
--- a/src/config/crystal_config.cpp
+++ b/src/config/crystal_config.cpp
@@ -161,11 +161,19 @@ namespace {
 // the key is written once rather than once per face.
 constexpr const char* kFaceDistanceSyncKey = "face_distance";
 
+// The pyramid-only keys, spelled here and nowhere else in the tree. Every layer
+// that reads or writes them goes through ShapeWedgeAngleKeyName /
+// ShapeIndicesKeyName below.
+constexpr const char* kShapeKeyUpperWedgeAngle = "upper_wedge_angle";
+constexpr const char* kShapeKeyLowerWedgeAngle = "lower_wedge_angle";
+constexpr const char* kShapeKeyUpperIndices = "upper_indices";
+constexpr const char* kShapeKeyLowerIndices = "lower_indices";
+
 // Read the optional "sync_group" sub-map. Keys name shape scalars the same way
 // the surrounding shape JSON names their distributions ("height", "prism_h",
-// "upper_h", "lower_h", "face_distance"), so a reader never has to know the
-// ShapeScalar integers. Absent key = every scalar independent, which is why an
-// older config file needs no edit at all.
+// "upper_h", "lower_h", "face_distance") — literally the same strings, which is
+// why both levels now read them from ShapeScalarSyncKeyName. Absent key = every
+// scalar independent, which is why an older config file needs no edit at all.
 void ReadSyncGroupJson(const nlohmann::json& j, int sync_group[kShapeScalarCount],
                        const std::pair<const char*, int>* scalar_keys, size_t scalar_key_cnt) {
   for (int i = 0; i < kShapeScalarCount; i++) {
@@ -270,12 +278,20 @@ const char* ShapeScalarSyncKeyName(CrystalKind kind, int slot) {
   return LookupSyncKey(kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys), slot);
 }
 
+const char* ShapeWedgeAngleKeyName(bool upper) {
+  return upper ? kShapeKeyUpperWedgeAngle : kShapeKeyLowerWedgeAngle;
+}
+
+const char* ShapeIndicesKeyName(bool upper) {
+  return upper ? kShapeKeyUpperIndices : kShapeKeyLowerIndices;
+}
+
 
 // convert to & from json object
 // ========== PrismCrystalParam ==========
 void to_json(nlohmann::json& j, const PrismCrystalParam& p) {
-  j["height"] = p.h_;
-  j["face_distance"] = p.d_;
+  j[ShapeScalarSyncKeyName(CrystalKind::kPrism, kShapeScalarHeight)] = p.h_;
+  j[ShapeScalarSyncKeyName(CrystalKind::kPrism, kShapeScalarFace0)] = p.d_;
   // Canonicalize a local copy: serialization must not depend on the caller having
   // normalized, and must not mutate what it was handed either.
   PrismCrystalParam canon = p;
@@ -284,8 +300,9 @@ void to_json(nlohmann::json& j, const PrismCrystalParam& p) {
 }
 
 void from_json(const nlohmann::json& j, PrismCrystalParam& p) {
-  if (j.contains("height")) {
-    j.at("height").get_to(p.h_);
+  const char* height_key = ShapeScalarSyncKeyName(CrystalKind::kPrism, kShapeScalarHeight);
+  if (j.contains(height_key)) {
+    j.at(height_key).get_to(p.h_);
   }
 
   // Face distance: default value 1.0 (1.0 = regular hexagon in FillHexCrystalCoef)
@@ -293,9 +310,10 @@ void from_json(const nlohmann::json& j, PrismCrystalParam& p) {
     x.type = DistributionType::kNoRandom;
     x.center = 1.0f;
   }
-  if (j.contains("face_distance")) {
+  const char* fd_key = ShapeScalarSyncKeyName(CrystalKind::kPrism, kShapeScalarFace0);
+  if (j.contains(fd_key)) {
     size_t i = 0;
-    for (const auto& elem : j.at("face_distance")) {
+    for (const auto& elem : j.at(fd_key)) {
       if (i >= 6) {
         break;
       }
@@ -322,39 +340,43 @@ static float MillerToAlpha(int i1, int i4) {
 
 // ========== PyramidCrystalParam ==========
 void to_json(nlohmann::json& j, const PyramidCrystalParam& p) {
-  j["prism_h"] = p.h_prs_;
-  j["upper_h"] = p.h_pyr_u_;
-  j["lower_h"] = p.h_pyr_l_;
-  j["upper_wedge_angle"] = p.wedge_angle_u_;
-  j["lower_wedge_angle"] = p.wedge_angle_l_;
-  j["face_distance"] = p.d_;
+  constexpr auto kKind = CrystalKind::kPyramid;
+  j[ShapeScalarSyncKeyName(kKind, kShapeScalarPrismH)] = p.h_prs_;
+  j[ShapeScalarSyncKeyName(kKind, kShapeScalarUpperH)] = p.h_pyr_u_;
+  j[ShapeScalarSyncKeyName(kKind, kShapeScalarLowerH)] = p.h_pyr_l_;
+  j[ShapeWedgeAngleKeyName(true)] = p.wedge_angle_u_;
+  j[ShapeWedgeAngleKeyName(false)] = p.wedge_angle_l_;
+  j[ShapeScalarSyncKeyName(kKind, kShapeScalarFace0)] = p.d_;
   PyramidCrystalParam canon = p;
   CanonicalizeSyncGroups(canon);
   WriteSyncGroupJson(j, canon.sync_group_, kPyramidSyncGroupKeys, std::size(kPyramidSyncGroupKeys));
 }
 
 void from_json(const nlohmann::json& j, PyramidCrystalParam& p) {
+  constexpr auto kKind = CrystalKind::kPyramid;
+
   // Heights
-  j.at("prism_h").get_to(p.h_prs_);
-  if (j.contains("upper_h")) {
-    j.at("upper_h").get_to(p.h_pyr_u_);
+  j.at(ShapeScalarSyncKeyName(kKind, kShapeScalarPrismH)).get_to(p.h_prs_);
+  const char* upper_h_key = ShapeScalarSyncKeyName(kKind, kShapeScalarUpperH);
+  if (j.contains(upper_h_key)) {
+    j.at(upper_h_key).get_to(p.h_pyr_u_);
   }
-  if (j.contains("lower_h")) {
-    j.at("lower_h").get_to(p.h_pyr_l_);
+  const char* lower_h_key = ShapeScalarSyncKeyName(kKind, kShapeScalarLowerH);
+  if (j.contains(lower_h_key)) {
+    j.at(lower_h_key).get_to(p.h_pyr_l_);
   }
 
-  // Wedge angle: prefer "upper_wedge_angle", fallback to "upper_indices" conversion
-  if (j.contains("upper_wedge_angle")) {
-    p.wedge_angle_u_ = j.at("upper_wedge_angle").get<float>();
-  } else if (j.contains("upper_indices") && j.at("upper_indices").is_array() && j.at("upper_indices").size() == 3) {
-    auto& ui = j.at("upper_indices");
-    p.wedge_angle_u_ = MillerToAlpha(ui[0].get<int>(), ui[2].get<int>());
-  }
-  if (j.contains("lower_wedge_angle")) {
-    p.wedge_angle_l_ = j.at("lower_wedge_angle").get<float>();
-  } else if (j.contains("lower_indices") && j.at("lower_indices").is_array() && j.at("lower_indices").size() == 3) {
-    auto& li = j.at("lower_indices");
-    p.wedge_angle_l_ = MillerToAlpha(li[0].get<int>(), li[2].get<int>());
+  // Wedge angle: prefer the explicit angle, fallback to the Miller-index conversion
+  for (bool upper : { true, false }) {
+    float& wedge_angle = upper ? p.wedge_angle_u_ : p.wedge_angle_l_;
+    const char* angle_key = ShapeWedgeAngleKeyName(upper);
+    const char* indices_key = ShapeIndicesKeyName(upper);
+    if (j.contains(angle_key)) {
+      wedge_angle = j.at(angle_key).get<float>();
+    } else if (j.contains(indices_key) && j.at(indices_key).is_array() && j.at(indices_key).size() == 3) {
+      const auto& idx = j.at(indices_key);
+      wedge_angle = MillerToAlpha(idx[0].get<int>(), idx[2].get<int>());
+    }
   }
 
   // Face distance: default value 1.0 (1.0 = regular hexagon in FillHexCrystalCoef)
@@ -362,9 +384,10 @@ void from_json(const nlohmann::json& j, PyramidCrystalParam& p) {
     x.type = DistributionType::kNoRandom;
     x.center = 1.0f;
   }
-  if (j.contains("face_distance")) {
+  const char* fd_key = ShapeScalarSyncKeyName(kKind, kShapeScalarFace0);
+  if (j.contains(fd_key)) {
     size_t i = 0;
-    for (const auto& elem : j.at("face_distance")) {
+    for (const auto& elem : j.at(fd_key)) {
       if (i >= 6) {
         break;
       }

--- a/src/config/crystal_config.hpp
+++ b/src/config/crystal_config.hpp
@@ -142,12 +142,19 @@ void PrepareSyncGroups(PyramidCrystalParam& p);
 //!   O(1), no allocation, no side effects — safe to call per row per frame.
 bool IsShapeScalarApplicable(CrystalKind kind, int slot);
 
-//! @brief The JSON key under `shape.sync_group` that names shape-scalar `slot`.
+//! @brief The JSON key naming shape-scalar `slot` — both under `shape` itself
+//!   and under `shape.sync_group`.
 //!
 //! @details Returns a static string, or nullptr when the slot does not apply to
 //!   `kind` (or is out of range). All six face slots share the single key
 //!   "face_distance", whose value is a 6-element array — callers write it once,
 //!   not once per face.
+//!
+//!   One key serves both levels because the sub-map names each scalar exactly as
+//!   the surrounding shape object does; they were always the same string, written
+//!   twice. The name still says "sync" for the reason a released C API symbol
+//!   (LUMICE_ShapeScalarSyncKeyName) does not get renamed to describe a widened
+//!   set of callers — the contract did not change, only who asks.
 //!
 //!   Same motive as IsShapeScalarApplicable: this used to be a `{key, slot}`
 //!   literal table copied into three translation units (here, the C API, the GUI
@@ -155,6 +162,24 @@ bool IsShapeScalarApplicable(CrystalKind kind, int slot);
 //!   symptom — the layer that drifted would silently drop the field — so the
 //!   copies are gone and every layer reads this.
 const char* ShapeScalarSyncKeyName(CrystalKind kind, int slot);
+
+//! @brief The JSON key under `shape` holding a pyramidal wedge angle, in degrees.
+//!
+//! @details Returns a static string, never null. Takes a plain `bool` rather
+//!   than a CrystalKind + slot pair, because unlike the shape scalars there is
+//!   nothing for a kind to select: both wedge angles exist only on a pyramid,
+//!   and every call site is already inside a `type == pyramid` branch. Two
+//!   states also do not earn an enum — there is no third wedge to name.
+const char* ShapeWedgeAngleKeyName(bool upper);
+
+//! @brief The JSON key under `shape` holding a pyramidal face's Miller indices.
+//!
+//! @details Returns a static string, never null. The legacy read-side spelling
+//!   of the same physical quantity ShapeWedgeAngleKeyName names: a parser falls
+//!   back to converting these three indices into an angle when the explicit
+//!   wedge-angle key is absent. Write paths never emit it. Same `bool upper`
+//!   parameterization, for the same reason.
+const char* ShapeIndicesKeyName(bool upper);
 
 using CrystalParam = std::variant<PrismCrystalParam, PyramidCrystalParam>;
 

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -597,6 +597,22 @@ void from_json(const nlohmann::json& obj, Distribution& dist) {
   }
 }
 
+namespace {
+
+// The three axis keys, spelled here and nowhere else in the tree. Indexed by
+// AxisScalar; every layer that reads or writes them goes through
+// AxisScalarKeyName below.
+constexpr const char* kAxisScalarKeys[kAxisScalarCount] = { "zenith", "azimuth", "roll" };
+
+}  // namespace
+
+const char* AxisScalarKeyName(int slot) {
+  if (slot < 0 || slot >= kAxisScalarCount) {
+    return nullptr;
+  }
+  return kAxisScalarKeys[slot];
+}
+
 void to_json(nlohmann::json& obj, const AxisDistribution& axis) {
   // Zenith: internal latitude → external zenith (zenith center = 90 - latitude center).
   // Must handle kNoRandom (serialized as number) vs others (serialized as object).
@@ -607,13 +623,13 @@ void to_json(nlohmann::json& obj, const AxisDistribution& axis) {
   } else {
     zenith["mean"] = 90.0f - axis.latitude_dist.center;
   }
-  obj["zenith"] = zenith;
-  obj["azimuth"] = axis.azimuth_dist;
-  obj["roll"] = axis.roll_dist;
+  obj[AxisScalarKeyName(kAxisScalarZenith)] = zenith;
+  obj[AxisScalarKeyName(kAxisScalarAzimuth)] = axis.azimuth_dist;
+  obj[AxisScalarKeyName(kAxisScalarRoll)] = axis.roll_dist;
 }
 
 void from_json(const nlohmann::json& obj, AxisDistribution& axis) {
-  obj.at("zenith").get_to(axis.latitude_dist);
+  obj.at(AxisScalarKeyName(kAxisScalarZenith)).get_to(axis.latitude_dist);
   axis.latitude_dist.center = 90.0f - axis.latitude_dist.center;
 
   axis.azimuth_dist.type = DistributionType::kUniform;
@@ -623,11 +639,13 @@ void from_json(const nlohmann::json& obj, AxisDistribution& axis) {
   axis.roll_dist.center = 0.0f;
   axis.roll_dist.spread = 360.0f;
 
-  if (obj.contains("azimuth")) {
-    obj.at("azimuth").get_to(axis.azimuth_dist);
+  const char* azimuth_key = AxisScalarKeyName(kAxisScalarAzimuth);
+  if (obj.contains(azimuth_key)) {
+    obj.at(azimuth_key).get_to(axis.azimuth_dist);
   }
-  if (obj.contains("roll")) {
-    obj.at("roll").get_to(axis.roll_dist);
+  const char* roll_key = AxisScalarKeyName(kAxisScalarRoll);
+  if (obj.contains(roll_key)) {
+    obj.at(roll_key).get_to(axis.roll_dist);
   }
 }
 

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -285,6 +285,35 @@ struct AxisDistribution {
   Distribution roll_dist;
 };
 
+//! @brief Index space for the three distributions of a crystal's `axis` object.
+//!
+//! @details Named after ShapeScalar because it answers the same question in the
+//!   same shape — an int slot in, one JSON key out — but the two models are not
+//!   parallel and should not be read as such: an axis has no crystal kind to
+//!   depend on and therefore no "applicable to this type" concept. Every slot
+//!   below always exists. Slot order is the serialization order, nothing more;
+//!   unlike ShapeScalar it is NOT an RNG draw order.
+//!
+//!   Note kAxisScalarZenith names the EXTERNAL wire quantity, which is the
+//!   complement of the internal AxisDistribution::latitude_dist it maps onto
+//!   (zenith = 90 - latitude). The key names the file format, not the field.
+enum AxisScalar : int {
+  kAxisScalarZenith = 0,
+  kAxisScalarAzimuth = 1,
+  kAxisScalarRoll = 2,
+  kAxisScalarCount = 3,
+};
+
+//! @brief The JSON key under a crystal's `axis` that names axis-scalar `slot`.
+//!
+//! @details Returns a static string, or nullptr when `slot` is out of range —
+//!   matching ShapeScalarSyncKeyName's convention, so a caller iterating a
+//!   mismatched slot count degrades to "no such key" instead of an invented one.
+//!
+//!   These three strings are core's schema. A layer that misspells one silently
+//!   drops the field rather than reporting an error, so no layer spells them out.
+const char* AxisScalarKeyName(int slot);
+
 
 namespace detail {
 // Internal — not part of public API.

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -276,8 +276,8 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
     j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H)] = SerializeShapeDist(c.prism_h);
     j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H)] = SerializeShapeDist(c.upper_h);
     j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H)] = SerializeShapeDist(c.lower_h);
-    j["shape"][LUMICE_ShapeWedgeAngleKeyName(1)] = c.upper_alpha;
-    j["shape"][LUMICE_ShapeWedgeAngleKeyName(0)] = c.lower_alpha;
+    j["shape"][LUMICE_ShapeWedgeAngleKeyName(true)] = c.upper_alpha;
+    j["shape"][LUMICE_ShapeWedgeAngleKeyName(false)] = c.lower_alpha;
   }
 
   // face_distance: only write when non-default. The default is the deterministic unit distance

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -267,16 +267,17 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
     j["name"] = c.name;
   }
 
+  const LUMICE_CrystalKind kind = (c.type == CrystalType::kPrism) ? LUMICE_CRYSTAL_PRISM : LUMICE_CRYSTAL_PYRAMID;
   if (c.type == CrystalType::kPrism) {
     j["type"] = "prism";
-    j["shape"]["height"] = SerializeShapeDist(c.height);
+    j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_HEIGHT)] = SerializeShapeDist(c.height);
   } else {
     j["type"] = "pyramid";
-    j["shape"]["prism_h"] = SerializeShapeDist(c.prism_h);
-    j["shape"]["upper_h"] = SerializeShapeDist(c.upper_h);
-    j["shape"]["lower_h"] = SerializeShapeDist(c.lower_h);
-    j["shape"]["upper_wedge_angle"] = c.upper_alpha;
-    j["shape"]["lower_wedge_angle"] = c.lower_alpha;
+    j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H)] = SerializeShapeDist(c.prism_h);
+    j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H)] = SerializeShapeDist(c.upper_h);
+    j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H)] = SerializeShapeDist(c.lower_h);
+    j["shape"][LUMICE_ShapeWedgeAngleKeyName(1)] = c.upper_alpha;
+    j["shape"][LUMICE_ShapeWedgeAngleKeyName(0)] = c.lower_alpha;
   }
 
   // face_distance: only write when non-default. The default is the deterministic unit distance
@@ -291,9 +292,11 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
     }
   }
   if (!is_default_fd) {
-    j["shape"]["face_distance"] = { SerializeShapeDist(c.face_distance[0]), SerializeShapeDist(c.face_distance[1]),
-                                    SerializeShapeDist(c.face_distance[2]), SerializeShapeDist(c.face_distance[3]),
-                                    SerializeShapeDist(c.face_distance[4]), SerializeShapeDist(c.face_distance[5]) };
+    j["shape"][LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] = {
+      SerializeShapeDist(c.face_distance[0]), SerializeShapeDist(c.face_distance[1]),
+      SerializeShapeDist(c.face_distance[2]), SerializeShapeDist(c.face_distance[3]),
+      SerializeShapeDist(c.face_distance[4]), SerializeShapeDist(c.face_distance[5])
+    };
   }
 
   // shape.sync_group: the embedded per-ShapeDist groups gathered back into the wire form's
@@ -301,15 +304,11 @@ static json SerializeCrystal(const CrystalConfig& c, int id) {
   // shape scalars themselves are written above.
   int sg[LUMICE_SHAPE_SCALAR_COUNT];
   FillSyncGroupArray(c, sg);
-  if (c.type == CrystalType::kPrism) {
-    WriteSyncGroupJson(j["shape"], sg, LUMICE_CRYSTAL_PRISM);
-  } else {
-    WriteSyncGroupJson(j["shape"], sg, LUMICE_CRYSTAL_PYRAMID);
-  }
+  WriteSyncGroupJson(j["shape"], sg, kind);
 
-  j["axis"]["zenith"] = SerializeAxisDist(c.zenith);
-  j["axis"]["azimuth"] = SerializeAxisDist(c.azimuth);
-  j["axis"]["roll"] = SerializeAxisDist(c.roll);
+  j["axis"][LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_ZENITH)] = SerializeAxisDist(c.zenith);
+  j["axis"][LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_AZIMUTH)] = SerializeAxisDist(c.azimuth);
+  j["axis"][LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_ROLL)] = SerializeAxisDist(c.roll);
 
   return j;
 }
@@ -721,57 +720,62 @@ static CrystalConfig ParseCrystal(const json& j) {
 
   auto type_str = j.value("type", "prism");
   c.type = (type_str == "pyramid") ? CrystalType::kPyramid : CrystalType::kPrism;
+  const LUMICE_CrystalKind kind = (c.type == CrystalType::kPrism) ? LUMICE_CRYSTAL_PRISM : LUMICE_CRYSTAL_PYRAMID;
 
   if (j.contains("shape")) {
     auto& s = j.at("shape");
     if (c.type == CrystalType::kPrism) {
-      if (s.contains("height")) {
-        c.height = ParseShapeDist(s["height"], 1.0f);
+      const char* height_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_HEIGHT);
+      if (s.contains(height_key)) {
+        c.height = ParseShapeDist(s[height_key], 1.0f);
       }
     } else {
       // Historical fallbacks preserved: prism_h defaults to 1.0, upper_h/lower_h to 0.0 when absent.
-      c.prism_h = s.contains("prism_h") ? ParseShapeDist(s["prism_h"], 1.0f) : ShapeDist(1.0f);
-      c.upper_h = s.contains("upper_h") ? ParseShapeDist(s["upper_h"], 0.0f) : ShapeDist(0.0f);
-      c.lower_h = s.contains("lower_h") ? ParseShapeDist(s["lower_h"], 0.0f) : ShapeDist(0.0f);
-      // Wedge angle: prefer "upper_wedge_angle", fallback to "upper_indices" conversion
-      if (s.contains("upper_wedge_angle") && s["upper_wedge_angle"].is_number()) {
-        c.upper_alpha = s["upper_wedge_angle"].get<float>();
-      } else if (s.contains("upper_indices") && s["upper_indices"].is_array() && s["upper_indices"].size() == 3) {
-        c.upper_alpha = MillerToAlpha(s["upper_indices"][0].get<int>(), s["upper_indices"][2].get<int>());
-      }
-      if (s.contains("lower_wedge_angle") && s["lower_wedge_angle"].is_number()) {
-        c.lower_alpha = s["lower_wedge_angle"].get<float>();
-      } else if (s.contains("lower_indices") && s["lower_indices"].is_array() && s["lower_indices"].size() == 3) {
-        c.lower_alpha = MillerToAlpha(s["lower_indices"][0].get<int>(), s["lower_indices"][2].get<int>());
+      const char* prism_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H);
+      const char* upper_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H);
+      const char* lower_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H);
+      c.prism_h = s.contains(prism_h_key) ? ParseShapeDist(s[prism_h_key], 1.0f) : ShapeDist(1.0f);
+      c.upper_h = s.contains(upper_h_key) ? ParseShapeDist(s[upper_h_key], 0.0f) : ShapeDist(0.0f);
+      c.lower_h = s.contains(lower_h_key) ? ParseShapeDist(s[lower_h_key], 0.0f) : ShapeDist(0.0f);
+      // Wedge angle: prefer the explicit angle, fallback to the Miller-index conversion
+      for (int upper = 1; upper >= 0; upper--) {
+        float& alpha = upper ? c.upper_alpha : c.lower_alpha;
+        const char* angle_key = LUMICE_ShapeWedgeAngleKeyName(upper);
+        const char* indices_key = LUMICE_ShapeIndicesKeyName(upper);
+        if (s.contains(angle_key) && s[angle_key].is_number()) {
+          alpha = s[angle_key].get<float>();
+        } else if (s.contains(indices_key) && s[indices_key].is_array() && s[indices_key].size() == 3) {
+          alpha = MillerToAlpha(s[indices_key][0].get<int>(), s[indices_key][2].get<int>());
+        }
       }
     }
     // face_distance: common to both Prism and Pyramid
-    if (s.contains("face_distance") && s["face_distance"].is_array()) {
-      size_t n = std::min(s["face_distance"].size(), static_cast<size_t>(6));
+    const char* fd_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+    if (s.contains(fd_key) && s[fd_key].is_array()) {
+      size_t n = std::min(s[fd_key].size(), static_cast<size_t>(6));
       for (size_t i = 0; i < n; i++) {
-        c.face_distance[i] = ParseShapeDist(s["face_distance"][i], 1.0f);
+        c.face_distance[i] = ParseShapeDist(s[fd_key][i], 1.0f);
       }
     }
     // shape.sync_group: read into the wire form's parallel array, then scatter back into each
     // ShapeDist. Must come AFTER the shape parses above — those assign whole ShapeDist values and
     // would overwrite an already-scattered group with the default 0.
     int sg[LUMICE_SHAPE_SCALAR_COUNT];
-    if (c.type == CrystalType::kPrism) {
-      ReadSyncGroupJson(s, sg, LUMICE_CRYSTAL_PRISM);
-    } else {
-      ReadSyncGroupJson(s, sg, LUMICE_CRYSTAL_PYRAMID);
-    }
+    ReadSyncGroupJson(s, sg, kind);
     ApplySyncGroupArray(sg, c);
   }
 
   if (j.contains("axis")) {
     auto& ax = j.at("axis");
-    if (ax.contains("zenith"))
-      c.zenith = ParseAxisDist(ax["zenith"]);
-    if (ax.contains("azimuth"))
-      c.azimuth = ParseAxisDist(ax["azimuth"]);
-    if (ax.contains("roll"))
-      c.roll = ParseAxisDist(ax["roll"]);
+    const char* zenith_key = LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_ZENITH);
+    const char* azimuth_key = LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_AZIMUTH);
+    const char* roll_key = LUMICE_AxisScalarKeyName(LUMICE_AXIS_SCALAR_ROLL);
+    if (ax.contains(zenith_key))
+      c.zenith = ParseAxisDist(ax[zenith_key]);
+    if (ax.contains(azimuth_key))
+      c.azimuth = ParseAxisDist(ax[azimuth_key]);
+    if (ax.contains(roll_key))
+      c.roll = ParseAxisDist(ax[roll_key]);
   }
 
   return c;

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -1078,6 +1078,11 @@ LUMICE_ErrorCode LUMICE_GetCrystalMesh(const LUMICE_CrystalParam* crystal, unsig
 // =============== Crystal Kind ===============
 // Coarse crystal classification used for raypath face-number validation.
 // GUI uses this to determine which face numbers are legal for a given crystal.
+// A value matching neither enumerator is treated as LUMICE_CRYSTAL_PYRAMID rather than reported:
+// every entry taking this type (LUMICE_IsLegalFace, LUMICE_IsShapeScalarApplicable,
+// LUMICE_ShapeScalarSyncKeyName) tests for LUMICE_CRYSTAL_PRISM and falls through. That is the
+// contract, not an oversight — but it is a lenient one, so a caller computing a kind rather than
+// writing a literal should validate before calling if it wants a bad value to be visible.
 typedef enum LUMICE_CrystalKind_ {
   LUMICE_CRYSTAL_PRISM,    // Basal + prism lateral faces (1,2,3-8)
   LUMICE_CRYSTAL_PYRAMID,  // All faces including upper/lower pyramidal (1,2,3-8,13-18,23-28)
@@ -1096,14 +1101,52 @@ int LUMICE_IsLegalFace(LUMICE_CrystalKind kind, int face);
 // crystal table display a distribution the simulation did not use.
 int LUMICE_IsShapeScalarApplicable(LUMICE_CrystalKind kind, int slot);
 
-// Returns the JSON key naming shape-scalar `slot` inside a crystal's `shape.sync_group` object,
-// or NULL when the slot does not apply to this kind (or is out of range). The returned string is
-// static storage — do not free it.
+// Returns the JSON key naming shape-scalar `slot` — both inside a crystal's `shape` object and
+// inside its `shape.sync_group` sub-map, which name each scalar identically. NULL when the slot
+// does not apply to this kind (or is out of range). The returned string is static storage — do
+// not free it.
 //
 // All six face slots share the one key "face_distance", whose value is a 6-element array; write it
 // once, not once per face. Use this instead of spelling the key names out: they are core's schema,
 // a layer that misspells one silently drops the field rather than reporting an error.
+//
+// The name still says "sync" for compatibility with v4.13, which shipped it: the contract has not
+// changed, only the set of callers that ask.
 const char* LUMICE_ShapeScalarSyncKeyName(LUMICE_CrystalKind kind, int slot);
+
+// Returns the JSON key inside a crystal's `shape` object holding a pyramidal wedge angle, in
+// degrees — the upper one when `upper` is non-zero, the lower one otherwise. Never NULL; static
+// storage, do not free.
+//
+// Takes a plain flag rather than a kind + slot pair because there is nothing for a kind to select:
+// both wedge angles exist only on a pyramid, and a caller is already inside a pyramid branch
+// before it needs the key. Same reason there is no LUMICE_AXIS_/LUMICE_SHAPE_SCALAR_-style index
+// constant to go with it — two states, no third.
+const char* LUMICE_ShapeWedgeAngleKeyName(int upper);
+
+// Returns the JSON key inside a crystal's `shape` object holding a pyramidal face's Miller
+// indices — the legacy read-side spelling of the quantity LUMICE_ShapeWedgeAngleKeyName names. A
+// parser converts these three indices into an angle when the explicit wedge-angle key is absent;
+// write paths never emit it. Never NULL; static storage, do not free.
+const char* LUMICE_ShapeIndicesKeyName(int upper);
+
+// =============== Axis Scalars ===============
+// Index space for the three distributions of a crystal's `axis` object, for LUMICE_AxisScalarKeyName.
+//
+// Named like the LUMICE_SHAPE_SCALAR_* indices and used the same way, but the two models are NOT
+// parallel: an axis has no crystal kind, hence no applicability concept — all three always exist.
+// The order is the serialization order only; unlike the shape scalars it is not an RNG draw order.
+#define LUMICE_AXIS_SCALAR_ZENITH 0   // .zenith
+#define LUMICE_AXIS_SCALAR_AZIMUTH 1  // .azimuth
+#define LUMICE_AXIS_SCALAR_ROLL 2     // .roll
+#define LUMICE_AXIS_SCALAR_COUNT 3
+
+// Returns the JSON key naming axis-scalar `slot` (a LUMICE_AXIS_SCALAR_* index) inside a crystal's
+// `axis` object, or NULL when `slot` is out of range. Static storage — do not free it.
+//
+// Note LUMICE_AXIS_SCALAR_ZENITH names the wire quantity, which is the complement of core's
+// internal latitude (zenith = 90 - latitude): the key names the file format, not the field.
+const char* LUMICE_AxisScalarKeyName(int slot);
 
 // =============== Raypath Validation ===============
 // Validation state for raypath text input (GUI border color + OK gate).

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -1535,13 +1535,16 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   if (!cj.contains("shape")) {
     return LUMICE_ERR_MISSING_FIELD;  // core: j.at("shape")
   }
+  // One derivation for the whole function: the check above already narrowed type_str to the two
+  // known spellings, so every key query below — per-type and type-independent alike — asks core's
+  // one table with this same kind.
+  const auto kind = (type_str == "prism") ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
   if (type_str == "prism") {
     cr->type = 0;
-    constexpr auto kKind = ns::CrystalKind::kPrism;
     // height is OPTIONAL: core PrismCrystalParam::h_ defaults to a deterministic 1.0 and
     // from_json only overwrites it when the key is present.
     cr->height = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 1.0f, 0.0f };
-    const char* height_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_HEIGHT);
+    const char* height_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_HEIGHT);
     if (cj.at("shape").contains(height_key)) {
       if (auto err = JsonToDistribution(cj.at("shape").at(height_key), &cr->height); err != LUMICE_OK) {
         return err;
@@ -1549,11 +1552,10 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
     }
   } else if (type_str == "pyramid") {
     cr->type = 1;
-    constexpr auto kKind = ns::CrystalKind::kPyramid;
     const auto& shape = cj.at("shape");
     // prism_h is required (core: j.at(prism_h)); the two pyramidal heights are optional and
     // default to a deterministic 0.0 (PyramidCrystalParam::h_pyr_u_ / h_pyr_l_).
-    const char* prism_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_PRISM_H);
+    const char* prism_h_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H);
     if (!shape.contains(prism_h_key)) {
       return LUMICE_ERR_MISSING_FIELD;
     }
@@ -1562,13 +1564,13 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
     }
     cr->upper_h = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 0.0f, 0.0f };
     cr->lower_h = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 0.0f, 0.0f };
-    const char* upper_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_UPPER_H);
+    const char* upper_h_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H);
     if (shape.contains(upper_h_key)) {
       if (auto err = JsonToDistribution(shape.at(upper_h_key), &cr->upper_h); err != LUMICE_OK) {
         return err;
       }
     }
-    const char* lower_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_LOWER_H);
+    const char* lower_h_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H);
     if (shape.contains(lower_h_key)) {
       if (auto err = JsonToDistribution(shape.at(lower_h_key), &cr->lower_h); err != LUMICE_OK) {
         return err;
@@ -1592,10 +1594,6 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   } else {
     return LUMICE_ERR_INVALID_VALUE;
   }
-
-  // Both shape-key groups below are type-independent in spelling, but the query still takes a
-  // kind: it is core's one table, and the six face slots are applicable to both types.
-  const auto kind = (type_str == "prism") ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
 
   // face_distance: every element defaults to a deterministic 1.0 (regular hexagon). A shorter
   // array leaves the remaining faces at that default and a longer one is truncated at 6 — core

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -349,16 +349,17 @@ static void ReadSyncGroupJson(const nlohmann::json& shape_j, int sync_group[LUMI
 // them; the mesh-preview path does not want them).
 nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr) {
   nlohmann::json j;
+  const auto kind = (cr.type == 0) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
   if (cr.type == 0) {
     j["type"] = "prism";
-    j["shape"]["height"] = DistributionToJson(cr.height);
+    j["shape"][ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_HEIGHT)] = DistributionToJson(cr.height);
   } else {
     j["type"] = "pyramid";
-    j["shape"]["prism_h"] = DistributionToJson(cr.prism_h);
-    j["shape"]["upper_h"] = DistributionToJson(cr.upper_h);
-    j["shape"]["lower_h"] = DistributionToJson(cr.lower_h);
-    j["shape"]["upper_wedge_angle"] = cr.upper_wedge_angle;
-    j["shape"]["lower_wedge_angle"] = cr.lower_wedge_angle;
+    j["shape"][ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H)] = DistributionToJson(cr.prism_h);
+    j["shape"][ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H)] = DistributionToJson(cr.upper_h);
+    j["shape"][ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H)] = DistributionToJson(cr.lower_h);
+    j["shape"][ns::ShapeWedgeAngleKeyName(true)] = cr.upper_wedge_angle;
+    j["shape"][ns::ShapeWedgeAngleKeyName(false)] = cr.lower_wedge_angle;
   }
   // face_distance: emit all 6 unconditionally (mirrors core crystal_config.cpp::to_json's
   // `j["face_distance"] = p.d_`). The "only when non-default" shortcut no longer fits now that
@@ -368,15 +369,11 @@ nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr) {
   for (int fi = 0; fi < 6; fi++) {
     fd.push_back(DistributionToJson(cr.face_distance[fi]));
   }
-  j["shape"]["face_distance"] = fd;
+  j["shape"][ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0)] = fd;
   // Only the keys applicable to this crystal type are emitted, so an inapplicable declaration
   // never reaches the wire in the first place (core's canonicalization zeroes such slots anyway,
   // as defense in depth).
-  if (cr.type == 0) {
-    WriteSyncGroupJson(j["shape"], cr.sync_group, ns::CrystalKind::kPrism);
-  } else {
-    WriteSyncGroupJson(j["shape"], cr.sync_group, ns::CrystalKind::kPyramid);
-  }
+  WriteSyncGroupJson(j["shape"], cr.sync_group, kind);
   return j;
 }
 
@@ -391,9 +388,9 @@ nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr) {
 static nlohmann::json CrystalToJson(const LUMICE_CrystalParam& cr, int id) {
   nlohmann::json j = CrystalShapeToJson(cr);  // {"type","shape"} single-source translation
   j["id"] = id;
-  j["axis"]["zenith"] = DistributionToJson(cr.zenith);
-  j["axis"]["azimuth"] = DistributionToJson(cr.azimuth);
-  j["axis"]["roll"] = DistributionToJson(cr.roll);
+  j["axis"][ns::AxisScalarKeyName(ns::kAxisScalarZenith)] = DistributionToJson(cr.zenith);
+  j["axis"][ns::AxisScalarKeyName(ns::kAxisScalarAzimuth)] = DistributionToJson(cr.azimuth);
+  j["axis"][ns::AxisScalarKeyName(ns::kAxisScalarRoll)] = DistributionToJson(cr.roll);
   return j;
 }
 
@@ -1540,34 +1537,40 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   }
   if (type_str == "prism") {
     cr->type = 0;
+    constexpr auto kKind = ns::CrystalKind::kPrism;
     // height is OPTIONAL: core PrismCrystalParam::h_ defaults to a deterministic 1.0 and
     // from_json only overwrites it when the key is present.
     cr->height = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 1.0f, 0.0f };
-    if (cj.at("shape").contains("height")) {
-      if (auto err = JsonToDistribution(cj.at("shape").at("height"), &cr->height); err != LUMICE_OK) {
+    const char* height_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_HEIGHT);
+    if (cj.at("shape").contains(height_key)) {
+      if (auto err = JsonToDistribution(cj.at("shape").at(height_key), &cr->height); err != LUMICE_OK) {
         return err;
       }
     }
   } else if (type_str == "pyramid") {
     cr->type = 1;
+    constexpr auto kKind = ns::CrystalKind::kPyramid;
     const auto& shape = cj.at("shape");
-    // prism_h is required (core: j.at("prism_h")); the two pyramidal heights are optional and
+    // prism_h is required (core: j.at(prism_h)); the two pyramidal heights are optional and
     // default to a deterministic 0.0 (PyramidCrystalParam::h_pyr_u_ / h_pyr_l_).
-    if (!shape.contains("prism_h")) {
+    const char* prism_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_PRISM_H);
+    if (!shape.contains(prism_h_key)) {
       return LUMICE_ERR_MISSING_FIELD;
     }
-    if (auto err = JsonToDistribution(shape.at("prism_h"), &cr->prism_h); err != LUMICE_OK) {
+    if (auto err = JsonToDistribution(shape.at(prism_h_key), &cr->prism_h); err != LUMICE_OK) {
       return err;
     }
     cr->upper_h = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 0.0f, 0.0f };
     cr->lower_h = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 0.0f, 0.0f };
-    if (shape.contains("upper_h")) {
-      if (auto err = JsonToDistribution(shape.at("upper_h"), &cr->upper_h); err != LUMICE_OK) {
+    const char* upper_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_UPPER_H);
+    if (shape.contains(upper_h_key)) {
+      if (auto err = JsonToDistribution(shape.at(upper_h_key), &cr->upper_h); err != LUMICE_OK) {
         return err;
       }
     }
-    if (shape.contains("lower_h")) {
-      if (auto err = JsonToDistribution(shape.at("lower_h"), &cr->lower_h); err != LUMICE_OK) {
+    const char* lower_h_key = ns::ShapeScalarSyncKeyName(kKind, LUMICE_SHAPE_SCALAR_LOWER_H);
+    if (shape.contains(lower_h_key)) {
+      if (auto err = JsonToDistribution(shape.at(lower_h_key), &cr->lower_h); err != LUMICE_OK) {
         return err;
       }
     }
@@ -1575,24 +1578,24 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
     // explicit angle nor the Miller indices are given — the zeroed struct would mean 0°.
     cr->upper_wedge_angle = 28.0f;
     cr->lower_wedge_angle = 28.0f;
-    // Wedge angle: prefer "upper_wedge_angle", fallback to "upper_indices" conversion
-    if (shape.contains("upper_wedge_angle") && shape.at("upper_wedge_angle").is_number()) {
-      cr->upper_wedge_angle = shape.at("upper_wedge_angle").get<float>();
-    } else if (shape.contains("upper_indices") && shape.at("upper_indices").is_array() &&
-               shape.at("upper_indices").size() == 3) {
-      cr->upper_wedge_angle =
-          MillerToAlpha(shape.at("upper_indices")[0].get<int>(), shape.at("upper_indices")[2].get<int>());
-    }
-    if (shape.contains("lower_wedge_angle") && shape.at("lower_wedge_angle").is_number()) {
-      cr->lower_wedge_angle = shape.at("lower_wedge_angle").get<float>();
-    } else if (shape.contains("lower_indices") && shape.at("lower_indices").is_array() &&
-               shape.at("lower_indices").size() == 3) {
-      cr->lower_wedge_angle =
-          MillerToAlpha(shape.at("lower_indices")[0].get<int>(), shape.at("lower_indices")[2].get<int>());
+    // Wedge angle: prefer the explicit angle, fallback to the Miller-index conversion
+    for (bool upper : { true, false }) {
+      float& wedge_angle = upper ? cr->upper_wedge_angle : cr->lower_wedge_angle;
+      const char* angle_key = ns::ShapeWedgeAngleKeyName(upper);
+      const char* indices_key = ns::ShapeIndicesKeyName(upper);
+      if (shape.contains(angle_key) && shape.at(angle_key).is_number()) {
+        wedge_angle = shape.at(angle_key).get<float>();
+      } else if (shape.contains(indices_key) && shape.at(indices_key).is_array() && shape.at(indices_key).size() == 3) {
+        wedge_angle = MillerToAlpha(shape.at(indices_key)[0].get<int>(), shape.at(indices_key)[2].get<int>());
+      }
     }
   } else {
     return LUMICE_ERR_INVALID_VALUE;
   }
+
+  // Both shape-key groups below are type-independent in spelling, but the query still takes a
+  // kind: it is core's one table, and the six face slots are applicable to both types.
+  const auto kind = (type_str == "prism") ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
 
   // face_distance: every element defaults to a deterministic 1.0 (regular hexagon). A shorter
   // array leaves the remaining faces at that default and a longer one is truncated at 6 — core
@@ -1600,8 +1603,9 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   for (int k = 0; k < 6; k++) {
     cr->face_distance[k] = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 1.0f, 0.0f };
   }
-  if (cj.at("shape").contains("face_distance")) {
-    const auto& fd = cj.at("shape").at("face_distance");
+  const char* fd_key = ns::ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_FACE_0);
+  if (cj.at("shape").contains(fd_key)) {
+    const auto& fd = cj.at("shape").at(fd_key);
     if (!fd.is_array()) {
       return LUMICE_ERR_INVALID_VALUE;
     }
@@ -1616,11 +1620,7 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   // Sync groups: read verbatim, only the keys this crystal type owns. Canonicalization and
   // leader normalization stay in core's from_json (see WriteSyncGroupJson's note); this struct
   // holds what the caller / config file declared.
-  if (type_str == "prism") {
-    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, ns::CrystalKind::kPrism);
-  } else {
-    ReadSyncGroupJson(cj.at("shape"), cr->sync_group, ns::CrystalKind::kPyramid);
-  }
+  ReadSyncGroupJson(cj.at("shape"), cr->sync_group, kind);
 
   // Axis distributions. The two cases are deliberately NOT symmetric, mirroring core:
   //   - `axis` absent      -> AxisDistribution's default constructor: zenith/azimuth/roll all
@@ -1634,25 +1634,28 @@ static LUMICE_ErrorCode JsonToCrystal(const nlohmann::json& cj, LUMICE_CrystalPa
   cr->roll = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 0.0f, 0.0f };
   if (cj.contains("axis")) {
     const auto& axis = cj.at("axis");
-    if (!axis.contains("zenith")) {
+    const char* zenith_key = ns::AxisScalarKeyName(ns::kAxisScalarZenith);
+    if (!axis.contains(zenith_key)) {
       return LUMICE_ERR_MISSING_FIELD;
     }
     // Core reads the zenith key into its latitude slot and then flips it (latitude = 90 - zenith),
     // unconditionally — so a zenith object that omits `mean` inherits the latitude default 90,
     // which is zenith 90 on this side of the flip (NOT zenith 0).
     cr->zenith = LUMICE_Distribution{ LUMICE_DIST_NO_RANDOM, 90.0f, 0.0f };
-    if (auto err = JsonToDistribution(axis.at("zenith"), &cr->zenith); err != LUMICE_OK) {
+    if (auto err = JsonToDistribution(axis.at(zenith_key), &cr->zenith); err != LUMICE_OK) {
       return err;
     }
     cr->azimuth = LUMICE_Distribution{ LUMICE_DIST_UNIFORM, 0.0f, 360.0f };
     cr->roll = LUMICE_Distribution{ LUMICE_DIST_UNIFORM, 0.0f, 360.0f };
-    if (axis.contains("azimuth")) {
-      if (auto err = JsonToDistribution(axis.at("azimuth"), &cr->azimuth); err != LUMICE_OK) {
+    const char* azimuth_key = ns::AxisScalarKeyName(ns::kAxisScalarAzimuth);
+    if (axis.contains(azimuth_key)) {
+      if (auto err = JsonToDistribution(axis.at(azimuth_key), &cr->azimuth); err != LUMICE_OK) {
         return err;
       }
     }
-    if (axis.contains("roll")) {
-      if (auto err = JsonToDistribution(axis.at("roll"), &cr->roll); err != LUMICE_OK) {
+    const char* roll_key = ns::AxisScalarKeyName(ns::kAxisScalarRoll);
+    if (axis.contains(roll_key)) {
+      if (auto err = JsonToDistribution(axis.at(roll_key), &cr->roll); err != LUMICE_OK) {
         return err;
       }
     }
@@ -3134,6 +3137,27 @@ int LUMICE_IsShapeScalarApplicable(LUMICE_CrystalKind kind, int slot) {
 const char* LUMICE_ShapeScalarSyncKeyName(LUMICE_CrystalKind kind, int slot) {
   auto core_kind = (kind == LUMICE_CRYSTAL_PRISM) ? ns::CrystalKind::kPrism : ns::CrystalKind::kPyramid;
   return ns::ShapeScalarSyncKeyName(core_kind, slot);
+}
+
+const char* LUMICE_ShapeWedgeAngleKeyName(int upper) {
+  return ns::ShapeWedgeAngleKeyName(upper != 0);
+}
+
+const char* LUMICE_ShapeIndicesKeyName(int upper) {
+  return ns::ShapeIndicesKeyName(upper != 0);
+}
+
+
+// =============== Axis Scalars ===============
+// The wire indices are passed straight through to core's, so they must BE core's. A silent
+// mismatch would hand every caller a neighbouring key rather than an error.
+static_assert(LUMICE_AXIS_SCALAR_ZENITH == ns::kAxisScalarZenith &&
+                  LUMICE_AXIS_SCALAR_AZIMUTH == ns::kAxisScalarAzimuth &&
+                  LUMICE_AXIS_SCALAR_ROLL == ns::kAxisScalarRoll && LUMICE_AXIS_SCALAR_COUNT == ns::kAxisScalarCount,
+              "LUMICE_AXIS_SCALAR_* must mirror core's AxisScalar enum");
+
+const char* LUMICE_AxisScalarKeyName(int slot) {
+  return ns::AxisScalarKeyName(slot);
 }
 
 

--- a/test/gui/functional/test_gui_import_export.cpp
+++ b/test/gui/functional/test_gui_import_export.cpp
@@ -711,6 +711,109 @@ void RegisterImportExportTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // The wedge-angle, Miller-index and axis keys, which the sync_group tests above do not reach:
+  // sync_group covers only the ten shape SCALARS, and lmc_full_roundtrip checks "zenith" alone.
+  // Every key here is a bare string literal on purpose — expressing them through
+  // LUMICE_ShapeWedgeAngleKeyName / LUMICE_AxisScalarKeyName would let the schema and its own test
+  // drift together and pass forever. Import and export are both checked because they are separate
+  // key lists in the code: a round-trip alone is self-consistent even when the GUI writes keys core
+  // cannot read.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "import_export", "wedge_angle_and_axis_keys_roundtrip");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      IM_UNUSED(ctx);
+      ResetTestState();
+
+      // --- Import: explicit wedge angles + all three axis keys, each a distinct value so a
+      // swapped pair (zenith read into roll, upper read into lower) cannot pass.
+      const std::string core_json = R"({
+        "crystal": [
+          {"id": 1, "type": "pyramid",
+           "shape": {"prism_h": 1.2, "upper_h": 0.1, "lower_h": 0.5,
+                     "upper_wedge_angle": 33.0, "lower_wedge_angle": 22.0},
+           "axis": {"zenith": {"type": "gauss", "mean": 12.0, "std": 1.0},
+                    "azimuth": {"type": "uniform", "mean": 34.0, "std": 2.0},
+                    "roll": {"type": "gauss", "mean": 56.0, "std": 3.0}}}
+        ],
+        "scene": {
+          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "ray_num": 1000,
+          "max_hits": 8,
+          "scattering": [
+            {"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0}]}
+          ]
+        }
+      })";
+
+      gui::GuiState loaded = gui::InitDefaultState();
+      IM_CHECK(gui::DeserializeFromJson(core_json, loaded));
+      IM_CHECK_EQ(static_cast<int>(loaded.layers.size()), 1);
+      const auto& c = gui::CrystalOf(loaded, loaded.layers[0].entries[0]);
+      IM_CHECK_EQ(c.type, gui::CrystalType::kPyramid);
+      IM_CHECK_LT(std::abs(c.upper_alpha - 33.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.lower_alpha - 22.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.zenith.mean - 12.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.azimuth.mean - 34.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.azimuth.std - 2.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.roll.mean - 56.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(c.roll.std - 3.0f), 1e-3f);
+
+      // --- Import, legacy arm: with the explicit angles gone, the Miller indices take over. The
+      // expected degrees are the same literals the core-side MillerIndexFallback tests pin.
+      const std::string indices_json = R"({
+        "crystal": [
+          {"id": 1, "type": "pyramid",
+           "shape": {"prism_h": 1.2, "upper_h": 0.1, "lower_h": 0.5,
+                     "upper_indices": [2, 0, 3], "lower_indices": [1, 0, 1]}}
+        ],
+        "scene": {
+          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "ray_num": 1000,
+          "max_hits": 8,
+          "scattering": [
+            {"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0}]}
+          ]
+        }
+      })";
+
+      gui::GuiState legacy = gui::InitDefaultState();
+      IM_CHECK(gui::DeserializeFromJson(indices_json, legacy));
+      const auto& lc = gui::CrystalOf(legacy, legacy.layers[0].entries[0]);
+      IM_CHECK_LT(std::abs(lc.upper_alpha - 38.57f), 0.01f);  // {2,0,3}
+      IM_CHECK_LT(std::abs(lc.lower_alpha - 28.00f), 0.01f);  // {1,0,1}
+
+      // --- Export: the same keys come back out, spelled the same way.
+      auto& cr = gui::CrystalOf(gui::g_state, gui::g_state.layers[0].entries[0]);
+      cr.type = gui::CrystalType::kPyramid;
+      cr.upper_alpha = 33.0f;
+      cr.lower_alpha = 22.0f;
+      cr.zenith = gui::AxisDist{ gui::AxisDistType::kGauss, 12.0f, 1.0f };
+      cr.azimuth = gui::AxisDist{ gui::AxisDistType::kUniform, 34.0f, 2.0f };
+      cr.roll = gui::AxisDist{ gui::AxisDistType::kGauss, 56.0f, 3.0f };
+
+      const auto doc = nlohmann::json::parse(gui::SerializeGuiStateJson(gui::g_state));
+      const auto& crystal_j = doc["layers"][0]["entries"][0]["crystal"];
+      const auto& shape = crystal_j["shape"];
+      IM_CHECK(shape.contains("upper_wedge_angle"));
+      IM_CHECK(shape.contains("lower_wedge_angle"));
+      IM_CHECK_LT(std::abs(shape["upper_wedge_angle"].get<float>() - 33.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(shape["lower_wedge_angle"].get<float>() - 22.0f), 1e-3f);
+      // Miller indices are read-only legacy: the writer converts to an angle and never emits them.
+      IM_CHECK(!shape.contains("upper_indices"));
+      IM_CHECK(!shape.contains("lower_indices"));
+
+      const auto& axis = crystal_j["axis"];
+      IM_CHECK(axis.contains("zenith"));
+      IM_CHECK(axis.contains("azimuth"));
+      IM_CHECK(axis.contains("roll"));
+      IM_CHECK_LT(std::abs(axis["zenith"]["mean"].get<float>() - 12.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(axis["azimuth"]["mean"].get<float>() - 34.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(axis["azimuth"]["std"].get<float>() - 2.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(axis["roll"]["mean"].get<float>() - 56.0f), 1e-3f);
+      IM_CHECK_LT(std::abs(axis["roll"]["std"].get<float>() - 3.0f), 1e-3f);
+    };
+  }
+
   // AC2, the other half: an all-independent crystal must emit NO "sync_group" key, so every .lmc
   // written before v4.13 keeps its exact wire form. Paired with a red/green flip — asserting only
   // absence would pass just as happily on a serializer that never writes the key at all.

--- a/test/unit-correctness/config/test_json.cpp
+++ b/test/unit-correctness/config/test_json.cpp
@@ -555,4 +555,147 @@ TEST(LensConfigGlobe, FFieldMapsLikeLinear) {
   EXPECT_NEAR(l.fov_, ll.fov_, 1e-5f);
 }
 
+
+// =============== Crystal schema key names ===============
+// Every key below is written as a bare string literal ON PURPOSE. These tests pin the wire format
+// against the file corpus in the wild, so their expectations must be independent of the functions
+// under test: expressing them as ShapeScalarSyncKeyName(...) would make the authority table and its
+// own test drift together and pass forever. That is also what makes them the red-state criterion —
+// renaming a key in core turns these red even though core would still be self-consistent, which is
+// the one class of drift a parser-vs-parser differential test cannot see.
+//
+// The sync_group SUB-map keys are pinned the same way in test_crystal_sync_group.cpp; these cover
+// the top-level `shape` object and the `axis` object.
+
+TEST(CrystalSchemaKeyNames, PrismToJsonEmitsTheDocumentedKeys) {
+  PrismCrystalParam p;
+  p.h_ = Distribution{ DistributionType::kGaussian, 1.3f, 0.2f };
+  for (int i = 0; i < 6; i++) {
+    p.d_[i] = Distribution{ DistributionType::kNoRandom, 0.7f + 0.1f * i, 0.0f };
+  }
+
+  nlohmann::json j = p;
+
+  ASSERT_TRUE(j.contains("height"));
+  EXPECT_EQ(j["height"]["mean"].get<float>(), 1.3f);
+  EXPECT_EQ(j["height"]["std"].get<float>(), 0.2f);
+  ASSERT_TRUE(j.contains("face_distance"));
+  ASSERT_EQ(j["face_distance"].size(), 6u);
+  EXPECT_NEAR(j["face_distance"][0].get<float>(), 0.7f, 1e-5f);
+  EXPECT_NEAR(j["face_distance"][5].get<float>(), 1.2f, 1e-5f);
+
+  // The pyramid-only keys must be ABSENT, not merely defaulted. This pins the type branch rather
+  // than just the spelling: a to_json that emitted every key for every type would satisfy the
+  // positive assertions above while putting a wedge angle on a crystal that has no pyramid.
+  EXPECT_FALSE(j.contains("prism_h"));
+  EXPECT_FALSE(j.contains("upper_h"));
+  EXPECT_FALSE(j.contains("lower_h"));
+  EXPECT_FALSE(j.contains("upper_wedge_angle"));
+  EXPECT_FALSE(j.contains("lower_wedge_angle"));
+  EXPECT_FALSE(j.contains("upper_indices"));
+  EXPECT_FALSE(j.contains("lower_indices"));
+}
+
+TEST(CrystalSchemaKeyNames, PyramidToJsonEmitsTheDocumentedKeys) {
+  PyramidCrystalParam p;
+  p.h_prs_ = Distribution{ DistributionType::kNoRandom, 1.2f, 0.0f };
+  p.h_pyr_u_ = Distribution{ DistributionType::kNoRandom, 0.1f, 0.0f };
+  p.h_pyr_l_ = Distribution{ DistributionType::kNoRandom, 0.5f, 0.0f };
+  p.wedge_angle_u_ = 38.57f;
+  p.wedge_angle_l_ = 14.9f;
+  for (auto& d : p.d_) {
+    d = Distribution{ DistributionType::kNoRandom, 0.9f, 0.0f };
+  }
+
+  nlohmann::json j = p;
+
+  ASSERT_TRUE(j.contains("prism_h"));
+  EXPECT_NEAR(j["prism_h"].get<float>(), 1.2f, 1e-5f);
+  ASSERT_TRUE(j.contains("upper_h"));
+  EXPECT_NEAR(j["upper_h"].get<float>(), 0.1f, 1e-5f);
+  ASSERT_TRUE(j.contains("lower_h"));
+  EXPECT_NEAR(j["lower_h"].get<float>(), 0.5f, 1e-5f);
+  ASSERT_TRUE(j.contains("upper_wedge_angle"));
+  EXPECT_NEAR(j["upper_wedge_angle"].get<float>(), 38.57f, 1e-5f);
+  ASSERT_TRUE(j.contains("lower_wedge_angle"));
+  EXPECT_NEAR(j["lower_wedge_angle"].get<float>(), 14.9f, 1e-5f);
+  ASSERT_TRUE(j.contains("face_distance"));
+  ASSERT_EQ(j["face_distance"].size(), 6u);
+  EXPECT_NEAR(j["face_distance"][3].get<float>(), 0.9f, 1e-5f);
+
+  // Miller indices are a read-only legacy spelling — the write side never emits them.
+  EXPECT_FALSE(j.contains("upper_indices"));
+  EXPECT_FALSE(j.contains("lower_indices"));
+  // And the prism-only height key stays off a pyramid.
+  EXPECT_FALSE(j.contains("height"));
+}
+
+TEST(CrystalSchemaKeyNames, PyramidFromJsonReadsTheDocumentedKeys) {
+  // Explicit angles win over indices, so give both and expect the angles.
+  nlohmann::json j = {
+    { "prism_h", 1.2f },
+    { "upper_h", 0.1f },
+    { "lower_h", 0.5f },
+    { "upper_wedge_angle", 33.0f },
+    { "lower_wedge_angle", 22.0f },
+    { "upper_indices", nlohmann::json::array({ 2, 0, 3 }) },
+    { "lower_indices", nlohmann::json::array({ 1, 0, 1 }) },
+    { "face_distance", nlohmann::json::array({ 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f }) },
+  };
+
+  auto p = j.get<PyramidCrystalParam>();
+  EXPECT_NEAR(p.h_prs_.center, 1.2f, 1e-5f);
+  EXPECT_NEAR(p.h_pyr_u_.center, 0.1f, 1e-5f);
+  EXPECT_NEAR(p.h_pyr_l_.center, 0.5f, 1e-5f);
+  EXPECT_NEAR(p.wedge_angle_u_, 33.0f, 1e-5f);
+  EXPECT_NEAR(p.wedge_angle_l_, 22.0f, 1e-5f);
+  EXPECT_NEAR(p.d_[0].center, 0.5f, 1e-5f);
+  EXPECT_NEAR(p.d_[5].center, 1.0f, 1e-5f);
+
+  // Drop the explicit angles and the Miller keys take over — the fallback reads its own two keys,
+  // not the ones it falls back from. Expected angles are the literals MillerIndexFallback pins.
+  j.erase("upper_wedge_angle");
+  j.erase("lower_wedge_angle");
+  auto q = j.get<PyramidCrystalParam>();
+  EXPECT_NEAR(q.wedge_angle_u_, 38.57f, 0.01f);  // {2,0,3}
+  EXPECT_NEAR(q.wedge_angle_l_, 28.00f, 0.01f);  // {1,0,1}
+}
+
+TEST(CrystalSchemaKeyNames, PrismFromJsonReadsTheDocumentedKeys) {
+  nlohmann::json j = {
+    { "height", 1.7f },
+    { "face_distance", nlohmann::json::array({ 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f }) },
+  };
+
+  auto p = j.get<PrismCrystalParam>();
+  EXPECT_NEAR(p.h_.center, 1.7f, 1e-5f);
+  EXPECT_NEAR(p.d_[0].center, 0.5f, 1e-5f);
+  EXPECT_NEAR(p.d_[5].center, 1.0f, 1e-5f);
+}
+
+TEST(CrystalSchemaKeyNames, AxisJsonUsesZenithAzimuthRoll) {
+  AxisDistribution axis;
+  axis.latitude_dist = Distribution{ DistributionType::kNoRandom, 65.0f, 0.0f };  // zenith 25
+  axis.azimuth_dist = Distribution{ DistributionType::kUniform, 10.0f, 40.0f };
+  axis.roll_dist = Distribution{ DistributionType::kGaussian, 5.0f, 1.5f };
+
+  nlohmann::json j = axis;
+
+  ASSERT_TRUE(j.contains("zenith"));
+  EXPECT_NEAR(j["zenith"].get<float>(), 25.0f, 1e-5f);  // 90 - latitude, the wire's own quantity
+  ASSERT_TRUE(j.contains("azimuth"));
+  EXPECT_NEAR(j["azimuth"]["mean"].get<float>(), 10.0f, 1e-5f);
+  ASSERT_TRUE(j.contains("roll"));
+  EXPECT_NEAR(j["roll"]["mean"].get<float>(), 5.0f, 1e-5f);
+  EXPECT_NEAR(j["roll"]["std"].get<float>(), 1.5f, 1e-5f);
+
+  // Read side: each of the three keys lands in its own slot, so a swap would show.
+  auto back = j.get<AxisDistribution>();
+  EXPECT_NEAR(back.latitude_dist.center, 65.0f, 1e-5f);
+  EXPECT_NEAR(back.azimuth_dist.center, 10.0f, 1e-5f);
+  EXPECT_NEAR(back.azimuth_dist.spread, 40.0f, 1e-5f);
+  EXPECT_NEAR(back.roll_dist.center, 5.0f, 1e-5f);
+  EXPECT_NEAR(back.roll_dist.spread, 1.5f, 1e-5f);
+}
+
 }  // namespace


### PR DESCRIPTION
## 背景

crystal shape 对象的字段键名（`height` / `prism_h` / `upper_h` / `lower_h` / `face_distance` /
`upper_wedge_angle` / `lower_wedge_angle` / `upper_indices` / `lower_indices`）与 axis 三键
（`zenith` / `azimuth` / `roll`），此前在 `crystal_config.cpp`、`c_api.cpp`、`file_io.cpp` **三份手写
字面量**里各自维护，没有任何编译期或运行期强制同步。

键名漂移的症状是**该层静默丢弃该字段、零告警**——这在 PR #228 期间真实发生过一次：`sync_group` 在 C API
层被静默丢弃，核心恒收全 0，跑 4 个配置零警告。PR #228 只把 sync-group 子映射的键表收敛为
`ShapeScalarSyncKeyName`，字段名这一层没动。

## 改动

延续 PR #228 已验证的「core 出查询函数 → C API 薄转发 → GUI 删本地表改查询」：

- **core 建单源**：`crystal_config` 新增 `ShapeWedgeAngleKeyName(bool)` / `ShapeIndicesKeyName(bool)`；
  `math` 新增 `AxisScalar` 枚举 + `AxisScalarKeyName(slot)`。core 自身的 `to_json`/`from_json` 改为消费
  它们——顶层字段键与 `sync_group` 子键两份拷贝就此合一。
- **C API 薄转发**：新增 `LUMICE_ShapeWedgeAngleKeyName` / `LUMICE_ShapeIndicesKeyName` /
  `LUMICE_AxisScalarKeyName`（追加式，非破坏性），并用 `static_assert` 把 `LUMICE_AXIS_SCALAR_*` 宏钉死
  在 core 枚举上，防止错位后静默返回邻键。
- **GUI 只经 C API 消费**，未新增 `#include`，边界不破。
- `JsonToCrystal` 内 `CrystalKind` 原有两处独立推导，收敛为一次（code-review 指出这正是本 PR 要消灭的形状）。

三个新查询函数在 core / C API / GUI 三侧均有真实生产调用点，非只被测试引用。

## 机制性判据（本 PR 的核心）

新增裸字符串字面量断言测试（期望值**不**调用被测权威函数，否则权威表与期望会一起漂移、测试永远绿）：
`CrystalSchemaKeyNames.*`（含 Prism 对 Pyramid-only 键的负向断言）+ GUI 侧 wedge angle / axis 三键 round-trip。

**四次真实突变自证**（core 权威表 / C API 写键 / GUI 读键 / axis 权威表各一次），逐次观察变红、撤销、确认
`git status` 干净。其中突变 1 暴露了一个**既有盲区**：`JsonParserParity` 差分测试两侧都从同一份被污染的
权威表取键名，彼此仍自洽 ⇒ **保持全绿**。真正抓住它的是那条不经过被测系统的裸字面量断言。

## 验证

- `./scripts/build.sh -gtj release` → ctest 5/5、GUI 486/486 + real-timing 6/6
- `pytest -q` fast e2e → 136 passed / 30 skipped
- `format.sh --check` / `check_policies.py` / `check_new_refs.py --range` → 全部 exit 0
- 行为等价：字面量值本身未改动，序列化格式逐字节不变

## 已知边界

`LUMICE_CrystalKind` 非法值静默按 Pyramid 处理这一既有惯例，本 PR **定性为「保留并写明契约」**并写进
`lumice.h`；「改为报错」跨越 `LUMICE_IsLegalFace` 等未触碰的入口，按 plan-review 共识延后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)