### PR TITLE
fix(gui-test): save_open 收敛判据改为累积光线数，消除负载相关假红

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,9 +42,11 @@ build() {
         #     Holds tests whose meaning depends on real wall-clock:
         #       - perf_test: measures main-loop FPS / rays-per-sec.
         #       - save_open_visual_consistency: compares the live poller preview
-        #         (which converges over ~30 frames of real wall-clock simulation)
-        #         against the saved snapshot; fixed-dt starves that accumulation
-        #         and drops its PSNR ~7 dB below threshold.
+        #         against the saved snapshot. It now waits on accumulated rays
+        #         rather than on a frame count, so fixed-dt no longer starves it
+        #         outright; it stays here because that wait is bounded by a real
+        #         wall-clock deadline, and fixed-dt decouples the test engine's
+        #         watchdog (which counts simulated frame time) from that deadline.
         #       - revert_repushes_server_display_state, zorder_priority_persists_across_rerun
         #         (task-color-migration code-review round-1 revision): both assert on
         #         LUMICE_GetCompositeResults() right after a display-time PushDisplayState()

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -6758,39 +6758,7 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       gui::DoRun(/*user_initiated=*/true);
       // Pump frames until the GPU produces a batch; SyncFromPoller polls the
       // async tally each Yield and fires the modal once it is populated.
-      const auto diag_t1 = std::chrono::steady_clock::now();
-      LUMICE_RayCount diag_srv1_start = 0;
-      LUMICE_GetSimRayCount(gui::g_server, &diag_srv1_start);
       const bool ran = WaitForSimRestartAtLeast(ctx, baseline_uploads, /*timeout_ms=*/8000);
-      {
-        LUMICE_RayCount diag_srv1_end = 0;
-        LUMICE_GetSimRayCount(gui::g_server, &diag_srv1_end);
-        fprintf(
-            stderr,
-            "[DIAG:p2_degrade] call=1 wall_ms=%lld ray_srv_start=%llu ray_srv_end=%llu ray_tex=%llu "
-            "upload_base=%llu upload_end=%llu ok=%d\n",
-            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t1)
-                .count(),
-            (unsigned long long)diag_srv1_start, (unsigned long long)diag_srv1_end,
-            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)baseline_uploads,
-            (unsigned long long)gui::g_state.texture_upload_count, ran ? 1 : 0);
-        auto diag_snap = gui::g_server_poller.LoadSnapshot();
-        fprintf(stderr,
-                "[DIAG:p2_gate] snap=%d valid=%d epoch=%llu lifecycle=%d serial=%llu has_new_tex=%d payload=%d "
-                "payload_epoch=%llu tex_rays=%llu intensity=%.6f is_comp=%d | committed_epoch=%llu floor=%llu "
-                "last_serial=%llu show_comp=%d last_as_comp=%d\n",
-                diag_snap ? 1 : 0, diag_snap && diag_snap->valid ? 1 : 0,
-                diag_snap ? (unsigned long long)diag_snap->epoch : 0ULL, diag_snap ? diag_snap->lifecycle : -1,
-                diag_snap ? (unsigned long long)diag_snap->texture_serial : 0ULL,
-                diag_snap && diag_snap->has_new_texture ? 1 : 0, diag_snap && diag_snap->payload ? 1 : 0,
-                diag_snap && diag_snap->payload ? (unsigned long long)diag_snap->payload->payload_epoch : 0ULL,
-                diag_snap && diag_snap->payload ? (unsigned long long)diag_snap->payload->texture_ray_count : 0ULL,
-                diag_snap && diag_snap->payload ? diag_snap->payload->snapshot_intensity : -1.0f,
-                diag_snap && diag_snap->payload && diag_snap->payload->is_composite ? 1 : 0,
-                (unsigned long long)gui::g_state.committed_epoch, (unsigned long long)gui::g_state.display_epoch_floor,
-                (unsigned long long)gui::g_state.last_uploaded_texture_serial,
-                gui::g_state.show_composite_preview ? 1 : 0, gui::g_state.last_uploaded_as_composite ? 1 : 0);
-      }
       IM_CHECK(ran);
       // Give SyncFromPoller a few extra ticks to observe the populated count.
       for (int i = 0; i < 20 && gui::PeekGuiWarning().empty(); ++i) {
@@ -6818,23 +6786,7 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       gui::g_state.raypath_color.clear();
       const unsigned long baseline_uploads2 = gui::g_state.texture_upload_count;
       gui::DoRun(/*user_initiated=*/true);
-      const auto diag_t2 = std::chrono::steady_clock::now();
-      LUMICE_RayCount diag_srv2_start = 0;
-      LUMICE_GetSimRayCount(gui::g_server, &diag_srv2_start);
       const bool ran2 = WaitForSimRestartAtLeast(ctx, baseline_uploads2, /*timeout_ms=*/8000);
-      {
-        LUMICE_RayCount diag_srv2_end = 0;
-        LUMICE_GetSimRayCount(gui::g_server, &diag_srv2_end);
-        fprintf(
-            stderr,
-            "[DIAG:p2_degrade] call=2 wall_ms=%lld ray_srv_start=%llu ray_srv_end=%llu ray_tex=%llu "
-            "upload_base=%llu upload_end=%llu ok=%d\n",
-            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t2)
-                .count(),
-            (unsigned long long)diag_srv2_start, (unsigned long long)diag_srv2_end,
-            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)baseline_uploads2,
-            (unsigned long long)gui::g_state.texture_upload_count, ran2 ? 1 : 0);
-      }
       IM_CHECK(ran2);
       for (int i = 0; i < 20; ++i) {
         ctx->Yield();

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -6758,7 +6758,39 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       gui::DoRun(/*user_initiated=*/true);
       // Pump frames until the GPU produces a batch; SyncFromPoller polls the
       // async tally each Yield and fires the modal once it is populated.
+      const auto diag_t1 = std::chrono::steady_clock::now();
+      LUMICE_RayCount diag_srv1_start = 0;
+      LUMICE_GetSimRayCount(gui::g_server, &diag_srv1_start);
       const bool ran = WaitForSimRestartAtLeast(ctx, baseline_uploads, /*timeout_ms=*/8000);
+      {
+        LUMICE_RayCount diag_srv1_end = 0;
+        LUMICE_GetSimRayCount(gui::g_server, &diag_srv1_end);
+        fprintf(
+            stderr,
+            "[DIAG:p2_degrade] call=1 wall_ms=%lld ray_srv_start=%llu ray_srv_end=%llu ray_tex=%llu "
+            "upload_base=%llu upload_end=%llu ok=%d\n",
+            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t1)
+                .count(),
+            (unsigned long long)diag_srv1_start, (unsigned long long)diag_srv1_end,
+            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)baseline_uploads,
+            (unsigned long long)gui::g_state.texture_upload_count, ran ? 1 : 0);
+        auto diag_snap = gui::g_server_poller.LoadSnapshot();
+        fprintf(stderr,
+                "[DIAG:p2_gate] snap=%d valid=%d epoch=%llu lifecycle=%d serial=%llu has_new_tex=%d payload=%d "
+                "payload_epoch=%llu tex_rays=%llu intensity=%.6f is_comp=%d | committed_epoch=%llu floor=%llu "
+                "last_serial=%llu show_comp=%d last_as_comp=%d\n",
+                diag_snap ? 1 : 0, diag_snap && diag_snap->valid ? 1 : 0,
+                diag_snap ? (unsigned long long)diag_snap->epoch : 0ULL, diag_snap ? diag_snap->lifecycle : -1,
+                diag_snap ? (unsigned long long)diag_snap->texture_serial : 0ULL,
+                diag_snap && diag_snap->has_new_texture ? 1 : 0, diag_snap && diag_snap->payload ? 1 : 0,
+                diag_snap && diag_snap->payload ? (unsigned long long)diag_snap->payload->payload_epoch : 0ULL,
+                diag_snap && diag_snap->payload ? (unsigned long long)diag_snap->payload->texture_ray_count : 0ULL,
+                diag_snap && diag_snap->payload ? diag_snap->payload->snapshot_intensity : -1.0f,
+                diag_snap && diag_snap->payload && diag_snap->payload->is_composite ? 1 : 0,
+                (unsigned long long)gui::g_state.committed_epoch, (unsigned long long)gui::g_state.display_epoch_floor,
+                (unsigned long long)gui::g_state.last_uploaded_texture_serial,
+                gui::g_state.show_composite_preview ? 1 : 0, gui::g_state.last_uploaded_as_composite ? 1 : 0);
+      }
       IM_CHECK(ran);
       // Give SyncFromPoller a few extra ticks to observe the populated count.
       for (int i = 0; i < 20 && gui::PeekGuiWarning().empty(); ++i) {
@@ -6786,7 +6818,23 @@ void RegisterLinkedEntriesTests(ImGuiTestEngine* engine) {
       gui::g_state.raypath_color.clear();
       const unsigned long baseline_uploads2 = gui::g_state.texture_upload_count;
       gui::DoRun(/*user_initiated=*/true);
+      const auto diag_t2 = std::chrono::steady_clock::now();
+      LUMICE_RayCount diag_srv2_start = 0;
+      LUMICE_GetSimRayCount(gui::g_server, &diag_srv2_start);
       const bool ran2 = WaitForSimRestartAtLeast(ctx, baseline_uploads2, /*timeout_ms=*/8000);
+      {
+        LUMICE_RayCount diag_srv2_end = 0;
+        LUMICE_GetSimRayCount(gui::g_server, &diag_srv2_end);
+        fprintf(
+            stderr,
+            "[DIAG:p2_degrade] call=2 wall_ms=%lld ray_srv_start=%llu ray_srv_end=%llu ray_tex=%llu "
+            "upload_base=%llu upload_end=%llu ok=%d\n",
+            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t2)
+                .count(),
+            (unsigned long long)diag_srv2_start, (unsigned long long)diag_srv2_end,
+            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)baseline_uploads2,
+            (unsigned long long)gui::g_state.texture_upload_count, ran2 ? 1 : 0);
+      }
       IM_CHECK(ran2);
       for (int i = 0; i < 20; ++i) {
         ctx->Yield();

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -643,9 +643,9 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       //
       // 3M rays puts the expected PSNR near 32.5 dB — over 4 dB of headroom above kPsnrThreshold —
       // and costs ~0.73s idle (the old fixed budget already bought ~2.4M, so this is not a
-      // meaningful slowdown of the idle path). The deadline is a hang bound, NOT a budget: at the
-      // worst throughput measured under heavy CPU contention (~0.64M rays/s) the target lands in
-      // ~4.7s, so 20s keeps a >4x margin. It also deliberately stays under ImGuiTestEngine's 30s
+      // meaningful slowdown of the idle path). The deadline is a hang bound, NOT a budget: the
+      // target was reached in 0.73s idle and in 1.7-1.8s under enough CPU contention to oversubscribe
+      // every core, so 20s leaves an order of magnitude. It also deliberately stays under ImGuiTestEngine's 30s
       // default ConfigWatchdogWarning (imgui_te_engine.h): this case runs WITHOUT --fixed-dt, so
       // the watchdog's simulated clock is the wall clock here, and keeping the deadline below it
       // is what lets this test skip the watchdog-widening dance that the --fixed-dt cases need.

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "include/lumice.h"
 #include "test_gui_shared.hpp"
 
 // Rebuild the crystal mesh (if changed) and render it into g_crystal_renderer's
@@ -621,6 +622,7 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
         r.exposure_offset = 0.0f;
       }
       gui::DoRun(/*user_initiated=*/true);
+      const auto diag_t0 = std::chrono::steady_clock::now();
 
       // Wait for first texture upload (up to 10s)
       auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
@@ -631,6 +633,16 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       // Let a few more frames accumulate for stable data
       for (int i = 0; i < 30; i++) {
         ctx->Yield();
+      }
+      {
+        LUMICE_RayCount diag_srv = 0;
+        LUMICE_GetSimRayCount(gui::g_server, &diag_srv);
+        fprintf(
+            stderr, "[DIAG:save_open] phase=1 ray_tex=%llu ray_srv=%llu wall_ms=%lld upload_cnt=%llu\n",
+            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)diag_srv,
+            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t0)
+                .count(),
+            (unsigned long long)gui::g_state.texture_upload_count);
       }
       IM_CHECK(gui::g_preview.HasTexture());
       IM_CHECK(gui::g_preview_vp.vp_w > 0);
@@ -649,6 +661,16 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       gui::g_state.ev_auto = 0.0f;
       ctx->Yield(1);
       const float live_snapshot_intensity = gui::g_state.snapshot_intensity;
+      {
+        LUMICE_RayCount diag_srv = 0;
+        LUMICE_GetSimRayCount(gui::g_server, &diag_srv);
+        fprintf(
+            stderr, "[DIAG:save_open] phase=2 ray_tex=%llu ray_srv=%llu wall_ms=%lld upload_cnt=%llu\n",
+            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)diag_srv,
+            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t0)
+                .count(),
+            (unsigned long long)gui::g_state.texture_upload_count);
+      }
       g_export_test.export_requested = true;
       ctx->Yield(2);
       IM_CHECK(g_export_test.export_done);
@@ -724,6 +746,7 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       double psnr = lumice::test::ComputePsnr(rgb_a.data(), rgb_b.data(), wa, ha, 3);
       fprintf(stderr, "[visual] save_open_visual_consistency: PSNR = %.2f dB (threshold = %.1f dB)\n", psnr,
               kPsnrThreshold);
+      fprintf(stderr, "[DIAG:save_open] phase=6 psnr=%.3f\n", psnr);
       IM_CHECK(psnr > kPsnrThreshold);
 
       // Cleanup

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -2,7 +2,6 @@
 #include <cstdio>
 #include <cstring>
 
-#include "include/lumice.h"
 #include "test_gui_shared.hpp"
 
 // Rebuild the crystal mesh (if changed) and render it into g_crystal_renderer's
@@ -624,7 +623,6 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
         r.exposure_offset = 0.0f;
       }
       gui::DoRun(/*user_initiated=*/true);
-      const auto diag_t0 = std::chrono::steady_clock::now();
 
       // Accumulate a fixed WORKLOAD (simulated rays), not a fixed number of frames.
       //
@@ -665,16 +663,9 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       }
       IM_CHECK_GE((unsigned long long)gui::g_state.stats_sim_ray_num, kMinAccumulatedRays);
       IM_CHECK_GT((int)gui::g_state.texture_upload_count, 0);
-      {
-        LUMICE_RayCount diag_srv = 0;
-        LUMICE_GetSimRayCount(gui::g_server, &diag_srv);
-        fprintf(
-            stderr, "[DIAG:save_open] phase=1 ray_tex=%llu ray_srv=%llu wall_ms=%lld upload_cnt=%llu\n",
-            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)diag_srv,
-            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t0)
-                .count(),
-            (unsigned long long)gui::g_state.texture_upload_count);
-      }
+      // Captured now, not read again in Phase 6: LoadLmcFile deserializes a whole GuiState over
+      // g_state, which resets the live counters back to zero.
+      const unsigned long long accumulated_rays = gui::g_state.stats_sim_ray_num;
       IM_CHECK(gui::g_preview.HasTexture());
       IM_CHECK(gui::g_preview_vp.vp_w > 0);
       IM_CHECK(gui::g_preview_vp.vp_h > 0);
@@ -692,16 +683,6 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       gui::g_state.ev_auto = 0.0f;
       ctx->Yield(1);
       const float live_snapshot_intensity = gui::g_state.snapshot_intensity;
-      {
-        LUMICE_RayCount diag_srv = 0;
-        LUMICE_GetSimRayCount(gui::g_server, &diag_srv);
-        fprintf(
-            stderr, "[DIAG:save_open] phase=2 ray_tex=%llu ray_srv=%llu wall_ms=%lld upload_cnt=%llu\n",
-            (unsigned long long)gui::g_state.stats_sim_ray_num, (unsigned long long)diag_srv,
-            (long long)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - diag_t0)
-                .count(),
-            (unsigned long long)gui::g_state.texture_upload_count);
-      }
       g_export_test.export_requested = true;
       ctx->Yield(2);
       IM_CHECK(g_export_test.export_done);
@@ -773,11 +754,19 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       // PSNR threshold: the save path gets a fresh snapshot from the server (slightly more accumulated
       // data than the poller's last upload), plus float→uint8 quantization (~48 dB theoretical max).
       // 28 dB catches major conversion errors (wrong EV, wrong matrix) while allowing for timing noise.
+      //
+      // Headroom, measured: with the Phase 1 wait gated on kMinAccumulatedRays the observed PSNR is
+      // 33.0 dB +/- 0.15 whether the machine is idle or heavily contended, so the margin here is
+      // ~5 dB rather than the ~0.2 dB it used to be on a busy machine. Injected defects of the two
+      // classes named above land at 22.7 dB (a one-stop EV mismatch baked in at save time) and
+      // 20.3 dB (the reloaded image shifted by 3 rows) — both still comfortably red.
       constexpr double kPsnrThreshold = 28.0;
       double psnr = lumice::test::ComputePsnr(rgb_a.data(), rgb_b.data(), wa, ha, 3);
-      fprintf(stderr, "[visual] save_open_visual_consistency: PSNR = %.2f dB (threshold = %.1f dB)\n", psnr,
-              kPsnrThreshold);
-      fprintf(stderr, "[DIAG:save_open] phase=6 psnr=%.3f\n", psnr);
+      // The accumulated ray count is printed alongside because it is what sets the noise floor this
+      // threshold is measured against: if this case ever fails, "did it reach the ray target?" is
+      // the first question, and the answer belongs in the failure output rather than in a rerun.
+      fprintf(stderr, "[visual] save_open_visual_consistency: PSNR = %.2f dB (threshold = %.1f dB, rays = %llu)\n",
+              psnr, kPsnrThreshold, accumulated_rays);
       IM_CHECK(psnr > kPsnrThreshold);
 
       // Cleanup

--- a/test/gui/visual/test_gui_visual.cpp
+++ b/test/gui/visual/test_gui_visual.cpp
@@ -580,12 +580,14 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
   // Tests the actual user workflow: the reopened file should look the same as the live display.
   // Regression test for PostSnapshot using stale CommitConfig-time EV instead of current GUI EV.
   //
-  // REAL-TIMING TEST: this case compares the live poller preview (which converges over the ~30
-  // Yield()s below via real wall-clock simulation) against the saved snapshot, so it needs real
-  // frame timing. build.sh runs it in the isolated real-timing pool, NOT the --fixed-dt pool
-  // (fixed-dt skips the frame-limit sleep and starves that accumulation, dropping PSNR ~7 dB).
-  // If this test is renamed, update the --filter lists in scripts/build.sh. See
-  // scratchpad/task-gui-test-fixed-dt.
+  // REAL-TIMING TEST: this case compares the live poller preview against the saved snapshot, and
+  // the preview only converges as the background simulation accumulates rays in real wall-clock
+  // time. build.sh runs it in the isolated real-timing pool, NOT the --fixed-dt pool. The wait
+  // below is gated on accumulated rays, so fixed-dt no longer starves it outright; what keeps it
+  // here is that its bound is a real-time deadline, and --fixed-dt decouples the engine watchdog's
+  // simulated clock from that deadline (the trap documented at length in
+  // test_gui_lens_projection.cpp). If this test is renamed, update the --filter lists in
+  // scripts/build.sh.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "visual", "save_open_visual_consistency");
     t->GuiFunc = [](ImGuiTestContext* /*ctx*/) {
@@ -624,16 +626,45 @@ void RegisterVisualTests(ImGuiTestEngine* engine) {
       gui::DoRun(/*user_initiated=*/true);
       const auto diag_t0 = std::chrono::steady_clock::now();
 
-      // Wait for first texture upload (up to 10s)
-      auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-      while (gui::g_state.texture_upload_count == 0) {
+      // Accumulate a fixed WORKLOAD (simulated rays), not a fixed number of frames.
+      //
+      // What Phase 6 compares is two Monte-Carlo estimates of the same image: screenshot A is the
+      // poller's last uploaded preview texture, screenshot B is the .lmc texture that
+      // RefreshCpuTextureForSave() (app.cpp) takes fresh from the server. Their difference is
+      // sampling noise, which falls as 1/sqrt(N) in the accumulated ray count N behind them.
+      // Measured on this case over a 6.5x range of N: PSNR = 10*log10(N) - 32.0 dB, +/-0.7.
+      //
+      // The predecessor of this loop was `for (i < 30) ctx->Yield();`, which fixes the WALL CLOCK
+      // rather than N: the real-timing pool keeps the ~16.7ms frame-limit sleep, so 30 Yields is a
+      // hard ~575ms budget (measured invariant under load). N is then whatever CPU the simulation
+      // threads happened to win inside that window — 2.4M rays idle, 0.37M rays under CPU
+      // contention. That is a ~7 dB PSNR swing (31.6 dB -> 24.5 dB) against a 28 dB threshold, and
+      // it is the whole reason this case went red on a busy machine. Gating on N makes the
+      // comparison's noise floor a property of the test rather than of the machine's spare
+      // capacity; the wall clock becomes an upper bound instead of the convergence condition.
+      //
+      // 3M rays puts the expected PSNR near 32.5 dB — over 4 dB of headroom above kPsnrThreshold —
+      // and costs ~0.73s idle (the old fixed budget already bought ~2.4M, so this is not a
+      // meaningful slowdown of the idle path). The deadline is a hang bound, NOT a budget: at the
+      // worst throughput measured under heavy CPU contention (~0.64M rays/s) the target lands in
+      // ~4.7s, so 20s keeps a >4x margin. It also deliberately stays under ImGuiTestEngine's 30s
+      // default ConfigWatchdogWarning (imgui_te_engine.h): this case runs WITHOUT --fixed-dt, so
+      // the watchdog's simulated clock is the wall clock here, and keeping the deadline below it
+      // is what lets this test skip the watchdog-widening dance that the --fixed-dt cases need.
+      constexpr unsigned long long kMinAccumulatedRays = 3'000'000;
+      // Zeroed here rather than trusted from ResetTestState(): a stale count carried over from the
+      // previous test would satisfy the wait on its very first frame, and the capture below would
+      // then read whatever texture happened to still be bound.
+      gui::g_state.stats_sim_ray_num = 0;
+      gui::g_state.texture_upload_count = 0;
+      const auto accumulate_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+      while (((unsigned long long)gui::g_state.stats_sim_ray_num < kMinAccumulatedRays ||
+              gui::g_state.texture_upload_count == 0) &&
+             std::chrono::steady_clock::now() < accumulate_deadline) {
         ctx->Yield();
-        IM_CHECK(std::chrono::steady_clock::now() < timeout);
       }
-      // Let a few more frames accumulate for stable data
-      for (int i = 0; i < 30; i++) {
-        ctx->Yield();
-      }
+      IM_CHECK_GE((unsigned long long)gui::g_state.stats_sim_ray_num, kMinAccumulatedRays);
+      IM_CHECK_GT((int)gui::g_state.texture_upload_count, 0);
       {
         LUMICE_RayCount diag_srv = 0;
         LUMICE_GetSimRayCount(gui::g_server, &diag_srv);


### PR DESCRIPTION
## 背景

`gui_test` 真实时序池的 `save_open_visual_consistency` 把**墙钟流逝量**当成了隐含的收敛预算，机器负载一高就假红。同机同二进制曾实测 PSNR 27.83（阈值 28.0）与 31.78 两极。

CI 不受影响——CI 从不运行 `gui_test`（`ci.yml:399-402` 明写 build-only，runner 无显示器；`build.sh:130` 遇 `CI` env 自动跳过）。本 PR 的价值在于降低本地 `./scripts/test.sh full`/`pr` 的误报裁决成本，这两个 scope 是 `AGENTS.md` 定的「回归扫描」与「开 PR 前」默认动作。

## 诊断（AC1，改动前完成，期间两个常量一字未动）

Phase 6 比较的是同一分布的两个蒙特卡洛估计（poller 最后上传的预览纹理 vs `.lmc` 里向 server 现取的快照），差异是采样噪声、随 1/√N 下降。实测拟合出闭式定律：

```
PSNR = 10*log10(N) - 32.0 dB   (+/- 0.7，N 跨 6.5x 变化，残差极差 1.3 dB)
```

旧判据 `for (i < 30) ctx->Yield();` 钉住的是墙钟（真实时序池保留 frame-limit ⇒ 30 次 Yield ≈ 573±5ms，实测 12 轮全部落在 571–597，**与负载无关**）。负载改变的是这段时间里仿真线程抢到多少 CPU：吞吐 4.1M → 0.64M rays/s ⇒ N 掉 6.5× ⇒ PSNR 掉 ~7 dB。

## 改动

`test/gui/visual/test_gui_visual.cpp` — Phase 1 换成单个 workload 轮询：

- 目标 `kMinAccumulatedRays = 3'000'000` — **由上述定律反推**（预测 32.5 dB，对 28.0 留 >4 dB 裕度），空载代价 0.57s → 0.73s
- 20s `steady_clock` 死线**只作挂死上限**，`IM_CHECK_GE`/`IM_CHECK_GT` 落在 workload 上、不落在死线上
- 死线刻意压在 ImGuiTestEngine 默认 `ConfigWatchdogWarning = 30s` 之下（本用例无 `--fixed-dt`，watchdog 的模拟时钟即墙钟）⇒ **无需 watchdog 放宽**，也就不需要 `lens_projection` 那套 RAII guard

`scripts/build.sh` — 池注释里「converges over ~30 frames」的旧机制描述已失真，同步改掉。**`--filter` 字符串与池划分未动**。

`kPsnrThreshold = 28.0` 与 `WaitForSimRestartAtLeast` 的 `timeout_ms=8000` **均未改动**（AC3：不以削弱检测力换绿）。无生产代码改动。

## 验证

| 条件 | 改前 | 改后 |
|---|---|---|
| 空载 | PSNR 27.83 / 31.78 两极 | 32.91–33.12（5 轮），独立复核 32.93–33.07（3 轮） |
| **16 忙等进程** | **6/6 全红**（24.46–27.90） | **6/6 全绿**，独立复核 33.04–33.08 —— 与空载重合 |
| `./scripts/test.sh full` ×5 | — | 5/5 PASS，真实时序层 0 假红 |

负载下与空载重合说明负载敏感性是被**消除**而非掩盖：钉住 N 后负载只改变达标用时，不改变达标质量。

检测力反证：两类缺陷红态探针仍红（22.66 / 20.26 dB），探针均已 revert。`p1_running` 组三处 `WaitForSimRestartAtLeast` 既有调用点取到正面回归证据（5/5 绿），本 PR 对该 helper 净改动为 0。

三闸 `format.sh --check` / `check_policies.py` / `check_new_refs.py --range` 均 exit 0。

## 范围说明：合并立项的另一半已转出

立项时本任务合并了两条 backlog 条目。第二条 `gpu_color_class_overflow_surfaces_async_warning` 经诊断**证明不是 flake、也与墙钟无关**（16 spinner 下等待仅 217–261ms，距 8000ms 差 30 倍），而是一条产品缺陷：

标定值写在全局 `g_server_poller` 上跨用例常驻（`ResetTestState()` 不复位）→ 质量闸拒收稀疏快照 → 本该兜底的 500ms 强制上传永远等不到，因为 `PollOnce` 在 `lifecycle==COMPLETED` 时自暂停、且自暂停位于质量闸之后 → 纹理永不上传。

**用户可见后果**：GUI 默认跑标定，用户跑一次总光线数低于标定阈值的有限仿真，预览图永远不出现。

该用例本 PR **零改动**——把它的判据改成工作量判据会立刻转绿，代价是永久掩盖这条缺陷（它目前唯一的可观测出口），直接违反 AC3。已按 owner 裁决转为独立 backlog 条目（含 10 秒最小复现 `gui_test --filter "calibration,p2_gpu_color_degrade"`、四环机制链、三个候选修法）。该缺陷在 `test.sh` 路径上不可达（两池分进程，已双向实测）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
