### PR TITLE
fix(gui): COMPLETED 代终帧绕过质量闸强制上屏（修有限低光线仿真预览永不出图）

### DIFF
--- a/doc/gui-preview-lifecycle-architecture.md
+++ b/doc/gui-preview-lifecycle-architecture.md
@@ -152,6 +152,35 @@ CUDA 超大 batch 中途无法响应。第一性原理：
 
 其中 **I3、I4 正是当前 bug 违反的两条**——回归测试应直接钉住它们。
 
+> **落地补丁（2026-08-01，PR 见 git log）：I6「终帧无条件上屏」曾长期未被落实。**
+> 这不是新增不变量，而是补上实现对 **I6 后半句**（§7 规则 2）的一次合规回归——I6 本身文本不变。
+>
+> gap（四环，每环都有生产代码位置）：①`ServerPoller::SetCalibratedThreshold` 把启动标定阈值
+> （真机量级 3–4×10⁴ 光线）写进全局 poller；②`PollOnce()` 的质量闸按该阈值拒绝稀疏快照；
+> ③质量闸本有 `kQualityGateTimeoutMs`(500ms) 兜底，但 **poller 的 COMPLETED 自暂停位于同一次
+> `PollOnce()` 调用内、且在质量闸之后**——有限低采样跑约 80ms 就 COMPLETED，此后再无轮询去触发兜底；
+> ④⇒ 纹理永不上传。**用户可见症状：把总光线数配到标定阈值以下的有限仿真，跑完了预览图也永远空白。**
+> 根因形态正是本文档要治理的「显示钟 × 生命周期钟」交界——§7 规则 1 的前提（"还有更好的将来帧"）
+> 在 COMPLETED 之后不成立，而实现把规则 1 无条件套到了终局帧上。
+>
+> 修复落点：`ServerPoller` 新增 **per-resume**（非 per-poller-lifetime）状态
+> `uploaded_since_resume_`，在每个 kPaused→kRunning 边沿（`Start()` 与 `TransitionToRunning()`，
+> 即 `WakeForRestart` 与 `WakeForRefresh` 两条唤醒入口）与 `last_generation_` /
+> `last_quality_pass_time_` 一起复位；`PollOnce()` 在 `lifecycle==COMPLETED` 且本次 resume 尚未
+> 上传过任何一帧时**绕过质量闸补投一帧**。三点值得记住：
+> - 该判据**故意求值在 `has_new_snapshot` 分支之外**——§6 的生命周期心跳与快照物化是两个解耦的钟，
+>   COMPLETED 完全可能落在一次不带新 generation 的 poll 上，只堵「快照与终态同一次到达」那条
+>   交错会留下另一条同形缺陷。
+> - 500ms 超时兜底**保留不动**，两者并列不替代：兜底救的是「运行中永远够不到门槛」，本补丁救的是
+>   「已经结束且结束在门槛之下」。
+> - `!uploaded_since_resume_` 是防止补投蜕化成「每次 COMPLETED 都重物化一帧」的唯一闸门（那会用稀疏帧
+>   盖掉已有好帧，正好制造质量闸本要防的闪烁）；per-resume 而非 per-lifetime 也是必需的，否则只有进程内
+>   **第一次**低光线完成跑被救到。`WakeForRefresh` 同样复位，是因为它的全部用途就是给已完成的跑买
+>   一次额外 poll 去重新物化（改染色 / composite EV），被质量闸吞掉的话该跑的显示编辑将永远不生效。
+>
+> 回归测试：`gui_test` 的 `gui_lifecycle` 组，三阶段分别覆盖首次完成跑、经 `WakeForRestart` 的第二次
+> 完成跑、以及经 `WakeForRefresh` 的 display-time 刷新。
+
 ---
 
 ## 10. 落地边界：最小核 vs 完整版

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -42,6 +42,10 @@ void ServerPoller::Start(LUMICE_Server* server) {
   last_generation_ = 0;
   // Reset quality gate timeout so fallback doesn't fire prematurely after restart.
   last_quality_pass_time_ = std::chrono::steady_clock::now();
+  // Re-arm the terminal-frame rescue for the resumed run (I6 — see the header). Kept next to the
+  // two resets above because all three are per-resume state; Start() does not route through
+  // TransitionToRunning(), so it carries its own copy of the same three-line reset.
+  uploaded_since_resume_ = false;
 
   {
     std::lock_guard<std::mutex> lk(mutex_);
@@ -91,6 +95,13 @@ bool ServerPoller::TransitionToRunning(LUMICE_Server* server, bool publish_reset
     server_ = server;
     last_generation_ = 0;
     last_quality_pass_time_ = std::chrono::steady_clock::now();
+    // Re-arm the terminal-frame rescue (I6 — see the header). Both wake variants reset it, and for
+    // the same reason: each buys the worker a poll it would otherwise never get. WakeForRestart
+    // opens a new sim generation; WakeForRefresh wakes an already-completed run for exactly ONE
+    // more poll to re-materialize it under new display state (colour edits / composite EV), after
+    // which PollOnce self-pauses again. If the gate swallows that single poll, a sparse completed
+    // run's display edits would silently never appear.
+    uploaded_since_resume_ = false;
     if (publish_reset) {
       PublishValidReset();
     }
@@ -236,6 +247,22 @@ void ServerPoller::PollOnce() {
   // Check if this is genuinely new snapshot data (generation changed)
   bool has_new_snapshot = xyz_results[0].xyz_buffer != nullptr && captured_xyz_generation != last_generation_;
 
+  // Terminal-frame rescue (invariant I6, "the final frame always reaches the screen" — the
+  // blueprint's §7 rule 2 / §9; see doc/gui-preview-lifecycle-architecture.md). The quality gate below
+  // suppresses sparse snapshots on the premise that a denser one is still coming; once the run has
+  // COMPLETED that premise is false, and the sparse result IS the result. The gate's 500ms timeout
+  // fallback cannot cover this: the self-pause at the bottom of this very function fires in the
+  // SAME call, so a finite low-ray run (~80ms) is never polled again and the fallback is never
+  // reached. Startup calibration sets the threshold to ~3-4×10^4 rays in the real GUI, so without
+  // this any run configured below that showed a permanently blank preview.
+  //
+  // Deliberately evaluated OUTSIDE the has_new_snapshot branch: the lifecycle heartbeat and the
+  // snapshot generation are decoupled clocks (§6), so COMPLETED may just as well arrive on a poll
+  // that carries no new generation. Gating the rescue on has_new_snapshot would fix only the
+  // interleaving that happened to be reproduced and leave the other one live.
+  const bool force_final_upload =
+      lc.lifecycle == LUMICE_LIFECYCLE_COMPLETED && !uploaded_since_resume_ && xyz_results[0].xyz_buffer != nullptr;
+
   // ---- Prepare candidate stats + texture payload OUTSIDE publish_mutex_ (no prev dependency).
   // The 24MB pixel memcpy happens here, never inside the publish critical section.
   bool have_new_stats = false;
@@ -245,8 +272,9 @@ void ServerPoller::PollOnce() {
   LUMICE_RayCount new_orientation = 0;
   std::shared_ptr<const TexturePayload> new_payload;  // non-null only when a fresh texture materialized
 
-  if (has_new_snapshot) {
-    // Always consume this generation (same generation data won't improve by waiting)
+  if (has_new_snapshot || force_final_upload) {
+    // Always consume this generation (same generation data won't improve by waiting). On the
+    // force_final_upload-only path this re-assigns the value already stored — idempotent.
     last_generation_ = captured_xyz_generation;
 
     // Get stats (used independently for status bar display)
@@ -275,6 +303,15 @@ void ServerPoller::PollOnce() {
         GUI_LOG_VERBOSE("[Poller] quality gate timeout: forcing upload after {}ms (rays={}, min={})", elapsed_ms,
                         cached_stats.sim_ray_num, min_rays);
       }
+    }
+
+    // Third and last way past the gate: the run is over and this resume has yet to put anything on
+    // screen (I6). Kept separate from the timeout above — that one rescues a RUNNING sim that will
+    // never reach the threshold; this one rescues a run that already ended below it.
+    if (!quality_ok && force_final_upload) {
+      quality_ok = true;
+      GUI_LOG_VERBOSE("[Poller] terminal frame: bypassing quality gate (rays={}, min={}) gen={}",
+                      cached_stats.sim_ray_num, min_rays, xyz_results[0].snapshot_generation);
     }
 
     if (quality_ok) {
@@ -320,6 +357,9 @@ void ServerPoller::PollOnce() {
       // (payload is default-constructed with rgb_data empty + is_composite=false,
       // so the not-active branch is a no-op; explicit reset would be redundant.)
       new_payload = std::move(payload);
+      // A frame exists for this resume — disarm the terminal rescue so a later COMPLETED poll
+      // cannot overwrite it with a sparser one (see the header: this is the anti-flicker guard).
+      uploaded_since_resume_ = true;
       GUI_LOG_VERBOSE("[Poller] staged: rays={} intensity={} gen={}", cached_stats.sim_ray_num,
                       xyz_results[0].snapshot_intensity, xyz_results[0].snapshot_generation);
     } else {

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -237,6 +237,21 @@ class ServerPoller {
   // Timeout fallback: force upload if quality gate has been rejecting for too long.
   // Reset in Start(), updated in PollOnce() on each quality_ok pass.
   std::chrono::steady_clock::time_point last_quality_pass_time_{ std::chrono::steady_clock::now() };
+
+  // Terminal-frame rescue (invariant I6, doc/gui-preview-lifecycle-architecture.md §7 rule 2 /
+  // §9): has a payload been materialized since the worker last resumed? Scope is per-RESUME, not
+  // per-poller-lifetime: it is reset alongside last_generation_/last_quality_pass_time_ at every
+  // kPaused→kRunning edge (Start() and TransitionToRunning(), i.e. both WakeForRestart — a fresh
+  // sim generation — and WakeForRefresh — one more poll to re-materialize a completed run under
+  // new display state). A poller-lifetime flag would rescue only the first low-ray completion in
+  // the process and silently leave every later one blank.
+  //
+  // PollOnce() consults it to let a COMPLETED generation bypass the quality gate exactly once:
+  // the gate suppresses sparse frames because a better one is still coming, and once the run is
+  // over that premise is false. `false` here is the sole guard keeping the bypass from firing on
+  // every completed poll (which would overwrite a good frame with a sparse one — the very
+  // flicker the gate exists to prevent), so it must stay in the condition.
+  bool uploaded_since_resume_{ false };
 };
 
 }  // namespace lumice::gui

--- a/test/gui/functional/test_gui_lifecycle.cpp
+++ b/test/gui/functional/test_gui_lifecycle.cpp
@@ -718,6 +718,124 @@ void RegisterLifecycleTests(ImGuiTestEngine* engine) {
     gui::g_state.display_epoch_floor = 0;
   };
 
+  // ---- Test 6c: I6 — a COMPLETED run below the calibrated quality gate still puts a frame on screen ----
+  // Pins blueprint invariant I6 (§9 "任何显示 gate 不得压制生命周期跃迁；终帧无条件上屏", §7 rule 2
+  // "终帧永远上屏"). The gate is a RUNNING-time anti-flicker device only: once the run has completed
+  // there is no better frame coming, so however sparse the result is, it is the result.
+  //
+  // The regression this guards: the quality gate rejected the terminal snapshot AND PollOnce's
+  // COMPLETED self-pause fired in the SAME call, after the gate — so the gate's 500ms timeout
+  // fallback could never be reached (a finite low-ray run completes in ~80ms) and the preview
+  // stayed blank forever. The real GUI calibrates the threshold to 3-4×10^4 rays at startup, so
+  // any user-configured run below that never showed a picture at all.
+  //
+  // Three phases, each ending in "the consumer got a frame". Phase A alone would pass against a
+  // WRONG fix that keys off poller-lifetime state (e.g. `texture_serial_ == 0`) instead of
+  // per-resume state — only the first low-ray completion in the process would be rescued. B and C
+  // exercise the two production wake seams that must re-arm the rescue: WakeForRestart (fresh
+  // commit) and WakeForRefresh (display-time refresh of an already-completed run — the colour /
+  // composite-EV push path, which likewise wakes the poller for exactly one more poll and would
+  // otherwise be swallowed by the same gate).
+  ImGuiTest* t6c = IM_REGISTER_TEST(engine, "gui_lifecycle", "completed_below_threshold_force_uploads");
+  t6c->TestFunc = [](ImGuiTestContext* ctx) {
+    IM_UNUSED(ctx);
+    gui::g_server_poller.Stop();
+    gui::g_server = nullptr;
+
+    LUMICE_Server* server = LUMICE_CreateServer();
+    IM_CHECK(server != nullptr);
+
+    // Phase A ---- first low-ray completion on a never-resumed poller.
+    const bool completed_a = RunFiniteToCompletion(server);
+    IM_CHECK(completed_a);
+    if (!completed_a) {
+      LUMICE_DestroyServer(server);
+      return;
+    }
+
+    // `local` is constructed AFTER the run, not before: its last_quality_pass_time_ starts at
+    // construction, and the gate's 500ms timeout fallback is measured from there. Constructing it
+    // first would let the sim's own wall-clock spend that budget, and the fallback — not the fix
+    // under test — would be what puts the frame on screen (an "invalid mutation produces a
+    // reassuring green").
+    gui::ServerPoller local;
+
+    // Arm the gate strictly above the ray count THIS run actually achieved. Derived from the
+    // measurement rather than hard-coded: the achieved count is a core/RNG-dependent number and
+    // pinning it here would make the test platform-dependent. `+1` rejects deterministically
+    // without assuming anything about its magnitude.
+    auto arm_gate_above_achieved = [&](LUMICE_RayCount* out_rays) {
+      LUMICE_StatsResult stats{};
+      LUMICE_GetCachedStats(server, &stats);
+      *out_rays = stats.sim_ray_num;
+      local.SetCalibratedThreshold(stats.sim_ray_num + 1);
+    };
+
+    LUMICE_RayCount rays_a = 0;
+    arm_gate_above_achieved(&rays_a);
+    // A genuinely zero-ray run takes the cold-start bypass (`sim_ray_num == 0` passes the gate
+    // unconditionally) and would exercise none of the path under test.
+    IM_CHECK(rays_a > 0);
+
+    local.ResetGenerationForTest();
+    local.PollOnceForTest(server);
+
+    auto sa = local.LoadSnapshot();
+    IM_CHECK(sa != nullptr);
+    IM_CHECK_EQ(sa->lifecycle, static_cast<int>(LUMICE_LIFECYCLE_COMPLETED));
+    IM_CHECK(sa->payload != nullptr);   // the terminal frame reached the consumer despite the gate
+    IM_CHECK(sa->has_new_texture);      // ... and THIS poll is what materialized it
+    IM_CHECK(sa->texture_serial != 0);  // ... under a fresh monotonic serial (the upload key)
+    const unsigned long long serial_a = sa->texture_serial;
+
+    // Phase B ---- second low-ray completion, re-armed through the production WakeForRestart seam
+    // (what DoRun calls on a fresh commit). Drives the real kPaused→kRunning reset, not the
+    // ResetGenerationForTest() test seam, so a rescue flag that is never re-armed shows up here.
+    const bool completed_b = RunFiniteToCompletion(server);
+    IM_CHECK(completed_b);
+    if (!completed_b) {
+      local.Stop();
+      LUMICE_DestroyServer(server);
+      return;
+    }
+    LUMICE_RayCount rays_b = 0;
+    arm_gate_above_achieved(&rays_b);
+    IM_CHECK(rays_b > 0);
+
+    local.WakeForRestart(server);
+    // The wake releases `local`'s worker thread. Stop() blocks until it has left the poll loop, so
+    // the synchronous PollOnceForTest below is the only writer — no data race on the poller's
+    // per-resume state. The worker may still have landed one poll inside that window, which is why
+    // the assertions below key on "the serial advanced" (true whichever thread materialized it)
+    // rather than on has_new_texture (true only for the poll that did it).
+    local.Stop();
+    local.PollOnceForTest(server);
+
+    auto sb = local.LoadSnapshot();
+    IM_CHECK(sb != nullptr);
+    IM_CHECK_EQ(sb->lifecycle, static_cast<int>(LUMICE_LIFECYCLE_COMPLETED));
+    IM_CHECK(sb->payload != nullptr);
+    IM_CHECK(sb->texture_serial != serial_a);  // a SECOND materialization, not phase A's carried forward
+    const unsigned long long serial_b = sb->texture_serial;
+
+    // Phase C ---- display-time refresh of the SAME completed run, through WakeForRefresh (what the
+    // colour-window PushDisplayState and the composite-EV push call). No new sim: the run is over
+    // and the user only changed how it is displayed. That wake exists to buy exactly one more poll
+    // before the poller self-pauses again, so if the gate swallows it the edit silently never shows.
+    local.WakeForRefresh(server);
+    local.Stop();  // same worker-race fence as phase B
+    local.PollOnceForTest(server);
+
+    auto sc = local.LoadSnapshot();
+    IM_CHECK(sc != nullptr);
+    IM_CHECK_EQ(sc->lifecycle, static_cast<int>(LUMICE_LIFECYCLE_COMPLETED));
+    IM_CHECK(sc->payload != nullptr);
+    IM_CHECK(sc->texture_serial != serial_b);  // the refresh produced a frame of its own
+
+    local.Stop();
+    LUMICE_DestroyServer(server);
+  };
+
   // ---- Test 7: task-color-migration M4 — WakeForRefresh preserves valid across the wake edge ----
   // Pins the semantic distinction between the two poller wake seams introduced by M4:
   //   WakeForRestart publishes valid=false on the kPaused→kRunning edge (fresh commit: consumers


### PR DESCRIPTION
## 问题

**总光线数低于标定阈值的有限仿真跑完后，预览图永远不出现**（跑完了也是空白）。

真实 GUI 启动默认就跑标定（`src/gui/main.cpp:320`，除非 `--skip-calibration`），
生产环境的 `calibrated_min_rays_` 是 3–4 万量级。用户跑一次总光线数低于该值的有限仿真，
预览永远是空白 —— 这是用户可见的产品缺陷，此前无任何测试覆盖。

### 机制链（四环，均在 `PollOnce()` 内）

1. `SetCalibratedThreshold` 把 `calibrated_min_rays_` 写进全局 poller，`ResetTestState()` 不复位 ⇒ 常驻。
2. 质量闸 `min_rays = calibrated_ ? calibrated_min_rays_ : kMinRaysFloor(5000)` 拒绝一切低于该值的快照。
3. 质量闸的 500ms 兜底（`kQualityGateTimeoutMs`）本可强制上传，但 COMPLETED 自暂停**位于质量闸之后
   的同一次调用中** —— 有限跑 ~80ms 就 COMPLETED ⇒ **再没有下一次轮询，兜底永远等不到**。
4. ⇒ 纹理永不上传。

单变量对照（同 filter、同进程）：20,000 条 → `payload=0` / 8009ms / 红；200,000 条 → `payload=1` / 385ms / 绿。
门控快照显示 epoch / floor / serial 三门全成立，唯一不成立的是 `payload != nullptr`。

## 修法

终局帧补投（invariant **I6**「最后一帧必须上屏」）：质量闸压制稀疏帧的前提是「还有更好的将来」，
一旦 COMPLETED 该前提为假 —— 稀疏结果**就是**结果。

- 新增 `uploaded_since_resume_`（**per-resume** 而非 per-lifetime，否则只救进程内第一次低光线完成）；
- `force_final_upload = COMPLETED && !uploaded_since_resume_ && xyz_buffer != nullptr`，
  作为质量闸的第三条放行路径，与 500ms 兜底**并列而非替代**（那条救的是仍在跑、永远到不了阈值的仿真；
  这条救的是已经结束在阈值之下的仿真）；
- 判据**刻意求值在 `has_new_snapshot` 之外** —— 生命周期心跳与快照世代是解耦的两口时钟，
  COMPLETED 完全可能落在不带新世代的那次轮询上；挂上去只会修好恰好被复现的那种交错；
- `!uploaded_since_resume_` 是防止补投用稀疏帧盖掉已有好帧的**唯一**护栏（= 质量闸原本要防的闪烁），
  两个 wake 变体（`WakeForRestart` / `WakeForRefresh`）都复位它。

`RUNNING` 期间 `force_final_upload` 恒 false ⇒ 仿真进行中的抗稀疏闪烁行为逐字节不变。

## 验证

- 新增回归测试 `test/gui/functional/test_gui_lifecycle.cpp`（三阶段 + 红态自证 + 两个定向探针，
  分别验证 `COMPLETED` 与 `!uploaded_since_resume_` 两个合取项各自承重）。
- 最小复现 `gui_test --filter "calibration,p2_gpu_color_degrade"`：修前 1/2 且等满 8s → 修后 **2/2, exit 0**。
- 机制探针实测：给 `force_final_upload` 加无条件日志跑全部 588 例，触发 20 次（全在 `gui_lifecycle` /
  `gui_composite_preview`），确认新分支真被走到、且新测试非空转。
- `doc/gui-preview-lifecycle-architecture.md` §9 I6 补「落地补丁」段（I6 原文不改，这是合规回归记录）。

### ⚠️ 已知未达成项：`./scripts/test.sh pr` 非全绿

`RESULT: FAIL (2/6 layers: fast-e2e, gui-correctness)`。**两条失败腿均已一手证明与本改动无因果**：

| 层 | 失败项 | 排除依据 |
|---|---|---|
| fast-e2e | 恰好 1 项 `test_benchmark_infinite_terminates_cpu`（79 passed） | 测的是 CLI 二进制：`nm -m .../Lumice \| grep -c ServerPoller` = **0**（同命令对 `gui_test` = 22）⇒ `src/gui/` 未链入，结构上不可达。单跑 **2 passed in 8.72s** vs 30s 死线；只在 `pytest -n auto` 吃满 12 核时超时 |
| gui-correctness | 7 项，**全部是 `auto_ev` 场景** | ① 机制层：上述探针在 `auto_ev` 的 15 个用例中触发 **0 次** ⇒ 补丁对该组逐字节等价于 base；② 经验层：在 `main`（`04a9998e`，零本 PR 代码）独立 worktree 重建实测 **`auto_ev` 红 7 个 / 580 of 587**，即该门禁在 main 上本就红 |

`auto_ev` 的红是**先于且独立于本 PR** 的既存问题（捕获判据 `texture_upload_count >= 3` 依赖墙钟 ⇒
PSNR 随机器负载浮动），已在 backlog / `scrum-417` 单独跟踪。本 PR **未**为让它转绿而调整任何阈值或
重拍参考图（`git diff --name-only` 命中 `thresholds`/`references` 的文件数 = 0）。

ctest / gui-real-timing / slow-e2e 三层均 PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
