### PR TITLE
feat(stats): report orientation sample count as an independent statistic

### DIFF
--- a/src/config/sim_data.cpp
+++ b/src/config/sim_data.cpp
@@ -39,8 +39,10 @@ namespace lumice {
 // = 3 × size_t = 24B) for the GPU color-degrade tally, bumping 328 → 352.
 // The crystal-sample-count contract splits crystal_count_ into an accumulated
 // stochastic half and an overwritten deterministic half (+1 size_t, 8B),
-// bumping 352 → 360.
-static_assert(sizeof(SimData) == 360, "SimData size changed — update copy/move ctors and operators");
+// bumping 352 → 360. The orientation-sample-count statistic adds its own
+// stochastic/deterministic pair (+2 size_t, 16B) — a separate statistic from the
+// crystal one, not a widening of it — bumping 360 → 376.
+static_assert(sizeof(SimData) == 376, "SimData size changed — update copy/move ctors and operators");
 
 namespace {
 
@@ -398,8 +400,10 @@ SimData::SimData(const SimData& other)
       xyz_landed_weight_(other.xyz_landed_weight_), lane_pixel_data_(other.lane_pixel_data_),
       lane_class_count_(other.lane_class_count_), root_ray_count_(other.root_ray_count_),
       stochastic_crystal_sample_count_(other.stochastic_crystal_sample_count_),
-      deterministic_crystal_count_(other.deterministic_crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
-      color_degrade_counts_(other.color_degrade_counts_) {}
+      deterministic_crystal_count_(other.deterministic_crystal_count_),
+      stochastic_orientation_sample_count_(other.stochastic_orientation_sample_count_),
+      deterministic_orientation_count_(other.deterministic_orientation_count_),
+      sim_scene_credit_(other.sim_scene_credit_), color_degrade_counts_(other.color_degrade_counts_) {}
 
 SimData::SimData(SimData&& other) noexcept
     : curr_wl_(other.curr_wl_), generation_(other.generation_), rays_(std::move(other.rays_)),
@@ -410,8 +414,10 @@ SimData::SimData(SimData&& other) noexcept
       xyz_landed_weight_(other.xyz_landed_weight_), lane_pixel_data_(std::move(other.lane_pixel_data_)),
       lane_class_count_(other.lane_class_count_), root_ray_count_(other.root_ray_count_),
       stochastic_crystal_sample_count_(other.stochastic_crystal_sample_count_),
-      deterministic_crystal_count_(other.deterministic_crystal_count_), sim_scene_credit_(other.sim_scene_credit_),
-      color_degrade_counts_(other.color_degrade_counts_) {}
+      deterministic_crystal_count_(other.deterministic_crystal_count_),
+      stochastic_orientation_sample_count_(other.stochastic_orientation_sample_count_),
+      deterministic_orientation_count_(other.deterministic_orientation_count_),
+      sim_scene_credit_(other.sim_scene_credit_), color_degrade_counts_(other.color_degrade_counts_) {}
 
 SimData& SimData::operator=(const SimData& other) {
   if (&other == this) {
@@ -438,6 +444,8 @@ SimData& SimData::operator=(const SimData& other) {
   root_ray_count_ = other.root_ray_count_;
   stochastic_crystal_sample_count_ = other.stochastic_crystal_sample_count_;
   deterministic_crystal_count_ = other.deterministic_crystal_count_;
+  stochastic_orientation_sample_count_ = other.stochastic_orientation_sample_count_;
+  deterministic_orientation_count_ = other.deterministic_orientation_count_;
   sim_scene_credit_ = other.sim_scene_credit_;
   color_degrade_counts_ = other.color_degrade_counts_;  // task-color-degrade-gui-surfacing (POD)
   return *this;
@@ -473,6 +481,8 @@ SimData& SimData::operator=(SimData&& other) noexcept {
   root_ray_count_ = other.root_ray_count_;
   stochastic_crystal_sample_count_ = other.stochastic_crystal_sample_count_;
   deterministic_crystal_count_ = other.deterministic_crystal_count_;
+  stochastic_orientation_sample_count_ = other.stochastic_orientation_sample_count_;
+  deterministic_orientation_count_ = other.deterministic_orientation_count_;
   sim_scene_credit_ = other.sim_scene_credit_;
   color_degrade_counts_ = other.color_degrade_counts_;  // task-color-degrade-gui-surfacing (POD)
   return *this;

--- a/src/config/sim_data.hpp
+++ b/src/config/sim_data.hpp
@@ -236,6 +236,24 @@ struct SimData {
   //     grain and the worker-pool size instead of a property of the scene.
   size_t deterministic_crystal_count_ = 0;
 
+  // The reported ORIENTATION count, carried as the same two-field pair and
+  // aggregated by the same two rules. It is a separate statistic, not a second
+  // view of the one above: IsDeterministic(CrystalParam) judges shape params
+  // only, so the commonest halo setup — a fixed shape under a random axis —
+  // reports one geometry and a great many orientations. Reporting only the
+  // former hides the sampling richness of the quantity that actually decides
+  // the halo shape.
+  //
+  // (c) Stochastic orientation draws THIS batch made — ACCUMULATED, same
+  //     reasoning as (a). Counts RAYS, not geometries: InitRay_rot resamples
+  //     the rotation for every ray of the buffer even when the geometry it is
+  //     paired with came from cache, so there is no geom_clock_-style reuse to
+  //     divide by and this number is legitimately much larger than (a).
+  size_t stochastic_orientation_sample_count_ = 0;
+  // (d) How many (layer, ci) slots of the committed scene carry an axis that
+  //     never draws — a CONFIG CONSTANT, so OVERWRITE, same reasoning as (b).
+  size_t deterministic_orientation_count_ = 0;
+
   // scrum-312 (third-clock drain): how many sim_scene_cnt_ units this SimData
   // accounts for on the consumer side. Normally 1 (one SimData per
   // SimulateOneWavelength* call, paired 1:1 with GenerateScene's per-wavelength

--- a/src/core/backend/cpu_trace_backend.cpp
+++ b/src/core/backend/cpu_trace_backend.cpp
@@ -259,6 +259,7 @@ void CpuTraceBackend::BeginSession(const SessionSpec& spec) {
   continuation_buf_ = RayBuffer{};
   exit_records_.clear();
   stochastic_sample_count_this_batch_ = 0;
+  stochastic_orientation_sample_count_this_batch_ = 0;
 
   // Design 2 (task-engine-redirect-design2): build the placement-scoped color
   // gate table for this session's scene × raypath_color config. Missing
@@ -391,6 +392,16 @@ LayerHandlePtr CpuTraceBackend::TraceLayer(const RootRaySource& roots) {
                                        roots.host.w != nullptr && roots.host.tf != nullptr) ?
                                           &roots.host :
                                           nullptr;
+    // Orientation draws for this (layer, ci). Gated on host_inject, NOT on the
+    // roots.host.crystal branch that gates the geometry counter above: the two
+    // host conditions are genuinely different (crystal vs d/p/w/tf pointers),
+    // and it is THIS one that decides whether TraceCrystalBatch reaches
+    // InitRayFirstMs/InitRayOtherMs at all — the host-ray path fills d/p/w/tf
+    // itself and never calls InitRay_rot, so it samples no orientation. Counting
+    // ci_n there would report draws that never happened.
+    if (host_inject == nullptr && !crystal_axis.IsAxisDeterministic()) {
+      stochastic_orientation_sample_count_this_batch_ += ci_n;
+    }
     BatchTraceSpec batch{ ms_info,
                           filter_spec.get(),
                           spec_.scene->light_source_.param_,
@@ -525,6 +536,7 @@ void CpuTraceBackend::EndSession() {
   ms_idx_ = 0;
   root_ray_count_ = 0;
   stochastic_sample_count_this_batch_ = 0;  // lifecycle symmetry with BeginSession
+  stochastic_orientation_sample_count_this_batch_ = 0;
   total_landed_weight_ = 0.0f;
   xyz_buf_.reset();
   continuation_buf_ = RayBuffer{};

--- a/src/core/backend/cpu_trace_backend.hpp
+++ b/src/core/backend/cpu_trace_backend.hpp
@@ -74,6 +74,13 @@ class CpuTraceBackend : public TraceBackend {
   // (layer, ci). See TraceBackend for the cross-backend contract.
   size_t GetLastBatchStochasticCrystalSampleCount() const override { return stochastic_sample_count_this_batch_; }
 
+  // Stochastic ORIENTATION draws this batch made — rays, not geometries. See
+  // TraceBackend for the cross-backend contract and why the two counts differ
+  // by orders of magnitude on the same scene.
+  size_t GetLastBatchStochasticOrientationSampleCount() const override {
+    return stochastic_orientation_sample_count_this_batch_;
+  }
+
  private:
   SessionSpec spec_{};
   RandomNumberGenerator rng_;
@@ -89,6 +96,11 @@ class CpuTraceBackend : public TraceBackend {
   // reused across batches are the deterministic ones, and those are counted from
   // the config rather than from any batch.
   size_t stochastic_sample_count_this_batch_ = 0;
+  // Output register for GetLastBatchStochasticOrientationSampleCount, same
+  // per-batch lifecycle as the counter above. Incremented by the whole
+  // population's ray count (not by 1) per (layer, ci) whose axis draws, because
+  // orientation is resampled per ray with no reuse at all.
+  size_t stochastic_orientation_sample_count_this_batch_ = 0;
   size_t ms_idx_ = 0;  // advances on each Recombine.
   float total_landed_weight_ = 0.0f;
 

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -1767,6 +1767,16 @@ struct CudaTraceBackend::Impl {
   // incremented in BuildGeomPool per shape drawn by a stochastic ci. Consumed by
   // `GetLastBatchStochasticCrystalSampleCount()`, which documents the contract.
   size_t pool_shape_count_this_batch_ = 0;
+
+  // Stochastic ORIENTATION draws this batch made, in RAYS. Unlike the shape
+  // counter above this one is NOT a function of P_ci: the K-shape pool
+  // diversifies GEOMETRY, while the orientation is redrawn per ray regardless of
+  // which pool slot that ray picked (gen_root_kernel / transit_root_kernel each
+  // call sample_lat_lon_roll per tid; the disable_device_gen_ fallback goes
+  // through InitRayFirstMs, which is per ray too). Incremented at exactly the
+  // three sites that advance gen_ray_count_ / transit_ray_count_ or run the host
+  // fallback — so, unlike the shape counter, the fallback path is NOT a gap here.
+  size_t orientation_count_this_batch_ = 0;
   bool        geom_pool_built_ = false;
   const void* pool_scene_      = nullptr;   // scene the pool was built for (rebuild guard)
   // True iff any (layer, ci) crystal param in `pool_scene_` carries a
@@ -2264,6 +2274,7 @@ void CudaTraceBackend::Impl::Reset(bool keep_persistent_buffers) {
     layer_ci_base_.clear(); pool_crystals_.clear();
     ci_pool_slot_base_.clear(); ci_pool_shape_count_.clear();  // K-shape pool
     pool_shape_count_this_batch_ = 0;
+    orientation_count_this_batch_ = 0;
     geom_pool_built_ = false;
     pool_scene_ = nullptr;
     // increment 4: filter descriptors + wl pool persist across the keep path;
@@ -3540,6 +3551,7 @@ void CudaTraceBackend::BeginSession(const SessionSpec& spec) {
     // that legitimately does not run. But do not read the paragraph above as "a
     // regression test will catch you if you remove this" — none will.
     impl_->pool_shape_count_this_batch_ = 0u;
+    impl_->orientation_count_this_batch_ = 0u;
 
     // scrum-306.2 increment 4: a scene change invalidates every per-session-constant
     // cache (geometry pool, filter descriptors, wl pool). Within one scene these are
@@ -4135,6 +4147,9 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
                                      static_cast<uint32_t>(impl_->lat_attempts_ci_start_ + probe_win_off));
       ck_reset(cudaPeekAtLastError(), "gen_root_kernel launch");
       impl_->gen_ray_count_ += ci_n;
+      if (!ms_setting.crystal_.axis_.IsAxisDeterministic()) {
+        impl_->orientation_count_this_batch_ += ci_n;
+      }
     } else if (first_ms) {
       // Host-roots fallback (LUMICE_DISABLE_DEVICE_GEN): InitRayFirstMs for ci_n
       // rays through ci_crystal, then H2D the staged root buffers [0, ci_n).
@@ -4222,6 +4237,9 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
           impl_->d_cont_component_[in_slot] + ci_start, impl_->d_root_component_);
       ck_reset(cudaPeekAtLastError(), "transit kernel launch");
       impl_->transit_ray_count_ += ci_n;
+      if (!ms_setting.crystal_.axis_.IsAxisDeterministic()) {
+        impl_->orientation_count_this_batch_ += ci_n;
+      }
       ci_start += ci_n;
     }
 
@@ -4864,6 +4882,14 @@ size_t CudaTraceBackend::GetLastBatchStochasticCrystalSampleCount() const {
   //     that requires per-ci accounting on the fallback path; still deferred as
   //     a diagnostic-only gap (the primary device-gen path is exact).
   return impl_->pool_shape_count_this_batch_;
+}
+
+size_t CudaTraceBackend::GetLastBatchStochasticOrientationSampleCount() const {
+  // Rays whose orientation was drawn this batch. See the member's declaration
+  // for why the K-shape pool does not enter into it, and trace_backend.hpp for
+  // the cross-backend contract (comparable in KIND to the CPU arms, still not
+  // assertable as equal).
+  return impl_->orientation_count_this_batch_;
 }
 
 ColorDegradeCounts CudaTraceBackend::GetLastColorDegradeCounts() const {

--- a/src/core/backend/cuda_trace_backend.cu
+++ b/src/core/backend/cuda_trace_backend.cu
@@ -4194,6 +4194,15 @@ LayerHandlePtr CudaTraceBackend::TraceLayer(const RootRaySource& roots) {
       cudaMemcpyAsync(impl_->d_root_wl_idx_, impl_->pinned_root_wl_idx_, ci_n * sizeof(uint32_t),
                       cudaMemcpyHostToDevice);
       ck_reset(cudaGetLastError(), "H2D batch");
+      // Same per-ray orientation draw as the device-gen branch above, just on
+      // the host: InitRayFirstMs samples a fresh orientation for each of the
+      // ci_n rays. This branch is only taken under LUMICE_DISABLE_DEVICE_GEN,
+      // which is exactly why it is easy to leave out of a count — and why
+      // leaving it out yields a plausible-looking low number rather than an
+      // obvious zero.
+      if (!ms_setting.crystal_.axis_.IsAxisDeterministic()) {
+        impl_->orientation_count_this_batch_ += ci_n;
+      }
     } else {
       // ── Continuation: transit cont[in_slot] slice [ci_start, ci_start+ci_n) ──
       // into root buf [0, ci_n) using THIS ci's crystal (orientation resample +

--- a/src/core/backend/cuda_trace_backend.hpp
+++ b/src/core/backend/cuda_trace_backend.hpp
@@ -141,6 +141,9 @@ class CudaTraceBackend : public TraceBackend {
   // BeginSession and incremented inside the pool build — which a reuse batch
   // skips entirely. See TraceBackend for the cross-backend contract.
   size_t GetLastBatchStochasticCrystalSampleCount() const override;
+  // Stochastic orientation draws this batch made, in rays. Backed by
+  // Impl::orientation_count_this_batch_, zeroed at the same points.
+  size_t GetLastBatchStochasticOrientationSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 

--- a/src/core/backend/metal_trace_backend.hpp
+++ b/src/core/backend/metal_trace_backend.hpp
@@ -140,6 +140,7 @@ class MetalTraceBackend : public TraceBackend {
   // SimData.stochastic_crystal_sample_count_; see TraceBackend for the
   // cross-backend contract.
   size_t GetLastBatchStochasticCrystalSampleCount() const override;
+  size_t GetLastBatchStochasticOrientationSampleCount() const override;
   // task-color-degrade-gui-surfacing: per-config GPU color-degrade tally.
   ColorDegradeCounts GetLastColorDegradeCounts() const override;
 

--- a/src/core/backend/metal_trace_backend.mm
+++ b/src/core/backend/metal_trace_backend.mm
@@ -826,6 +826,20 @@ struct MetalTraceBackend::Impl {
   // cross-backend contract.
   size_t                   pool_shape_count_this_batch_ = 0;
 
+  // Stochastic ORIENTATION draws this batch made, in RAYS. Metal samples the
+  // per-ray rotation on device (gen_root_kernel / transit_root_kernel both call
+  // sample_lat_lon_roll per tid) or, on the host-gen fallback, through the very
+  // same InitRayFirstMs the CPU arms use — either way one draw per ray, with no
+  // K-shape pool reuse: the pool diversifies GEOMETRY, orientation is redrawn
+  // regardless of which pool slot a ray picks. So unlike the shape counter above
+  // this one is NOT a function of P_ci. Incremented at exactly the three sites
+  // that advance root_ray_count / transit_ray_count_, which is the existing
+  // single authority on "this ray consumed a gen draw"; the test-only
+  // InjectHostRoots path advances neither and samples no orientation, so it is
+  // correctly excluded for free. Read out by
+  // GetLastBatchStochasticOrientationSampleCount().
+  size_t                   orientation_count_this_batch_ = 0;
+
   // Unified area-measure inverse-CDF latitude LUT (330.2). Three fixed-size
   // (LatLut::kNodes float) shared buffers rebuilt per-ci by UploadLatLut when the
   // orientation distribution routes to kLatPathLutInverseCdf. Metal forbids nil
@@ -2054,6 +2068,9 @@ size_t MetalTraceBackend::Impl::GenerateFirstLayerRootsForCi(const ScatteringSet
     // is always consumed within the same ci iteration.
     pending_gen_params_ = gp;
     root_ray_count += crystal_ray_num;
+    if (!setting.crystal_.axis_.IsAxisDeterministic()) {
+      orientation_count_this_batch_ += crystal_ray_num;
+    }
     return crystal_ray_num;
   }
 
@@ -2147,6 +2164,9 @@ size_t MetalTraceBackend::Impl::GenerateFirstLayerRootsForCi(const ScatteringSet
   // Accumulate the host-gen count too so a future device-gen-eligible call
   // within the same session keeps gen_ray_base globally monotone.
   root_ray_count += n;
+  if (!setting.crystal_.axis_.IsAxisDeterministic()) {
+    orientation_count_this_batch_ += n;
+  }
   return n;
 }
 
@@ -2909,6 +2929,7 @@ void MetalTraceBackend::BeginSession(const SessionSpec& spec) {
   // session). See GetLastBatchStochasticCrystalSampleCount for the unified
   // semantics.
   impl_->pool_shape_count_this_batch_ = 0u;
+  impl_->orientation_count_this_batch_ = 0u;
   // task-color-degrade-gui-surfacing: reset the GPU color-degrade tally at the
   // single per-config entry point, BEFORE both the color-class clamp below
   // (~L2700) and EnsureFilterBuffers (~L2711, where the symmetry-group /
@@ -3363,6 +3384,9 @@ LayerHandlePtr MetalTraceBackend::TraceLayer(const RootRaySource& roots) {
         // via WaitAndReadbackLayer's status check (same recovery semantics as
         // gen+trace fusion — assert in debug, log+continue in release).
         impl_->transit_ray_count_ += ci_n;
+        if (!setting.crystal_.axis_.IsAxisDeterministic()) {
+          impl_->orientation_count_this_batch_ += ci_n;
+        }
         ci_start += ci_n;
         in_count = ci_n;  // all cont rays already filter+prob-passed by the
                           // prior layer's device emit gate; transit cannot
@@ -3674,6 +3698,14 @@ size_t MetalTraceBackend::GetLastBatchStochasticCrystalSampleCount() const {
   // unset (P_ci ≡ 1) such a ci contributes 1 per batch; with the K knob on it
   // contributes ~ci_n/K.
   return impl_->pool_shape_count_this_batch_;
+}
+
+size_t MetalTraceBackend::GetLastBatchStochasticOrientationSampleCount() const {
+  // Rays whose orientation was drawn this batch. Deliberately unrelated to the
+  // K-shape pool size — see the member's declaration. Comparable in KIND to the
+  // CPU arms' number (both are per-ray, no reuse), though still not assertable
+  // as equal across backends: which rays exist at all differs.
+  return impl_->orientation_count_this_batch_;
 }
 
 ColorDegradeCounts MetalTraceBackend::GetLastColorDegradeCounts() const {

--- a/src/core/backend/trace_backend.hpp
+++ b/src/core/backend/trace_backend.hpp
@@ -586,6 +586,44 @@ class TraceBackend {
   // "fix" it, and do NOT put this value in a cross-backend parity assertion.
   virtual size_t GetLastBatchStochasticCrystalSampleCount() const { return 0; }
 
+  // How many STOCHASTIC ORIENTATION draws THIS batch made, summed across every
+  // (layer, ci). Read by Simulator into
+  // SimData::stochastic_orientation_sample_count_. Same two-term structure as
+  // the crystal count above:
+  //
+  //     orientations = (# of (layer, ci) slots whose axis is deterministic)
+  //                  + Σ over batches and workers of THIS getter
+  //
+  // with the same aggregation split for the same reasons, and the same single
+  // predicate rule: the judgement is AxisDistribution::IsAxisDeterministic, and
+  // a new backend should apply THAT at whatever point it draws rather than
+  // hand-rolling a second copy — or, worse, reusing IsDeterministic(CrystalParam).
+  // The two predicates disagree in the case that matters most: a fixed shape
+  // under a random axis is deterministic on shape and stochastic on orientation,
+  // which is precisely why this is a second statistic instead of a second name
+  // for the first one.
+  //
+  // What differs from the crystal count, and is not an oversight:
+  //   * This counts RAYS, not draws-of-a-reusable-thing. On the CPU arms
+  //     InitRay_rot resamples the rotation for every ray in the buffer even when
+  //     the geometry was served from cache, so there is no reuse factor to
+  //     divide by. Expect this number to dwarf the crystal count on the same
+  //     scene; that ratio is the reuse asymmetry, made visible.
+  //   * A batch whose axes are all deterministic reports 0 here, and its whole
+  //     count comes from the config-constant term.
+  //
+  // Cross-backend equality is NOT claimed — MORE emphatically than for the
+  // crystal count, because the GPU arms do not necessarily sample orientation
+  // per ray at all. Do not put this value in a cross-backend parity assertion,
+  // and do not "fix" a divergence. What a backend must NOT do is report a
+  // plausible-looking stand-in when it cannot count: neither a silent 0 (which
+  // reads as "this backend never randomizes orientation" — a lie, not an
+  // absence) nor the crystal count copied across (structurally impossible given
+  // the per-ray/no-reuse asymmetry above, and the disclaimer would live in a
+  // source comment no CLI or C API caller ever sees). Report an explicitly
+  // unavailable value that both consumer surfaces can distinguish instead.
+  virtual size_t GetLastBatchStochasticOrientationSampleCount() const { return 0; }
+
   // Per-committed-config tally of GPU-side raypath-color drops (see
   // ColorDegradeCounts above). Base + CPU backend have no such caps and return
   // all-zeros; Metal/CUDA override. Value is recomputed from scratch on each

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -563,6 +563,17 @@ bool AxisDistribution::IsAzRotationallySymmetric() const {
 }
 
 
+bool AxisDistribution::IsAxisDeterministic() const {
+  // kNoRandom is the one type that consumes no RNG: RandomNumberGenerator::Get
+  // returns dist.Value() outright for it, and SampleSphericalPointsSph's
+  // kNoRandom latitude branch yields the single deterministic orientation. So
+  // "all three kNoRandom" is literally "zero draws, one fixed rotation", not an
+  // approximation of it.
+  return azimuth_dist.type == DistributionType::kNoRandom && latitude_dist.type == DistributionType::kNoRandom &&
+         roll_dist.type == DistributionType::kNoRandom;
+}
+
+
 // The on-disk JSON keys stay "mean" / "std": that is the published config file format (see
 // doc/configuration.md and examples/config_example.json). Only the C++ member names changed, so
 // this is the one place where the two vocabularies meet. Serialization is type-erased by nature —

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -287,13 +287,20 @@ struct AxisDistribution {
   //!   independent axes of a crystal setting, and conflating them is exactly the gap this
   //!   predicate closes — the commonest halo setup (fixed shape + random orientation) is
   //!   deterministic on the shape axis and stochastic on this one.
-  //! @note It needs no !IsFullSphereUniform() guard. InitRay_rot's `full_sphere` branch
-  //!   variable IS that predicate (a literal call, simulator.cpp), and the predicate requires
-  //!   both azimuth_dist and latitude_dist to be kUniform, so a full-sphere axis can never
-  //!   satisfy the all-kNoRandom test — the two are mutually exclusive by construction and an
-  //!   added guard would be a dead conjunct. That mutual exclusion is implicit, so the test
-  //!   AxisDeterminismMatchesRuntimeOrientation pins this predicate against what InitRay_rot
-  //!   actually produces; a future decoupling turns it red rather than silently misreporting.
+  //! @note It needs no !IsFullSphereUniform() guard: that predicate requires both
+  //!   azimuth_dist and latitude_dist to be kUniform, so a full-sphere axis can never satisfy
+  //!   the all-kNoRandom test below. The two are mutually exclusive by construction and an
+  //!   added guard would be a dead conjunct.
+  //! @note What AxisDeterminismMatchesRuntimeOrientation (test_simulator.cpp) pins, and what it
+  //!   does not. It pins the load-bearing claim: an all-kNoRandom axis really does yield one
+  //!   bit-identical rotation for every ray, and a stochastic one really does vary. That is what
+  //!   the sample count depends on, and it is invisible to a truth-table test — a change making
+  //!   kNoRandom consume the RNG turns the pin red while every truth-table case stays green
+  //!   (verified by mutation). It does NOT pin which branch InitRay_rot takes: since the unified
+  //!   area-measure LatLut, the full_sphere fast path and the parameterized path are
+  //!   statistically equivalent (measured: fraction of |world z| < 0.5 is 0.5000 vs 0.4977 over
+  //!   20k samples), so that branch is an optimization rather than a correctness fork and
+  //!   decoupling it is not behaviorally detectable. Do not add a test claiming otherwise.
   bool IsAxisDeterministic() const;
 
   Distribution azimuth_dist;

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -280,6 +280,22 @@ struct AxisDistribution {
   //! @details Only checks the azimuth type and its full range; latitude and roll are ignored.
   bool IsAzRotationallySymmetric() const;
 
+  //! @brief Check whether every one of azimuth/latitude/roll is kNoRandom — i.e. this axis
+  //!   never consumes the RNG and yields one fixed orientation for every ray.
+  //! @details The orientation-side counterpart of IsDeterministic(const CrystalParam&)
+  //!   (trace_ops.hpp), and deliberately NOT the same predicate: shape and axis are
+  //!   independent axes of a crystal setting, and conflating them is exactly the gap this
+  //!   predicate closes — the commonest halo setup (fixed shape + random orientation) is
+  //!   deterministic on the shape axis and stochastic on this one.
+  //! @note It needs no !IsFullSphereUniform() guard. InitRay_rot's `full_sphere` branch
+  //!   variable IS that predicate (a literal call, simulator.cpp), and the predicate requires
+  //!   both azimuth_dist and latitude_dist to be kUniform, so a full-sphere axis can never
+  //!   satisfy the all-kNoRandom test — the two are mutually exclusive by construction and an
+  //!   added guard would be a dead conjunct. That mutual exclusion is implicit, so the test
+  //!   AxisDeterminismMatchesRuntimeOrientation pins this predicate against what InitRay_rot
+  //!   actually produces; a future decoupling turns it red rather than silently misreporting.
+  bool IsAxisDeterministic() const;
+
   Distribution azimuth_dist;
   Distribution latitude_dist;
   Distribution roll_dist;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -482,6 +482,18 @@ size_t DeterministicCrystalCount(const SceneConfig& config) {
   return n;
 }
 
+size_t DeterministicOrientationCount(const SceneConfig& config) {
+  size_t n = 0;
+  for (const auto& ms : config.ms_) {
+    for (const auto& setting : ms.setting_) {
+      if (setting.crystal_.axis_.IsAxisDeterministic()) {
+        n++;
+      }
+    }
+  }
+  return n;
+}
+
 
 RayBuffer AllocateAllData(const SceneConfig& config, size_t ray_num) {
   // Calculate total rays (expected value) used in the whole simulation.

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1014,6 +1014,7 @@ void Simulator::Run() {
     // Single derivation point for the config-constant half of the crystal count
     // (see the member's declaration for why it is not gated on a generation change).
     deterministic_crystal_count_ = DeterministicCrystalCount(config);
+    deterministic_orientation_count_ = DeterministicOrientationCount(config);
 
     // Reset carry when config changes (new generation = new proportions).
     if (generation != prev_generation) {
@@ -1157,6 +1158,13 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   // copies made when a shape is reused, and it deliberately excludes
   // deterministic draws — see the assignment at the end of this function.
   size_t stochastic_sample_count = 0;
+  // The orientation counterpart, and NOT the same number: orientations are
+  // resampled per ray with no reuse whatsoever (InitRay_rot loops over every ray
+  // of the buffer even when the geometry above was served from cache), so this
+  // counts rays, not geometry draws, and is legitimately far larger. Declared
+  // beside stochastic_sample_count and therefore OUTSIDE the ms loop below, so
+  // continuation layers' resampling (InitRayOtherMs) accumulates here too.
+  size_t stochastic_orientation_sample_count = 0;
 
   bool first_ms = true;
   for (size_t mi = 0; mi < config.ms_.size() && !stop_; mi++) {
@@ -1199,6 +1207,18 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
           ColorGatePlacementFor(color_gate_table, static_cast<IdType>(mi), s.crystal_.id_);
 
       bool deterministic = IsDeterministic(s.crystal_.param_);
+
+      // Orientation draws for this (layer, ci), added ONCE here rather than in
+      // the cn loop below: whether the axis is stochastic is a ci-level
+      // constant, and the cn loop's curr_ray_num sums to exactly
+      // crystal_ray_num[ci], so the ci-level add is the same number without an
+      // increment on the batch path. It is exact rather than an upper bound
+      // because a `stop_` anywhere below returns before any SimData is
+      // emplaced (see the `if (stop_) return;` after the ms loop) — a partial
+      // count is never published.
+      if (!s.crystal_.axis_.IsAxisDeterministic()) {
+        stochastic_orientation_sample_count += crystal_ray_num[ci];
+      }
 
       // Look up cross-call cache for deterministic crystal params.
       const CrystalParam* param_ptr = &s.crystal_.param_;
@@ -1359,6 +1379,8 @@ void Simulator::SimulateOneWavelength(const SceneConfig& config, const RaypathCo
   // this function on its own Simulator).
   sim_data.stochastic_crystal_sample_count_ = stochastic_sample_count;
   sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
+  sim_data.stochastic_orientation_sample_count_ = stochastic_orientation_sample_count;
+  sim_data.deterministic_orientation_count_ = deterministic_orientation_count_;
   data_queue_->Emplace(std::move(sim_data));
 }
 
@@ -1413,6 +1435,8 @@ void Simulator::DrainDeviceXyz(TraceBackend* backend) {
   // OVERWRITE semantics, same as color_degrade_counts_ below: a config constant
   // is carried through the window, never summed over its batches.
   sim_data.deterministic_crystal_count_ = xyz_win_.deterministic_crystals;
+  sim_data.stochastic_orientation_sample_count_ = xyz_win_.stochastic_orientation_samples;
+  sim_data.deterministic_orientation_count_ = xyz_win_.deterministic_orientations;
   // task-color-degrade-gui-surfacing: carry the window's GPU color-degrade tally
   // into the drained SimData (config constant, direct copy — not accumulated).
   sim_data.color_degrade_counts_ = xyz_win_.color_degrade_counts_;
@@ -1561,8 +1585,10 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
       xyz_win_.pending = true;
       xyz_win_.root_rays += ray_num;
       xyz_win_.stochastic_crystal_samples += backend.GetLastBatchStochasticCrystalSampleCount();
+      xyz_win_.stochastic_orientation_samples += backend.GetLastBatchStochasticOrientationSampleCount();
       // OVERWRITE (not +=) — config constant, identical on every batch.
       xyz_win_.deterministic_crystals = deterministic_crystal_count_;
+      xyz_win_.deterministic_orientations = deterministic_orientation_count_;
       xyz_win_.generation = generation;
       xyz_win_.w = w;
       xyz_win_.h = h;
@@ -1585,6 +1611,8 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
     sim_data.root_ray_count_ = ray_num;
     sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
     sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
+    sim_data.stochastic_orientation_sample_count_ = backend.GetLastBatchStochasticOrientationSampleCount();
+    sim_data.deterministic_orientation_count_ = deterministic_orientation_count_;
     // task-color-degrade-gui-surfacing: carry the GPU color-degrade tally on the
     // legacy per-batch drain too. Dead for today's backends (Metal + CUDA both take
     // the third-clock window branch above), but keeps this path from silently
@@ -1655,6 +1683,8 @@ void Simulator::SimulateOneWavelengthWithBackend(TraceBackend& backend, const Sc
                                        // server.cpp::ConsumeData).
   sim_data.stochastic_crystal_sample_count_ = backend.GetLastBatchStochasticCrystalSampleCount();
   sim_data.deterministic_crystal_count_ = deterministic_crystal_count_;
+  sim_data.stochastic_orientation_sample_count_ = backend.GetLastBatchStochasticOrientationSampleCount();
+  sim_data.deterministic_orientation_count_ = deterministic_orientation_count_;
   sim_data.outgoing_d_ = std::move(exit_d);
   sim_data.outgoing_w_ = std::move(exit_w);
   sim_data.outgoing_wl_ = std::move(exit_wl);

--- a/src/core/simulator.hpp
+++ b/src/core/simulator.hpp
@@ -117,6 +117,11 @@ class Simulator {
     // GetLastBatchStochasticCrystalSampleCount for why the two cannot be one.
     size_t stochastic_crystal_samples = 0;
     size_t deterministic_crystals = 0;
+    // Orientation stats ride the window under the identical two-rule split (Σ
+    // vs OVERWRITE). Separate from the crystal pair above because they are a
+    // separate statistic -- see SimData for the field-level contract.
+    size_t stochastic_orientation_samples = 0;
+    size_t deterministic_orientations = 0;
     uint64_t generation = 0;  // generation the window belongs to
     int w = 0;                // render resolution of the window
     int h = 0;
@@ -161,6 +166,9 @@ class Simulator {
   // starts at 0, so a generation-keyed cache would skip the first committed
   // config whenever generations are 0-based and silently publish 0.
   size_t deterministic_crystal_count_ = 0;
+  // Same role for the orientation count, derived at the same single point in
+  // Run() from the same committed config, for the same reasons.
+  size_t deterministic_orientation_count_ = 0;
 
   QueuePtrS<SimBatch> config_queue_;
   QueuePtrS<SimData> data_queue_;

--- a/src/core/trace_ops.hpp
+++ b/src/core/trace_ops.hpp
@@ -104,6 +104,16 @@ bool IsDeterministic(const CrystalParam& param);
 // the worker-pool size.
 size_t DeterministicCrystalCount(const SceneConfig& config);
 
+// How many (layer, ci) slots of `config` carry a deterministic axis — the
+// config-constant half of the reported ORIENTATION count, mirroring
+// DeterministicCrystalCount's contract for the shape half (scene slots, not
+// slots a given run happened to trace; that is what buys immunity to the
+// dispatch grain and the worker count). The predicate is
+// AxisDistribution::IsAxisDeterministic, NOT IsDeterministic(CrystalParam):
+// shape and axis are independent, and the commonest halo setup is
+// deterministic on one and stochastic on the other.
+size_t DeterministicOrientationCount(const SceneConfig& config);
+
 }  // namespace lumice
 
 #endif  // CORE_TRACE_OPS_H_

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -35,7 +35,17 @@ extern "C" {
 // callers of the removed symbols fail to compile, which is the intended migration signal.
 // The LUMICE_MAX_CONFIG_* ceilings survive the struct: they are now the Scene's Add*/Set*
 // per-kind soft caps, not the dimensions of an inline array.
-#define LUMICE_API_VERSION 413
+//
+// BREAKING (v4.14): LUMICE_StatsResult gains a fourth field, `orientation_num`
+// — the count of distinct crystal ORIENTATIONS sampled, previously invisible
+// (only the geometry count was reported, and on the commonest halo setup, a
+// fixed shape under a random axis, that count is 1 no matter how richly the
+// orientation was sampled). This is an APPEND, not a removal or a reorder, so
+// existing field offsets are unchanged; but sizeof(LUMICE_StatsResult) grows
+// from 24 to 32, so a caller that was NOT recompiled and passes an array of the
+// old struct to LUMICE_GetStatsResults will have it written past the end of
+// each element. Recompile against this header.
+#define LUMICE_API_VERSION 414
 #define LUMICE_MAX_RENDER_RESULTS 16
 #define LUMICE_MAX_STATS_RESULTS 1
 
@@ -177,7 +187,18 @@ typedef struct LUMICE_RawXyzResult_ {
 typedef struct LUMICE_StatsResult_ {
   LUMICE_RayCount ray_seg_num;
   LUMICE_RayCount sim_ray_num;
-  LUMICE_RayCount crystal_num;
+  LUMICE_RayCount crystal_num;  // Distinct crystal GEOMETRIES sampled this run.
+  // Distinct crystal ORIENTATIONS sampled this run. A separate quantity, not a
+  // rescaling of crystal_num: the shape and the axis of a crystal setting are
+  // independent, and the commonest halo configuration — a fixed shape under a
+  // random axis — yields one geometry and a great many orientations. Expect this
+  // to be far larger than crystal_num: orientation is redrawn per ray with no
+  // reuse, while geometry is reused across a batch of rays.
+  //
+  // NOT comparable across backends, and not usable as a parity assertion: the
+  // CPU and GPU routes sample at different densities and that difference is
+  // precisely what the number exposes.
+  LUMICE_RayCount orientation_num;
   // Sentinel: all zeros (sim_ray_num == 0)
 } LUMICE_StatsResult;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -307,7 +307,8 @@ void PrintStats(LUMICE_Server* server) {
     return;
   }
   for (int i = 0; stats[i].sim_ray_num != 0; i++) {
-    std::cout << "Stats: sim_rays=" << stats[i].sim_ray_num << ", crystals=" << stats[i].crystal_num << "\n";
+    std::cout << "Stats: sim_rays=" << stats[i].sim_ray_num << ", crystals=" << stats[i].crystal_num
+              << ", orientations=" << stats[i].orientation_num << "\n";
   }
 }
 

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -2728,6 +2728,7 @@ LUMICE_ErrorCode LUMICE_GetStatsResults(LUMICE_Server* server, LUMICE_StatsResul
       out[0].ray_seg_num = stats_result->ray_seg_num_;
       out[0].sim_ray_num = stats_result->sim_ray_num_;
       out[0].crystal_num = stats_result->crystal_num_;
+      out[0].orientation_num = stats_result->orientation_num_;
       count = 1;
     }
   }
@@ -2751,6 +2752,7 @@ LUMICE_ErrorCode LUMICE_GetCachedStats(LUMICE_Server* server, LUMICE_StatsResult
     out->ray_seg_num = result->ray_seg_num_;
     out->sim_ray_num = result->sim_ray_num_;
     out->crystal_num = result->crystal_num_;
+    out->orientation_num = result->orientation_num_;
   } else {
     std::memset(out, 0, sizeof(LUMICE_StatsResult));
   }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1178,6 +1178,15 @@ void ServerImpl::ConsumeData() {
           auto t_lock0 = std::chrono::steady_clock::now();
           std::lock_guard<TicketMutex> lock(consumer_mutex_);
           auto t_lock1 = std::chrono::steady_clock::now();
+          // WARNING for anyone adding a SimData field: the chunk below is a
+          // hand-rolled field-by-field copy, NOT a copy of sim_data, so a new
+          // field silently arrives at the consumers as a default-constructed 0
+          // on this path — and ONLY on this path, which is what makes it hard to
+          // see (the legacy CPU route hands the whole SimData over intact, so it
+          // keeps working while the backend route quietly reports nothing).
+          // Every stats field needs a line here, on the correct side of the
+          // accumulated/overwritten split below.
+          //
           // task-268.4: chunk by kCommitCap on the backend exit-seam path
           // (outgoing_d_ populated AND rays_ empty). Only the FIRST chunk
           // carries root_ray_count_ + the stochastic crystal-draw count —
@@ -1208,6 +1217,7 @@ void ServerImpl::ConsumeData() {
               if (emitted == 0) {
                 chunk.root_ray_count_ = sim_data.root_ray_count_;
                 chunk.stochastic_crystal_sample_count_ = sim_data.stochastic_crystal_sample_count_;
+                chunk.stochastic_orientation_sample_count_ = sim_data.stochastic_orientation_sample_count_;
                 chunk.crystals_ = sim_data.crystals_;
                 chunk.crystal_axis_dists_ = sim_data.crystal_axis_dists_;
               }
@@ -1217,6 +1227,7 @@ void ServerImpl::ConsumeData() {
               // published. The inverse of the rule above, for the inverse
               // aggregation.
               chunk.deterministic_crystal_count_ = sim_data.deterministic_crystal_count_;
+              chunk.deterministic_orientation_count_ = sim_data.deterministic_orientation_count_;
               if (chunk_count > 0) {
                 chunk.outgoing_d_.assign(
                     sim_data.outgoing_d_.begin() + static_cast<std::ptrdiff_t>(emitted) * 3,

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -161,6 +161,9 @@ struct StatsResult {
   size_t ray_seg_num_;
   size_t sim_ray_num_;
   size_t crystal_num_;
+  // Distinct crystal ORIENTATIONS sampled, alongside the geometry count above.
+  // Not derivable from crystal_num_ — see SimData for the field-level contract.
+  size_t orientation_num_;
 };
 
 using Result = std::variant<NoneResult, RenderResult, StatsResult>;

--- a/src/server/stats.cpp
+++ b/src/server/stats.cpp
@@ -16,16 +16,22 @@ void StatsConsumer::Consume(const SimData& data) {
   // color-degrade tally). See SimData for the field-level contract.
   stochastic_crystal_samples_ += data.stochastic_crystal_sample_count_;
   deterministic_crystals_ = data.deterministic_crystal_count_;
+  // Orientation count: identical split for identical reasons. Keeping the two
+  // statistics on separate accumulators is the point — a scene of fixed shapes
+  // under random axes reports a small crystal count and a large orientation one.
+  stochastic_orientation_samples_ += data.stochastic_orientation_sample_count_;
+  deterministic_orientations_ = data.deterministic_orientation_count_;
 }
 
 void StatsConsumer::PrepareSnapshot() {
   snapshot_total_rays_ = total_rays_;
   snapshot_sim_rays_ = sim_rays_;
   snapshot_crystals_ = deterministic_crystals_ + stochastic_crystal_samples_;
+  snapshot_orientations_ = deterministic_orientations_ + stochastic_orientation_samples_;
 }
 
 Result StatsConsumer::GetResult() const {
-  return StatsResult{ snapshot_total_rays_, snapshot_sim_rays_, snapshot_crystals_ };
+  return StatsResult{ snapshot_total_rays_, snapshot_sim_rays_, snapshot_crystals_, snapshot_orientations_ };
 }
 
 void StatsConsumer::Reset() {
@@ -33,9 +39,12 @@ void StatsConsumer::Reset() {
   sim_rays_ = 0;
   stochastic_crystal_samples_ = 0;
   deterministic_crystals_ = 0;
+  stochastic_orientation_samples_ = 0;
+  deterministic_orientations_ = 0;
   snapshot_total_rays_ = 0;
   snapshot_sim_rays_ = 0;
   snapshot_crystals_ = 0;
+  snapshot_orientations_ = 0;
 }
 
 }  // namespace lumice

--- a/src/server/stats.hpp
+++ b/src/server/stats.hpp
@@ -31,9 +31,15 @@ class StatsConsumer : public IConsume {
   // reported crystal count; see Consume() for why they cannot be one counter.
   size_t stochastic_crystal_samples_ = 0;
   size_t deterministic_crystals_ = 0;
+  // Same two accumulators, same two rules, for the orientation count. A second
+  // pair rather than a reuse of the one above: the two statistics answer
+  // different questions and routinely disagree by orders of magnitude.
+  size_t stochastic_orientation_samples_ = 0;
+  size_t deterministic_orientations_ = 0;
   size_t snapshot_total_rays_ = 0;
   size_t snapshot_sim_rays_ = 0;
   size_t snapshot_crystals_ = 0;
+  size_t snapshot_orientations_ = 0;
 };
 
 }  // namespace lumice

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -84,20 +84,53 @@ assert ctypes.sizeof(LUMICE_RenderResult) == 32, (
 )
 
 
-# Mirrors LUMICE_StatsResult in src/include/lumice.h. All three fields are
+# Mirrors LUMICE_StatsResult in src/include/lumice.h. All four fields are
 # LUMICE_RayCount = `unsigned long long` (64-bit on every platform, unlike
 # `unsigned long` on Windows — see the static_assert next to the typedef).
 class LUMICE_StatsResult(ctypes.Structure):
     _fields_ = [
-        ("ray_seg_num",  ctypes.c_ulonglong),
-        ("sim_ray_num",  ctypes.c_ulonglong),
-        ("crystal_num",  ctypes.c_ulonglong),
+        ("ray_seg_num",      ctypes.c_ulonglong),
+        ("sim_ray_num",      ctypes.c_ulonglong),
+        ("crystal_num",      ctypes.c_ulonglong),
+        ("orientation_num",  ctypes.c_ulonglong),
     ]
 
 
-assert ctypes.sizeof(LUMICE_StatsResult) == 24, (
-    "LUMICE_StatsResult size mismatch — verify lumice.h field layout"
-)
+def _assert_stats_mirror_matches_header() -> None:
+    """Cross-check this mirror against the field list in lumice.h.
+
+    A plain ``assert ctypes.sizeof(...) == N`` — which is what guarded this
+    struct until orientation_num was added — compares the mirror to a number
+    typed next to it, so it cannot notice the C struct growing underneath: both
+    sides of the comparison live in this file. It stayed green while the C side
+    went to four fields, and the failure it let through is not a wrong assertion
+    but a heap overflow: LUMICE_GetStatsResults writes sizeof(C struct) per row
+    into an array Python sized from the mirror, so a stale mirror means the
+    library writes past the end of the buffer (and the sentinel memset writes
+    further still). Read the header instead, so the next added field turns this
+    red at import time rather than corrupting memory in whichever test runs first.
+    """
+    header = Path(__file__).resolve().parents[2] / "src" / "include" / "lumice.h"
+    if not header.is_file():  # source tree not available (e.g. installed wheel)
+        return
+    body = re.search(
+        r"typedef struct LUMICE_StatsResult_\s*\{(.*?)\}\s*LUMICE_StatsResult;",
+        header.read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+    assert body is not None, "could not locate LUMICE_StatsResult in lumice.h"
+    # Field declarations only: strip // comments, then take `<type> <name>;`.
+    decls = re.sub(r"//.*", "", body.group(1))
+    header_fields = re.findall(r"LUMICE_RayCount\s+(\w+)\s*;", decls)
+    mirror_fields = [name for name, _ in LUMICE_StatsResult._fields_]
+    assert header_fields == mirror_fields, (
+        f"LUMICE_StatsResult drift — lumice.h has {header_fields}, "
+        f"this mirror has {mirror_fields}. Update the mirror (and any code "
+        f"reading the struct) before the C API writes past the Python buffer."
+    )
+
+
+_assert_stats_mirror_matches_header()
 
 # lumice.h LUMICE_MAX_STATS_RESULTS. The out array must hold one extra slot for
 # the all-zero sentinel LUMICE_GetStatsResults writes past the last filled row.
@@ -136,18 +169,23 @@ _LUMICE_SERVER_NOT_READY = 2
 class SimResult:
     """Subset of LUMICE_RawXyzResult fields exposed to test code.
 
-    `crystal_num` comes from LUMICE_StatsResult (a different C API call), read
-    once after the run reached IDLE-with-valid-data: how many distinct crystal
-    geometries the run actually drew. Its two halves aggregate differently — the
-    deterministic population is a config constant carried by OVERWRITE, the
-    stochastic draws accumulate per batch and per worker — so it is only
-    meaningful once the simulation finished. See doc/c_api.md for the contract.
+    `crystal_num` and `orientation_num` come from LUMICE_StatsResult (a
+    different C API call), read once after the run reached
+    IDLE-with-valid-data: how many distinct crystal geometries, and how many
+    crystal orientations, the run actually drew. Each has two halves that
+    aggregate differently — the deterministic population is a config constant
+    carried by OVERWRITE, the stochastic draws accumulate per batch and per
+    worker — so both are only meaningful once the simulation finished. The two
+    are independent quantities, not a rescaling of each other: a scene of fixed
+    shapes under random axes reports a tiny crystal_num and a huge
+    orientation_num. See doc/c_api.md for the contract.
     """
 
     snapshot_intensity: float
     has_valid_data: bool
     effective_pixels: int
     crystal_num: int = 0
+    orientation_num: int = 0
 
 
 @dataclass
@@ -174,6 +212,7 @@ class BufferedSimResult:
     fell_back: bool = False
     log_lines: List[str] = field(default_factory=list)
     crystal_num: int = 0
+    orientation_num: int = 0
 
 
 def _project_root() -> Path:
@@ -364,8 +403,12 @@ def _summarize_backend(lines: List[str]) -> tuple[str, bool]:
     return routed, fell_back
 
 
-def _read_crystal_num(lib, server) -> int:
-    """Read LUMICE_StatsResult.crystal_num for the run that just finished.
+def _read_sample_counts(lib, server) -> tuple:
+    """Read (crystal_num, orientation_num) from LUMICE_StatsResult.
+
+    One call rather than two: both come from the same LUMICE_GetStatsResults
+    row, and LUMICE_GetStatsResults triggers DoSnapshot, so reading them
+    separately would take two snapshots of a run that is supposed to be over.
 
     Call only after the polling loop observed has_valid_data AND IDLE. The value
     is the deterministic population (a config constant, OVERWRITTEN on the way
@@ -382,7 +425,9 @@ def _read_crystal_num(lib, server) -> int:
         raise RuntimeError(f"GetStatsResults failed err={err}")
     # Row 0 is the only stats row (LUMICE_MAX_STATS_RESULTS == 1); sim_ray_num
     # == 0 is the sentinel meaning "no row produced".
-    return int(stats[0].crystal_num) if stats[0].sim_ray_num != 0 else 0
+    if stats[0].sim_ray_num == 0:
+        return 0, 0
+    return int(stats[0].crystal_num), int(stats[0].orientation_num)
 
 
 def _commit_config(lib, server, config_path: str) -> None:
@@ -466,11 +511,13 @@ def run_scene_capi(config_path: str, sim_seed: int = 0, timeout_sec: int = 180) 
             time.sleep(0.2)
 
         r = results[0]
+        crystal_num, orientation_num = _read_sample_counts(lib, server)
         return SimResult(
             snapshot_intensity=float(r.snapshot_intensity),
             has_valid_data=bool(r.has_valid_data),
             effective_pixels=int(r.effective_pixels),
-            crystal_num=_read_crystal_num(lib, server),
+            crystal_num=crystal_num,
+            orientation_num=orientation_num,
         )
 
     finally:
@@ -673,7 +720,7 @@ def run_scene_capi_buffered(
                     .reshape(rr_h, rr_w, 3)
                 )
 
-                crystal_num = _read_crystal_num(lib, server)
+                crystal_num, orientation_num = _read_sample_counts(lib, server)
 
             finally:
                 lib.LUMICE_DestroyServer(server)
@@ -699,6 +746,7 @@ def run_scene_capi_buffered(
                 fell_back=fell_back,
                 log_lines=list(log_lines),
                 crystal_num=crystal_num,
+                orientation_num=orientation_num,
             )
     finally:
         # Restore env state regardless of success/failure.

--- a/test/e2e/configs/orientation_sample_count_deterministic.json
+++ b/test/e2e/configs/orientation_sample_count_deterministic.json
@@ -1,0 +1,139 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.0
+      },
+      "axis": {
+        "zenith": 90.0,
+        "azimuth": 0.0,
+        "roll": 0.0
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 0.3
+      },
+      "axis": {
+        "zenith": 0.0,
+        "azimuth": 30.0,
+        "roll": 15.0
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": 45.0,
+        "azimuth": 60.0,
+        "roll": 90.0
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": {
+        "height": 0.6
+      },
+      "axis": {
+        "zenith": 30.0,
+        "azimuth": 120.0,
+        "roll": 180.0
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": {
+        "height": 2.0
+      },
+      "axis": {
+        "zenith": 60.0,
+        "azimuth": 240.0,
+        "roll": 270.0
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360.0
+      },
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "resolution": [
+        256,
+        128
+      ],
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 540,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 60.0
+          },
+          {
+            "crystal": 2,
+            "proportion": 40.0
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 3,
+            "proportion": 40.0
+          },
+          {
+            "crystal": 4,
+            "proportion": 30.0
+          },
+          {
+            "crystal": 5,
+            "proportion": 30.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/orientation_sample_count_random.json
+++ b/test/e2e/configs/orientation_sample_count_random.json
@@ -1,0 +1,199 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 0.3
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 0.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": {
+        "height": 0.6
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": {
+        "height": 2.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360.0
+      },
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "resolution": [
+        256,
+        128
+      ],
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 540,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 60.0
+          },
+          {
+            "crystal": 2,
+            "proportion": 40.0
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 3,
+            "proportion": 40.0
+          },
+          {
+            "crystal": 4,
+            "proportion": 30.0
+          },
+          {
+            "crystal": 5,
+            "proportion": 30.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/orientation_sample_count_single_layer_random.json
+++ b/test/e2e/configs/orientation_sample_count_single_layer_random.json
@@ -1,0 +1,182 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 90.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 0.3
+      },
+      "axis": {
+        "zenith": {
+          "type": "gauss",
+          "mean": 0.0,
+          "std": 1.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": {
+        "height": 0.6
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": {
+        "height": 2.0
+      },
+      "axis": {
+        "zenith": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "azimuth": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        },
+        "roll": {
+          "type": "uniform",
+          "mean": 0.0,
+          "std": 360.0
+        }
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360.0
+      },
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "resolution": [
+        256,
+        128
+      ],
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 540,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 60.0
+          },
+          {
+            "crystal": 2,
+            "proportion": 40.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/orientation_sample_count_zero_proportion.json
+++ b/test/e2e/configs/orientation_sample_count_zero_proportion.json
@@ -1,0 +1,139 @@
+{
+  "crystal": [
+    {
+      "id": 1,
+      "type": "prism",
+      "shape": {
+        "height": 1.0
+      },
+      "axis": {
+        "zenith": 90.0,
+        "azimuth": 0.0,
+        "roll": 0.0
+      }
+    },
+    {
+      "id": 2,
+      "type": "prism",
+      "shape": {
+        "height": 0.3
+      },
+      "axis": {
+        "zenith": 0.0,
+        "azimuth": 30.0,
+        "roll": 15.0
+      }
+    },
+    {
+      "id": 3,
+      "type": "prism",
+      "shape": {
+        "height": 1.2
+      },
+      "axis": {
+        "zenith": 45.0,
+        "azimuth": 60.0,
+        "roll": 90.0
+      }
+    },
+    {
+      "id": 4,
+      "type": "prism",
+      "shape": {
+        "height": 0.6
+      },
+      "axis": {
+        "zenith": 30.0,
+        "azimuth": 120.0,
+        "roll": 180.0
+      }
+    },
+    {
+      "id": 5,
+      "type": "prism",
+      "shape": {
+        "height": 2.0
+      },
+      "axis": {
+        "zenith": 60.0,
+        "azimuth": 240.0,
+        "roll": 270.0
+      }
+    }
+  ],
+  "filter": [],
+  "render": [
+    {
+      "id": 1,
+      "lens": {
+        "type": "dual_fisheye_equal_area",
+        "fov": 360.0
+      },
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "resolution": [
+        256,
+        128
+      ],
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "intensity_factor": 1.0,
+      "opacity": 1.0,
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "type": "sun",
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": [
+        {
+          "wavelength": 540,
+          "weight": 1.0
+        }
+      ]
+    },
+    "ray_num": 20000,
+    "max_hits": 6,
+    "scattering": [
+      {
+        "prob": 0.6,
+        "entries": [
+          {
+            "crystal": 1,
+            "proportion": 60.0
+          },
+          {
+            "crystal": 2,
+            "proportion": 40.0
+          }
+        ]
+      },
+      {
+        "prob": 0.0,
+        "entries": [
+          {
+            "crystal": 3,
+            "proportion": 40.0
+          },
+          {
+            "crystal": 4,
+            "proportion": 30.0
+          },
+          {
+            "crystal": 5,
+            "proportion": 0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_cpu_trace_backend.cpp
@@ -68,6 +68,16 @@ void MakeShapeStochastic(ScatteringSetting& setting) {
   prism.h_ = Distribution{ DistributionType::kGaussian, 1.0f, 0.15f };
 }
 
+// The orientation-side counterpart: flip the AXIS to a distribution so
+// IsAxisDeterministic() is false and InitRay_rot draws per ray. Only azimuth is
+// touched — one field is enough to flip the predicate, and leaving latitude/roll
+// alone keeps this from doubling as a full-sphere-uniform scene (which takes a
+// different sampler branch and would confound "did the count move" with "did the
+// sampling path change").
+void MakeAxisStochastic(ScatteringSetting& setting) {
+  setting.crystal_.axis_.azimuth_dist = Distribution{ DistributionType::kUniform, 0.0f, 360.0f };
+}
+
 RenderConfig MakeRenderConfig() {
   RenderConfig cfg;
   cfg.id_ = 0;
@@ -615,6 +625,101 @@ TEST(CpuTraceBackend, CountsStochasticCrystalDrawsAcrossLayers) {
     backend.TraceLayer(roots1);
     EXPECT_EQ(backend.GetLastBatchStochasticCrystalSampleCount(), 1u)
         << "3 (layer, ci) slots, exactly one of them stochastic";
+    backend.EndSession();
+  }
+}
+
+// =============================================================================
+// Test — stochastic ORIENTATION-draw count. Sibling of the crystal counter
+// above and deliberately NOT the same number: orientations are redrawn per RAY
+// with no ray-group reuse, so a stochastic-axis (layer, ci) contributes its whole
+// ray count, not 1. A deterministic axis contributes 0 (its population rides the
+// scene's config constant), exactly as a deterministic shape does on the counter
+// above.
+// =============================================================================
+TEST(CpuTraceBackend, CountsStochasticOrientationDrawsAcrossLayers) {
+  constexpr size_t kRays = 256;
+
+  // Deterministic axis: MakeSimpleScene leaves axis_ default-constructed, which
+  // is all-kNoRandom (one fixed rotation, zero rng draws) — so 0 on every batch.
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
+    ASSERT_TRUE(scene.ms_[0].setting_[0].crystal_.axis_.IsAxisDeterministic())
+        << "precondition: this arm needs a deterministic axis to mean anything";
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 1;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = kRays;
+    host.crystal = nullptr;
+    backend.TraceLayer(RootRaySource::FromHost(host));
+    EXPECT_EQ(backend.GetLastBatchStochasticOrientationSampleCount(), 0u)
+        << "Deterministic axis: every ray gets the same fixed rotation and no rng draw happens";
+    backend.EndSession();
+  }
+
+  // Stochastic axis, single layer: every one of the layer's rays is a draw.
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/1);
+    MakeAxisStochastic(scene.ms_[0].setting_[0]);
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 3;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = kRays;
+    host.crystal = nullptr;
+    backend.TraceLayer(RootRaySource::FromHost(host));
+    EXPECT_EQ(backend.GetLastBatchStochasticOrientationSampleCount(), kRays)
+        << "Per-RAY, not per-ray-group: a count near kRays/kSmallBatchRayNum would mean the "
+           "orientation counter picked up the geometry side's batch-reuse structure, which "
+           "orientation sampling does not have";
+    backend.EndSession();
+  }
+
+  // Multi-MS, stochastic axes on both layers: the count is the cross-layer sum
+  // of each layer's ray count. Layer 1 traces the continuation rays that
+  // survived layer 0, so the total exceeds kRays but is not a fixed multiple —
+  // assert the structure (strictly more than one layer's worth) rather than a
+  // number that would silently encode this scene's survival rate.
+  {
+    auto scene = MakeSimpleScene(/*max_hits=*/4, /*ms_layers=*/2);
+    MakeAxisStochastic(scene.ms_[0].setting_[0]);
+    MakeAxisStochastic(scene.ms_[1].setting_[0]);
+    auto render = MakeRenderConfig();
+    SessionSpec spec;
+    spec.scene = &scene;
+    spec.render = &render;
+    spec.wl = WlParam{ 550.0f, 1.0f };
+    spec.seed = 5;
+
+    CpuTraceBackend backend;
+    backend.BeginSession(spec);
+    HostRayBatch host;
+    host.count = kRays;
+    host.crystal = nullptr;
+    auto h0 = backend.TraceLayer(RootRaySource::FromHost(host));
+    ASSERT_NE(h0, nullptr);
+    EXPECT_EQ(backend.GetLastBatchStochasticOrientationSampleCount(), kRays) << "after layer 0";
+
+    RecombineSpec rspec;
+    rspec.shuffle = true;
+    auto roots1 = backend.Recombine(std::move(h0), rspec);
+    backend.TraceLayer(roots1);
+    EXPECT_GT(backend.GetLastBatchStochasticOrientationSampleCount(), kRays)
+        << "the continuation layer resamples orientation for its own rays too (InitRayOtherMs "
+           "calls InitRay_rot), so the counter must keep climbing across MS layers";
     backend.EndSession();
   }
 }

--- a/test/regression-sentinel/test_orientation_count_dispatch_invariance.py
+++ b/test/regression-sentinel/test_orientation_count_dispatch_invariance.py
@@ -1,0 +1,388 @@
+"""Gate: `LUMICE_StatsResult.orientation_num` is a scene property, not a schedule artifact.
+
+`orientation_num` (CLI `Stats: orientations=N`) is defined as **how many crystal
+orientations this run actually sampled**. It is the sibling of `crystal_num` and
+carries the same two-term contract — a config-constant deterministic half plus an
+accumulated stochastic half — so it inherits the same three obligations, gated
+here against the same two pure-CPU arms as
+`test_crystal_count_dispatch_invariance.py`:
+
+1. **Dispatch invariance.** `LUMICE_DISPATCH_RAY_NUM` is a scheduling grain.
+   Sweeping it must not move `orientation_num`.
+
+2. **Randomization observability.** An all-deterministic-axis scene samples no
+   orientation at all, so `orientation_num` must equal the scene's (layer, ci)
+   count. Its random-axis twin redraws per ray and must report vastly more.
+
+3. **Worker invariance.** The deterministic half must not scale with the pool.
+
+What this file gates that its crystal-side sibling structurally CANNOT: the two
+statistics come apart. Every fixture here holds `shape.height` at a fixed scalar,
+so on the shape axis all three scenes are identical and `crystal_num` is pinned at
+the (layer, ci) count throughout. Any variation observed below is attributable to
+the axis alone. `test_orientation_and_crystal_counts_are_independent` makes that
+explicit, because it is the whole reason this statistic exists: the predicate
+behind `crystal_num` (`IsDeterministic(CrystalParam)`) looks only at shape params,
+so the commonest halo setup — a fixed shape under a random axis — reports one
+geometry no matter how richly the orientation was sampled. Wiring the orientation
+count to the shape predicate would leave every other test in this file green.
+
+Note the counts are per RAY, not per ray-group: orientations are redrawn for every
+ray even when the geometry it is paired with came from cache, so the stochastic
+figures here are ~ray_num-scale rather than the ~ray_num/32 the crystal side sees.
+That asymmetry is the reuse difference, reported honestly.
+
+One consequence shapes the fixture choices below and is easy to rediscover the
+hard way: on a MULTI-layer scene the stochastic total is itself a random
+variable. How many rays survive a layer's `prob` roll depends on the RNG, and
+re-partitioning the run into a different number of batches changes the stream
+partitioning, so the layer-1 population — and with it the total — moves by ~1%
+across dispatch grains (measured: 69154 vs 69787). That is the scene being
+stochastic, not the counter tracking the schedule. Exact equality is therefore
+only assertable on the single-layer fixture, which is what the dispatch-invariance
+test uses; the multi-layer fixture carries the ordering and scale claims instead.
+
+Seed discipline is inherited deliberately and must NOT be "tidied": the first two
+tests pin `sim_seed != 0`, which collapses the CPU route to one worker and makes
+their expectations exact; the worker-invariance test must run at `sim_seed == 0`,
+because a pinned seed removes the very axis it exists to sweep. That is how the
+crystal-side defect survived its own first two tests.
+
+Marked `@pytest.mark.slow`: drives the C API through the shared library
+(`./scripts/build.sh -sj release`), like every other capi_runner-based test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+from typing import Iterator, Optional
+
+import pytest
+
+from test.e2e.capi_runner import BufferedSimResult, run_scene_capi_buffered
+from test.e2e.runner import get_project_root
+
+
+_CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
+_DETERMINISTIC_CFG = _CONFIGS_DIR / "orientation_sample_count_deterministic.json"
+_ZERO_PROPORTION_CFG = _CONFIGS_DIR / "orientation_sample_count_zero_proportion.json"
+_RANDOM_CFG = _CONFIGS_DIR / "orientation_sample_count_random.json"
+# Single-MS-layer twin of _RANDOM_CFG. Needed by the dispatch-invariance test —
+# see its docstring for why the multi-layer scene cannot carry that assertion.
+_SINGLE_LAYER_RANDOM_CFG = _CONFIGS_DIR / "orientation_sample_count_single_layer_random.json"
+
+# Non-zero → single worker on the CPU route (see the module docstring).
+_SIM_SEED = 20260728
+_TIMEOUT = 240
+
+# The fixtures carry ray_num=20000. 128 is the shipped CPU default grain;
+# 20000 puts the whole run in ONE batch.
+_DISPATCH_SMALL = 128
+_DISPATCH_WHOLE_RUN = 20000
+
+# Positive control on the dispatch knob actually taking effect.
+_MIN_BATCH_COUNT_RATIO = 4.0
+
+_WORKERS_ONE = 1
+_WORKERS_MANY = 4
+
+_RE_CONSUME_PROFILE = re.compile(r"Consume profile: (\d+) batches")
+_RE_WORKER_COUNT = re.compile(r"ServerImpl: gpu_route=\w+ worker_count=(\d+)")
+
+
+def _layer_ci_total(config_path) -> int:
+    """Σ over MS layers of that layer's entry count — the (layer, ci) pair count.
+
+    For an all-deterministic-axis scene this is the whole reported orientation
+    count: no slot draws, so the config-constant half is the entire answer.
+    Derived from the fixture rather than hardcoded so editing the fixture cannot
+    silently decouple the expectation from the scene.
+    """
+    with open(config_path) as f:
+        cfg = json.load(f)
+    return sum(len(layer["entries"]) for layer in cfg["scene"]["scattering"])
+
+
+def _ray_num(config_path) -> int:
+    with open(config_path) as f:
+        return int(json.load(f)["scene"]["ray_num"])
+
+
+@contextlib.contextmanager
+def _dispatch_grain(n: Optional[int]) -> Iterator[None]:
+    """Pin LUMICE_DISPATCH_RAY_NUM (+ COMMIT, for the batch-count witness).
+
+    Same rationale as the crystal-count gate: leaving commit at its default
+    clamps the chunk count regardless of the dispatch grain and erases the ratio
+    signal the positive control depends on.
+    """
+    keys = ("LUMICE_DISPATCH_RAY_NUM", "LUMICE_COMMIT_RAY_NUM")
+    saved = {k: os.environ.get(k) for k in keys}
+    try:
+        if n is not None:
+            for k in keys:
+                os.environ[k] = str(n)
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _consumed_batches(result: BufferedSimResult) -> int:
+    """Batch count the RenderConsumer actually saw (0 if the line never logged)."""
+    counts = [int(m.group(1)) for ln in result.log_lines
+              for m in [_RE_CONSUME_PROFILE.search(ln)] if m]
+    return max(counts) if counts else 0
+
+
+def _worker_count(result: BufferedSimResult) -> int:
+    """Workers the server actually spawned (0 if the line never logged)."""
+    counts = [int(m.group(1)) for ln in result.log_lines
+              for m in [_RE_WORKER_COUNT.search(ln)] if m]
+    return max(counts) if counts else 0
+
+
+def _run(config_path, backend: str, dispatch: Optional[int],
+         sim_seed: int = _SIM_SEED, num_workers: int = 0) -> BufferedSimResult:
+    with _dispatch_grain(dispatch):
+        result = run_scene_capi_buffered(
+            str(config_path),
+            sim_seed=sim_seed,
+            backend=backend,
+            timeout_sec=_TIMEOUT,
+            num_workers=num_workers,
+            preserve_dispatch_env=True,
+        )
+    assert result.has_valid_data, f"{config_path.name} @ {backend}: no valid data"
+    assert result.routed_backend == backend and not result.fell_back, (
+        f"{config_path.name}: asked for {backend!r} but ran "
+        f"{result.routed_backend!r} (fell_back={result.fell_back}); the "
+        f"measurement would be about the wrong backend"
+    )
+    return result
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_orientation_num_is_dispatch_invariant(backend: str) -> None:
+    """Same scene, two dispatch grains → orientation_num == ray_num exactly, both times.
+
+    Three fixture choices here are load-bearing, and each rules out a way this
+    test could look right while proving nothing:
+
+    * RANDOM axes, not deterministic ones. On a deterministic-axis scene the
+      stochastic half is identically zero and the whole reported value is a
+      config constant, so dispatch invariance would hold even for a counter that
+      summed per batch — there would be nothing to sum.
+
+    * SINGLE MS layer. On the multi-layer fixture the count is genuinely NOT
+      grain-invariant, and that is a property of the scene rather than a defect
+      in the counter: how many rays survive layer 0's `prob` roll is a random
+      variable, and re-partitioning 20000 rays into 157 batches instead of 1
+      changes the RNG stream partitioning, hence the layer-1 population. Measured
+      spread across grains is ~1% (e.g. 69154 vs 69787) — the honest invariant
+      there is distributional, and asserting equality would produce a test that
+      fails for a true reason. With one layer and `prob: 0.0` there is no
+      survivor term, so the count is exact.
+
+    * An EXACT expected value (ray_num), not just equality between the two runs.
+      Every ray draws exactly one orientation and the run traces ray_num rays at
+      any grain, so the answer is pinned on both sides independently. Equality
+      alone would also hold if both runs were wrong by the same factor — which is
+      exactly what the pre-fix per-batch-summed counter did to `crystal_num`.
+    """
+    expected = _ray_num(_SINGLE_LAYER_RANDOM_CFG)
+
+    small = _run(_SINGLE_LAYER_RANDOM_CFG, backend, _DISPATCH_SMALL)
+    whole = _run(_SINGLE_LAYER_RANDOM_CFG, backend, _DISPATCH_WHOLE_RUN)
+
+    # Positive control first: a no-op env knob would make the invariance
+    # assertion below trivially true.
+    n_small, n_whole = _consumed_batches(small), _consumed_batches(whole)
+    assert n_small > 0 and n_whole > 0, (
+        f"{backend}: no 'Consume profile: N batches' line captured "
+        f"({n_small} / {n_whole}) — cannot confirm the dispatch grain took "
+        f"effect, so the invariance assertion below would be unwitnessed"
+    )
+    assert n_small >= n_whole * _MIN_BATCH_COUNT_RATIO, (
+        f"{backend}: dispatch grain did not take effect — batches consumed "
+        f"{n_small} @ grain {_DISPATCH_SMALL} vs {n_whole} @ grain "
+        f"{_DISPATCH_WHOLE_RUN}; expected at least {_MIN_BATCH_COUNT_RATIO}x. "
+        f"Both runs traced the same schedule, so orientation_num equality "
+        f"proves nothing."
+    )
+
+    assert small.orientation_num == whole.orientation_num, (
+        f"{backend}: orientation_num moved with the dispatch grain — "
+        f"{small.orientation_num} @ LUMICE_DISPATCH_RAY_NUM={_DISPATCH_SMALL} "
+        f"vs {whole.orientation_num} @ {_DISPATCH_WHOLE_RUN}. Both runs trace "
+        f"the same {expected} rays and each ray draws one orientation; only the "
+        f"grain they are grouped into changed."
+    )
+    assert small.orientation_num == expected, (
+        f"{backend}: single-layer random-axis run over {expected} rays reported "
+        f"orientation_num={small.orientation_num}. Every ray draws exactly one "
+        f"orientation and none are reused, so the answer is pinned at "
+        f"{expected}. A multiple of it means a per-batch quantity is being "
+        f"summed; a fraction means some population is going uncounted"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_orientation_num_observes_axis_randomization(backend: str) -> None:
+    """Deterministic-axis scene → exactly the (layer, ci) count; random twin → far more.
+
+    The two fixtures are structurally identical (same layers, entries,
+    proportions, ray_num, and the same FIXED shape on every crystal); they differ
+    only in whether the axis distributions are scalars or distributions. So any
+    difference in orientation_num is attributable to axis randomization alone —
+    the fixtures' generator asserts that field-level equality directly.
+    """
+    expected = _layer_ci_total(_DETERMINISTIC_CFG)
+    ray_num = _ray_num(_RANDOM_CFG)
+
+    fixed = _run(_DETERMINISTIC_CFG, backend, None)
+    assert fixed.orientation_num == expected, (
+        f"{backend}: deterministic-axis scene reported orientation_num="
+        f"{fixed.orientation_num}, expected {expected} = Σ over MS layers of "
+        f"that layer's entry count. An all-kNoRandom axis consumes no RNG and "
+        f"yields one fixed rotation for every ray, so anything larger means "
+        f"rays that reused a single orientation are being counted as draws"
+    )
+
+    stochastic = _run(_RANDOM_CFG, backend, None)
+    assert stochastic.orientation_num > fixed.orientation_num, (
+        f"{backend}: random-axis scene reported orientation_num="
+        f"{stochastic.orientation_num}, no more than its deterministic twin's "
+        f"{fixed.orientation_num}. This stat exists to answer 'did my "
+        f"orientation randomization take effect?' and would be blind to it"
+    )
+    # Scale, not just ordering. Orientations are per-ray with NO reuse, so the
+    # first MS layer alone must account for ray_num draws; anything materially
+    # below that means whole populations are going uncounted (e.g. only the
+    # first MS layer wired up, or a per-ray-group count sneaking in).
+    assert stochastic.orientation_num >= ray_num, (
+        f"{backend}: random-axis scene reported only "
+        f"{stochastic.orientation_num} orientation draws for a {ray_num}-ray "
+        f"run whose every slot randomizes its axis. Orientation is resampled "
+        f"per ray with no ray-group reuse, so the first MS layer alone owes "
+        f"{ray_num}; a smaller total means some population or some MS layer is "
+        f"not being counted"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_orientation_num_is_worker_invariant(backend: str) -> None:
+    """Same scene, 1 vs N workers → identical orientation_num.
+
+    Runs at `sim_seed == 0` on purpose: a pinned seed clamps the CPU route to a
+    single worker, so a seeded version of this test would sweep nothing and pass
+    against a counter that scales linearly with the pool. Do not "stabilise"
+    this test by pinning the seed — that reintroduces the blind spot the
+    crystal-side gate was written to close.
+    """
+    expected = _layer_ci_total(_DETERMINISTIC_CFG)
+
+    one = _run(_DETERMINISTIC_CFG, backend, None, sim_seed=0, num_workers=_WORKERS_ONE)
+    many = _run(_DETERMINISTIC_CFG, backend, None, sim_seed=0, num_workers=_WORKERS_MANY)
+
+    # Positive control: `num_workers` is a request, and the server is free to
+    # clamp it. If both runs ended up with the same pool, equality is vacuous.
+    w_one, w_many = _worker_count(one), _worker_count(many)
+    assert w_one == _WORKERS_ONE and w_many == _WORKERS_MANY, (
+        f"{backend}: asked for {_WORKERS_ONE} / {_WORKERS_MANY} workers but the "
+        f"server spawned {w_one} / {w_many} (from the 'ServerImpl: ... "
+        f"worker_count=' log line) — the pool size did not vary, so the "
+        f"invariance assertion below would prove nothing"
+    )
+
+    assert one.orientation_num == many.orientation_num, (
+        f"{backend}: orientation_num scaled with the worker pool — "
+        f"{one.orientation_num} @ {_WORKERS_ONE} worker vs "
+        f"{many.orientation_num} @ {_WORKERS_MANY}. Every worker redundantly "
+        f"derives the same deterministic axes; a ratio of ~{_WORKERS_MANY}x "
+        f"means the deterministic half is being summed per worker instead of "
+        f"carried as the config constant it is"
+    )
+    assert many.orientation_num == expected, (
+        f"{backend}: {_WORKERS_MANY}-worker run reported orientation_num="
+        f"{many.orientation_num}, expected {expected}. Equality with the "
+        f"1-worker run above would also hold if both were wrong by the same "
+        f"factor"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_orientation_num_counts_scene_slots_not_traced_slots(backend: str) -> None:
+    """A crystal_proportion_ == 0 slot still counts toward the deterministic half.
+
+    This pins the property that BUYS the immunity asserted above, and it is the
+    one a well-meaning change is most likely to break: counting only the
+    (layer, ci) slots a run actually reached looks strictly more accurate, and it
+    silently reintroduces the defect the whole gate exists to catch. Which slots
+    get traced is a function of the ray partition, so it moves with the dispatch
+    grain and the worker pool.
+    """
+    expected = _layer_ci_total(_ZERO_PROPORTION_CFG)
+    zeroed = _run(_ZERO_PROPORTION_CFG, backend, None)
+
+    assert zeroed.orientation_num == expected, (
+        f"{backend}: scene with a proportion=0 slot reported orientation_num="
+        f"{zeroed.orientation_num}, expected {expected} = every (layer, ci) slot "
+        f"in the committed config. Counting only slots the run actually traced "
+        f"makes the value a function of the ray partition again"
+    )
+    assert zeroed.orientation_num == _layer_ci_total(_DETERMINISTIC_CFG), (
+        f"{backend}: zeroing a slot's proportion changed orientation_num; the "
+        f"deterministic half is a property of the committed config, and setting "
+        f"a population's share to 0 does not remove it from the config"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend", ["legacy", "cpu_backend"])
+def test_orientation_and_crystal_counts_are_independent(backend: str) -> None:
+    """The two statistics come apart on the scene that motivated this one.
+
+    Every fixture in this file holds `shape.height` at a fixed scalar, so on the
+    shape axis all of them are the same deterministic scene and `crystal_num` is
+    pinned at the (layer, ci) count. Swapping the axes from scalars to
+    distributions must therefore move `orientation_num` by orders of magnitude
+    while leaving `crystal_num` untouched.
+
+    This is the assertion that fails if anyone routes the orientation count
+    through `IsDeterministic(CrystalParam)` — the shape predicate — instead of
+    `AxisDistribution::IsAxisDeterministic`. Every other test in this file would
+    stay green under that mistake: they compare orientation counts to each other
+    and to the slot total, and the shape predicate reports "deterministic" for
+    both fixtures, collapsing the random one's stochastic half to zero in a way
+    that only shows up beside the crystal count.
+    """
+    slots = _layer_ci_total(_DETERMINISTIC_CFG)
+
+    fixed = _run(_DETERMINISTIC_CFG, backend, None)
+    random = _run(_RANDOM_CFG, backend, None)
+
+    assert fixed.crystal_num == slots and random.crystal_num == slots, (
+        f"{backend}: crystal_num was expected to stay at the slot total {slots} "
+        f"across both fixtures (every shape is a fixed scalar in both), but got "
+        f"{fixed.crystal_num} / {random.crystal_num}. The fixtures have drifted "
+        f"on the shape axis, so the independence claim below is confounded"
+    )
+    assert random.orientation_num > random.crystal_num * 100, (
+        f"{backend}: fixed shapes under random axes reported crystal_num="
+        f"{random.crystal_num} and orientation_num={random.orientation_num}. "
+        f"The orientation count is supposed to dwarf the geometry count on this "
+        f"scene — that gap IS the sampling richness the geometry count cannot "
+        f"see. A value in the same range as crystal_num means the orientation "
+        f"count is being judged by the shape predicate"
+    )

--- a/test/unit-correctness/config/test_sim_data.cpp
+++ b/test/unit-correctness/config/test_sim_data.cpp
@@ -60,8 +60,9 @@ static_assert(sizeof(void*) == 8, "SimData layout assumes 64-bit pointers");
 // = 3 × size_t = 24B) for the GPU color-degrade tally, bumping 328 → 352.
 // The crystal-sample-count contract splits crystal_count_ into an accumulated
 // stochastic half and an overwritten deterministic half (+1 size_t, 8B),
-// bumping 352 → 360.
-static_assert(sizeof(SimData) == 360,
+// bumping 352 → 360. The orientation-sample-count statistic adds its own
+// stochastic/deterministic pair (+2 size_t, 16B), bumping 360 → 376.
+static_assert(sizeof(SimData) == 376,
               "SimData layout changed — update test_sim_data.cpp DeepCopy/Move assertions "
               "and sim_data.cpp's static_assert.");
 #endif
@@ -131,6 +132,10 @@ SimData MakePopulatedSimData() {
   // dropped one and duplicated the other would still pass a single-value probe.
   s.stochastic_crystal_sample_count_ = 4;
   s.deterministic_crystal_count_ = 9;
+  // Distinct from the crystal values above so a copy/move that crossed the two
+  // pairs of fields cannot pass by coincidence.
+  s.stochastic_orientation_sample_count_ = 6400;
+  s.deterministic_orientation_count_ = 3;
   // scrum-312: third-clock drain counter-balance credit propagation coverage.
   s.sim_scene_credit_ = 11;
   // task-color-degrade-gui-surfacing: GPU color-degrade tally propagation coverage.
@@ -984,6 +989,8 @@ TEST(SimDataTest, CopyConstructDeepCopy) {
   EXPECT_EQ(copy.lane_class_count_, 2u) << "lane_class_count_ not copied";
   EXPECT_EQ(copy.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not copied";
   EXPECT_EQ(copy.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not copied";
+  EXPECT_EQ(copy.stochastic_orientation_sample_count_, 6400u) << "stochastic_orientation_sample_count_ not copied";
+  EXPECT_EQ(copy.deterministic_orientation_count_, 3u) << "deterministic_orientation_count_ not copied";
   EXPECT_EQ(copy.sim_scene_credit_, 11u) << "sim_scene_credit_ not copied";  // scrum-312
   EXPECT_EQ(copy.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not copied";
   EXPECT_EQ(copy.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not copied";
@@ -1043,6 +1050,8 @@ TEST(SimDataTest, CopyAssignmentDeepCopy) {
   EXPECT_EQ(target.lane_class_count_, 2u) << "lane_class_count_ not assigned";
   EXPECT_EQ(target.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not assigned";
   EXPECT_EQ(target.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not assigned";
+  EXPECT_EQ(target.stochastic_orientation_sample_count_, 6400u) << "stochastic_orientation_sample_count_ not assigned";
+  EXPECT_EQ(target.deterministic_orientation_count_, 3u) << "deterministic_orientation_count_ not assigned";
   EXPECT_EQ(target.sim_scene_credit_, 11u) << "sim_scene_credit_ not assigned";  // scrum-312
   EXPECT_EQ(target.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not assigned";
   EXPECT_EQ(target.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not assigned";
@@ -1105,6 +1114,8 @@ TEST(SimDataTest, MoveConstructTransfersOwnership) {
   EXPECT_EQ(moved.lane_class_count_, 2u) << "lane_class_count_ not moved";
   EXPECT_EQ(moved.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not moved";
   EXPECT_EQ(moved.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not moved";
+  EXPECT_EQ(moved.stochastic_orientation_sample_count_, 6400u) << "stochastic_orientation_sample_count_ not moved";
+  EXPECT_EQ(moved.deterministic_orientation_count_, 3u) << "deterministic_orientation_count_ not moved";
   EXPECT_EQ(moved.sim_scene_credit_, 11u) << "sim_scene_credit_ not moved";  // scrum-312
   EXPECT_EQ(moved.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not moved";
   EXPECT_EQ(moved.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not moved";
@@ -1155,6 +1166,9 @@ TEST(SimDataTest, MoveAssignAndSelfMove) {
   EXPECT_EQ(dst.crystals_.size(), 1u);
   EXPECT_EQ(dst.stochastic_crystal_sample_count_, 4u) << "stochastic_crystal_sample_count_ not move-assigned";
   EXPECT_EQ(dst.deterministic_crystal_count_, 9u) << "deterministic_crystal_count_ not move-assigned";
+  EXPECT_EQ(dst.stochastic_orientation_sample_count_, 6400u)
+      << "stochastic_orientation_sample_count_ not move-assigned";
+  EXPECT_EQ(dst.deterministic_orientation_count_, 3u) << "deterministic_orientation_count_ not move-assigned";
   EXPECT_EQ(dst.sim_scene_credit_, 11u) << "sim_scene_credit_ not move-assigned";  // scrum-312
   EXPECT_EQ(dst.color_degrade_counts_.symmetry_group_overflow, 5u) << "color_degrade symmetry not move-assigned";
   EXPECT_EQ(dst.color_degrade_counts_.or_summand_overflow, 6u) << "color_degrade or_summand not move-assigned";

--- a/test/unit-correctness/core/test_math.cpp
+++ b/test/unit-correctness/core/test_math.cpp
@@ -354,4 +354,55 @@ TEST(IsAzRotationallySymmetric, GaussianAz_ReturnsFalse) {
   EXPECT_FALSE(d.IsAzRotationallySymmetric());
 }
 
+// --- AxisDistribution::IsAxisDeterministic: the orientation-side predicate ---
+// Truth table. The default-constructed axis is all-kNoRandom, so each negative
+// case flips exactly ONE of the three distributions — that is what makes each
+// EXPECT_FALSE attributable to the field it names rather than to the pair.
+
+TEST(IsAxisDeterministic, DefaultCtorAllNoRandom_ReturnsTrue) {
+  AxisDistribution d{};
+  ASSERT_EQ(d.azimuth_dist.type, DistributionType::kNoRandom);
+  ASSERT_EQ(d.latitude_dist.type, DistributionType::kNoRandom);
+  ASSERT_EQ(d.roll_dist.type, DistributionType::kNoRandom);
+  EXPECT_TRUE(d.IsAxisDeterministic());
+}
+
+TEST(IsAxisDeterministic, RandomAzimuthOnly_ReturnsFalse) {
+  AxisDistribution d{};
+  d.azimuth_dist.type = DistributionType::kUniform;
+  d.azimuth_dist.spread = 360.0f;
+  EXPECT_FALSE(d.IsAxisDeterministic());
+}
+
+TEST(IsAxisDeterministic, RandomLatitudeOnly_ReturnsFalse) {
+  AxisDistribution d{};
+  d.latitude_dist.type = DistributionType::kGaussian;
+  d.latitude_dist.spread = 5.0f;
+  EXPECT_FALSE(d.IsAxisDeterministic());
+}
+
+TEST(IsAxisDeterministic, RandomRollOnly_ReturnsFalse) {
+  // Roll is the field a shape-side predicate would never look at, and the one
+  // an "azimuth+latitude only" reading of "orientation" would drop. It still
+  // consumes the RNG and still produces a different rotation per ray.
+  AxisDistribution d{};
+  d.roll_dist.type = DistributionType::kUniform;
+  d.roll_dist.spread = 360.0f;
+  EXPECT_FALSE(d.IsAxisDeterministic());
+}
+
+TEST(IsAxisDeterministic, FullSphereUniform_ReturnsFalse) {
+  // Documents the mutual exclusion the predicate relies on instead of guarding
+  // for: a full-sphere axis is kUniform on azimuth AND latitude, so it can
+  // never read as deterministic. The RUNTIME half of this claim — that
+  // InitRay_rot's full_sphere branch really is driven by the same predicate —
+  // is pinned behaviorally by AxisDeterminismMatchesRuntimeOrientation in
+  // test_simulator.cpp; this one only fixes the static relationship.
+  AxisDistribution d{};
+  d.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  d.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  ASSERT_TRUE(d.IsFullSphereUniform());
+  EXPECT_FALSE(d.IsAxisDeterministic());
+}
+
 }  // namespace

--- a/test/unit-correctness/core/test_simulator.cpp
+++ b/test/unit-correctness/core/test_simulator.cpp
@@ -543,9 +543,17 @@ std::vector<std::array<float, 9>> SampleOrientations(const AxisDistribution& axi
 // the predicate to what InitRay_rot ACTUALLY PRODUCES, not to another pure
 // predicate: an assertion like "a full-sphere axis is not axis-deterministic"
 // reads the same dist.type fields both predicates read, so it is true by
-// construction and stays green even if InitRay_rot's branch stops being driven
-// by IsFullSphereUniform. Comparing rotations instead makes that decoupling —
-// or any loosening of either predicate — turn this red.
+// construction and cannot fail.
+//
+// Scope, established by mutation rather than assumed. This catches a change that
+// makes kNoRandom stop meaning "no draw" at runtime — jittering the kNoRandom
+// latitude branch turns the first case red while all five truth-table cases in
+// test_math.cpp stay green, which is the gap this test exists to fill. It does
+// NOT catch InitRay_rot's full_sphere branch being decoupled from
+// IsFullSphereUniform: the two sampler paths are statistically equivalent since
+// the unified area-measure LatLut, so nothing observable changes. Do not "fix"
+// that by weakening these assertions into a distributional check — there is no
+// difference to detect.
 TEST(AxisDeterminismMatchesRuntimeOrientation, DeterministicAxisYieldsOneFixedRotation) {
   AxisDistribution axis;  // default ctor: all three kNoRandom
   ASSERT_TRUE(axis.IsAxisDeterministic());

--- a/test/unit-correctness/core/test_simulator.cpp
+++ b/test/unit-correctness/core/test_simulator.cpp
@@ -516,6 +516,118 @@ TEST(CollectDataFilterDispatch, FilterPassNoProbEmitsOutgoing) {
 // (see the inline notes at each one).
 // ============================================================================
 
+// --- Orientation-count predicate: behavioral pin + config aggregation ---
+
+// Sample `n` orientations for `axis` through the production path and return
+// the raw 3x3 matrices, so a caller can compare them bit-for-bit.
+std::vector<std::array<float, 9>> SampleOrientations(const AxisDistribution& axis, size_t n, uint32_t seed) {
+  RandomNumberGenerator rng(seed);
+  RayBuffer buffer_data[2];
+  buffer_data[0].Reset(n);
+  buffer_data[1].Reset(n);
+  buffer_data[0].size_ = n;
+  InitRay_rot(rng, axis, buffer_data);
+
+  std::vector<std::array<float, 9>> out;
+  out.reserve(n);
+  for (size_t i = 0; i < n; i++) {
+    std::array<float, 9> m{};
+    const float* mat = buffer_data[0].rays_[i].crystal_rot_.GetMat();
+    std::copy(mat, mat + 9, m.begin());
+    out.push_back(m);
+  }
+  return out;
+}
+
+// The pin AxisDistribution::IsAxisDeterministic's doc comment names. It binds
+// the predicate to what InitRay_rot ACTUALLY PRODUCES, not to another pure
+// predicate: an assertion like "a full-sphere axis is not axis-deterministic"
+// reads the same dist.type fields both predicates read, so it is true by
+// construction and stays green even if InitRay_rot's branch stops being driven
+// by IsFullSphereUniform. Comparing rotations instead makes that decoupling —
+// or any loosening of either predicate — turn this red.
+TEST(AxisDeterminismMatchesRuntimeOrientation, DeterministicAxisYieldsOneFixedRotation) {
+  AxisDistribution axis;  // default ctor: all three kNoRandom
+  ASSERT_TRUE(axis.IsAxisDeterministic());
+
+  constexpr size_t kN = 16;
+  auto mats = SampleOrientations(axis, kN, /*seed=*/1234);
+  ASSERT_EQ(mats.size(), kN);
+  for (size_t i = 1; i < kN; i++) {
+    EXPECT_EQ(mats[i], mats[0]) << "ray " << i << " got a different rotation from a deterministic axis";
+  }
+}
+
+TEST(AxisDeterminismMatchesRuntimeOrientation, FullSphereAxisIsStochasticAndVaries) {
+  // roll stays kNoRandom on purpose: this is the combination most likely to be
+  // misjudged by a predicate that stops short of all three fields.
+  AxisDistribution axis;
+  axis.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  axis.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  ASSERT_TRUE(axis.IsFullSphereUniform());
+  EXPECT_FALSE(axis.IsAxisDeterministic());
+
+  constexpr size_t kN = 16;
+  auto mats = SampleOrientations(axis, kN, /*seed=*/1234);
+  ASSERT_EQ(mats.size(), kN);
+  size_t distinct_from_first = 0;
+  for (size_t i = 1; i < kN; i++) {
+    if (mats[i] != mats[0]) {
+      distinct_from_first++;
+    }
+  }
+  EXPECT_EQ(distinct_from_first, kN - 1) << "predicate says stochastic but InitRay_rot repeated a rotation";
+}
+
+TEST(DeterministicOrientationCountTest, CountsAxisDeterministicSlotsAcrossLayers) {
+  auto make_setting = [](bool axis_random) {
+    ScatteringSetting s;
+    s.crystal_.id_ = 0;
+    s.crystal_.param_ = PrismCrystalParam{};
+    if (axis_random) {
+      s.crystal_.axis_.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+    }
+    s.crystal_proportion_ = 1.0f;
+    return s;
+  };
+
+  SceneConfig config{};
+  MsInfo layer0;
+  layer0.prob_ = 0.0f;
+  layer0.setting_.push_back(make_setting(/*axis_random=*/false));
+  layer0.setting_.push_back(make_setting(/*axis_random=*/true));
+  layer0.setting_.push_back(make_setting(/*axis_random=*/false));
+  MsInfo layer1;
+  layer1.prob_ = 0.0f;
+  layer1.setting_.push_back(make_setting(/*axis_random=*/true));
+  layer1.setting_.push_back(make_setting(/*axis_random=*/false));
+  config.ms_.push_back(std::move(layer0));
+  config.ms_.push_back(std::move(layer1));
+
+  // 3 of the 5 (layer, ci) slots carry a deterministic axis, across BOTH layers.
+  EXPECT_EQ(DeterministicOrientationCount(config), 3u);
+}
+
+TEST(DeterministicOrientationCountTest, IsIndependentOfTheShapePredicate) {
+  // The task in one assertion: the commonest halo setup is deterministic on the
+  // shape axis and stochastic on the orientation axis. Wiring the orientation
+  // count to IsDeterministic(CrystalParam) would make these two counts equal.
+  ScatteringSetting s;
+  s.crystal_.id_ = 0;
+  s.crystal_.param_ = PrismCrystalParam{};  // fixed shape
+  s.crystal_.axis_.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  s.crystal_proportion_ = 1.0f;
+
+  SceneConfig config{};
+  MsInfo layer;
+  layer.prob_ = 0.0f;
+  layer.setting_.push_back(std::move(s));
+  config.ms_.push_back(std::move(layer));
+
+  EXPECT_EQ(DeterministicCrystalCount(config), 1u) << "shape is fixed";
+  EXPECT_EQ(DeterministicOrientationCount(config), 0u) << "axis is random";
+}
+
 TEST(ComponentMaskPropagation, InitRayFirstMsZeroesComponentSlots) {
   Crystal crystal = Crystal::CreatePrism(1.0f);
   RandomNumberGenerator rng(42);

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1279,6 +1279,11 @@ TEST_F(ServerLifecycleApi, GetStatsResults) {
   // After running 1000 rays through one crystal with single-pass scattering:
   EXPECT_GT(out[0].sim_ray_num, 0u);
   EXPECT_GT(out[0].crystal_num, 0u);
+  // The orientation half must be mapped too. c_api.cpp fills this struct with a
+  // hand-written field-by-field copy, which is the copy-paste shape where a new
+  // field is easiest to forget — and forgetting it yields 0, which reads as
+  // "this scene never randomizes orientation" rather than as a missing wire.
+  EXPECT_GT(out[0].orientation_num, 0u);
 
   // Sentinel: sim_ray_num == 0 marks end of array
   EXPECT_EQ(out[1].sim_ray_num, 0u);
@@ -1301,6 +1306,7 @@ TEST_F(ServerLifecycleApi, GetCachedStatsConsistency) {
   ASSERT_EQ(LUMICE_GetCachedStats(server_, &cached), LUMICE_OK);
   EXPECT_EQ(cached.sim_ray_num, fresh[0].sim_ray_num);
   EXPECT_EQ(cached.crystal_num, fresh[0].crystal_num);
+  EXPECT_EQ(cached.orientation_num, fresh[0].orientation_num);
   EXPECT_EQ(cached.ray_seg_num, fresh[0].ray_seg_num);
 
   // Cache stability: a second GetCachedStats call without any intervening Get*Results
@@ -1309,6 +1315,7 @@ TEST_F(ServerLifecycleApi, GetCachedStatsConsistency) {
   ASSERT_EQ(LUMICE_GetCachedStats(server_, &cached_again), LUMICE_OK);
   EXPECT_EQ(cached_again.sim_ray_num, cached.sim_ray_num);
   EXPECT_EQ(cached_again.crystal_num, cached.crystal_num);
+  EXPECT_EQ(cached_again.orientation_num, cached.orientation_num);
 }
 
 

--- a/test/unit-correctness/server/test_stats_consumer.cpp
+++ b/test/unit-correctness/server/test_stats_consumer.cpp
@@ -193,5 +193,106 @@ TEST(StatsConsumer, DeterministicHalfIsOverwrittenSoEveryBatchMustCarryIt) {
          "not re-derive server.cpp's produced-batch predicate here.";
 }
 
+size_t OrientationNum(StatsConsumer& stats) {
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  EXPECT_TRUE(std::holds_alternative<StatsResult>(result));
+  return std::get<StatsResult>(result).orientation_num_;
+}
+
+// ── Orientation half ────────────────────────────────────────────────────────
+// The orientation count carries the SAME two-rule split as the crystal count
+// (stochastic ACCUMULATE / deterministic OVERWRITE), so it inherits the same
+// defect family. These are separate tests rather than extra assertions inside
+// the crystal ones on purpose: the two counts are independent axes of a crystal
+// setting, and a test that only ever moves them together cannot tell a genuine
+// orientation counter from one that shadows the crystal count.
+
+TEST(StatsConsumer, StochasticOrientationSamplesAccumulateAcrossBatches) {
+  StatsConsumer stats;
+
+  SimData batch1;
+  batch1.stochastic_orientation_sample_count_ = 30;
+  batch1.root_ray_count_ = 100;
+  stats.Consume(batch1);
+
+  SimData batch2;
+  batch2.stochastic_orientation_sample_count_ = 50;
+  batch2.root_ray_count_ = 200;
+  stats.Consume(batch2);
+
+  EXPECT_EQ(OrientationNum(stats), 80u) << "orientation is redrawn per ray with no reuse — draws sum";
+}
+
+TEST(StatsConsumer, DeterministicOrientationCountIsOverwrittenNotSummed) {
+  constexpr size_t kSceneDeterministicAxes = 5;
+  constexpr int kProducers = 4;
+
+  StatsConsumer stats;
+  for (int i = 0; i < kProducers; i++) {
+    SimData batch;
+    batch.root_ray_count_ = 64;
+    batch.deterministic_orientation_count_ = kSceneDeterministicAxes;
+    stats.Consume(batch);
+  }
+
+  EXPECT_EQ(OrientationNum(stats), kSceneDeterministicAxes)
+      << "the deterministic-axis population is a config constant every producer reports "
+         "identically; summing it would make the stat scale with the worker pool";
+}
+
+// The task's whole point at unit scope: shape determinism and axis determinism
+// are independent, so the two reported counts must be able to diverge. The
+// headline scene — one fixed geometry, an orientation redrawn per ray — is
+// exactly where a counter that merely shadows the crystal count looks right in
+// every other test and is wrong here.
+TEST(StatsConsumer, OrientationAndCrystalCountsAreIndependentAxes) {
+  StatsConsumer stats;
+
+  SimData batch;
+  batch.root_ray_count_ = 20000;
+  batch.deterministic_crystal_count_ = 1;  // one fixed shape
+  batch.stochastic_crystal_sample_count_ = 0;
+  batch.deterministic_orientation_count_ = 0;
+  batch.stochastic_orientation_sample_count_ = 20000;  // redrawn per ray
+  stats.Consume(batch);
+
+  stats.PrepareSnapshot();
+  auto result = stats.GetResult();
+  ASSERT_TRUE(std::holds_alternative<StatsResult>(result));
+  const auto& r = std::get<StatsResult>(result);
+  EXPECT_EQ(r.crystal_num_, 1u);
+  EXPECT_EQ(r.orientation_num_, 20000u);
+  EXPECT_NE(r.crystal_num_, r.orientation_num_) << "the two counts must not be wired to the same source";
+}
+
+// Regression pin for a defect this task actually shipped and then fixed:
+// server.cpp::ConsumeData rebuilds SimData field-by-field when chunking the
+// exit-seam path, and the two orientation fields were initially left out — so
+// the backend route reported orientations=0 while the legacy route (which hands
+// the whole SimData over intact) kept working, which is what hid it. Found by
+// the e2e cpu_backend arm; pinned here so it is caught in milliseconds instead.
+TEST(StatsConsumer, ChunkedDispatchCarriesBothOrientationHalves) {
+  constexpr size_t kStochasticOrientations = 4096;
+  constexpr size_t kDeterministicOrientations = 3;
+  constexpr size_t kOriginalRootRays = 512;
+  constexpr int kChunkCount = 5;
+
+  StatsConsumer stats;
+  for (int i = 0; i < kChunkCount; i++) {
+    SimData chunk;
+    if (i == 0) {
+      chunk.stochastic_orientation_sample_count_ = kStochasticOrientations;
+      chunk.root_ray_count_ = kOriginalRootRays;
+    }
+    chunk.deterministic_orientation_count_ = kDeterministicOrientations;  // every chunk, per server.cpp
+    stats.Consume(chunk);
+  }
+
+  EXPECT_EQ(OrientationNum(stats), kStochasticOrientations + kDeterministicOrientations)
+      << "a chunk copy that drops either orientation field reports a plausible-looking "
+         "low number (or 0) on the backend route only — the legacy route keeps working";
+}
+
 }  // namespace
 }  // namespace lumice


### PR DESCRIPTION
## 目标

`IsDeterministic(CrystalParam)` 只看形状参数、完全不看 axis，所以 task-406 收敛出的 `crystals=N`
在最常见的配置——**固定形状 + 随机朝向**——下报 "1"，用户完全看不到朝向采样的丰富度，而朝向恰恰是
决定光晕形态的主因。本 PR 把「朝向采样数」做成与几何采样数并列的独立统计量。

沿用 task-406 定案的聚合纪律（**确定性部分 = config 常量、随机部分逐次累加**），使其成为**场景属性**，
对 worker 数 / dispatch 粒度 / batch 数免疫。

## 主要改动

- `AxisDistribution::IsAxisDeterministic()` + `DeterministicOrientationCount(config)` —— 与几何侧
  `IsDeterministic` **并列而非复用**的对偶判据。
- 四后端（legacy CPU / cpu_backend / Metal / CUDA）per-ray 计数；口径经白盒定案为 per-ray
  （`InitRay_rot` 逐光线重抽，与 `geom_clock_` 批复用无关）。
- `SimData` → `StatsConsumer` → `server::StatsResult` → `LUMICE_StatsResult` → CLI `Stats:` 全链路镜像。
- 回归门禁 `test/regression-sentinel/test_orientation_count_dispatch_invariance.py`（dispatch / worker
  不变性含空洞性 positive control）+ 单测 + 行为级判据钉子。

## Breaking change

`LUMICE_StatsResult` 新增 `orientation_num` 字段，`LUMICE_API_VERSION` 413 → 414。C API 消费方需重新编译。

## 实施中发现并修复的两个真缺陷

1. **`server.cpp::ConsumeData` 出射 seam 切块漏搬新字段** —— 该处是手写逐字段拷贝，新字段在 backend
   路径静默变 0，而 legacy 路径整体传 `SimData` 照常工作（`cpu_backend` 报 0 / `legacy` 报 69775）。
   「legacy 绿 ⇒ 功能正常」是错觉。已修 + 就地留下警告注释。
2. **CUDA host-gen 回退分支（`LUMICE_DISABLE_DEVICE_GEN`）漏计朝向** —— Metal 三处消耗点都补了、
   CUDA 只补了两处，漏掉的分支产出「偏低但看起来正常」的数字而非显眼的 0。

## 验证

- `build.sh -tj/-sj release` exit 0；ctest 5/5；gui_test 5/5
- `pytest -q` 146 passed / 30 skipped；`pytest -q -m slow` 66 passed
- 三闸（format / policies / new-refs）exit 0
- **AC4 门禁之外的独立探针**：真实 CLI、默认 12 worker、不 pin seed → 确定性朝向 config 报
  `orientations=5`（= config 常量，非 `5×12`），随机朝向报 ~69k
- **红态自证**：5 个探针（含把 `+=` 改 `=`）均按预期变红且**有区分度**（不依赖累加的用例保持绿），
  验后 revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)