### PR TITLE
test(gui): auto_ev/lens_proj 捕获判据换成「有限 ray_num + 等 COMPLETED」

### DIFF
--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -15,6 +15,7 @@
 #include "imgui.h"
 #include "imgui_te_context.h"
 #include "imgui_te_engine.h"
+#include "include/lumice.h"
 #include "test_screenshot.hpp"
 
 namespace gui = lumice::gui;
@@ -170,6 +171,25 @@ extern bool g_keep_export_png;
 
 constexpr int kSynthTexW = 64;
 constexpr int kSynthTexH = 64;
+
+// ========== Shared helpers ==========
+
+// Rays a finite run will actually simulate for a given SimConfig::ray_num_millions.
+// Mirrors the one conversion the GUI performs when it hands the budget to the core
+// (src/gui/file_io.cpp, BuildScene -> LUMICE_SceneSetSimParams): float millions,
+// promoted to double, times 1e6, truncated to LUMICE_RayCount.
+//
+// A test that waits for a run to COMPLETE and then asserts the exact ray count needs this
+// number, and there is no getter to read it back from the scene. Keeping the expression in
+// one place stops the two visual-regression suites from drifting apart; it stays a mirror of
+// production rather than a shared owner, which is why callers should pin ray_num_millions to
+// a value whose product with 1e6 is exact in float (i.e. a dyadic fraction such as 0.375f or
+// 0.4375f). At those values truncation and rounding agree, so the mirror survives a change of
+// rounding policy on the production side instead of silently going red — or, worse, staying
+// green by coincidence.
+inline unsigned long long ExpectedSimRayNum(float ray_num_millions) {
+  return static_cast<unsigned long long>(static_cast<LUMICE_RayCount>(ray_num_millions * 1e6));
+}
 
 // ========== Shared functions (defined in test_gui_main.cpp) ==========
 

--- a/test/gui/visual/test_gui_auto_ev.cpp
+++ b/test/gui/visual/test_gui_auto_ev.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -14,6 +15,10 @@ struct AutoEvScene {
   int render_w;
   int render_h;
   double psnr_threshold;
+  // Ray budget for this scene's run. The scene is captured after the run has COMPLETED, so
+  // this is the exact number of rays behind every capture rather than a lower bound; see the
+  // note above kScenes[] for how the values were chosen and why they are dyadic.
+  float ray_num_millions;
   // Overlay regression fields (defaults keep legacy scenes unchanged: enable_overlay=false
   // bypasses the overlay branch in TestFunc; remaining fields are inert in that case).
   bool enable_overlay = false;
@@ -42,19 +47,40 @@ struct AutoEvScene {
 // optimistic — skips the ~240-test warm-up; that optimism was the original flake source).
 // Each threshold = floor((mean − 4σ) · 2) / 2 over the 25 pooled full-suite PSNRs; all sit
 // below every observed run's minimum with margin. (mean / σ / min per scene shown inline.)
+//
+// ray_num_millions pins the ray budget of the run each capture is taken from. It exists
+// because the capture used to be triggered by a timing proxy (the third texture upload), and
+// an upload carries however much data happened to have arrived — so the work behind a capture
+// moved with machine load, and PSNR moved with it. Measured on the three full-suite runs that
+// preceded this change, the third upload landed anywhere between 0.42M and 0.55M rays for the
+// same scene (color), a 1.3x swing over an idle machine alone. Configuring a finite budget and
+// waiting for the run to reach COMPLETED instead makes the work behind every capture the exact
+// same number, whatever the machine is doing.
+//
+// Each value is the scene's own measured third-upload capture point (mean of those three
+// full-suite runs), rounded to the nearest 1/16 M. Matching the old working point is what keeps
+// the existing references and thresholds valid — the references are means of captures taken at
+// that work level, and PSNR against them is a function of it. The values differ per scene
+// because throughput does: multi_scat traces two scattering layers, so the same wall-clock
+// window buys it far fewer rays than the single-layer scenes.
+//
+// The 1/16 M grid is not cosmetic: 1/16 is a dyadic fraction, so ray_num_millions * 1e6 is an
+// exact integer in float and the float->LUMICE_RayCount conversion in BuildScene neither
+// truncates nor rounds. That is what lets ExpectedSimRayNum() assert the ray count exactly
+// (see its note in test_gui_shared.hpp). A decimal such as 0.45f would simulate 449999 rays.
 static const AutoEvScene kScenes[] = {
-  {"halo_22",    LUMICE_E2E_CONFIG_DIR "/halo_22.json",                           256, 256, 18.5},  // mean 20.00 σ0.141 (N=10 recalib 2026-07-31)
-  {"multi_scat", LUMICE_E2E_CONFIG_DIR "/multi_scatter.json",                     256, 256, 16.0},  // mean 17.08 σ0.209 (N=10 recalib 2026-07-31) (regen: real 2-layer scattering)
-  {"color",      LUMICE_E2E_CONFIG_DIR "/color.json",                             256, 256, 20.0},  // mean 21.13 σ0.227 (N=10 recalib 2026-07-31)
-  {"pyramid",    LUMICE_E2E_CONFIG_DIR "/pyramid.json",                           256, 256, 19.5},  // mean 20.53 σ0.194 (N=10 recalib 2026-07-31)
-  {"cza",        LUMICE_E2E_CONFIG_DIR "/cza.json",                               256, 256, 35.5},  // mean 36.70 σ0.242 (N=10 recalib 2026-07-31)
-  {"parhelion",  LUMICE_E2E_CONFIG_DIR "/parhelion.json",                         256, 256, 26.0},  // mean 27.82 σ0.360 (N=10 recalib 2026-07-31)
-  {"filters",    LUMICE_E2E_CONFIG_DIR "/filters.json",                           256, 256, 24.5},  // mean 25.91 σ0.239 (N=10 recalib 2026-07-31)
-  {"rp46",       LUMICE_E2E_CONFIG_DIR "/raypath_symmetry_4_6.json",              256, 256, 27.5},  // mean 29.22 σ0.367 (N=10 recalib 2026-07-31)
-  {"rp46_nof",   LUMICE_E2E_CONFIG_DIR "/raypath_symmetry_4_6_nofilter.json",     256, 256, 19.5},  // mean 20.59 σ0.184 (N=10 recalib 2026-07-31)
+  {"halo_22",    LUMICE_E2E_CONFIG_DIR "/halo_22.json",                           256, 256, 18.5,  0.4375f},  // mean 20.00 σ0.141 (N=10 recalib 2026-07-31)
+  {"multi_scat", LUMICE_E2E_CONFIG_DIR "/multi_scatter.json",                     256, 256, 16.0,  0.1875f},  // mean 17.08 σ0.209 (N=10 recalib 2026-07-31) (regen: real 2-layer scattering)
+  {"color",      LUMICE_E2E_CONFIG_DIR "/color.json",                             256, 256, 20.0,  0.5f},     // mean 21.13 σ0.227 (N=10 recalib 2026-07-31)
+  {"pyramid",    LUMICE_E2E_CONFIG_DIR "/pyramid.json",                           256, 256, 19.5,  0.25f},    // mean 20.53 σ0.194 (N=10 recalib 2026-07-31)
+  {"cza",        LUMICE_E2E_CONFIG_DIR "/cza.json",                               256, 256, 35.5,  0.4375f},  // mean 36.70 σ0.242 (N=10 recalib 2026-07-31)
+  {"parhelion",  LUMICE_E2E_CONFIG_DIR "/parhelion.json",                         256, 256, 26.0,  0.375f},   // mean 27.82 σ0.360 (N=10 recalib 2026-07-31)
+  {"filters",    LUMICE_E2E_CONFIG_DIR "/filters.json",                           256, 256, 24.5,  0.4375f},  // mean 25.91 σ0.239 (N=10 recalib 2026-07-31)
+  {"rp46",       LUMICE_E2E_CONFIG_DIR "/raypath_symmetry_4_6.json",              256, 256, 27.5,  0.375f},   // mean 29.22 σ0.367 (N=10 recalib 2026-07-31)
+  {"rp46_nof",   LUMICE_E2E_CONFIG_DIR "/raypath_symmetry_4_6_nofilter.json",     256, 256, 19.5,  0.4375f},  // mean 20.59 σ0.184 (N=10 recalib 2026-07-31)
   // Overlay regression scene (task-288.7): fisheye EA at elevation=45° with zenith marker +
   // coordinate grid.
-  {"overlay_ea", LUMICE_E2E_CONFIG_DIR "/halo_22.json",                           256, 256, 20.0,  // mean 21.30 σ0.165 (N=10 recalib 2026-07-31)
+  {"overlay_ea", LUMICE_E2E_CONFIG_DIR "/halo_22.json",                           256, 256, 20.0,  0.375f,    // mean 21.30 σ0.165 (N=10 recalib 2026-07-31)
    true, lumice::gui::kLensTypeFisheyeEqualArea, 180.0f, 45.0f, true, true},
 };
 // clang-format on
@@ -96,37 +122,52 @@ void RegisterAutoEvRegressionTests(ImGuiTestEngine* engine) {
       // 3. Force sim_resolution_index=0 (512) to speed up CI without changing GUI option count
       gui::g_state.renderer.sim_resolution_index = 0;
 
+      // 3b. Override the config's own ray budget with this scene's finite one. The e2e configs
+      // are sized for a CLI render (5M-50M rays) and some of them ask for "infinite"; either
+      // way the run would never reach COMPLETED, which is what step 5 waits for.
+      gui::g_state.sim.infinite = false;
+      gui::g_state.sim.ray_num_millions = scene.ray_num_millions;
+
       // 4. DoRun → triggers BuildScene (dual-fisheye override) → starts poller.
       // DoRun sets the intent (run_intent=kRunning); sim_state is reconcile-derived on the next
       // frame, so assert the intent here (the wait loop below drives frames to kSimulating/data).
       gui::DoRun(/*user_initiated=*/true);
       IM_CHECK_EQ((int)gui::g_state.run_intent, (int)gui::RunIntent::kRunning);
 
-      // 5. Reset counter so the wait loop below starts from 0
-      // (DeserializeFromJson already did a full reset, but DoRun may trigger callbacks)
-      gui::g_state.texture_upload_count = 0;
-
-      // 6. Wait for stable data (texture_upload_count >= 3).
-      // rp46 scenes use a 60s timeout because ray path filtering makes photons sparse.
-      const int timeout_frames = (ctx->Test->ArgVariant >= 7) ? 60 * 60 : 30 * 60;
-      for (int i = 0; i < timeout_frames && gui::g_state.texture_upload_count < 3; ++i) {
+      // 5. Wait for THIS run to finish, then capture its final frame. sim_state reaching kDone
+      // means the backend reported LUMICE_LIFECYCLE_COMPLETED for the committed epoch
+      // (ReconcileSimState, app.cpp), i.e. all scene.ray_num_millions rays have been traced —
+      // so every capture of this scene is built from the exact same amount of work, on an idle
+      // machine and a saturated one alike. The final frame reaches the texture even when the
+      // run is too sparse to satisfy the preview quality gate, because a COMPLETED lifecycle
+      // forces the last upload through it (server_poller.cpp, force_final_upload; PR #240).
+      //
+      // The deadline only guards against a hang, it is not a budget: these scenes trace at most
+      // 0.5M rays, which the ray-gated lens_proj suite next door covers with 34s per million.
+      // Missing it means the run never completed, and stretching it would not fix that.
+      const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+      while (gui::g_state.sim_state != gui::GuiState::SimState::kDone &&
+             std::chrono::steady_clock::now() < wait_deadline) {
         ctx->Yield(1);
       }
-      IM_CHECK_GE((int)gui::g_state.texture_upload_count, 3);
+      IM_CHECK_EQ((int)gui::g_state.sim_state, (int)gui::GuiState::SimState::kDone);
+      // The point of the change, asserted rather than assumed: a completed run traced exactly
+      // its configured budget, so this number is identical on every machine and every rerun.
+      IM_CHECK_EQ((unsigned long long)gui::g_state.stats_sim_ray_num, ExpectedSimRayNum(scene.ray_num_millions));
 
-      // 7. Stop simulation; ev_auto and snapshot_intensity remain in g_state
+      // 6. Stop simulation; ev_auto and snapshot_intensity remain in g_state
       gui::g_server_poller.Stop();
       LUMICE_StopServer(gui::g_server);
       LUMICE_DestroyServer(gui::g_server);
       gui::g_server = nullptr;
       gui::g_state.run_intent = gui::RunIntent::kNone;  // reconcile → kIdle (server gone)
 
-      // 8. Capture exposure parameters
+      // 7. Capture exposure parameters
       const float si = gui::g_state.snapshot_intensity;
       const float ev = gui::g_state.ev_auto;
       IM_CHECK_GT(si, 0.0f);
 
-      // 9. Build viewport with auto-EV applied — the actual GUI display state.
+      // 8. Build viewport with auto-EV applied — the actual GUI display state.
       // (The legacy "off" capture at intensity_factor=1.0 was dropped: GUI has no
       // auto-EV toggle anymore, so off is a degenerate non-default state and exercises
       // no code path the auto-EV-applied capture doesn't already cover. See
@@ -167,13 +208,13 @@ void RegisterAutoEvRegressionTests(ImGuiTestEngine* engine) {
         }
       }
 
-      // 10. Export capture, then compare against reference. The "_on" tag/filename is
+      // 9. Export capture, then compare against reference. The "_on" tag/filename is
       // retained so the existing auto_ev_<scene>_on.jpg references stay valid.
       const std::string path_on = std::string("/tmp/lumice_auto_ev_") + scene.name + "_on.png";
       const std::string ref_on = std::string(LUMICE_TEST_REF_DIR) + "/auto_ev_" + scene.name + "_on.jpg";
       IM_CHECK(RequestAndWaitExport(ctx, vp, path_on));
 
-      // 11. Compare against reference
+      // 10. Compare against reference
       IM_CHECK(lumice::test::CheckAgainstReference("auto_ev", (std::string(scene.name) + "_on").c_str(), path_on,
                                                    ref_on, scene.psnr_threshold, g_keep_export_png));
     };

--- a/test/gui/visual/test_gui_lens_projection.cpp
+++ b/test/gui/visual/test_gui_lens_projection.cpp
@@ -48,10 +48,10 @@ struct LensProjScene {
   int render_w;
   int render_h;
   double psnr_threshold;
-  // Simulated rays to accumulate before capturing. Higher = less Monte-Carlo noise in the
+  // Ray budget for this scene's run, in millions. Higher = less Monte-Carlo noise in the
   // capture, which is what limits how small a geometric error the PSNR comparison can
   // resolve; see the note above kScenes[].
-  unsigned long long min_rays;
+  float ray_num_millions;
   LensSetup setup;
   // Consumed only when setup == kOverrideViewProj.
   int lens_type = 0;
@@ -76,23 +76,33 @@ struct LensProjScene {
 // and the equirect map spans the full ±180° x ±90° sky. A square frame would only add
 // black bands.
 //
-// Capture timing is gated on accumulated RAYS, not on a texture-upload count as the auto_ev
-// scenes are. An upload carries however much data happened to arrive, so the same upload
-// count buys different ray counts depending on machine load — measured here, 40 uploads was
-// 6.43M rays on an idle machine and 4.56M under load. That leaks load into the noise level
-// and therefore into PSNR, inflating the calibrated sigma (a contended 60-run batch measured
-// 0.63 dB against 0.22 dB for the same scene run undisturbed) and forcing a threshold too
-// loose to catch anything. Gating on rays makes the capture reproducible instead.
+// Each scene configures a finite ray budget and captures the frame its run COMPLETES on,
+// rather than watching a counter and stopping the run once it passes a threshold. Both forms
+// fix the work behind a capture, but only the completed run fixes it exactly: waiting for a
+// counter to cross a bound stops at the first poll that observed the crossing, and how far
+// past the bound that poll lands depends on how big a batch the poller happened to pick up.
+// The predecessor of both — capturing on a texture-upload count, as the auto_ev scenes did —
+// did not fix the work at all: an upload carries however much data happened to arrive, so the
+// same upload count bought 6.43M rays on an idle machine and 4.56M under load. That leaked
+// load into the noise level and therefore into PSNR, inflating the calibrated sigma (a
+// contended 60-run batch measured 0.63 dB against 0.22 dB for the same scene run undisturbed)
+// and forcing a threshold too loose to catch anything.
 //
-// min_rays differs per scene because detection power does. The comparison is one noisy
+// ray_num_millions differs per scene because detection power does. The comparison is one noisy
 // capture against a smooth 10-run mean, so per-run Monte-Carlo noise sets the PSNR floor,
 // and a projection error only moves PSNR by as much of the frame as it disturbs. The
 // single-fisheye scenes fill their frame with the halo and resolve a perturbed projection
 // easily at 0.4M rays. The two full-sky scenes spread the same structure over a much larger
 // frame, leaving most pixels empty sky: at that budget, a lens-scale error that visibly
 // stretches the halo ring into an ellipse moved PSNR only ~1.2 dB and did not even cross the
-// threshold. They accumulate 5M rays instead, which drops the noise floor far enough for the
+// threshold. They trace 5M rays instead, which drops the noise floor far enough for the
 // geometric term to dominate, and stays well inside halo_22.json's 10M ray budget.
+//
+// The budgets are unchanged from the ray counts these scenes previously waited for, so the
+// committed references and their thresholds still describe the same working point. Both reach
+// their intended integer under truncation and rounding alike (0.4f * 1e6 is 400000.006, 5.0f
+// is exact), which is what lets ExpectedSimRayNum() assert the resulting ray count exactly —
+// see its note in test_gui_shared.hpp before changing either value.
 //
 // References are pixel-averaged means of N=10 runs; thresholds come from
 // scripts/regen_gui_test_refs.py --group lens_proj (Phase B, mean − 4σ floored to 0.5 dB,
@@ -100,16 +110,16 @@ struct LensProjScene {
 // test/gui/references/_thresholds.json and repeated inline below.
 static const LensProjScene kScenes[] = {
   // mean 20.293 σ0.1742
-  {"fisheye_equal_area_120",       LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 256, 19.0,  400000ULL,
+  {"fisheye_equal_area_120",       LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 256, 19.0,  0.4f,
    LensSetup::kOverrideViewProj, lumice::gui::kLensTypeFisheyeEqualArea,   120.0f, 20.0f},
   // mean 21.1458 σ0.199
-  {"fisheye_orthographic_180",     LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 256, 20.0,  400000ULL,
+  {"fisheye_orthographic_180",     LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 256, 20.0,  0.4f,
    LensSetup::kOverrideViewProj, lumice::gui::kLensTypeFisheyeOrthographic, 180.0f, 20.0f},
   // mean 27.7147 σ0.0643
-  {"dual_fisheye_equal_area_full", LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 128, 26.5,  5000000ULL,
+  {"dual_fisheye_equal_area_full", LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 128, 26.5,  5.0f,
    LensSetup::kDualFisheyeExport},
   // mean 26.5703 σ0.0876
-  {"rectangular",                  LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 128, 25.5,  5000000ULL,
+  {"rectangular",                  LUMICE_E2E_CONFIG_DIR "/halo_22.json", 256, 128, 25.5,  5.0f,
    LensSetup::kEquirectExport},
 };
 // clang-format on
@@ -133,9 +143,9 @@ static bool RequestAndWaitExport(ImGuiTestContext* ctx, const gui::PreviewViewpo
 // IM_CHECK*() macros expand to `return;` on failure, so any of them firing between server
 // creation and the manual teardown below would skip Stop/Destroy and leak a running server +
 // poller thread into the next IM_REGISTER_TEST case (ResetTestState() only nulls the pointer,
-// it does not tear one down). The min_rays wait this scene relies on has an observed real
-// chance of not finishing in time under load (see the note above), which made that early-return
-// path newly reachable rather than theoretical. Ordinary `return` still unwinds the C++ stack,
+// it does not tear one down). The wait for the run to complete has an observed real chance of
+// not finishing in time under load (see the note above), which made that early-return path
+// newly reachable rather than theoretical. Ordinary `return` still unwinds the C++ stack,
 // so a scope guard here is sufficient; disarm it via server_owned once the normal path has torn
 // the server down itself, to avoid a double Stop/Destroy.
 struct ScopedServerAndWatchdogGuard {
@@ -189,15 +199,23 @@ void RegisterLensProjectionTests(ImGuiTestEngine* engine) {
       // under test (the shader resamples the source texture either way).
       gui::g_state.renderer.sim_resolution_index = 0;
 
+      // 3b. Override the config's own ray budget with this scene's. halo_22.json asks for 10M
+      // rays; the run has to be finite AND this size for step 5's wait to end on the working
+      // point the references were captured at.
+      gui::g_state.sim.infinite = false;
+      gui::g_state.sim.ray_num_millions = scene.ray_num_millions;
+
       // 4. DoRun sets the intent; sim_state is reconcile-derived on the next frame.
       gui::DoRun(/*user_initiated=*/true);
       IM_CHECK_EQ((int)gui::g_state.run_intent, (int)gui::RunIntent::kRunning);
 
-      // 5. Accumulate scene.min_rays simulated rays, then stop the simulation. stats_sim_ray_num
-      // tracks the ray count behind the currently displayed texture (app.cpp:1363-1365). Both
-      // counters are zeroed here rather than trusted from ResetTestState: a stale ray count
-      // left by the previous scene satisfies the wait on the very first frame, and the capture
-      // then reads whatever texture happened to still be bound.
+      // 5. Let the run finish, then stop the simulation and capture its final frame.
+      // sim_state reaching kDone means the backend reported LUMICE_LIFECYCLE_COMPLETED for the
+      // committed epoch (ReconcileSimState, app.cpp) — every ray of the budget traced, and the
+      // final frame pushed to the texture even if it is too sparse for the preview quality gate
+      // (server_poller.cpp, force_final_upload; PR #240). Nothing needs zeroing beforehand:
+      // unlike a counter threshold, a stale value from the previous scene cannot satisfy this
+      // wait, because kDone is derived from the lifecycle of the epoch DoRun just committed.
       //
       // The wait below is bounded by real elapsed time, not iteration count: --fixed-dt injects a
       // fixed 1/60s frame dt but also skips the frame-limit sleep (runs "at full speed"), so an
@@ -226,15 +244,15 @@ void RegisterLensProjectionTests(ImGuiTestEngine* engine) {
       // every other test still gets the tight default.
       guard.engine_io->ConfigWatchdogWarning = 50000.0f;
       guard.engine_io->ConfigWatchdogKillTest = 100000.0f;
-      gui::g_state.texture_upload_count = 0;
-      gui::g_state.stats_sim_ray_num = 0;
       const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(170);
-      while ((gui::g_state.stats_sim_ray_num < scene.min_rays || gui::g_state.texture_upload_count == 0) &&
+      while (gui::g_state.sim_state != gui::GuiState::SimState::kDone &&
              std::chrono::steady_clock::now() < wait_deadline) {
         ctx->Yield(1);
       }
-      IM_CHECK_GE((unsigned long long)gui::g_state.stats_sim_ray_num, scene.min_rays);
-      IM_CHECK_GT((int)gui::g_state.texture_upload_count, 0);
+      IM_CHECK_EQ((int)gui::g_state.sim_state, (int)gui::GuiState::SimState::kDone);
+      // A completed run traced exactly its configured budget, so this number is identical on
+      // every machine and every rerun — that is the property the capture inherits.
+      IM_CHECK_EQ((unsigned long long)gui::g_state.stats_sim_ray_num, ExpectedSimRayNum(scene.ray_num_millions));
 
       guard.server_owned = false;
       gui::g_server_poller.Stop();


### PR DESCRIPTION
## 问题

`auto_ev`（10 场景）与 `lens_proj`（4 场景）的截图捕获判据是**时序代理量**——等第 N 次纹理上传 /
等累积到某个光线数。一次上传携带多少数据取决于机器当时在干什么，所以每次捕获背后的**工作量随
负载漂移**，PSNR 随之漂移。

实测（干净机器、同一二进制）：`color` 的第三次上传落在 **0.42M–0.55M** 光线之间，仅空闲状态下
就有 1.3× 摆动。

## 改法

配一个**有限** `ray_num`，等 `lifecycle == COMPLETED`（GUI 侧 `sim_state == kDone`）后截**终帧**：

```
配置有限 ray_num  →  等 COMPLETED  →  截终帧
```

每次捕获背后的工作量因此是**精确相同的数字**，与机器状态无关。

依赖的原语由 #240 刚补齐（COMPLETED 终帧绕过质量闸强制上屏）——没有它，稀疏的有限仿真跑完后
永远不上屏。

## 明确没做的事

- **不钉 `sim_seed`**：会触发单 worker 钳制（实测 4.2× 耗时），且把一次抽样冻住——若该实现偏低
  则该平台永久红、σ 再也测不出
- **不改比较方式**：均值参考图 + `mean − 4σ` 阈值原样保留。统计式比较只依赖分布不依赖随机流，
  这正是它跨平台可移植的原因
- **参考图与阈值零改动**：每个场景的 `ray_num` 取自它自己实测的旧捕获点，刻意匹配旧工作点
- **`src/` 零改动**

## 验证

| 判据 | 结果 |
|---|---|
| 空闲 3 轮，15 条 `sim_ray_num` 断言 | 逐位置完全相同 |
| 高负载 2 轮（`top` idle **0.0%**） | 与空闲轮 15/15 位置相同 |
| 负载下 `auto_ev`/`lens_proj` 破线条数 | 0 |
| `./scripts/test.sh pr` | 六层全 PASS |

## 实现细节

- `ray_num` 取**二进分数**（7/16、3/8、1/4、1/2、3/16），使 `ray_num_millions * 1e6` 在 float 下
  精确 ⇒ float→`LUMICE_RayCount` 既不截断也不舍入，`ExpectedSimRayNum()` 才能断言精确值
  （`0.45f` 会模拟 449999 条）
- `test_gui_shared.hpp::ExpectedSimRayNum()` 明注自己是**生产侧转换的镜像而非 owner**

🤖 Generated with [Claude Code](https://claude.com/claude-code)