### PR TITLE
fix(install-hooks): resolve the hooks dir via git rev-parse --git-path

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
-# Install Lumice's local git hooks into .git/hooks. Currently installs the
+# Install Lumice's local git hooks into the repo's hooks directory (resolved
+# via `git rev-parse --git-path hooks`, not assumed to be .git/hooks — in a
+# git worktree, .git is a file, not a directory, and hooks live in the main
+# checkout's .git/hooks, shared across all worktrees). Currently installs the
 # pre-commit hook (policy checks + clang-format on staged files). The existing
 # git-lfs hooks (post-checkout / post-commit / post-merge / pre-push) are left
 # untouched — we only add pre-commit, which git-lfs does not use.
@@ -11,7 +14,8 @@
 set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 HOOK_SRC="$REPO_ROOT/scripts/hooks/pre-commit"
-HOOK_DST="$REPO_ROOT/.git/hooks/pre-commit"
+HOOK_DIR=$(git -C "$REPO_ROOT" rev-parse --git-path hooks)
+HOOK_DST="$HOOK_DIR/pre-commit"
 
 chmod +x "$HOOK_SRC"
 


### PR DESCRIPTION
`./scripts/install-hooks.sh` fails inside a git worktree.

## What happens

The destination was hardcoded as `$REPO_ROOT/.git/hooks/pre-commit`. In a worktree, `.git` is a *file* holding `gitdir: <main>/.git/worktrees/<name>`, not a directory — so both the `ln` and the `cp` fallback fail:

```
cp: .../.git/hooks/pre-commit: Not a directory      # rc=1, "Done." never prints
```

In the main repo `.git` is a directory, so it has always worked there.

`git rev-parse --git-path hooks` resolves correctly in both: inside a worktree it returns the *main repo's* hooks directory, which is the right answer — hooks are shared across worktrees. The relative symlink target `../../scripts/hooks/pre-commit` still resolves from that directory, so it is unchanged.

## Severity — narrower than it first looks

Worth stating so nobody over-reads this: the failure is **visible** (an error, `rc=1`, and no `Done.` line), not silent. And because hooks are shared across worktrees, installing once from the main repo already covers every worktree — which is why this went unnoticed. The only configuration that actually loses the hook is "never installed from the main repo, and only ever works inside a worktree".

## Verification

Both environments, exit codes taken by redirect rather than a pipe (a pipe reports `tail`'s status, not the command's):

| | `install-hooks.sh` | hook actually fires |
|---|---|---|
| worktree | rc=0, prints `Done.` | yes — an empty commit runs the policy + new-reference checks |
| main repo | rc=0, prints `Done.` | unchanged; still a symlink to `scripts/hooks/pre-commit` |

Red-state: reverting to the hardcoded path reproduces `rc=1` with the same error inside a worktree, then goes green again on restore.

## Provenance

Found by the documentation-fidelity pass in #233, which ran every command in `AGENTS.md` and compared the result against what the docs claim. This was the single mismatch it turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)