### PR TITLE
feat(gui): show sampling density (crystal/orientation draws) in the status bar

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <fstream>
 #include <future>
 #include <optional>
@@ -1295,6 +1296,82 @@ bool ShouldDefaultEnableColorsOnOpen(bool raypath_color_empty) {
 // rendering call site from drifting away from the same read.
 bool ShouldTintColorsButton(bool raypath_color_empty) {
   return !raypath_color_empty;
+}
+
+namespace {
+
+// Magnitude notation shared with the status bar's "Total rays" segment (app_panels.cpp): a count is
+// shown as "5.4 x10^6". Keeping one notation across the whole row matters because the sampling
+// readout sits directly beside "Total rays" — two notations side by side read as two different
+// kinds of quantity. Below 1e3 the scaled form would be sillier than the plain integer ("1 per
+// 0.0 x10^3 rays"), so small ratios print bare.
+std::string FormatMagnitude(double v) {
+  char buf[64];
+  if (v >= 1e9) {
+    snprintf(buf, sizeof(buf), "%.1f x10^9", v / 1e9);
+  } else if (v >= 1e6) {
+    snprintf(buf, sizeof(buf), "%.1f x10^6", v / 1e6);
+  } else if (v >= 1e3) {
+    snprintf(buf, sizeof(buf), "%.1f x10^3", v / 1e3);
+  } else {
+    snprintf(buf, sizeof(buf), "%.0f", v);
+  }
+  return buf;
+}
+
+// Thousands-grouped raw count for the tooltip ("5,419,520"). Hand-rolled rather than via
+// std::locale: the grouping character is locale-dependent, and a reference screenshot taken on one
+// machine must not depend on the locale of the machine that runs the test.
+std::string FormatGrouped(LUMICE_RayCount n) {
+  std::string digits = std::to_string(n);
+  std::string out;
+  int count = 0;
+  for (auto it = digits.rbegin(); it != digits.rend(); ++it) {
+    if (count > 0 && count % 3 == 0) {
+      out.push_back(',');
+    }
+    out.push_back(*it);
+    ++count;
+  }
+  std::reverse(out.begin(), out.end());
+  return out;
+}
+
+// Placeholder for both "nothing traced yet" and "no draws recorded". One shared spelling on
+// purpose: from the user's side the two are the same statement — this run has no density to report.
+constexpr const char* kSamplingNotAvailable = "n/a";
+
+}  // namespace
+
+// See app.hpp for the full branch contract.
+std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays) {
+  if (rays == 0 || draws == 0) {
+    return kSamplingNotAvailable;
+  }
+  if (draws >= rays) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%.2f/ray", static_cast<double>(draws) / static_cast<double>(rays));
+    return buf;
+  }
+  return "1 per " + FormatMagnitude(static_cast<double>(rays) / static_cast<double>(draws)) + " rays";
+}
+
+std::string FormatSamplingSegment(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays) {
+  // U+00B7 MIDDLE DOT, spelled as UTF-8 bytes so the source file stays plain ASCII.
+  return "| Sampling: shape " + FormatSamplingDensity(crystals, rays) + " \xC2\xB7 orient " +
+         FormatSamplingDensity(orientations, rays);
+}
+
+std::string FormatSamplingTooltip(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays) {
+  // Raw counts alongside the densities: the density answers "is this dimension sampled?", the raw
+  // count is what a user quotes in a bug report, and neither substitutes for the other.
+  std::string out = "Sampling density -- this run\n";
+  out += "  Rays traced         " + FormatGrouped(rays) + "\n";
+  out += "  Shape draws         " + FormatGrouped(crystals) + "   " + FormatSamplingDensity(crystals, rays) + "\n";
+  out += "  Orientation draws   " + FormatGrouped(orientations) + "   " + FormatSamplingDensity(orientations, rays) +
+         "\n\n";
+  out += kSamplingCrossBackendNote;
+  return out;
 }
 
 // task-348.3 (⑤/⑥) shared writer — see app.hpp. Two-line function on purpose: the whole

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1341,10 +1341,6 @@ std::string FormatGrouped(LUMICE_RayCount n) {
 // purpose: from the user's side the two are the same statement — this run has no density to report.
 constexpr const char* kSamplingNotAvailable = "n/a";
 
-}  // namespace
-
-namespace {
-
 // Single implementation behind both spellings — see app.hpp. `with_rays_word` only ever adds or
 // omits a trailing literal; every number is computed once, here.
 std::string FormatDensityImpl(LUMICE_RayCount draws, LUMICE_RayCount rays, bool with_rays_word) {

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1103,6 +1103,8 @@ bool DoRun(bool user_initiated) {
     g_state.run_intent = RunIntent::kRunning;
     g_state.stats_ray_seg_num = 0;
     g_state.stats_sim_ray_num = 0;
+    g_state.stats_crystal_num = 0;
+    g_state.stats_orientation_num = 0;
     // Safety check: if GUI predicted reuse but server rebuilt consumers, the poller
     // was not stopped and may hold dangling pointers. This should never happen because
     // the GUI comparison is a superset of the server's NeedsRebuild check.
@@ -1400,6 +1402,8 @@ void SyncFromPoller() {
   if (snap->epoch == g_state.committed_epoch && snap->stats_sim_ray_num > 0) {
     g_state.stats_ray_seg_num = snap->stats_ray_seg_num;
     g_state.stats_sim_ray_num = snap->stats_sim_ray_num;
+    g_state.stats_crystal_num = snap->stats_crystal_num;
+    g_state.stats_orientation_num = snap->stats_orientation_num;
   }
 
   // Upload XYZ float texture (GL call — must be on main thread). Gate is the pure

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1343,8 +1343,11 @@ constexpr const char* kSamplingNotAvailable = "n/a";
 
 }  // namespace
 
-// See app.hpp for the full branch contract.
-std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays) {
+namespace {
+
+// Single implementation behind both spellings — see app.hpp. `with_rays_word` only ever adds or
+// omits a trailing literal; every number is computed once, here.
+std::string FormatDensityImpl(LUMICE_RayCount draws, LUMICE_RayCount rays, bool with_rays_word) {
   if (rays == 0 || draws == 0) {
     return kSamplingNotAvailable;
   }
@@ -1353,13 +1356,31 @@ std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays) {
     snprintf(buf, sizeof(buf), "%.2f/ray", static_cast<double>(draws) / static_cast<double>(rays));
     return buf;
   }
-  return "1 per " + FormatMagnitude(static_cast<double>(rays) / static_cast<double>(draws)) + " rays";
+  std::string out = "1 per " + FormatMagnitude(static_cast<double>(rays) / static_cast<double>(draws));
+  if (with_rays_word) {
+    out += " rays";
+  }
+  return out;
+}
+
+}  // namespace
+
+// See app.hpp for the full branch contract.
+std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays) {
+  return FormatDensityImpl(draws, rays, true);
+}
+
+std::string FormatSamplingDensityCompact(LUMICE_RayCount draws, LUMICE_RayCount rays) {
+  return FormatDensityImpl(draws, rays, false);
 }
 
 std::string FormatSamplingSegment(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays) {
+  // No "Sampling:" prefix: the two labels below already say what the numbers are, the tooltip's
+  // first line spells it out in full, and at 1024 px (the enforced minimum window width) the row
+  // has no spare space for a word that carries no information the labels do not.
   // U+00B7 MIDDLE DOT, spelled as UTF-8 bytes so the source file stays plain ASCII.
-  return "| Sampling: shape " + FormatSamplingDensity(crystals, rays) + " \xC2\xB7 orient " +
-         FormatSamplingDensity(orientations, rays);
+  return "| shape " + FormatSamplingDensityCompact(crystals, rays) + " \xC2\xB7 orient " +
+         FormatSamplingDensityCompact(orientations, rays);
 }
 
 std::string FormatSamplingTooltip(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays) {

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -329,6 +329,13 @@ inline constexpr const char* kSamplingCrossBackendNote =
 // change with no signal whatsoever arriving here.
 std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays);
 
+// Same reading without the trailing " rays" ("1 per 5.4 x10^6"). The status bar is a single
+// non-wrapping SameLine run sharing one row with the Log button, and measurement put the verbose
+// form 477 px wide in its worst case against a 1024 px enforced minimum window width -- it did not
+// fit. The word is kept in the tooltip, which has the room. Both spellings come out of one
+// implementation so the numbers cannot drift apart.
+std::string FormatSamplingDensityCompact(LUMICE_RayCount draws, LUMICE_RayCount rays);
+
 // The exact status-bar segment text, and the exact hover-tooltip text. Split out as pure functions
 // so a test can pin what the status bar says without doing OCR on a screenshot, while the
 // screenshot test independently pins that this text reaches actual pixels.

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <filesystem>
 #include <memory>
+#include <string>
 
 #include "gui/crystal_preview.hpp"
 #include "gui/crystal_renderer.hpp"
@@ -298,6 +299,41 @@ bool ShouldDefaultEnableColorsOnOpen(bool raypath_color_empty);
 // new state source per scrum-353 GUI state governance). Pure predicate; the
 // caller in RenderTopBar wraps ImGui::Button with PushStyleColor when true.
 bool ShouldTintColorsButton(bool raypath_color_empty);
+
+// ---- Sampling-density readout (status bar) ----
+//
+// The two counters behind this readout are NOT comparable across backends: the GPU route draws one
+// geometry per batch by design, so its shape count sits orders of magnitude below the CPU route's
+// for the same scene. That difference IS the sampling-density difference, made visible — it is not
+// a regression, and it must never be turned into a cross-backend parity assertion.
+//
+// This sentence is the only thing standing between a user and a false bug report, and plain tooltip
+// prose is exactly what gets deleted by a passing refactor without any signal. Hence: a named
+// constant, asserted by test_gui_sampling_density_stats.cpp to still be present in the assembled
+// tooltip. Reword it freely; deleting it is the thing the test is there to catch.
+inline constexpr const char* kSamplingCrossBackendNote =
+    "Not comparable across backends: the GPU route reuses one\n"
+    "geometry per batch by design, so shape reads lower on GPU.";
+
+// Format one sampling counter as a density relative to the rays actually traced. Pure function;
+// the whole numeric contract of the readout lives here so the render call site cannot drift.
+//
+//   rays == 0                -> "n/a"   (cold start: nothing has been traced yet)
+//   draws == 0 && rays > 0   -> "n/a"   (would be the second division by zero, see below)
+//   draws >= rays            -> "1.00/ray"          (this dimension is resampled per ray)
+//   0 < draws < rays         -> "1 per 5.4 x10^6 rays"  (this dimension is barely sampled)
+//
+// Both zero branches are the function's own responsibility, not the caller's. The `draws == 0` one
+// in particular cannot be waved off as unreachable: reaching it needs only the two-term counter
+// convention in trace_backend.hpp to change, and that is a DIFFERENT module's invariant — it would
+// change with no signal whatsoever arriving here.
+std::string FormatSamplingDensity(LUMICE_RayCount draws, LUMICE_RayCount rays);
+
+// The exact status-bar segment text, and the exact hover-tooltip text. Split out as pure functions
+// so a test can pin what the status bar says without doing OCR on a screenshot, while the
+// screenshot test independently pins that this text reaches actual pixels.
+std::string FormatSamplingSegment(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays);
+std::string FormatSamplingTooltip(LUMICE_RayCount crystals, LUMICE_RayCount orientations, LUMICE_RayCount rays);
 
 // task-348.3 AC1/AC2 shared writer: toggle the user preference `show_composite_preview`.
 // Called from both the top-bar Colored checkbox (app_panels.cpp; icon-only Button in

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1261,6 +1261,25 @@ void RenderStatusBar(float window_width, float window_height) {
       snprintf(buf, sizeof(buf), "| Total rays: %.1f x10^3", n / 1e3);
     }
     ImGui::Text("%s", buf);
+
+    // Sampling density. Deliberately inside the SAME `stats_sim_ray_num > 0` gate as "Total rays"
+    // above and under no additional condition of its own: whether a dimension is randomized is
+    // exactly what this readout is for, so hiding it when a dimension is fixed would suppress the
+    // answer in the case the user most needs it ("1 per 5.4 x10^6 rays" IS the explanation for an
+    // over-sharp render). The shared gate only asks "has a run happened", which is orthogonal.
+    //
+    // Plain text on purpose: no progress bar, no color grading, no check/cross. Neither counter has
+    // a "good" value -- a low shape count is correct for a fixed shape and expected on the GPU
+    // route -- so any better/worse styling here would manufacture false alarms.
+    ImGui::SameLine();
+    const std::string sampling =
+        FormatSamplingSegment(g_state.stats_crystal_num, g_state.stats_orientation_num, g_state.stats_sim_ray_num);
+    ImGui::TextUnformatted(sampling.c_str());
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("%s", FormatSamplingTooltip(g_state.stats_crystal_num, g_state.stats_orientation_num,
+                                                    g_state.stats_sim_ray_num)
+                                  .c_str());
+    }
   }
 
   // Sim resolution + lens info (renderer is always embedded in GuiState).

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1271,6 +1271,12 @@ void RenderStatusBar(float window_width, float window_height) {
     // Plain text on purpose: no progress bar, no color grading, no check/cross. Neither counter has
     // a "good" value -- a low shape count is correct for a fixed shape and expected on the GPU
     // route -- so any better/worse styling here would manufacture false alarms.
+    // NOTE: this segment builds its text in a pure function (app.cpp) while "Total rays" above
+    // formats inline. The inconsistency is deliberate, not an oversight — do NOT "unify" it by
+    // inlining this one. `ImGui::Text`/`TextUnformatted` submit an item ID of 0, so a test cannot
+    // address the rendered string through the item API; extracting the text lets the string itself
+    // be asserted, with a separate pixel test proving it reaches the framebuffer. A future status
+    // bar segment that wants test coverage should follow THIS pattern rather than the inline one.
     ImGui::SameLine();
     const std::string sampling =
         FormatSamplingSegment(g_state.stats_crystal_num, g_state.stats_orientation_num, g_state.stats_sim_ray_num);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -1049,6 +1049,13 @@ struct GuiState {
   // Stats from last poll
   LUMICE_RayCount stats_ray_seg_num = 0;
   LUMICE_RayCount stats_sim_ray_num = 0;
+  // Sampling-density counters, mirroring LUMICE_StatsResult::crystal_num / ::orientation_num. Same
+  // snapshot and staleness semantics as the two above — they travel the identical poller path, epoch gate and
+  // DoRun reset, so "updates as the run progresses" holds by construction rather than by a second
+  // update path. NOT comparable across backends (see lumice.h: the GPU route reuses one geometry
+  // per batch by design); the status-bar tooltip carries that caveat.
+  LUMICE_RayCount stats_crystal_num = 0;
+  LUMICE_RayCount stats_orientation_num = 0;
   float snapshot_intensity = 0;                 // Per-pixel landed intensity for XYZ→RGB normalization
   int effective_pixels = 0;                     // Non-zero pixel count (for stats display)
   unsigned long long texture_upload_count = 0;  // Cumulative texture uploads (diagnostic counter)

--- a/src/gui/gui_state_tiers.hpp
+++ b/src/gui/gui_state_tiers.hpp
@@ -135,6 +135,8 @@ inline constexpr const char* kDerivedFieldsExcludeList[] = {
     // Stats readbacks (populated from poller snapshots)
     "stats_ray_seg_num",
     "stats_sim_ray_num",
+    "stats_crystal_num",
+    "stats_orientation_num",
     "snapshot_intensity",
     "effective_pixels",
     "texture_upload_count",

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -241,6 +241,8 @@ void ServerPoller::PollOnce() {
   bool have_new_stats = false;
   LUMICE_RayCount new_ray_seg = 0;
   LUMICE_RayCount new_sim_ray = 0;
+  LUMICE_RayCount new_crystal = 0;
+  LUMICE_RayCount new_orientation = 0;
   std::shared_ptr<const TexturePayload> new_payload;  // non-null only when a fresh texture materialized
 
   if (has_new_snapshot) {
@@ -254,6 +256,8 @@ void ServerPoller::PollOnce() {
       have_new_stats = true;
       new_ray_seg = cached_stats.ray_seg_num;
       new_sim_ray = cached_stats.sim_ray_num;
+      new_crystal = cached_stats.crystal_num;
+      new_orientation = cached_stats.orientation_num;
     }
 
     // Quality gate: skip texture overwrite for sparse snapshots (too few rays = visible flicker).
@@ -340,9 +344,13 @@ void ServerPoller::PollOnce() {
     if (have_new_stats) {
       next->stats_ray_seg_num = new_ray_seg;
       next->stats_sim_ray_num = new_sim_ray;
+      next->stats_crystal_num = new_crystal;
+      next->stats_orientation_num = new_orientation;
     } else if (prev) {
       next->stats_ray_seg_num = prev->stats_ray_seg_num;
       next->stats_sim_ray_num = prev->stats_sim_ray_num;
+      next->stats_crystal_num = prev->stats_crystal_num;
+      next->stats_orientation_num = prev->stats_orientation_num;
     }
     // Texture: a freshly materialized payload gets a new monotonic serial; otherwise carry the
     // previous payload pointer + serial forward (sparse / gate-rejected / no-new-generation) so

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -65,6 +65,9 @@ struct PreviewSnapshot {
   int lifecycle = LUMICE_LIFECYCLE_IDLE;
   LUMICE_RayCount stats_ray_seg_num = 0;
   LUMICE_RayCount stats_sim_ray_num = 0;
+  // Sampling-density counters, carried in the same coherent bundle as the two above.
+  LUMICE_RayCount stats_crystal_num = 0;
+  LUMICE_RayCount stats_orientation_num = 0;
   // Display payload: shared, immutable. Null / carried-forward on sparse / gate-rejected /
   // invalidated polls.
   std::shared_ptr<const TexturePayload> payload;

--- a/test/gui/CMakeLists.txt
+++ b/test/gui/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(gui_test
     functional/test_gui_lifecycle.cpp
     functional/test_gui_composite_preview.cpp
     functional/test_gui_state_reconcile.cpp
+    functional/test_gui_sampling_density_stats.cpp
     functional/test_gui_user_defaults.cpp
     functional/test_gui_defaults_diff.cpp
     functional/test_gui_defaults_panel.cpp

--- a/test/gui/functional/test_gui_sampling_density_stats.cpp
+++ b/test/gui/functional/test_gui_sampling_density_stats.cpp
@@ -11,23 +11,74 @@
 //  4. sampling_density/draws_zero        — the SECOND division by zero (rays / draws)
 //  5. sampling_density/cross_backend_note_present — the tooltip caveat is still in the tooltip
 //  6. sampling_density/segment_shows_both_counters — both dimensions reach the segment text
+//  7. sampling_density/status_bar_renders_sampling — the readout reaches actual framebuffer pixels
+//  8. sampling_density/status_bar_width_budget     — the row still fits at the minimum window width
+//
+// Tests 7 and 8 need a live frame; 1-6 are pure and touch neither GL nor the server.
 //
 // Cases 3 and 4 are not symmetric decoration. Case 4 guards `rays / draws` in the ratio < 1 branch,
 // whose "cannot happen" rests on the two-term counter convention in trace_backend.hpp — an
 // invariant owned by a different module, which can therefore change without any signal reaching
 // this file.
 
+#include <cmath>
 #include <string>
+#include <vector>
 
+#include "IconsFontAwesome6.h"
 #include "gui/app.hpp"
+#include "gui/gui_constants.hpp"
 #include "test_gui_shared.hpp"
 
 namespace {
 
 using lumice::gui::FormatSamplingDensity;
+using lumice::gui::FormatSamplingDensityCompact;
 using lumice::gui::FormatSamplingSegment;
 using lumice::gui::FormatSamplingTooltip;
+using lumice::gui::g_state;
 using lumice::gui::kSamplingCrossBackendNote;
+
+// Capture the live rectangle of the status-bar window out of the default framebuffer. Mirrors the
+// coordinate conversion in the modal_layout suite: ImGui is origin-top-left in window coordinates,
+// glReadPixels is origin-bottom-left in framebuffer pixels.
+bool CaptureStatusBar(ImGuiTestContext* ctx, std::vector<unsigned char>* out) {
+  ImGuiWindow* win = ctx->GetWindowByRef("##StatusBar");
+  if (win == nullptr) {
+    return false;
+  }
+  const ImGuiIO& io = ImGui::GetIO();
+  const float win_h = io.DisplaySize.y;
+  const float sx = io.DisplayFramebufferScale.x;
+  const float sy = io.DisplayFramebufferScale.y;
+  const ImVec2 vp_pos = ImGui::GetMainViewport()->Pos;
+  const float lx = win->Pos.x - vp_pos.x;
+  const float ly = win->Pos.y - vp_pos.y;
+
+  g_fullframe_capture.Reset();
+  g_fullframe_capture.rect_x = static_cast<int>(std::lround(lx * sx));
+  g_fullframe_capture.rect_y = static_cast<int>(std::lround((win_h - (ly + win->Size.y)) * sy));
+  g_fullframe_capture.rect_w = static_cast<int>(std::lround(win->Size.x * sx));
+  g_fullframe_capture.rect_h = static_cast<int>(std::lround(win->Size.y * sy));
+  g_fullframe_capture.requested.store(true);
+  for (int i = 0; i < 10 && !g_fullframe_capture.done.load(); ++i) {
+    ctx->Yield(1);
+  }
+  if (!g_fullframe_capture.done.load()) {
+    return false;
+  }
+  *out = g_fullframe_capture.pixels;
+  return !out->empty();
+}
+
+// Inject a poll result directly. SyncFromPoller only writes these fields when a snapshot's epoch
+// matches committed_epoch and its ray count is non-zero, and no run happens in this suite, so the
+// injected values survive across frames.
+void InjectStats(unsigned long long crystals, unsigned long long orientations, unsigned long long rays) {
+  g_state.stats_crystal_num = crystals;
+  g_state.stats_orientation_num = orientations;
+  g_state.stats_sim_ray_num = rays;
+}
 
 bool Contains(const std::string& haystack, const std::string& needle) {
   return haystack.find(needle) != std::string::npos;
@@ -83,6 +134,15 @@ void RegisterSamplingDensityStatsTests(ImGuiTestEngine* engine) {
     // The GPU route's one-geometry-per-batch reading — an order of magnitude below the CPU route's
     // for the same scene, and specifically NOT an error state. It must format normally.
     IM_CHECK_STR_EQ(FormatSamplingDensity(5, 5000000).c_str(), "1 per 1.0 x10^6 rays");
+
+    // The compact spelling differs from the verbose one by the trailing word and nothing else --
+    // the status bar and the tooltip must never disagree about the number itself.
+    IM_CHECK_STR_EQ(FormatSamplingDensityCompact(1, 5419520).c_str(), "1 per 5.4 x10^6");
+    IM_CHECK_STR_EQ((FormatSamplingDensityCompact(1, 5419520) + " rays").c_str(),
+                    FormatSamplingDensity(1, 5419520).c_str());
+    // The branches with no trailing word are spelled identically by both.
+    IM_CHECK_STR_EQ(FormatSamplingDensityCompact(100, 100).c_str(), FormatSamplingDensity(100, 100).c_str());
+    IM_CHECK_STR_EQ(FormatSamplingDensityCompact(0, 100).c_str(), FormatSamplingDensity(0, 100).c_str());
   };
 
   // ---- Test 3: rays == 0 (cold start) ----
@@ -155,7 +215,10 @@ void RegisterSamplingDensityStatsTests(ImGuiTestEngine* engine) {
     // to a per-ray orientation draw). Pinning both readings in one string is what proves the
     // segment does not quietly show one dimension twice.
     const std::string segment = FormatSamplingSegment(1, 5419520, 5419520);
-    IM_CHECK(Contains(segment, "shape 1 per 5.4 x10^6 rays"));
+    // The status bar carries the compact spelling (no trailing " rays"); the tooltip carries the
+    // verbose one. Both are pinned so a change to either has to be deliberate.
+    IM_CHECK(Contains(segment, "shape 1 per 5.4 x10^6 \xC2\xB7"));
+    IM_CHECK(!Contains(segment, "rays"));
     IM_CHECK(Contains(segment, "orient 1.00/ray"));
 
     // Raw counts belong to the tooltip, grouped, and locale-independently so a run on another
@@ -167,5 +230,117 @@ void RegisterSamplingDensityStatsTests(ImGuiTestEngine* engine) {
     // dense enough", which ray_seg_num does not speak to. Nothing here should mention segments.
     IM_CHECK(!Contains(segment, "seg"));
     IM_CHECK(!Contains(tooltip, "Ray segments"));
+  };
+
+  // ---- Test 7: the readout reaches actual pixels, driven by the two new fields ----
+  //
+  // Why a differential capture rather than reading the item's text back: ImGui::TextUnformatted
+  // submits its item with ID 0, so imgui_test_engine's ItemInfo (which is keyed by ID) cannot
+  // address it. Holding stats_sim_ray_num fixed while varying only the two sampling counters makes
+  // the "Total rays" segment byte-identical between the two frames, so ANY pixel difference in the
+  // status bar has to have come from the sampling segment. That is a stronger statement than a
+  // string comparison would be: it proves delivery all the way to the framebuffer, and it fails if
+  // the segment is never rendered, is gated out, or reads the wrong field.
+  ImGuiTest* t7 = IM_REGISTER_TEST(engine, "sampling_density", "status_bar_renders_sampling");
+  t7->TestFunc = [](ImGuiTestContext* ctx) {
+    ResetTestState();
+    ctx->Yield(3);
+    // A hovered status bar would pop the tooltip and contaminate the comparison.
+    ctx->MouseMoveToPos(ImVec2(-100.0f, -100.0f));
+    ctx->Yield(2);
+
+    constexpr unsigned long long kRays = 5419520;
+
+    // Frame A: fixed shape + per-ray orientation (the common configuration).
+    InjectStats(1, kRays, kRays);
+    ctx->Yield(3);
+    std::vector<unsigned char> frame_a;
+    IM_CHECK(CaptureStatusBar(ctx, &frame_a));
+
+    // A capture that silently read back zeros would make every comparison below vacuous.
+    bool has_nonzero = false;
+    for (size_t i = 0; i < frame_a.size() && !has_nonzero; ++i) {
+      has_nonzero = frame_a[i] != 0;
+    }
+    IM_CHECK(has_nonzero);
+
+    // Frame B: same ray count, different sampling counters -> a different sampling segment
+    // ("1 per 5.4 x10^6 rays" becomes "1.00/ray"), and an identical "Total rays" segment.
+    IM_CHECK_STR_NE(FormatSamplingSegment(1, kRays, kRays).c_str(), FormatSamplingSegment(kRays, 1, kRays).c_str());
+    InjectStats(kRays, 1, kRays);
+    ctx->Yield(3);
+    std::vector<unsigned char> frame_b;
+    IM_CHECK(CaptureStatusBar(ctx, &frame_b));
+    IM_CHECK_EQ(frame_a.size(), frame_b.size());
+    IM_CHECK(frame_a != frame_b);
+
+    // Frame C: back to frame A's values. Equality here is what makes the inequality above mean
+    // something -- without it, frame_a != frame_b could just be capture noise.
+    InjectStats(1, kRays, kRays);
+    ctx->Yield(3);
+    std::vector<unsigned char> frame_c;
+    IM_CHECK(CaptureStatusBar(ctx, &frame_c));
+    IM_CHECK(frame_a == frame_c);
+
+    InjectStats(0, 0, 0);
+  };
+
+  // ---- Test 8: the status bar's left cluster still fits beside the Log button (AC7) ----
+  //
+  // The concrete failure this guards: ImGui does not ellipsize a SameLine run. An over-long left
+  // cluster simply overflows, and the right-aligned Log button (positioned at WindowWidth - log_w -
+  // WindowPadding.x) gets overlapped and pushed out of reach. Measuring text extents is what makes
+  // this checkable without resizing a real window.
+  //
+  // The floor is kMinWindowWidth, which main.cpp hands to glfwSetWindowSizeLimits: the user cannot
+  // drag the window narrower than that, so it is the actual narrowest case rather than a number
+  // chosen here. The one budget figure this test does have to declare is the file name allowance,
+  // because the file name is unbounded and can overflow this row with or without a sampling
+  // readout -- a pre-existing property of the status bar, not something this feature introduces.
+  ImGuiTest* t8 = IM_REGISTER_TEST(engine, "sampling_density", "status_bar_width_budget");
+  t8->TestFunc = [](ImGuiTestContext* ctx) {
+    ResetTestState();
+    ctx->Yield(3);
+
+    const ImGuiStyle& style = ImGui::GetStyle();
+    const float spacing = style.ItemSpacing.x;
+
+    // Worst case on every bounded segment simultaneously: the longest status word, a ten-digit ray
+    // count, the longest lens name, and both sampling counters in their widest (barely-sampled)
+    // form -- which is a real configuration, not a contrived one: a scene with a fixed shape AND a
+    // fixed orientation reads "1 per N" on both.
+    const std::string status_word = "Simulating...";
+    const std::string total_rays = "| Total rays: 9.9 x10^9";
+    const std::string sampling = FormatSamplingSegment(1, 1, 9900000000ULL);
+    const std::string res_lens = "| 1024x512  Dual Fisheye  FOV:180";
+    const std::string log_label = ICON_FA_CHEVRON_RIGHT " Log";
+
+    // Both-barely-sampled really is the widest the segment gets, so the budget below is not
+    // measuring an accidentally narrow case.
+    const float sampling_w = ImGui::CalcTextSize(sampling.c_str()).x;
+    IM_CHECK_GE(sampling_w, ImGui::CalcTextSize(FormatSamplingSegment(1, 1, 1).c_str()).x);
+    IM_CHECK_GE(sampling_w, ImGui::CalcTextSize(FormatSamplingSegment(0, 0, 0).c_str()).x);
+
+    // Declared allowance for the (unbounded) file name segment. "scene.lmc *" is the shape of the
+    // repo's own example config plus the dirty marker.
+    const float filename_allowance = ImGui::CalcTextSize("| scene.lmc *").x;
+
+    const float bounded = style.WindowPadding.x + ImGui::CalcTextSize(status_word.c_str()).x + spacing +
+                          ImGui::CalcTextSize(total_rays.c_str()).x + spacing + sampling_w + spacing +
+                          ImGui::CalcTextSize(res_lens.c_str()).x + spacing;
+    const float log_button = ImGui::CalcTextSize(log_label.c_str()).x + style.FramePadding.x * 2;
+    const float required = bounded + filename_allowance + spacing + log_button + style.WindowPadding.x;
+    const float floor_width = static_cast<float>(lumice::gui::kMinWindowWidth);
+
+    fprintf(stderr,
+            "[sampling_density] sampling=%.1f bounded=%.1f filename_allowance=%.1f log=%.1f required=%.1f "
+            "min_window=%.1f headroom=%.1f\n",
+            sampling_w, bounded, filename_allowance, log_button, required, floor_width, floor_width - required);
+
+    IM_CHECK_LE(required, floor_width);
+
+    // The sampling segment must not become the row's dominant consumer. Without this the check
+    // above could be satisfied by shrinking the file name allowance to nothing.
+    IM_CHECK_LT(sampling_w, ImGui::CalcTextSize(res_lens.c_str()).x + ImGui::CalcTextSize(total_rays.c_str()).x);
   };
 }

--- a/test/gui/functional/test_gui_sampling_density_stats.cpp
+++ b/test/gui/functional/test_gui_sampling_density_stats.cpp
@@ -1,0 +1,171 @@
+// PURE unit tests for the status-bar sampling-density readout. No GL, no server — peer to
+// test_gui_state_reconcile.cpp: the TestFunc calls the formatter directly and checks its output.
+//
+// Why these live in gui_test rather than the ctest unit binary: the functions under test are
+// GUI-local (declared in gui/app.hpp), and src/gui/ is not linked into unit_correctness_test.
+//
+// Tests:
+//  1. sampling_density/ratio_ge_one      — the resampled-per-ray branch, including draws == rays
+//  2. sampling_density/ratio_lt_one      — the barely-sampled branch and its x10^N notation
+//  3. sampling_density/rays_zero         — cold start: no division by zero, no inf/nan text
+//  4. sampling_density/draws_zero        — the SECOND division by zero (rays / draws)
+//  5. sampling_density/cross_backend_note_present — the tooltip caveat is still in the tooltip
+//  6. sampling_density/segment_shows_both_counters — both dimensions reach the segment text
+//
+// Cases 3 and 4 are not symmetric decoration. Case 4 guards `rays / draws` in the ratio < 1 branch,
+// whose "cannot happen" rests on the two-term counter convention in trace_backend.hpp — an
+// invariant owned by a different module, which can therefore change without any signal reaching
+// this file.
+
+#include <string>
+
+#include "gui/app.hpp"
+#include "test_gui_shared.hpp"
+
+namespace {
+
+using lumice::gui::FormatSamplingDensity;
+using lumice::gui::FormatSamplingSegment;
+using lumice::gui::FormatSamplingTooltip;
+using lumice::gui::kSamplingCrossBackendNote;
+
+bool Contains(const std::string& haystack, const std::string& needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+// Any of these appearing in user-facing text means a division went unguarded somewhere. Checked as
+// text rather than as a float predicate because the text is what the user would actually see, and
+// because snprintf spells them differently across platforms ("inf" / "-nan(ind)").
+bool LooksNumericallyBroken(const std::string& s) {
+  return Contains(s, "inf") || Contains(s, "nan") || Contains(s, "ind");
+}
+
+}  // namespace
+
+void RegisterSamplingDensityStatsTests(ImGuiTestEngine* engine) {
+  // ---- Test 1: ratio >= 1 — this dimension is resampled per ray ----
+  ImGuiTest* t1 = IM_REGISTER_TEST(engine, "sampling_density", "ratio_ge_one");
+  t1->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    // Exactly one draw per ray — the overwhelmingly common "random orientation" reading, and the
+    // boundary between the two branches. It must land in the >= branch, not the < one.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(5419520, 5419520).c_str(), "1.00/ray");
+
+    // Above one (multi-scattering layers can draw more than once per ray).
+    IM_CHECK_STR_EQ(FormatSamplingDensity(200, 100).c_str(), "2.00/ray");
+
+    // Rounding is to two decimals, and does not silently truncate to an integer.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(150, 100).c_str(), "1.50/ray");
+
+    // The value is a ratio, not a raw count: two runs with the same density but wildly different
+    // absolute sizes must read identically. This is the property that makes the number comparable
+    // across runs at all.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(3, 2).c_str(), FormatSamplingDensity(3000000, 2000000).c_str());
+  };
+
+  // ---- Test 2: ratio < 1 — this dimension is barely sampled ----
+  ImGuiTest* t2 = IM_REGISTER_TEST(engine, "sampling_density", "ratio_lt_one");
+  t2->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    // The measured "fixed shape + random orientation" case: 1 crystal over 5,419,520 rays. This is
+    // the reading the whole feature exists to make visible, so it is pinned literally.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(1, 5419520).c_str(), "1 per 5.4 x10^6 rays");
+
+    // x10^N notation matches the "Total rays" segment beside it (app_panels.cpp), across decades.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(1, 2000000000ULL).c_str(), "1 per 2.0 x10^9 rays");
+    IM_CHECK_STR_EQ(FormatSamplingDensity(1, 50000).c_str(), "1 per 50.0 x10^3 rays");
+
+    // Below 1e3 the scaled form would read "1 per 0.5 x10^3 rays"; print the plain integer instead.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(1, 500).c_str(), "1 per 500 rays");
+
+    // The GPU route's one-geometry-per-batch reading — an order of magnitude below the CPU route's
+    // for the same scene, and specifically NOT an error state. It must format normally.
+    IM_CHECK_STR_EQ(FormatSamplingDensity(5, 5000000).c_str(), "1 per 1.0 x10^6 rays");
+  };
+
+  // ---- Test 3: rays == 0 (cold start) ----
+  ImGuiTest* t3 = IM_REGISTER_TEST(engine, "sampling_density", "rays_zero");
+  t3->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    const std::string zero_rays = FormatSamplingDensity(42, 0);
+    IM_CHECK_STR_EQ(zero_rays.c_str(), "n/a");
+    IM_CHECK(!LooksNumericallyBroken(zero_rays));
+
+    // Both counters zero: still no division, still no inf/nan.
+    const std::string all_zero = FormatSamplingDensity(0, 0);
+    IM_CHECK_STR_EQ(all_zero.c_str(), "n/a");
+    IM_CHECK(!LooksNumericallyBroken(all_zero));
+
+    // The whole assembled segment and tooltip stay clean too — a guard in the formatter is worth
+    // nothing if the strings built around it reintroduce the artifact.
+    const std::string segment = FormatSamplingSegment(0, 0, 0);
+    IM_CHECK(!LooksNumericallyBroken(segment));
+    const std::string tooltip = FormatSamplingTooltip(0, 0, 0);
+    IM_CHECK(!LooksNumericallyBroken(tooltip));
+  };
+
+  // ---- Test 4: draws == 0 with rays > 0 (the second division by zero) ----
+  ImGuiTest* t4 = IM_REGISTER_TEST(engine, "sampling_density", "draws_zero");
+  t4->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    // Reaching the ratio < 1 branch with draws == 0 would evaluate rays / draws.
+    const std::string no_draws = FormatSamplingDensity(0, 5419520);
+    IM_CHECK_STR_EQ(no_draws.c_str(), "n/a");
+    IM_CHECK(!LooksNumericallyBroken(no_draws));
+
+    // A run where one dimension reports draws and the other does not: the reporting dimension must
+    // still format normally rather than the whole segment collapsing to a placeholder.
+    const std::string segment = FormatSamplingSegment(0, 1000, 1000);
+    IM_CHECK(!LooksNumericallyBroken(segment));
+    IM_CHECK(Contains(segment, "n/a"));
+    IM_CHECK(Contains(segment, "1.00/ray"));
+  };
+
+  // ---- Test 5: the cross-backend caveat survives in the tooltip ----
+  ImGuiTest* t5 = IM_REGISTER_TEST(engine, "sampling_density", "cross_backend_note_present");
+  t5->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    // This is the assertion that gives the caveat a failure signal. Without it the sentence is
+    // ordinary tooltip prose, and prose disappears in refactors without anything going red — which
+    // is the failure mode that produces false "the GPU backend regressed" bug reports.
+    IM_CHECK(Contains(FormatSamplingTooltip(1, 5419520, 5419520), kSamplingCrossBackendNote));
+
+    // Present regardless of which branch the densities take, including the degenerate run.
+    IM_CHECK(Contains(FormatSamplingTooltip(5000000, 5000000, 5000000), kSamplingCrossBackendNote));
+    IM_CHECK(Contains(FormatSamplingTooltip(0, 0, 0), kSamplingCrossBackendNote));
+
+    // The constant must actually say the thing, so that a future edit blanking it out (which would
+    // keep the substring check trivially true) does not pass.
+    const std::string note = kSamplingCrossBackendNote;
+    IM_CHECK_GT(note.size(), 40u);
+    IM_CHECK(Contains(note, "backend"));
+  };
+
+  // ---- Test 6: both counters reach the segment, with the raw counts in the tooltip ----
+  ImGuiTest* t6 = IM_REGISTER_TEST(engine, "sampling_density", "segment_shows_both_counters");
+  t6->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+
+    // The six-orders-of-magnitude spread between the two counters IS the signal (a fixed shape next
+    // to a per-ray orientation draw). Pinning both readings in one string is what proves the
+    // segment does not quietly show one dimension twice.
+    const std::string segment = FormatSamplingSegment(1, 5419520, 5419520);
+    IM_CHECK(Contains(segment, "shape 1 per 5.4 x10^6 rays"));
+    IM_CHECK(Contains(segment, "orient 1.00/ray"));
+
+    // Raw counts belong to the tooltip, grouped, and locale-independently so a run on another
+    // machine formats identically.
+    const std::string tooltip = FormatSamplingTooltip(1, 5419520, 5419520);
+    IM_CHECK(Contains(tooltip, "5,419,520"));
+
+    // AC6: ray-segment counts are deliberately absent from this readout — it answers "is sampling
+    // dense enough", which ray_seg_num does not speak to. Nothing here should mention segments.
+    IM_CHECK(!Contains(segment, "seg"));
+    IM_CHECK(!Contains(tooltip, "Ray segments"));
+  };
+}

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -403,6 +403,7 @@ int main(int argc, char** argv) {
   RegisterLifecycleTests(engine);
   RegisterCompositePreviewTests(engine);
   RegisterStateReconcileTests(engine);
+  RegisterSamplingDensityStatsTests(engine);
   RegisterPreviewAnimationTests(engine);
   RegisterCaptureHarnessTests(engine);
   RegisterUserDefaultsTests(engine);

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -208,6 +208,7 @@ void RegisterHandednessGuardTests(ImGuiTestEngine* engine);
 void RegisterLifecycleTests(ImGuiTestEngine* engine);
 void RegisterCompositePreviewTests(ImGuiTestEngine* engine);
 void RegisterStateReconcileTests(ImGuiTestEngine* engine);
+void RegisterSamplingDensityStatsTests(ImGuiTestEngine* engine);
 void RegisterPreviewAnimationTests(ImGuiTestEngine* engine);
 void RegisterCaptureHarnessTests(ImGuiTestEngine* engine);
 void RegisterLensProjectionTests(ImGuiTestEngine* engine);

--- a/test/unit-correctness/gui/test_user_defaults_eligibility.cpp
+++ b/test/unit-correctness/gui/test_user_defaults_eligibility.cpp
@@ -37,7 +37,11 @@ namespace {
 // default by accident.
 // 64 since defaults_panel_open (the defaults panel's open flag) was registered kSession: it is
 // runtime UI state, never persisted, so it is deliberately ineligible as a personal default.
-constexpr std::size_t kExpectedGovernedFieldCount = 64;
+// 66 since stats_crystal_num / stats_orientation_num joined kDerivedFieldsExcludeList: they are
+// run-result readbacks polled off LUMICE_GetCachedStats, exactly like the stats_ray_seg_num /
+// stats_sim_ray_num pair beside them, so they are kDerivedRuntime and deliberately ineligible as
+// personal defaults — a measurement of the last run is not a preference a user can pre-set.
+constexpr std::size_t kExpectedGovernedFieldCount = 66;
 
 std::vector<std::string> AllGovernedFieldNames() {
   std::vector<std::string> names;


### PR DESCRIPTION
`crystal_num` (task-406) and `orientation_num` (task-409) have been in
`LUMICE_StatsResult` all along, and the CLI prints both. The GUI consumed
neither — `src/gui/` had zero references to either field, so "how densely is
this scene being sampled?" was answerable from the CLI and not from the app
where the question actually arises. This closes that half of the delivery.

## What it shows

A permanently visible status bar segment beside "Total rays", plus a tooltip:

```
| shape 1 per 5.4 x10^6 · orient 1.00/ray
```

The readout is a **density relative to rays traced**, not a raw count. That
choice follows from the counters' shape: each is `(deterministic slots) +
(stochastic draws ≈ ray count)`, so each reads either ≈1 or ≈N_rays. The six
orders of magnitude between them in the commonest scene (fixed shape, random
orientation) is the signal, not a formatting problem — presenting them as two
peer integers would flatten exactly the information the user wants. Density is
also a pure function of the stats, so it needs no config coupling; a "fixed"
label would have, and could not distinguish a genuinely fixed shape from the
GPU reusing one geometry per batch (both report single digits).

Deliberately plain text — no progress bar, no colour grading, no check/cross.
Neither counter has a "good" value: a low shape count is correct for a fixed
shape and expected on the GPU route, so better/worse styling would manufacture
false alarms. The tooltip states the cross-backend caveat, which
`lumice.h:199` and `trace_backend.hpp:582` both spell out in the imperative;
switching to the GPU backend drops the shape count by ~4 orders of magnitude
and must not read as a regression.

## Scope

Display only. No C API change, no core change, and `ray_seg_num` is left
alone. Two `GuiState` fields ride the exact statements the existing
`stats_*` fields already ride (8 touch points, including the governance
union's cardinality gate), so the live-update semantics transfer by
construction rather than via a second update path.

## Verification

- `./scripts/test.sh full` PASS — ctest / fast-e2e / gui-correctness / gui-real-timing
- `gui_test` 587/587; the 8 new cases cover the formatter's four branches
  (both division-by-zero mouths), a three-frame differential pixel assertion
  proving the segment reaches the framebuffer, and a width budget assertion
- No reference image re-shoot: `capture_harness/fullframe` stays `PSNR=inf`,
  because that scene never runs a simulation and the segment shares the
  existing `stats_sim_ray_num > 0` gate
- Three gates (format / policies / new-refs) exit 0

The width assertion measures against `kMinWindowWidth` (the enforced
`glfwSetWindowSizeLimits` floor) rather than a chosen number, and caught a real
violation during implementation: the original wording measured 477px and
overran the budget, which is why the segment carries no `Sampling:` prefix.
Headroom at the floor is 8px, so anything later added to this row will need
the wording re-compressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)