### PR TITLE
fix(gui): ServerPoller 状态复位收敛为单一 owner + 修重启后状态栏上屏陈旧统计

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1262,6 +1262,13 @@ bool ShouldUploadPayload(const PreviewSnapshot& snap, unsigned long long last_up
          payload->payload_epoch > display_epoch_floor;
 }
 
+// Stats-apply gate — see app.hpp. Deliberately reads snap.stats_epoch and NOT snap.epoch: the
+// bundle epoch is re-stamped on every poll, so it says nothing about which generation produced
+// the stats travelling with it.
+bool ShouldApplyStats(const PreviewSnapshot& snap, uint64_t committed_epoch) {
+  return snap.stats_epoch == committed_epoch && snap.stats_sim_ray_num > 0;
+}
+
 // task-345.4 effective composite/xyz choice — see app.hpp. Pure boolean AND: server must have
 // produced a composite (raypath_color active) AND the user preference must be "show composite".
 // When raypath_color is empty the poller leaves is_composite=false → this returns false → the
@@ -1491,9 +1498,11 @@ void SyncFromPoller() {
     return;  // No observation yet (or a valid=false restart reset). State already reconciled.
   }
 
-  // Stats: apply only when the observation matches the committed generation (I1), so a stale
-  // bundle can't backfill the status bar with a prior run's counts.
-  if (snap->epoch == g_state.committed_epoch && snap->stats_sim_ray_num > 0) {
+  // Stats: apply only when the STATS THEMSELVES were produced under the committed generation (I1),
+  // so a stale carry-forward can't backfill the status bar with a prior run's counts. Keyed on the
+  // stats' own stamp rather than the bundle epoch — see ShouldApplyStats in app.hpp for why the
+  // bundle epoch cannot answer this.
+  if (ShouldApplyStats(*snap, g_state.committed_epoch)) {
     g_state.stats_ray_seg_num = snap->stats_ray_seg_num;
     g_state.stats_sim_ray_num = snap->stats_sim_ray_num;
     g_state.stats_crystal_num = snap->stats_crystal_num;

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -271,6 +271,14 @@ bool ShouldUploadPayload(const PreviewSnapshot& snap, unsigned long long last_up
 // Without that distinction a restart republishes the previous run's ray/crystal/sampling counts
 // under the newly committed epoch and the status bar shows them. The rays > 0 lower bound is
 // retained unchanged — it is what keeps a zero from overwriting a value already on screen.
+//
+// The epoch parameter is spelled uint64_t while PreviewSnapshot::stats_epoch it is compared against
+// is unsigned long long. That split is the module's existing convention, not an oversight: snapshot
+// FIELDS follow epoch/payload_epoch (unsigned long long), while predicate epoch PARAMETERS follow
+// ShouldUploadPayload's display_epoch_floor (uint64_t), because the argument sites are GuiState
+// members and those are uint64_t. Same underlying type on every supported platform, so nothing
+// narrows. Written down here because the convention is implicit enough that reviewing it twice
+// produced the wrong answer once.
 bool ShouldApplyStats(const PreviewSnapshot& snap, uint64_t committed_epoch);
 
 // Effective per-frame composite/xyz upload decision (task-345.4). Folds server-side composite

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -265,6 +265,14 @@ GuiState::SimState ReconcileSimState(RunIntent intent, uint64_t committed_epoch,
 bool ShouldUploadPayload(const PreviewSnapshot& snap, unsigned long long last_uploaded_texture_serial,
                          uint64_t display_epoch_floor);
 
+// Stats-apply gate. Pure predicate mirroring ShouldUploadPayload's texture-side pattern on the
+// stats side: it keys on the stats' OWN generation stamp (snap.stats_epoch), not on the bundle
+// epoch, because the bundle epoch is re-stamped on every poll while carried-forward stats are not.
+// Without that distinction a restart republishes the previous run's ray/crystal/sampling counts
+// under the newly committed epoch and the status bar shows them. The rays > 0 lower bound is
+// retained unchanged — it is what keeps a zero from overwriting a value already on screen.
+bool ShouldApplyStats(const PreviewSnapshot& snap, uint64_t committed_epoch);
+
 // Effective per-frame composite/xyz upload decision (task-345.4). Folds server-side composite
 // availability (`payload_is_composite`) with the user's display-time preference
 // (`show_composite_preview`) into a single boolean the upload branch consumes. Pure predicate,

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -38,14 +38,7 @@ void ServerPoller::Start(LUMICE_Server* server) {
   // the shared payload pointer) keeps the preview on screen during the gap between restart and
   // first new snapshot, preventing visible flicker during slider scrubbing.
   PublishValidReset();
-  // Reset generation tracking so the worker detects the first snapshot as new data.
-  last_generation_ = 0;
-  // Reset quality gate timeout so fallback doesn't fire prematurely after restart.
-  last_quality_pass_time_ = std::chrono::steady_clock::now();
-  // Re-arm the terminal-frame rescue for the resumed run (I6 — see the header). Kept next to the
-  // two resets above because all three are per-resume state; Start() does not route through
-  // TransitionToRunning(), so it carries its own copy of the same three-line reset.
-  uploaded_since_resume_ = false;
+  ResetPerResumeState();
 
   {
     std::lock_guard<std::mutex> lk(mutex_);
@@ -93,15 +86,7 @@ bool ServerPoller::TransitionToRunning(LUMICE_Server* server, bool publish_reset
     }
     // kPaused → resume polling
     server_ = server;
-    last_generation_ = 0;
-    last_quality_pass_time_ = std::chrono::steady_clock::now();
-    // Re-arm the terminal-frame rescue (I6 — see the header). Both wake variants reset it, and for
-    // the same reason: each buys the worker a poll it would otherwise never get. WakeForRestart
-    // opens a new sim generation; WakeForRefresh wakes an already-completed run for exactly ONE
-    // more poll to re-materialize it under new display state (colour edits / composite EV), after
-    // which PollOnce self-pauses again. If the gate swallows that single poll, a sparse completed
-    // run's display edits would silently never appear.
-    uploaded_since_resume_ = false;
+    ResetPerResumeState();
     if (publish_reset) {
       PublishValidReset();
     }
@@ -142,6 +127,26 @@ void ServerPoller::PublishValidReset() {
   next->valid = false;
   next->has_new_texture = false;
   StorePublished(std::move(next));
+}
+
+// Single owner of the per-resume reset (see the header contract). All three fields describe "what
+// has happened since the worker last resumed", so they are re-armed together at every
+// kPaused→kRunning edge:
+//   - last_generation_        : so the worker detects the first snapshot of the resume as new data.
+//   - last_quality_pass_time_ : so the quality gate's 500ms timeout fallback doesn't fire
+//                               prematurely against time that elapsed while paused.
+//   - uploaded_since_resume_  : re-arms the terminal-frame rescue (I6 — see the header). Both wake
+//                               variants reset it, and for the same reason: each buys the worker a
+//                               poll it would otherwise never get. WakeForRestart opens a new sim
+//                               generation; WakeForRefresh wakes an already-completed run for
+//                               exactly ONE more poll to re-materialize it under new display state
+//                               (colour edits / composite EV), after which PollOnce self-pauses
+//                               again. If the gate swallows that single poll, a sparse completed
+//                               run's display edits would silently never appear.
+void ServerPoller::ResetPerResumeState() {
+  last_generation_ = 0;
+  last_quality_pass_time_ = std::chrono::steady_clock::now();
+  uploaded_since_resume_ = false;
 }
 
 void ServerPoller::InvalidateStagedTexture() {

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -275,6 +275,7 @@ void ServerPoller::PollOnce() {
   LUMICE_RayCount new_sim_ray = 0;
   LUMICE_RayCount new_crystal = 0;
   LUMICE_RayCount new_orientation = 0;
+  unsigned long long new_stats_epoch = 0;
   std::shared_ptr<const TexturePayload> new_payload;  // non-null only when a fresh texture materialized
 
   if (has_new_snapshot || force_final_upload) {
@@ -282,15 +283,30 @@ void ServerPoller::PollOnce() {
     // force_final_upload-only path this re-assigns the value already stored — idempotent.
     last_generation_ = captured_xyz_generation;
 
-    // Get stats (used independently for status bar display)
+    // Get stats (used independently for status bar display).
+    //
+    // has_valid_data is load-bearing here, not belt-and-braces: the server's cached stats are NOT
+    // cleared by a restart (ServerImpl::Stop resets snapshot_dirty_ + has_ever_consumed_ and leaves
+    // cached_stats_result_ alone — only DoSnapshot overwrites it), so between a commit and the new
+    // run's first produced batch this call returns the PREVIOUS run's numbers with a perfectly
+    // healthy-looking sim_ray_num > 0. has_valid_data mirrors has_ever_consumed_, which the restart
+    // did reset, and is the only field here that tells the two apart.
+    //
+    // Ordering makes this safe in the direction that matters: LUMICE_GetRawXyzAndCompositeResults
+    // above enters through DoSnapshot(), so any dirty batch has already been folded into
+    // cached_stats_result_ by the time we read it — has_valid_data true therefore implies the cache
+    // belongs to the current generation. The reverse window (a first ConsumeData landing between
+    // the two calls) merely defers fresh stats by one poll, which the carry-forward below absorbs.
     LUMICE_StatsResult cached_stats{};
     LUMICE_GetCachedStats(server, &cached_stats);
-    if (cached_stats.sim_ray_num > 0) {
+    if (cached_stats.sim_ray_num > 0 && xyz_results[0].has_valid_data) {
       have_new_stats = true;
       new_ray_seg = cached_stats.ray_seg_num;
       new_sim_ray = cached_stats.sim_ray_num;
       new_crystal = cached_stats.crystal_num;
       new_orientation = cached_stats.orientation_num;
+      // Same read window as payload_epoch takes for the texture (see the quality_ok block below).
+      new_stats_epoch = xyz_results[0].epoch;
     }
 
     // Quality gate: skip texture overwrite for sparse snapshots (too few rays = visible flicker).
@@ -384,18 +400,24 @@ void ServerPoller::PollOnce() {
     // Lifecycle level signal (clock ④ / I4): carried on every poll.
     next->lifecycle = lc.lifecycle;
     // Stats: fresh value if this generation produced one; else carry forward prev's (coherent
-    // bundle — no torn zero). The consumer applies stats only when >0, so this is behavior-
-    // equivalent to the old swap-to-0-then-skip, and is a positive I5 side effect.
+    // bundle — no torn zero). The stats' own generation stamp travels WITH them in both branches:
+    // freshly read stats are stamped with the generation that produced them, and a carry-forward
+    // keeps the stamp it already had rather than being re-stamped with lc.epoch like the bundle
+    // epoch above. That asymmetry is the whole point — it is what lets the consumer tell "this
+    // poll produced no new stats, here are the current run's last known ones" apart from "this
+    // poll produced no new stats because the run just restarted, and these belong to the old one".
     if (have_new_stats) {
       next->stats_ray_seg_num = new_ray_seg;
       next->stats_sim_ray_num = new_sim_ray;
       next->stats_crystal_num = new_crystal;
       next->stats_orientation_num = new_orientation;
+      next->stats_epoch = new_stats_epoch;
     } else if (prev) {
       next->stats_ray_seg_num = prev->stats_ray_seg_num;
       next->stats_sim_ray_num = prev->stats_sim_ray_num;
       next->stats_crystal_num = prev->stats_crystal_num;
       next->stats_orientation_num = prev->stats_orientation_num;
+      next->stats_epoch = prev->stats_epoch;
     }
     // Texture: a freshly materialized payload gets a new monotonic serial; otherwise carry the
     // previous payload pointer + serial forward (sparse / gate-rejected / no-new-generation) so

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -195,6 +195,17 @@ class ServerPoller {
   // Serializes under publish_mutex_. Called from Start()/WakeForRestart() on the main thread.
   void PublishValidReset();
 
+  // Single owner of the per-RESUME state reset. The three fields it clears
+  // (last_generation_ / last_quality_pass_time_ / uploaded_since_resume_) share one scope — they
+  // describe "what has happened since the worker last resumed" — so they must be re-armed together
+  // at every kPaused→kRunning edge or the survivors silently misreport the new resume as a
+  // continuation of the old one. Start() does not route through TransitionToRunning(), so both call
+  // this; before this method existed each carried its own verbatim copy of the same three lines and
+  // the invariant was held only by a comment. Callers must already hold whatever lock their own
+  // contract requires (TransitionToRunning calls it under mutex_; Start() before taking it) — this
+  // method takes no lock of its own.
+  void ResetPerResumeState();
+
   // Shared body of WakeForRestart/WakeForRefresh: idempotently drive kPaused → kRunning with
   // `server`, resetting the generation/quality-pass tracking under mutex_ and notifying the
   // worker. The ONLY behavioral difference between the two public callers is whether a

--- a/src/gui/server_poller.hpp
+++ b/src/gui/server_poller.hpp
@@ -53,9 +53,12 @@ struct TexturePayload {
 // field-bag + data_mutex_/staged_/std::swap channel.
 struct PreviewSnapshot {
   bool valid = false;  // false until the worker's first successful poll
-  // Bundle epoch: committed lifecycle epoch at poll time (LUMICE_GetSimLifecycle). One epoch
-  // covers the whole coherent snapshot (stats + lifecycle + texture); see §6 (StatsResult.epoch
-  // deliberately NOT added — the bundle epoch suffices).
+  // Bundle epoch: committed lifecycle epoch at poll time (LUMICE_GetSimLifecycle). Re-stamped on
+  // EVERY publish, so it answers "which generation was committed when this poll ran" — NOT "which
+  // generation produced the contents". Fields that can outlive their generation via carry-forward
+  // therefore carry their own stamp beside it (payload_epoch for the texture, stats_epoch below).
+  // This used to read "StatsResult.epoch deliberately NOT added — the bundle epoch suffices"; that
+  // was wrong, and stale stats reaching the status bar after a restart is what disproved it.
   unsigned long long epoch = 0;
   // GetSimLifecycle.lifecycle (blueprint clock ④, see §6). This is the sole completion signal the
   // main thread reconciles on (ReconcileSimState: COMPLETED@matching-epoch → kDone) and the sole
@@ -68,6 +71,14 @@ struct PreviewSnapshot {
   // Sampling-density counters, carried in the same coherent bundle as the two above.
   LUMICE_RayCount stats_crystal_num = 0;
   LUMICE_RayCount stats_orientation_num = 0;
+  // The lifecycle epoch the four stats fields above were actually produced under. Symmetric to
+  // TexturePayload::payload_epoch: it may LAG the bundle epoch when the stats are carried forward
+  // across a restart, and that lag is exactly the signal the consumer needs. The server's cached
+  // stats survive a restart (ServerImpl::Stop clears the dirty/consumed flags but not
+  // cached_stats_result_) while the bundle epoch advances immediately, so without this stamp a
+  // carried-forward value is indistinguishable from a freshly produced one and the previous run's
+  // ray/crystal/sampling counts reappear on the status bar. Consumed via ShouldApplyStats.
+  unsigned long long stats_epoch = 0;
   // Display payload: shared, immutable. Null / carried-forward on sparse / gate-rejected /
   // invalidated polls.
   std::shared_ptr<const TexturePayload> payload;

--- a/test/unit-correctness/gui/test_import_export_logic.cpp
+++ b/test/unit-correctness/gui/test_import_export_logic.cpp
@@ -2738,11 +2738,19 @@ TEST(ImportExport, document_switch_leaves_no_stale_status_bar_stats) {
   // DoOpen(.lmc) hands the LIVE g_state to LoadLmcFile rather than building a separate one, so it
   // is the path where a leftover field would actually survive if the deserializer stopped clearing.
   const std::filesystem::path lmc_path = std::filesystem::temp_directory_path() / "lumice_stats_switch_test.lmc";
+  // RAII rather than a trailing remove(): the ASSERT_TRUE below returns from the TEST on failure,
+  // which would skip a trailing cleanup and leave the file behind for every later run on this host.
+  struct TempFileGuard {
+    std::filesystem::path path;
+    ~TempFileGuard() {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);  // best-effort: a teardown failure must not fail the test
+    }
+  } lmc_guard{ lmc_path };
   ASSERT_TRUE(gui::SaveLmcFile(lmc_path, gui::g_state, gui::g_preview, /*save_texture=*/false));
   seed_stats();
   gui::DoOpen(lmc_path);
   expect_cleared("DoOpen(.lmc)");
-  std::filesystem::remove(lmc_path);
 
   // (C) Revert — the carve-out, pinned deliberately rather than for symmetry: Revert restores
   // config into the SAME document and does not end the run whose numbers are on screen, so those

--- a/test/unit-correctness/gui/test_import_export_logic.cpp
+++ b/test/unit-correctness/gui/test_import_export_logic.cpp
@@ -2696,3 +2696,63 @@ TEST(ImportExport, dorevert_invalidates_effects_baselines_via_owner) {
   // the kRevert branch leaves the baseline populated and this assertion fails.
   ASSERT_TRUE(!gui::g_state.last_pushed_display_state.has_value());
 }
+
+// A document switch leaves no status-bar stats behind; a Revert keeps them.
+//
+// The status bar's ray / crystal / sampling-density readout describes the run of the document on
+// screen, and its display gate is `stats_sim_ray_num > 0` (app_panels.cpp). A leftover value from
+// the previous document satisfies that gate, and no poll follows a document switch to correct it —
+// the poller-side stats-epoch gate filters INCOMING updates and never clears what is already
+// displayed. So this property cannot be inferred from the poller fix; it needs its own guard.
+//
+// It currently holds structurally rather than by an explicit reset: every document-switch path
+// replaces the whole GuiState before ResetFrontendState runs (DoNew via MakeNewDocumentState;
+// DoOpen(.json) via a local new_state; DoOpen(.lmc) via DeserializeGuiStateJson, which opens with
+// `state = GuiState{}`), and GuiState default-initializes all four counters to 0. That is exactly
+// why this test drives the real DoNew / DoOpen entry points instead of calling ResetFrontendState
+// directly: what is being pinned is the end-to-end property, not any one implementation of it. An
+// added reset inside ResetFrontendState would be unreachable dead code today — and a future change
+// that stops replacing the whole state on open is precisely what this case is here to catch.
+TEST(ImportExport, document_switch_leaves_no_stale_status_bar_stats) {
+  // Non-zero on all four, so a partial reset cannot pass by clearing only the gate field.
+  auto seed_stats = []() {
+    gui::g_state.stats_ray_seg_num = 4321;
+    gui::g_state.stats_sim_ray_num = 200000;
+    gui::g_state.stats_crystal_num = 77;
+    gui::g_state.stats_orientation_num = 88;
+  };
+  auto expect_cleared = [](const char* which) {
+    SCOPED_TRACE(which);
+    EXPECT_EQ(gui::g_state.stats_ray_seg_num, 0u);
+    EXPECT_EQ(gui::g_state.stats_sim_ray_num, 0u);
+    EXPECT_EQ(gui::g_state.stats_crystal_num, 0u);
+    EXPECT_EQ(gui::g_state.stats_orientation_num, 0u);
+  };
+
+  // (A) New document.
+  seed_stats();
+  gui::DoNew();
+  expect_cleared("DoNew");
+
+  // (B) Open a .lmc. This is the path worth spending a file on: unlike DoNew and the .json import,
+  // DoOpen(.lmc) hands the LIVE g_state to LoadLmcFile rather than building a separate one, so it
+  // is the path where a leftover field would actually survive if the deserializer stopped clearing.
+  const std::filesystem::path lmc_path = std::filesystem::temp_directory_path() / "lumice_stats_switch_test.lmc";
+  ASSERT_TRUE(gui::SaveLmcFile(lmc_path, gui::g_state, gui::g_preview, /*save_texture=*/false));
+  seed_stats();
+  gui::DoOpen(lmc_path);
+  expect_cleared("DoOpen(.lmc)");
+  std::filesystem::remove(lmc_path);
+
+  // (C) Revert — the carve-out, pinned deliberately rather than for symmetry: Revert restores
+  // config into the SAME document and does not end the run whose numbers are on screen, so those
+  // numbers still describe what is displayed. Without this assertion a later "let's clear stats on
+  // every reset reason" change would silently blank a still-accurate status bar.
+  gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+  seed_stats();
+  gui::DoRevert();
+  EXPECT_EQ(gui::g_state.stats_ray_seg_num, 4321u);
+  EXPECT_EQ(gui::g_state.stats_sim_ray_num, 200000u);
+  EXPECT_EQ(gui::g_state.stats_crystal_num, 77u);
+  EXPECT_EQ(gui::g_state.stats_orientation_num, 88u);
+}

--- a/test/unit-correctness/gui/test_lifecycle.cpp
+++ b/test/unit-correctness/gui/test_lifecycle.cpp
@@ -28,6 +28,10 @@
 //  5. snapshot_bundle_coherence
 //  6. completed_below_threshold_force_uploads
 //  7. wake_for_refresh_preserves_valid
+//  8a. resume_rearms_generation_tracker  } the two per-resume fields 6c structurally cannot reach
+//  8b. resume_rearms_quality_gate_clock  } (see the block comment above them for why)
+//  9a. stats_apply_gate_rejects_stale_generation — PURE test of the stats-apply gate
+//  9b. restart_does_not_republish_prior_run_stats — producer end-to-end over the Run->Run edge
 //
 // Their five frame-driven siblings stay in test/gui/functional/test_gui_lifecycle.cpp.
 
@@ -512,6 +516,9 @@ TEST(GuiLifecycle, snapshot_bundle_coherence) {
   // coherence relation section A omits. (On carry-forward payload_epoch may deliberately LAG the
   // bundle epoch; here the texture is freshly materialized so they MUST agree.)
   EXPECT_EQ(s->payload->payload_epoch, done_epoch);
+  // Same relation for the stats' own stamp: freshly produced stats belong to the bundle's
+  // generation. (On carry-forward stats_epoch may deliberately LAG, exactly like payload_epoch.)
+  EXPECT_EQ(s->stats_epoch, done_epoch);
   EXPECT_TRUE(s->texture_serial != 0);  // a fresh monotonic serial was minted for this materialization
 
   // Two consecutive loads observe the SAME whole object (atomic pointer handoff, no partial
@@ -721,6 +728,132 @@ TEST(GuiLifecycle, wake_for_refresh_preserves_valid) {
 //
 // Both drive the production WakeForRefresh seam (not the ResetGenerationForTest test seam), so they
 // fail if the reset is dropped from the production path only.
+
+// ---- Tests 9a/9b: stats carry their OWN generation stamp, so a stale carry-forward is rejected ----
+// The bug: PollOnce() re-stamps next->epoch with the CURRENT lifecycle epoch on every publish, while
+// the four stats fields are carried forward from prev when this poll produced none. After a restart
+// those two facts combine into a snapshot whose stats belong to the PREVIOUS run but whose bundle
+// epoch says "current" — and the consumer's gate (epoch match + rays > 0) is satisfied by exactly
+// that combination, so the status bar showed the previous run's ray/crystal/sampling numbers.
+//
+// Measured server-side mechanics this rests on (probe run against a live server, not inference):
+//   after RunFiniteToCompletion then a re-commit, BEFORE the new run produces anything —
+//     epoch: 1 -> 2      (RawXyzResult.epoch_ is committed_epoch_ read LIVE in the getter,
+//                         server.cpp; it is not stored with the snapshot)
+//     cached stats: unchanged, still the previous run's 200000 rays
+//                        (ServerImpl::Stop resets snapshot_dirty_/has_ever_consumed_ but does NOT
+//                         clear cached_stats_result_, which only DoSnapshot() overwrites)
+//     has_valid_data: 1 -> 0   <-- the ONLY field that distinguishes stale cache from fresh data
+// So "stamp the stats with xyz_results[0].epoch" alone would stamp the STALE stats with the NEW
+// epoch and change nothing. Freshness must be decided by has_valid_data; the epoch stamp then
+// records which generation those stats were actually produced under and travels with them.
+//
+// 9a pins the consumer predicate; 9b pins the producer end-to-end against a real server.
+
+// 9a — the pure gate. Mirrors ShouldUploadPayload's texture-side pattern on the stats side.
+TEST(GuiLifecycle, stats_apply_gate_rejects_stale_generation) {
+  constexpr uint64_t kOldGen = 7;
+  constexpr uint64_t kNewGen = 8;
+
+  // The bug scenario: stats carried forward from the previous generation. The BUNDLE epoch would
+  // say kNewGen here (PollOnce re-stamps it every poll) — the gate must key on the stats' own stamp.
+  {
+    gui::PreviewSnapshot snap;
+    snap.valid = true;
+    snap.epoch = kNewGen;  // bundle epoch: current, and deliberately NOT what the gate reads
+    snap.stats_epoch = kOldGen;
+    snap.stats_sim_ray_num = 200000;  // a plausible non-zero leftover from the previous run
+    EXPECT_TRUE(!gui::ShouldApplyStats(snap, kNewGen));
+  }
+
+  // Fresh stats produced under the committed generation: applied.
+  {
+    gui::PreviewSnapshot snap;
+    snap.valid = true;
+    snap.epoch = kNewGen;
+    snap.stats_epoch = kNewGen;
+    snap.stats_sim_ray_num = 1234;
+    EXPECT_TRUE(gui::ShouldApplyStats(snap, kNewGen));
+  }
+
+  // The pre-existing lower bound must survive the change: zero rays never overwrite a shown value
+  // (this is what keeps a torn zero off the status bar, and it is why the carry-forward exists).
+  {
+    gui::PreviewSnapshot snap;
+    snap.valid = true;
+    snap.epoch = kNewGen;
+    snap.stats_epoch = kNewGen;
+    snap.stats_sim_ray_num = 0;
+    EXPECT_TRUE(!gui::ShouldApplyStats(snap, kNewGen));
+  }
+}
+
+// 9b — the producer, end-to-end against a real server. This is the case that reproduces the actual
+// user-visible defect: it drives the real Run -> restart edge and asserts the published bundle does
+// not present the previous run's stats as belonging to the newly committed generation.
+TEST(GuiLifecycle, restart_does_not_republish_prior_run_stats) {
+  gui::g_server_poller.Stop();
+  gui::g_server = nullptr;
+
+  LUMICE_Server* server = LUMICE_CreateServer();
+  ASSERT_TRUE(server != nullptr);
+  const bool completed = RunFiniteToCompletion(server);
+  EXPECT_TRUE(completed);
+  if (!completed) {
+    LUMICE_DestroyServer(server);
+    return;
+  }
+
+  gui::ServerPoller local;
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+
+  const unsigned long long epoch_a = CurrentEpoch(server);
+  LUMICE_RayCount rays_a = 0;
+  {
+    auto sa = local.LoadSnapshot();
+    ASSERT_TRUE(sa != nullptr);
+    ASSERT_TRUE(sa->stats_sim_ray_num > 0);
+    EXPECT_EQ(sa->stats_epoch, epoch_a);               // fresh stats are stamped with the generation that made them
+    EXPECT_TRUE(gui::ShouldApplyStats(*sa, epoch_a));  // ... and are applied
+    rays_a = sa->stats_sim_ray_num;
+  }
+
+  // The Run -> Run edge: re-commit mints a new epoch. The server's cached stats still hold run A's
+  // numbers at this instant (measured above), which is precisely the window the bug lived in.
+  ASSERT_EQ(CommitJsonConfig(server, kFiniteConfig), LUMICE_OK);
+  const unsigned long long epoch_b = CurrentEpoch(server);
+  ASSERT_TRUE(epoch_b != epoch_a);  // the restart really did mint a new generation
+
+  // Pin the bug's window open DETERMINISTICALLY instead of racing run B's first batch. Two facts
+  // make this exact rather than lucky:
+  //   - LUMICE_StopServer unconditionally clears has_ever_consumed_, so has_valid_data reads 0
+  //     whether or not run B managed to consume anything first.
+  //   - cached_stats_result_ is only ever overwritten inside DoSnapshot(), and DoSnapshot only runs
+  //     from a Get*Results call. Nothing between the commit above and this line makes one, so the
+  //     server's cached stats are still run A's — no timing assumption.
+  // An earlier draft of this case polled straight after the commit and asserted on whichever state
+  // it happened to find. That version PASSED against the un-fixed code: run B routinely produced
+  // fresh stats before the poll, so the case never entered the branch it existed to check.
+  LUMICE_StopServer(server);
+
+  local.ResetGenerationForTest();  // what a resume does to the generation tracker, minus the worker
+  local.PollOnceForTest(server);
+
+  auto sb = local.LoadSnapshot();
+  ASSERT_TRUE(sb != nullptr);
+  // The bug's exact shape: the bundle epoch is the NEW generation's...
+  EXPECT_EQ(sb->epoch, epoch_b);
+  // ... while the stats riding in that bundle are still run A's, and say so.
+  EXPECT_EQ(sb->stats_sim_ray_num, rays_a);
+  EXPECT_EQ(sb->stats_epoch, epoch_a);
+  // ... so the gate keeps them off the status bar. Before the fix this combination read as fresh
+  // (bundle epoch == committed epoch, rays > 0) and run A's counts were displayed under run B.
+  EXPECT_TRUE(!gui::ShouldApplyStats(*sb, epoch_b));
+
+  local.Stop();
+  LUMICE_DestroyServer(server);
+}
 
 // 8a — `last_generation_ = 0`: after a resume, a snapshot the poller has ALREADY consumed must be
 // treated as new again, so a display-time refresh re-materializes the frame it is refreshing.

--- a/test/unit-correctness/gui/test_lifecycle.cpp
+++ b/test/unit-correctness/gui/test_lifecycle.cpp
@@ -698,3 +698,151 @@ TEST(GuiLifecycle, wake_for_refresh_preserves_valid) {
   gui::g_server_poller.Stop();
   LUMICE_DestroyServer(server);
 }
+
+// ---- Tests 8a/8b: the two per-resume fields that test 6c structurally CANNOT reach ----
+// ResetPerResumeState() re-arms three fields at every kPaused->kRunning edge. Test 6c
+// (completed_below_threshold_force_uploads) pins `uploaded_since_resume_` — deleting that line
+// makes it fail. The other two are invisible to it, and NOT by accident:
+//
+// 6c resumes against a COMPLETED run, and on a COMPLETED run `force_final_upload`
+// (== COMPLETED && !uploaded_since_resume_ && buffer) is true on the first post-resume poll.
+// That single flag both (a) enters the materialize branch on its own, making `last_generation_ = 0`
+// redundant for has_new_snapshot, and (b) bypasses the quality gate outright, making
+// `last_quality_pass_time_`'s 500ms timeout unreachable. So under COMPLETED, `uploaded_since_resume_`
+// MASKS its two siblings: delete either one alone and every existing case stays green (measured, not
+// assumed — each line was deleted individually against the full suite).
+//
+// The masking lifts in exactly one state: lifecycle == IDLE with a materialized snapshot still
+// cached. LUMICE_StopServer resets has_ever_consumed_, so GetSimLifecycle reports IDLE rather than
+// COMPLETED (server.cpp GetSimLifecycle), while snapshot_generation_ deliberately survives — "NOT
+// reset on Stop (poller resets its own tracker)" (server.cpp declaration comment). That comment names
+// this exact contract: the SERVER keeps its counter, so the POLLER must clear its own on resume.
+// These two cases are that contract's red-state guard.
+//
+// Both drive the production WakeForRefresh seam (not the ResetGenerationForTest test seam), so they
+// fail if the reset is dropped from the production path only.
+
+// 8a — `last_generation_ = 0`: after a resume, a snapshot the poller has ALREADY consumed must be
+// treated as new again, so a display-time refresh re-materializes the frame it is refreshing.
+// Without the reset, has_new_snapshot stays false (the server's generation counter did not move)
+// and — with force_final_upload structurally false under IDLE — the refresh produces nothing.
+TEST(GuiLifecycle, resume_rearms_generation_tracker) {
+  gui::g_server_poller.Stop();
+  gui::g_server = nullptr;
+
+  LUMICE_Server* server = LUMICE_CreateServer();
+  ASSERT_TRUE(server != nullptr);
+  const bool completed = RunFiniteToCompletion(server);
+  EXPECT_TRUE(completed);
+  if (!completed) {
+    LUMICE_DestroyServer(server);
+    return;
+  }
+
+  gui::ServerPoller local;
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);  // consumes generation G: last_generation_ = G, uploaded = true
+  auto s0 = local.LoadSnapshot();
+  ASSERT_TRUE(s0 != nullptr);
+  ASSERT_TRUE(s0->payload != nullptr);
+  const unsigned long long serial0 = s0->texture_serial;
+  EXPECT_TRUE(serial0 != 0);
+
+  // Freeze into IDLE-with-data: this is what removes force_final_upload from the picture and
+  // leaves last_generation_ as the ONLY thing that can re-open the materialize branch.
+  LUMICE_StopServer(server);
+  {
+    LUMICE_SimLifecycleResult lc{};
+    EXPECT_EQ(LUMICE_GetSimLifecycle(server, &lc), LUMICE_OK);
+    ASSERT_EQ(lc.lifecycle, static_cast<int>(LUMICE_LIFECYCLE_IDLE));  // NOT COMPLETED — see header
+  }
+
+  // Control: without a resume, a poll in this state materializes nothing (same generation, and no
+  // rescue). This is the "before" half of the red-state pair — it proves the assertion below is
+  // driven by the resume and not by the server handing out a fresh generation on its own.
+  local.PollOnceForTest(server);
+  {
+    auto s1 = local.LoadSnapshot();
+    ASSERT_TRUE(s1 != nullptr);
+    EXPECT_EQ(s1->texture_serial, serial0);
+  }
+
+  // Resume through the production seam: ResetPerResumeState() clears last_generation_, so the
+  // already-consumed generation G reads as new and the frame re-materializes.
+  local.WakeForRefresh(server);
+  local.Stop();  // fence the worker thread (same discipline as test 6c phases B/C)
+  local.PollOnceForTest(server);
+  {
+    auto s2 = local.LoadSnapshot();
+    ASSERT_TRUE(s2 != nullptr);
+    EXPECT_TRUE(s2->texture_serial != serial0);  // RED if `last_generation_ = 0` is dropped
+  }
+
+  local.Stop();
+  LUMICE_DestroyServer(server);
+}
+
+// 8b — `last_quality_pass_time_`: the gate's 500ms timeout fallback must be measured from the
+// RESUME, not from whenever the gate last passed in a previous run. Without the reset, time the
+// poller spent paused (a user reading the last result before hitting Run again — seconds, routinely)
+// is charged against the new run's budget, so its first sparse poll is force-uploaded and the
+// anti-flicker gate is silently disarmed exactly when it is supposed to engage.
+TEST(GuiLifecycle, resume_rearms_quality_gate_clock) {
+  gui::g_server_poller.Stop();
+  gui::g_server = nullptr;
+
+  LUMICE_Server* server = LUMICE_CreateServer();
+  ASSERT_TRUE(server != nullptr);
+  const bool completed = RunFiniteToCompletion(server);
+  EXPECT_TRUE(completed);
+  if (!completed) {
+    LUMICE_DestroyServer(server);
+    return;
+  }
+
+  gui::ServerPoller local;
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+  auto s0 = local.LoadSnapshot();
+  ASSERT_TRUE(s0 != nullptr);
+  ASSERT_TRUE(s0->payload != nullptr);
+  const unsigned long long serial0 = s0->texture_serial;
+
+  // Same IDLE-with-data freeze as 8a, for the same reason: force_final_upload must be off the table
+  // or it bypasses the gate before the timeout is ever consulted.
+  LUMICE_StopServer(server);
+  {
+    LUMICE_SimLifecycleResult lc{};
+    EXPECT_EQ(LUMICE_GetSimLifecycle(server, &lc), LUMICE_OK);
+    ASSERT_EQ(lc.lifecycle, static_cast<int>(LUMICE_LIFECYCLE_IDLE));
+  }
+
+  // Arm the gate strictly above the ray count this run achieved, so the post-resume poll is one the
+  // gate MUST reject. Derived from the measurement rather than hard-coded (same rationale as 6c).
+  LUMICE_RayCount rays = 0;
+  {
+    LUMICE_StatsResult stats{};
+    LUMICE_GetCachedStats(server, &stats);
+    rays = stats.sim_ray_num;
+    local.SetCalibratedThreshold(stats.sim_ray_num + 1);
+  }
+  EXPECT_TRUE(rays > 0);  // a zero-ray run takes the cold-start bypass and tests nothing
+
+  // Spend more than the whole timeout budget while PAUSED. A correct reset makes this irrelevant;
+  // a missing one makes it decisive.
+  std::this_thread::sleep_for(std::chrono::milliseconds(gui::kQualityGateTimeoutMs + 100));
+
+  local.WakeForRefresh(server);
+  local.Stop();
+  local.PollOnceForTest(server);
+
+  // The gate rejects: the resume restarted the timeout clock, so ~0ms of the 500ms budget is spent.
+  // Drop `last_quality_pass_time_ = now()` and the paused time above is charged instead, the timeout
+  // fires, and this sparse frame is force-uploaded under a fresh serial.
+  auto s1 = local.LoadSnapshot();
+  ASSERT_TRUE(s1 != nullptr);
+  EXPECT_EQ(s1->texture_serial, serial0);  // RED if `last_quality_pass_time_ = now()` is dropped
+
+  local.Stop();
+  LUMICE_DestroyServer(server);
+}


### PR DESCRIPTION
## 背景

合并两条 backlog（task-421 `server-poller-state-reset-ownership`）：

1. **`ServerPoller` 的三个 per-resume 字段「必须同址复位」只靠注释维持**（来源：task-416 code-review Minor 3）。`Start()` 不经过 `TransitionToRunning()`，所以 `last_generation_` / `last_quality_pass_time_` / `uploaded_since_resume_` 三行复位被逐字复制到两处，不变量只由一句注释保证。字段数已从 2 涨到 3。
2. **`ServerPoller` 结转陈旧 stats 并盖当前 epoch 戳**（来源：scrum-419.1 explore 取证项 G1）。用户可见症状：Run→Stop→Run 后状态栏短暂显示**上一次运行**的光线数/晶体数/采样密度。task-413 新增的采样密度段吃的正是这四个字段，可见面已扩大。

## 根因（白盒定性，非推测）

发布路径 `PollOnce()` 每次都把 `next->epoch` 盖成当前 `lc.epoch`，而四个 stats 字段在「本轮无新快照」时原样结转——结转来源可能属于**上一个生命周期世代**。消费侧 `app.cpp` 的闸只检查「整包 epoch」，检查不出「stats 载荷本身产于哪一代」，于是陈旧值骗过过滤闸。

⭐ **实施期实测推翻了立项时的假设，修法因此比原设想多一半**：`ServerImpl::Stop()` 复位 `has_ever_consumed_` / `snapshot_dirty_` 但**不清 `cached_stats_result_`**，所以重启后到新一代首批数据产出之前，`LUMICE_GetCachedStats` 会返回上一次运行的数字，且 `sim_ray_num > 0` 看起来完全健康。若只加世代戳字段，「新鲜」分支会把旧数据打上新世代戳——等于把 bug 原样搬进新字段。判别器是 `RawXyzResult.has_valid_data`（`= has_ever_consumed_`），已在 C API 上暴露，无需改服务端。

## 改动

- **`ResetPerResumeState()`**：per-resume 三字段复位的唯一 owner，`Start()` 与 `TransitionToRunning()` 共同调用，约束从注释升级为结构。
- **`PreviewSnapshot::stats_epoch`**：stats 自带生产世代戳，与纹理侧既有的 `payload_epoch` 对称。结转分支保留「产于哪一代」而非重新盖章。
- **`have_new_stats` 追加 `has_valid_data` 前提**：区分「真新鲜」与「服务端缓存里的上一代残留」。
- **`ShouldApplyStats(snap, committed_epoch)`**：新增纯谓词，判据由 `snap.epoch` 改为 `snap.stats_epoch`；`stats_sim_ray_num > 0` 下限判据原样保留，torn-zero 结转机制未被削弱。声明/定义位置与同族 `ShouldUploadPayload` 一致，headless 可测。

「切文档」半边核实为**本就成立**（每条切文档路径在调用 `ResetFrontendState` 前已整体替换 `GuiState`，`file_io.cpp` 的 `state = GuiState{}` 是机制依赖），故**不加死代码**，只补一条走真实 `.lmc` 入口的端到端守卫用例——删掉 `state = GuiState{}` 即变红。

## 验证

- **AC1 红态自证**：三行逐行破坏（每次先 commit 再施加、`-gtj` 重建、当场带 ref 还原）。实测证实 `last_generation_` 与 `last_quality_pass_time_` 删掉后**现有测试全绿**，3 行里 2 行毫无保护 ⇒ 补钉子用例后三行各被一条不同用例杀死。
- **AC2 三个突变逐一被杀**：去掉 `has_valid_data` / 结转分支改盖 `lc.epoch` / 谓词改读 `snap.epoch`。
- `./scripts/test.sh full` 四层全 PASS（ctest / fast-e2e / gui-correctness 325/325 / gui-real-timing），`gui_test` 与 `gui_unit_test` 两个宿主都覆盖。

## 附带

- backlog 条目「[GUI 测试隔离] 标定阈值跨用例常驻」经独立复核确认前提已随 scrum-420 消失（唯一测试消费者写局部实例，不碰全局态），已归档并保留原文。
- 记录三条后续项到 backlog：纹理侧 `payload_epoch` 同族「活读 epoch」（**未定性**，且语义与 stats 侧不对称——纹理结转是有意的防闪烁设计，不能照搬判据）、世代戳模式第三次出现时升为具名 doc 约定、`PreviewSnapshot` 构造点结构债。

🤖 Generated with [Claude Code](https://claude.com/claude-code)