### PR TITLE
chore: 崩溃哨兵设施补两处诊断缺口（挂起检出 + 两臂 build 日志留痕）

### DIFF
--- a/scripts/verify_crash_sentinel_detection_power.sh
+++ b/scripts/verify_crash_sentinel_detection_power.sh
@@ -62,18 +62,24 @@ REVERTED_WORKTREE="$WORK_PARENT/reverted"
 cleanup() {
   local exit_code="$1"
   echo "--- cleanup: removing worktrees ---"
-  git worktree remove --force "$FIXED_WORKTREE" 2>/dev/null || true
-  # exit 2 (INCONCLUSIVE) and exit 4 (INFRASTRUCTURE ERROR) both tell the user
-  # to inspect $REVERTED_WORKTREE/build/ — deleting it here would make that
-  # instruction unfollowable. Keep the reverted worktree (and its parent) on
-  # those two paths; every other path cleans up as before.
+  # exit 2 (INCONCLUSIVE) and exit 4 (INFRASTRUCTURE ERROR) both point the user
+  # at an arm's build tree or build log to explain the verdict — deleting them
+  # here would make that instruction unfollowable. Keep both worktrees and
+  # $WORK_PARENT (which holds {fixed,reverted}_build.log and the pytest log) on
+  # those two paths; every other path cleans up as before. Both arms are kept,
+  # not just the reverted one: a build failure can land on either arm, and the
+  # failing arm is exactly the one worth inspecting.
   if [ "$exit_code" -eq 2 ] || [ "$exit_code" -eq 4 ]; then
     git worktree prune
-    echo "cleanup: exit $exit_code — retaining reverted arm worktree for inspection:" >&2
-    echo "  $REVERTED_WORKTREE" >&2
-    echo "  (remove manually with: git worktree remove --force '$REVERTED_WORKTREE' && rm -rf '$WORK_PARENT')" >&2
+    echo "cleanup: exit $exit_code — retaining worktrees and logs for inspection:" >&2
+    echo "  $WORK_PARENT" >&2
+    echo "  (remove manually with:" >&2
+    echo "     git worktree remove --force '$FIXED_WORKTREE' 2>/dev/null" >&2
+    echo "     git worktree remove --force '$REVERTED_WORKTREE' 2>/dev/null" >&2
+    echo "     rm -rf '$WORK_PARENT')" >&2
     return
   fi
+  git worktree remove --force "$FIXED_WORKTREE" 2>/dev/null || true
   git worktree remove --force "$REVERTED_WORKTREE" 2>/dev/null || true
   rm -rf "$WORK_PARENT"
   # Prune stale worktree registrations.
@@ -82,13 +88,40 @@ cleanup() {
 }
 trap 'cleanup $?' EXIT
 
+# Build one arm, keeping the full build log on disk.
+#
+# stdout goes to $WORK_PARENT/<arm>_build.log (a clean-rebuild log is thousands
+# of compiler lines and would bury the verdict); stderr stays on the terminal so
+# a failure is visible while it happens. The two halves are deliberately NOT
+# merged: the terminal keeps the short version, the file keeps the long one.
+#
+# On failure this exits 4 rather than letting `set -e` propagate build.sh's own
+# exit code. That is the whole point of the log: any code other than 2 or 4
+# sends cleanup() down the delete-everything path, which would remove
+# $WORK_PARENT — taking the log that was just written down with it, and the
+# worktree with it, leaving nothing to diagnose but terminal scrollback.
+build_arm() {
+  local arm="$1" worktree="$2"
+  local log="$WORK_PARENT/${arm}_build.log"
+  echo "building $arm arm — stdout → $log (stderr stays on this terminal)"
+  if ! (
+    cd "$worktree"
+    rm -rf build
+    ./scripts/build.sh -sj release >"$log"
+  ); then
+    echo "" >&2
+    echo "INFRASTRUCTURE ERROR: $arm arm failed to build." >&2
+    echo "No conclusion about sentinel detection power can be drawn from this run" >&2
+    echo "— the sentinel never ran. Retained for inspection:" >&2
+    echo "  build log: $log" >&2
+    echo "  worktree:  $worktree" >&2
+    exit 4
+  fi
+}
+
 echo "=== fixed arm (HEAD=$FIXED_HEAD) ==="
 git worktree add --detach "$FIXED_WORKTREE" "$FIXED_HEAD"
-(
-  cd "$FIXED_WORKTREE"
-  rm -rf build
-  ./scripts/build.sh -sj release >/dev/null
-)
+build_arm fixed "$FIXED_WORKTREE"
 FIXED_BIN="$FIXED_WORKTREE/build/cmake_install/shared/Lumice"
 FIXED_MD5="$(md5 -q "$FIXED_BIN" 2>/dev/null || md5sum "$FIXED_BIN" | awk '{print $1}')"
 echo "fixed arm binary: $FIXED_BIN"
@@ -96,11 +129,7 @@ echo "fixed arm md5:    $FIXED_MD5"
 
 echo "=== reverted arm (base=$REVERT_BASE) ==="
 git worktree add --detach "$REVERTED_WORKTREE" "$REVERT_BASE"
-(
-  cd "$REVERTED_WORKTREE"
-  rm -rf build
-  ./scripts/build.sh -sj release >/dev/null
-)
+build_arm reverted "$REVERTED_WORKTREE"
 REVERTED_BIN="$REVERTED_WORKTREE/build/cmake_install/shared/Lumice"
 REVERTED_MD5="$(md5 -q "$REVERTED_BIN" 2>/dev/null || md5sum "$REVERTED_BIN" | awk '{print $1}')"
 echo "reverted arm binary: $REVERTED_BIN"
@@ -141,6 +170,11 @@ set -e
 # contain neither "signal-death" nor "clean non-zero exit". Detect this first
 # so it is never miscounted as "0 signal deaths observed" (AMBIGUOUS below);
 # it means the reverted arm never got to run the parametrized loop at all.
+# Covers both shapes of "the binary cannot run": a non-zero exit and a hang.
+#
+# Anchor: this literal is the single source `_INFRA_ANCHOR` in
+# test_face_distance_crash.py, which carries a matching comment pointing back
+# here. Change one side without the other and this grep silently stops firing.
 if grep -q "Lumice binary infrastructure check failed" "$WORK_PARENT/reverted_arm.log"; then
   echo "" >&2
   echo "INFRASTRUCTURE ERROR: reverted arm's module-scope smoke check failed —" >&2
@@ -183,6 +217,36 @@ if [ "$CLEAN_NONZERO_COUNT" -ge 1 ] && [ "$SIGNAL_DEATH_COUNT" -eq 0 ]; then
   echo "build output at $REVERTED_WORKTREE/build/ before drawing conclusions" >&2
   echo "about sentinel detection power." >&2
   exit 2
+fi
+
+# Second net, for infrastructure failures that never reach the anchored
+# assertion above: a collection/import error, `find_lumice_binary()` raising,
+# an unhandled exception in the fixture, or a hang in the *parametrized* loop
+# (whose `subprocess.TimeoutExpired` surfaces as pytest FAILED, not ERROR).
+# None of those produce "signal-death" or "clean non-zero exit" either, so
+# without this they land in the AMBIGUOUS branch below and get reported as
+# "could be luck — rerun with a bigger N" when nothing ran at all.
+#
+# Deliberately placed AFTER the PASS branch: an error in one test must not
+# retract detection power that another test actually demonstrated.
+#
+# The patterns match pytest's own report structure, not free text — the
+# short-test-summary line (`ERROR <path>.py::<nodeid> - ...`), the final
+# counts line (`=== N errors in 1.23s ===`), and the stdlib exception name a
+# hang prints verbatim. Lumice's own log lines cannot collide: spdlog emits
+# `[timestamp] [logger] [level] msg`, so they never start with `ERROR `.
+if grep -qE '^ERROR .*\.py|[0-9]+ errors? in |subprocess\.TimeoutExpired' \
+     "$WORK_PARENT/reverted_arm.log"; then
+  echo "" >&2
+  echo "INFRASTRUCTURE ERROR: the reverted-arm pytest run reported errors (or a" >&2
+  echo "timeout), not test failures — so the parametrized sentinel loop did not" >&2
+  echo "complete. 0 signal deaths here does NOT mean 'no detection power'; it" >&2
+  echo "means this run produced no evidence either way. Offending lines:" >&2
+  grep -nE '^ERROR .*\.py|[0-9]+ errors? in |subprocess\.TimeoutExpired' \
+    "$WORK_PARENT/reverted_arm.log" | head -20 >&2
+  echo "Full log: $WORK_PARENT/reverted_arm.log" >&2
+  echo "Inspect $REVERTED_WORKTREE/build/ before drawing any conclusion." >&2
+  exit 4
 fi
 
 # 0/N signal deaths does not by itself mean "sentinel has lost detection

--- a/scripts/verify_crash_sentinel_detection_power.sh
+++ b/scripts/verify_crash_sentinel_detection_power.sh
@@ -73,9 +73,21 @@ cleanup() {
     git worktree prune
     echo "cleanup: exit $exit_code — retaining worktrees and logs for inspection:" >&2
     echo "  $WORK_PARENT" >&2
+    # Only name worktrees that were actually created. The fixed arm can fail its
+    # build and exit 4 before `git worktree add` for the reverted arm has run at
+    # all, and telling someone to remove a path that never existed hands them a
+    # confusing error in the one message they are reading precisely because
+    # something already went wrong.
+    # `if`, not `[ -d … ] && echo`: this runs from an EXIT trap under `set -e`,
+    # where a failing `&&` list is the loop body's exit status and would abort
+    # cleanup partway through its own instructions.
     echo "  (remove manually with:" >&2
-    echo "     git worktree remove --force '$FIXED_WORKTREE' 2>/dev/null" >&2
-    echo "     git worktree remove --force '$REVERTED_WORKTREE' 2>/dev/null" >&2
+    local wt
+    for wt in "$FIXED_WORKTREE" "$REVERTED_WORKTREE"; do
+      if [ -d "$wt" ]; then
+        echo "     git worktree remove --force '$wt'" >&2
+      fi
+    done
     echo "     rm -rf '$WORK_PARENT')" >&2
     return
   fi
@@ -229,6 +241,13 @@ fi
 #
 # Deliberately placed AFTER the PASS branch: an error in one test must not
 # retract detection power that another test actually demonstrated.
+#
+# These patterns encode pytest's own report *format*, which is a contract
+# nobody promised us: a major-version bump that rewords the short-summary or
+# counts line degrades this net silently — it does not error, it just stops
+# matching, and the verdict slides back to AMBIGUOUS with nothing announcing
+# that the net tore. Re-check them against a real failing run after any pytest
+# major upgrade; the shapes below were read off actual output, not assumed.
 #
 # The patterns match pytest's own report structure, not free text — the
 # short-test-summary line (`ERROR <path>.py::<nodeid> - ...`), the final

--- a/scripts/verify_crash_sentinel_detection_power.sh
+++ b/scripts/verify_crash_sentinel_detection_power.sh
@@ -241,9 +241,22 @@ if grep -qE '^ERROR .*\.py|[0-9]+ errors? in |subprocess\.TimeoutExpired' \
   echo "INFRASTRUCTURE ERROR: the reverted-arm pytest run reported errors (or a" >&2
   echo "timeout), not test failures — so the parametrized sentinel loop did not" >&2
   echo "complete. 0 signal deaths here does NOT mean 'no detection power'; it" >&2
-  echo "means this run produced no evidence either way. Offending lines:" >&2
-  grep -nE '^ERROR .*\.py|[0-9]+ errors? in |subprocess\.TimeoutExpired' \
-    "$WORK_PARENT/reverted_arm.log" | head -20 >&2
+  echo "means this run produced no evidence either way. First 20 offending lines:" >&2
+  # `grep -m 20` rather than `grep … | head -20`, and `|| true` on top. Under
+  # this script's `set -euo pipefail`, piping into `head` is a live trap: once
+  # head has its 20 lines it closes the read end, grep takes SIGPIPE on the
+  # next write, pipefail surfaces 141, and `set -e` kills the script *before*
+  # the `exit 4` below ever runs — landing on an exit code outside {2,4}, which
+  # sends cleanup() down the delete-everything path and destroys the worktree
+  # and build logs this very block was added to preserve. Measured here: 20
+  # matching lines exits 4 correctly, 200 (~42KB) already exits 141. That is
+  # not a hypothetical range — a high-error run is exactly what this block
+  # exists to report on, and SENTINEL_N doubling (which the AMBIGUOUS branch
+  # below recommends) walks straight into it. -m bounds the output with no
+  # second process, so there is no pipe to break; `|| true` additionally keeps
+  # a diagnostic print from ever deciding control flow.
+  grep -m 20 -nE '^ERROR .*\.py|[0-9]+ errors? in |subprocess\.TimeoutExpired' \
+    "$WORK_PARENT/reverted_arm.log" >&2 || true
   echo "Full log: $WORK_PARENT/reverted_arm.log" >&2
   echo "Inspect $REVERTED_WORKTREE/build/ before drawing any conclusion." >&2
   exit 4

--- a/test/regression-sentinel/test_face_distance_crash.py
+++ b/test/regression-sentinel/test_face_distance_crash.py
@@ -106,9 +106,18 @@ def _smoke_check_binary() -> None:
     try:
         result = _run_config(_SMOKE_CONFIG_PATH, timeout=_SMOKE_TIMEOUT_S)
     except subprocess.TimeoutExpired as exc:
-        # `raise AssertionError` rather than a bare `assert`: the message must
-        # survive even if the suite is ever run under `python -O`, which strips
-        # assert statements and would take the anchor with them.
+        # Both failure branches raise AssertionError explicitly rather than
+        # using a bare `assert`. Not because a bare assert fails today: pytest
+        # rewrites asserts in the modules it collects, so under `python -O` the
+        # anchor still reaches the log from here (measured — 15/15 either way).
+        # The point is what that survival rests on. Strip the rewriting and the
+        # interpreter drops the statement whole, message included, and the
+        # downstream `grep -q` sees a silent pass instead of a broken binary —
+        # and rewriting stops applying the moment this helper moves somewhere
+        # pytest does not collect, e.g. beside find_lumice_binary() in
+        # test/e2e/runner.py, which is imported, never collected. pytest says as
+        # much on an -O run: "assertions not in test modules or plugins will be
+        # ignored". An explicit raise owes nothing to where the function lives.
         raise AssertionError(
             f"{_INFRA_ANCHOR} (hung — no exit within {_SMOKE_TIMEOUT_S}s) — "
             f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
@@ -120,15 +129,16 @@ def _smoke_check_binary() -> None:
             f"command: {exc.cmd}"
         ) from exc
 
-    assert result.returncode == 0, (
-        f"{_INFRA_ANCHOR} (returncode={result.returncode}) — "
-        f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
-        f"config. Check LUMICE_BIN, the shared-library build (`./scripts/build.sh -j "
-        f"release`), or the linker. This sentinel will now skip the parametrized "
-        f"runs to avoid misattributing infrastructure failure to the random-face_distance "
-        f"crash it is written to catch.\n"
-        f"stderr:\n{result.stderr}"
-    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{_INFRA_ANCHOR} (returncode={result.returncode}) — "
+            f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
+            f"config. Check LUMICE_BIN, the shared-library build (`./scripts/build.sh -j "
+            f"release`), or the linker. This sentinel will now skip the parametrized "
+            f"runs to avoid misattributing infrastructure failure to the random-face_distance "
+            f"crash it is written to catch.\n"
+            f"stderr:\n{result.stderr}"
+        )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/test/regression-sentinel/test_face_distance_crash.py
+++ b/test/regression-sentinel/test_face_distance_crash.py
@@ -71,6 +71,16 @@ def _run_once() -> subprocess.CompletedProcess:
     return _run_config(_CONFIG_PATH, timeout=60.0)
 
 
+# Anchor: scripts/verify_crash_sentinel_detection_power.sh greps the reverted-arm
+# log for this literal to tell "the reverted build is broken" apart from "the
+# sentinel observed no crash". It is a cross-file contract — changing a single
+# character here without updating that script's `grep -q` silently turns a real
+# infrastructure failure back into an AMBIGUOUS "could be luck" verdict.
+_INFRA_ANCHOR = "Lumice binary infrastructure check failed"
+
+_SMOKE_TIMEOUT_S = 30.0
+
+
 def _smoke_check_binary() -> None:
     """Fail fast before N runs if the binary can't even start on a stable config.
 
@@ -82,10 +92,36 @@ def _smoke_check_binary() -> None:
     fixed-face-distance config first: if the binary is broken at the
     infrastructure level, the assertion fires with a clear message before the
     parametrized loop starts.
+
+    A *hang* is the same infrastructure failure wearing a different shape (a
+    wedged GPU-backend init, a binary blocked on a device that never answers).
+    Left uncaught, `subprocess.TimeoutExpired` escapes this fixture as a raw
+    stdlib exception whose text does not contain the anchor below, so the
+    two-arm verification script sees no anchor, counts zero signal deaths, and
+    reports AMBIGUOUS — "rerun with a bigger N" — for a machine that will hang
+    again every single time. Convert it to the same anchored assertion failure
+    the non-zero-exit path produces, so both variants of "the binary cannot
+    run" are reported as what they are.
     """
-    result = _run_config(_SMOKE_CONFIG_PATH, timeout=30.0)
+    try:
+        result = _run_config(_SMOKE_CONFIG_PATH, timeout=_SMOKE_TIMEOUT_S)
+    except subprocess.TimeoutExpired as exc:
+        # `raise AssertionError` rather than a bare `assert`: the message must
+        # survive even if the suite is ever run under `python -O`, which strips
+        # assert statements and would take the anchor with them.
+        raise AssertionError(
+            f"{_INFRA_ANCHOR} (hung — no exit within {_SMOKE_TIMEOUT_S}s) — "
+            f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
+            f"config to completion. Check LUMICE_BIN, the shared-library build "
+            f"(`./scripts/build.sh -j release`), the linker, or a wedged compute backend. "
+            f"This sentinel will now skip the parametrized runs to avoid misattributing "
+            f"infrastructure failure to the random-face_distance crash it is written to "
+            f"catch.\n"
+            f"command: {exc.cmd}"
+        ) from exc
+
     assert result.returncode == 0, (
-        f"Lumice binary infrastructure check failed (returncode={result.returncode}) — "
+        f"{_INFRA_ANCHOR} (returncode={result.returncode}) — "
         f"this is not a SIGSEGV regression; the binary itself cannot run a known-good "
         f"config. Check LUMICE_BIN, the shared-library build (`./scripts/build.sh -j "
         f"release`), or the linker. This sentinel will now skip the parametrized "


### PR DESCRIPTION
## 背景

崩溃哨兵设施的两处诊断缺口，同源于 PR #189 的 code-review 复核（当轮裁决「只记录不修」），经 backlog 挑入后合并为一个 chore。

被改的两处**本身就是「检出力保障」设施**——它们只在出故障时才被读到，改坏了没人会发现。它们失真的后果不是「少一条日志」，而是**把一次真实的基础设施故障翻译成「可能只是运气不好，加大 N 重跑」**，把排查引向完全错误的方向。

## 改动

**1. 挂起不再逃出哨兵的 smoke check**（`test/regression-sentinel/test_face_distance_crash.py`）

`_smoke_check_binary()` 原先只处理「进程干净退出但返回码非 0」。若二进制**挂起**（wedged GPU 后端初始化、阻塞在永不应答的设备上），`subprocess.TimeoutExpired` 作为裸 stdlib 异常逃出 fixture，其文案**不含**下游 `grep -q` 依赖的锚点串 ⇒ 两臂验证脚本看不到锚点、数到 0 次 signal death，对一台**每次都会再挂一遍**的机器报出 AMBIGUOUS「加大 N 重跑」。

现捕获后转成**带同一锚点**的 `AssertionError`。锚点串顺带收敛为单一常量 `_INFRA_ANCHOR`，跨文件契约在 Python 侧从此只有一个源头。两个失败分支统一为显式 `raise AssertionError` 而非裸 `assert`——不是因为裸 assert 今天会失效（实测 `python -O` 下锚点仍 15/15 命中，pytest 的 assertion rewriting 顶住了），而是因为那份存活**依赖该函数一直待在被 pytest 收集的测试模块里**；一旦挪到 `test/e2e/runner.py` 那类「被 import 不被收集」的位置，`-O` 会把整条语句连同锚点一起丢掉。

**2. 第二道网：非锚点形态的 pytest ERROR 也不再落进 AMBIGUOUS**（`scripts/verify_crash_sentinel_detection_power.sh`）

覆盖收集/导入错误、`find_lumice_binary()` 抛错、fixture 未捕获异常、以及参数化循环自身挂起——这些都不产生锚点，同样会被误判。pattern 匹配的是 pytest **自身的报告结构**（short-summary 行 / 计数行 / stdlib 异常名），**先实测取证再定，未凭印象猜格式**。刻意放在 PASS 分支之后：一个 error 不得回撤另一个用例已经证明的检出力。

判定矩阵（每格为脚本退出码，白盒抽取判定块真实字节驱动）：

| 用例 | fix 前 | fix 后 |
|---|---|---|
| A 挂起日志、无锚点、有 pytest ERROR | **3 AMBIGUOUS**（即本次要修的误判） | **4 INFRASTRUCTURE ERROR** ✅ |
| B 挂起日志、有锚点（改动 1 的产出） | 4 | 4 |
| C 含 signal-death（PASS 不得被回撤） | 0 | **0** ✅ |
| D 全绿无 error（AMBIGUOUS 兜底须保留） | 3 | **3** ✅ |

A 行是改动 2 的独有贡献，B 行是改动 1 的独有贡献——**二者互补，均不冗余**。

**3. 两臂 build 日志落盘而非丢弃**（同脚本）

原先两臂各自 `./scripts/build.sh -sj release >/dev/null`。某臂 build 失败时 `set -e` 以退出码 1 终止，而 `cleanup()` 只在 exit 2/4 保留 ⇒ 走 `rm -rf "$WORK_PARENT"`，**连 worktree 一起删**，唯一线索只剩终端滚屏。排查「验证脚本自己为什么跑不起来」反而比它要防的原问题更难复现。

抽出 `build_arm()`：stdout → `$WORK_PARENT/{fixed,reverted}_build.log`，stderr 仍留终端；失败显式 `exit 4`。issue 原本写「日志落盘 / 保留 worktree 两个方向选一即可」——白盒读 `cleanup()` 后确认**不成立**：只做落盘无效，日志会被同一次清理删掉，两者必须同时做。顺带把保留路径从「只留 reverted 臂」改为**两臂都留**（build 失败可能落在任一臂，失败的那臂才值得看；原 `cleanup()` 在函数开头无条件删 fixed 臂，exit 2/4 也照删，属既有缺陷，一并修正）。

## 评审抓出的真缺陷（已修）

code-review 第一轮 **Major**：我在修「诊断证据被 cleanup 吃掉」的那段代码里，把同一类故障重新引入了一次。新增判定块的 `grep -nE … | head -20 >&2` 在脚本已声明的 `set -euo pipefail` 下是活陷阱——`head` 取够 20 行即关读端，`grep` 下次写收到 SIGPIPE，`pipefail` 抬出 141，`set -e` 在**执行到 `exit 4` 之前**中止脚本 ⇒ 退出码落在 {2,4} 之外 ⇒ `cleanup()` 走全删分支，把改动 3 刚保下来的 worktree 与 build log 一起删掉。

不是边角场景：该判定块**存在的意义**就是报告高错误量运行，而 AMBIGUOUS 分支自己建议的 `SENTINEL_N` 翻倍会直接走进去。

修法**未采用**评审建议的 `| head -20 … || true`（那只是掩掉非零码，管道仍在），改用 `grep -m 20 … >&2 || true`——`-m` 在 grep 内部截断，**根本没有管道可断**，结构上消除而非遮蔽。

独立复现（4 档匹配行数 × 两种写法）：`| head` = `4 / 141 / 141 / 141`（**200 行、约 42KB 即触发**，比评审报告的 600 行更早），`grep -m` = `4 / 4 / 4 / 4`。

## 验证

三条改动各自红绿双态；红态一律先 commit 再施加，探针后 `git checkout --` 还原并核验工作树干净。

- **改动 1**（`LUMICE_BIN` 指向 `exec sleep 600` 的假二进制，不改源码）：红（base）锚点命中 **0**、逃出裸 `TimeoutExpired`；绿锚点命中 **15**、最终异常 `AssertionError`。四组合 {returncode≠0, 挂起} × {正常, `python -O`} 全部 15/15。
- **改动 2**：从脚本 `sed` 抽出判定块**真实字节**（非重打副本）跑四用例，与 base 同法抽出的旧判定块对照 ⇒ 上表 A/B/C/D。
- **改动 3**：抽出 `cleanup()` + `build_arm()` 真实字节，喂必然失败的桩 `build.sh`：红（base 的内联 `>/dev/null` + 旧 cleanup）退出码 1、`$WORK_PARENT` 整个被删、**日志文件数 0**、worktree 一并消失；绿退出码 4、`$WORK_PARENT` 保留、`fixed_build.log` 内容完整、worktree 保留；成功路径回归桩返回 0 ⇒ 退出码 0、正常清理不残留。
- **锚点跨文件契约**：Python `_INFRA_ANCHOR` 与 shell `grep -q` 字面量提取后字符串相等。
- `bash -n` 通过；`pytest test/regression-sentinel/test_face_distance_crash.py` ⇒ **15 passed**（退出码直读 `$?`，未走管道）。
- `./scripts/test.sh quick` ⇒ `RESULT: PASS`（ctest 6/6、fast-e2e 80 passed 1 skipped、gui-correctness 325/325）。

code-review 两轮：round 1 `REQUEST_CHANGES`（Major 1 / Minor 1），round 2 `APPROVE`（0 Critical / 0 Major）。

## 诚实边界

`verify_crash_sentinel_detection_power.sh` 的**端到端全流程本轮未真实跑过一次**——它需要两臂各自 clean rebuild（本机 ~20min/臂），且 `SENTINEL_REVERT_BASE` 指向另一条历史分支。改为白盒抽真实字节逐块驱动，**覆盖的分支面比端到端跑一遍更宽**（红态、两臂 build 失败、四种判定分支、SIGPIPE 四档全部独立验证；端到端跑一次只会经过其中一条路径），但仍不能替代一次真实调用可能暴露的集成时序问题。建议后续找空档补跑一次留痕。

第二道网的正则把 pytest 的报告格式当成了没人承诺过的跨版本契约——大版本升级改文案会让这张网**静默退化**（不报错，只是不再匹配，判定滑回 AMBIGUOUS）。已在脚本注释里留下「升级后须对真实失败运行重新核对本 pattern」的可检索线索。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
