### PR TITLE
fix(gui): 纹理 payload 只在内容确属当前世代时才物化

### DIFF
--- a/doc/gui-preview-lifecycle-architecture.md
+++ b/doc/gui-preview-lifecycle-architecture.md
@@ -181,6 +181,45 @@ CUDA 超大 batch 中途无法响应。第一性原理：
 > 回归测试：`gui_test` 的 `gui_lifecycle` 组，三阶段分别覆盖首次完成跑、经 `WakeForRestart` 的第二次
 > 完成跑、以及经 `WakeForRefresh` 的 display-time 刷新。
 
+> **落地补丁（2026-08-03，PR 见 git log）：I1 的前提「世代号是诚实的」曾不成立。**
+> 同样不是新增不变量，而是补上实现对 I1 的一次合规回归——I1 文本不变。
+>
+> I1 靠**世代号**丢弃陈旧观测，`ShouldUploadPayload`（`src/gui/app.cpp`）的
+> `payload_epoch > display_epoch_floor` 是它在纹理通道的落地。但这道闸只能问「号是多少」，
+> 问不了「这份内容是不是真产自该号」——**前提是生产端不会给旧内容盖新号**。生产端曾会：
+> ①`RenderConsumer::Reset()` 显式不清 `snapshot_xyz_`（"PrepareSnapshot will memcpy over it"），
+> 而 `PrepareSnapshot()` 只在 `snapshot_dirty_` 为真时跑，`ServerImpl::Stop()` 刚把它清掉
+> ⇒ 重启后、新一代首批落地前，缓冲区**原封不动**是上一代的完整图像；
+> ②`RawXyzResult::epoch` 每次读取都无条件重取活的 `committed_epoch_`，`CommitConfig` 已 bump；
+> ③`ServerPoller::PollOnce()` 用这对值构造 payload ⇒ 旧图 + 新号。
+> 此时 `MarkStructHardDirty` 抬到**旧** `committed_epoch` 的 floor 恰好拦不住（新号 > 旧 floor），
+> 于是"新一代还没出图就先把上一代的图当本代成果推上屏"，把 floor 这道围栏原地架空。
+>
+> 注意与 `ServerImpl::GetRawXyzAndCompositeResults` 处那句「锁下序列化，不会出现 new epoch with
+> stale data 的 tear」**不是同一件事**：那句说的是同一次读取内不会读到半更新的配对。此处两个值
+> **各自完整自洽**，错的是配对本身——**无 tear ≠ 无陈旧**。
+>
+> 修复落点：`PollOnce()` 在质量闸的两条 bypass（超时兜底、终帧救援）**之后**追加一道内容世代闸，
+> 只在「内容确属当前世代」时才允许物化 payload。判据不是裸 `has_valid_data`：它镜像
+> `has_ever_consumed_`，被 `Stop()` 清除，因而为两种语义相反的原因转 false——「新一代尚未产出」
+> （须抑制）与「用户按了 Stop，手上这帧仍属本代」（display-time 编辑须能重绘，是活路径）。
+> 故改为比世代：`has_valid_data` 为 false 期间像素缓冲被冻结（只有 `ConsumeData` 能置
+> `snapshot_dirty_`，且它在同一临界区内一并置 `has_ever_consumed_`），其真实世代即上一份已物化
+> payload 的 `payload_epoch`；与活 epoch 相等 ⟺ 自像素产出以来没发生过 commit。
+> 置于两条 bypass 之后是刻意的：兜底救「产出中但太稀疏」、终帧救「结束在门槛之下」，
+> 都不构成发布别代像素的许可。I6 实质不受影响——COMPLETED 由 `has_ever_consumed_` 派生，
+> 终帧必然满足第一个析取项。染色通道自动同覆盖：`PopulateCompositePayload` 就在同一个
+> `if (quality_ok)` 块内，且 `cached_composite_results_` 同样不随 `Stop()` 清除。
+>
+> **主动接受的窄缺口**：某一代若产出了数据、又在 poller 从未 poll 过的间隙里被 Stop，则没有任何
+> payload 记录过该代 epoch，其画面会被抑制、屏幕停在上一帧。闭掉它需要**服务端**戳出
+> "`snapshot_xyz_` 是在哪一代填的"（新的 C API 字段）——poller 侧状态**结构上做不到**，因为它
+> 按定义从未观测过那一代。判定其代价大于该缺口，故留白。
+>
+> 回归测试：`gui_unit_test` 的 `GuiLifecycle.restart_does_not_republish_prior_run_pixels`
+> 与 `GuiLifecycle.restart_window_does_not_republish_prior_run_composite`，均断言**像素/合成字节的
+> 内容指纹**而非只断言世代号——只断言号会在时序恰好没撞上时以错误理由变绿。
+
 ---
 
 ## 10. 落地边界：最小核 vs 完整版

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -336,17 +336,18 @@ void ServerPoller::PollOnce() {
     }
 
     // Content-freshness gate: does the image about to be stamped with xyz_results[0].epoch actually
-    // belong to that generation? Nothing a restart does clears the pixels — RenderConsumer::Reset()
-    // deliberately leaves snapshot_xyz_ alone ("PrepareSnapshot will memcpy over it") and
-    // PrepareSnapshot only runs on a dirty snapshot, which Stop() just cleared — so between a commit
-    // and the new run's first produced batch the buffer still holds the PREVIOUS run's image, while
-    // RawXyzResult::epoch already reads the bumped committed_epoch_. A payload built from that pair
-    // carries the old image under the new generation's number.
+    // belong to that generation? Between a commit and the new run's first produced batch it does not
+    // — the pixel buffer still holds the PREVIOUS run's image while RawXyzResult::epoch already reads
+    // the bumped committed_epoch_, and the upload gate downstream can only compare epoch NUMBERS, so
+    // a payload wearing the new number is indistinguishable there from a genuinely fresh frame. That
+    // is why the decision has to be made here.
     //
-    // Nothing downstream can undo it, which is why the decision has to be made here. The upload gate
-    // fences the old generation by epoch NUMBER (payload_epoch > display_epoch_floor, the floor
-    // raised to the OLD committed epoch by MarkStructHardDirty), so a payload wearing the NEW number
-    // clears it exactly like a genuinely fresh frame; at that point the two are indistinguishable.
+    // The full mechanism (why the buffer survives a restart, why the floor cannot see it, and what
+    // this gate restores) is written up once in doc/gui-preview-lifecycle-architecture.md §9, in the
+    // "I1 的前提「世代号是诚实的」曾不成立" patch note — that section is the authority; keep the
+    // reasoning there rather than growing a second copy here.
+    //
+    // What is NOT in the doc, because it is about this code's shape rather than the invariant:
     //
     // has_valid_data alone is too coarse to be the answer, even though it is exactly right for the
     // stats read above. It mirrors has_ever_consumed_, which Stop() clears, so it goes false for two
@@ -379,13 +380,18 @@ void ServerPoller::PollOnce() {
     // definition never observed that generation. Left alone deliberately: that stamp is a wider
     // change than this defect warrants.
     if (quality_ok && !xyz_results[0].has_valid_data) {
-      auto prev_for_content = LoadPublished();
-      const bool content_belongs_to_this_epoch = prev_for_content && prev_for_content->payload &&
-                                                 prev_for_content->payload->payload_epoch == xyz_results[0].epoch;
+      auto prev_published = LoadPublished();
+      const bool content_belongs_to_this_epoch =
+          prev_published && prev_published->payload && prev_published->payload->payload_epoch == xyz_results[0].epoch;
       if (!content_belongs_to_this_epoch) {
         quality_ok = false;
-        GUI_LOG_VERBOSE("[Poller] stale content: nothing produced under epoch {} yet, carrying previous frame gen={}",
-                        xyz_results[0].epoch, xyz_results[0].snapshot_generation);
+        // epoch and snapshot_generation are two INDEPENDENT server counters — epoch is what this gate
+        // compares, snapshot_generation is what has_new_snapshot above compares. Spelled out in full
+        // so a log line never reads as though they were the same number.
+        GUI_LOG_VERBOSE(
+            "[Poller] stale content: nothing produced under epoch {} yet, carrying previous frame "
+            "(snapshot_generation={})",
+            xyz_results[0].epoch, xyz_results[0].snapshot_generation);
       }
     }
 

--- a/src/gui/server_poller.cpp
+++ b/src/gui/server_poller.cpp
@@ -335,6 +335,60 @@ void ServerPoller::PollOnce() {
                       cached_stats.sim_ray_num, min_rays, xyz_results[0].snapshot_generation);
     }
 
+    // Content-freshness gate: does the image about to be stamped with xyz_results[0].epoch actually
+    // belong to that generation? Nothing a restart does clears the pixels — RenderConsumer::Reset()
+    // deliberately leaves snapshot_xyz_ alone ("PrepareSnapshot will memcpy over it") and
+    // PrepareSnapshot only runs on a dirty snapshot, which Stop() just cleared — so between a commit
+    // and the new run's first produced batch the buffer still holds the PREVIOUS run's image, while
+    // RawXyzResult::epoch already reads the bumped committed_epoch_. A payload built from that pair
+    // carries the old image under the new generation's number.
+    //
+    // Nothing downstream can undo it, which is why the decision has to be made here. The upload gate
+    // fences the old generation by epoch NUMBER (payload_epoch > display_epoch_floor, the floor
+    // raised to the OLD committed epoch by MarkStructHardDirty), so a payload wearing the NEW number
+    // clears it exactly like a genuinely fresh frame; at that point the two are indistinguishable.
+    //
+    // has_valid_data alone is too coarse to be the answer, even though it is exactly right for the
+    // stats read above. It mirrors has_ever_consumed_, which Stop() clears, so it goes false for two
+    // very different reasons: "a new generation was committed and has produced nothing yet" (stale —
+    // suppress) and "the user pressed Stop, and the frame on hand is still this generation's"
+    // (current — a display-time edit must still be able to repaint it). Gating on it alone silently
+    // breaks the second, which is a live path, not a corner: DoStop → recolor → WakeForRefresh.
+    //
+    // So compare generations instead. While has_valid_data is false the buffer is frozen — only
+    // ConsumeData can dirty a snapshot and it sets has_ever_consumed_ in the same critical section —
+    // so the generation the pixels were produced under is the one the last materialized payload
+    // recorded, and prev->payload->payload_epoch is that record. Equal to the live epoch means no
+    // commit has happened since the pixels were made.
+    //
+    // Deliberately applied AFTER both bypasses above rather than folded into quality_ok's initial
+    // value: the timeout fallback rescues a run producing too sparsely, the terminal-frame rescue a
+    // run that ended below threshold — neither is a licence to publish another generation's pixels,
+    // so neither may override this. I6 is unaffected in substance anyway: force_final_upload requires
+    // lifecycle == COMPLETED, which the server derives from has_ever_consumed_, so a terminal frame
+    // always has valid data and takes the first disjunct.
+    //
+    // The carry-forward below is what makes suppression the right answer rather than a black screen:
+    // with no new payload the previous frame stays on screen under its OWN epoch (§5.4 anti-flicker),
+    // which is the honest rendering of "this generation has produced nothing yet".
+    //
+    // Known narrow gap, accepted: if a generation produces data and is stopped without the poller
+    // ever polling in between, no payload recorded its epoch, so its frame is suppressed and the
+    // previous one stays up. Closing it needs the SERVER to stamp the generation it filled
+    // snapshot_xyz_ under (a new C-API field) — no poller-side state can, since the poller by
+    // definition never observed that generation. Left alone deliberately: that stamp is a wider
+    // change than this defect warrants.
+    if (quality_ok && !xyz_results[0].has_valid_data) {
+      auto prev_for_content = LoadPublished();
+      const bool content_belongs_to_this_epoch = prev_for_content && prev_for_content->payload &&
+                                                 prev_for_content->payload->payload_epoch == xyz_results[0].epoch;
+      if (!content_belongs_to_this_epoch) {
+        quality_ok = false;
+        GUI_LOG_VERBOSE("[Poller] stale content: nothing produced under epoch {} yet, carrying previous frame gen={}",
+                        xyz_results[0].epoch, xyz_results[0].snapshot_generation);
+      }
+    }
+
     if (quality_ok) {
       last_quality_pass_time_ = now;
       auto payload = std::make_shared<TexturePayload>();

--- a/test/unit-correctness/gui/test_lifecycle.cpp
+++ b/test/unit-correctness/gui/test_lifecycle.cpp
@@ -32,6 +32,8 @@
 //  8b. resume_rearms_quality_gate_clock  } (see the block comment above them for why)
 //  9a. stats_apply_gate_rejects_stale_generation — PURE test of the stats-apply gate
 //  9b. restart_does_not_republish_prior_run_stats — producer end-to-end over the Run->Run edge
+//  10a. restart_does_not_republish_prior_run_pixels  } 9b's texture-channel siblings: the same
+//  10b. restart_window_does_not_republish_prior_run_composite } window, asserted on image content
 //
 // Their five frame-driven siblings stay in test/gui/functional/test_gui_lifecycle.cpp.
 
@@ -117,6 +119,41 @@ unsigned long long CurrentEpoch(LUMICE_Server* server) {
   LUMICE_SimLifecycleResult lc{};
   LUMICE_GetSimLifecycle(server, &lc);
   return lc.epoch;
+}
+
+// Block until the server has drained to IDLE with produced data, for a config already committed by
+// the caller. RunFiniteToCompletion above is this plus a kFiniteConfig commit; cases that need a
+// different config (e.g. one carrying raypath_color) commit their own and then wait here.
+bool WaitForValidData(LUMICE_Server* server) {
+  constexpr int kMaxWaitMs = 5000;
+  for (int waited = 0; waited < kMaxWaitMs; waited += 10) {
+    LUMICE_ServerState st = LUMICE_SERVER_RUNNING;
+    LUMICE_QueryServerState(server, &st);
+    if (st == LUMICE_SERVER_IDLE) {
+      LUMICE_RawXyzResult xyz[2]{};
+      LUMICE_GetRawXyzResults(server, xyz, 1);
+      if (xyz[0].has_valid_data) {
+        return true;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return false;
+}
+
+// Content fingerprint of a payload's pixels. The point of the cases below is that a payload can
+// carry the PREVIOUS run's image, so they must compare the image itself — asserting only on
+// payload_epoch would pass for the wrong reason whenever the timing happened not to line up
+// (see the "assert pixel content, not just the stamp" requirement in the task's risk analysis).
+// A plain FNV-1a over the raw float bytes: no tolerance, no interpretation, just "same bytes?".
+uint64_t PixelFingerprint(const std::vector<float>& xyz) {
+  uint64_t h = 1469598103934665603ULL;
+  const auto* bytes = reinterpret_cast<const unsigned char*>(xyz.data());
+  const size_t n = xyz.size() * sizeof(float);
+  for (size_t i = 0; i < n; ++i) {
+    h = (h ^ bytes[i]) * 1099511628211ULL;
+  }
+  return h;
 }
 
 }  // namespace
@@ -975,6 +1012,234 @@ TEST(GuiLifecycle, resume_rearms_quality_gate_clock) {
   auto s1 = local.LoadSnapshot();
   ASSERT_TRUE(s1 != nullptr);
   EXPECT_EQ(s1->texture_serial, serial0);  // RED if `last_quality_pass_time_ = now()` is dropped
+
+  local.Stop();
+  LUMICE_DestroyServer(server);
+}
+
+// 10a — the texture-channel sibling of 9b, over the same Run -> restart edge and the same
+// deterministically-pinned window. 9b showed the server's cached STATS survive a restart; the
+// pixels survive it too, and for a different reason:
+//   - RenderConsumer::Reset() deliberately does NOT zero snapshot_xyz_ ("PrepareSnapshot will
+//     memcpy over it"), and PrepareSnapshot only runs when DoSnapshot sees snapshot_dirty_, which
+//     Stop() cleared. So in the window the buffer still holds the PREVIOUS run's image, byte for
+//     byte, and xyz_buffer is non-null because Stop() explicitly does not clear consumers_.
+//   - RawXyzResult::epoch is stamped from the LIVE committed_epoch_ on every read, which the commit
+//     already bumped. So the pair handed to the poller is "new generation number, old image".
+// Neither value is torn — each is complete and self-consistent; it is the PAIRING that is wrong,
+// which is why the "no new-epoch-with-stale-data tear can occur" reasoning at the stamp site does
+// not cover this.
+//
+// The downstream epoch floor cannot separate the two: MarkStructHardDirty raises the floor to the
+// OLD committed epoch precisely so the old generation's frames are fenced out until the new one
+// produces something — but a payload mis-stamped with the NEW epoch clears that floor exactly like
+// a genuinely fresh frame would. The floor filters by generation NUMBER; it has no way to ask
+// whether the content was really produced under it. So the gate has to be upstream, at the point
+// where a payload is allowed to be constructed at all.
+//
+// Asserts the CONTENT fingerprint, not only the stamp: a case that checked payload_epoch alone
+// would pass for the wrong reason on any run where the timing happened not to line up.
+TEST(GuiLifecycle, restart_does_not_republish_prior_run_pixels) {
+  gui::g_server_poller.Stop();
+  gui::g_server = nullptr;
+
+  LUMICE_Server* server = LUMICE_CreateServer();
+  ASSERT_TRUE(server != nullptr);
+  const bool completed = RunFiniteToCompletion(server);
+  EXPECT_TRUE(completed);
+  if (!completed) {
+    LUMICE_DestroyServer(server);
+    return;
+  }
+
+  gui::ServerPoller local;
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+
+  const unsigned long long epoch_a = CurrentEpoch(server);
+  uint64_t pixels_a = 0;
+  unsigned long long serial_a = 0;
+  {
+    auto sa = local.LoadSnapshot();
+    ASSERT_TRUE(sa != nullptr);
+    ASSERT_TRUE(sa->payload != nullptr);
+    EXPECT_EQ(sa->payload->payload_epoch, epoch_a);
+    EXPECT_TRUE(sa->payload->texture_ray_count > 0);
+    pixels_a = PixelFingerprint(sa->payload->xyz_data);
+    serial_a = sa->texture_serial;
+  }
+
+  // The Run -> Run edge mints a new generation while the consumer's snapshot buffer is untouched.
+  ASSERT_EQ(CommitJsonConfig(server, kFiniteConfig), LUMICE_OK);
+  const unsigned long long epoch_b = CurrentEpoch(server);
+  ASSERT_TRUE(epoch_b > epoch_a);
+
+  // Pin the window open deterministically rather than racing run B's first batch — same two facts
+  // 9b relies on, applied to the pixel channel: Stop() unconditionally clears has_ever_consumed_
+  // (so has_valid_data reads 0 whether or not run B got anything in first) and clears
+  // snapshot_dirty_ (so no DoSnapshot from here on can refresh snapshot_xyz_). No sleep, no
+  // "at least one hit in N tries": the window is held by construction.
+  LUMICE_StopServer(server);
+
+  local.ResetGenerationForTest();  // what a resume does to the generation tracker, minus the worker
+  local.PollOnceForTest(server);
+
+  auto sb = local.LoadSnapshot();
+  ASSERT_TRUE(sb != nullptr);
+  ASSERT_TRUE(sb->payload != nullptr);
+
+  // The image in the window IS run A's, in both worlds — this is the premise of the case, not the
+  // defect. What must not happen is that image being re-published as run B's work.
+  EXPECT_EQ(PixelFingerprint(sb->payload->xyz_data), pixels_a);
+
+  // The defect's exact shape, all four RED before the fix: the poller materializes a "fresh"
+  // payload out of run A's pixels, stamps it epoch_b, and mints a new serial for it.
+  EXPECT_EQ(sb->payload->payload_epoch, epoch_a);  // carried forward, keeping its own generation
+  EXPECT_EQ(sb->texture_serial, serial_a);         // carry-forward keeps the serial (anti-flicker)
+  EXPECT_TRUE(!sb->has_new_texture);
+  // ... and therefore the display gate keeps it off screen. Before the fix this returned true:
+  // epoch_b clears a floor raised to epoch_a, and the serial is unseen, so the fence
+  // MarkStructHardDirty put up around the old generation is defeated by the mis-stamp.
+  EXPECT_TRUE(!gui::ShouldUploadPayload(*sb, serial_a, /*display_epoch_floor=*/epoch_a));
+
+  // The suppression must be scoped to the window, not permanent: once a generation actually
+  // produces data, its frame reaches the screen normally.
+  ASSERT_EQ(CommitJsonConfig(server, kFiniteConfig), LUMICE_OK);
+  const unsigned long long epoch_c = CurrentEpoch(server);
+  ASSERT_TRUE(WaitForValidData(server));
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+  {
+    auto sc = local.LoadSnapshot();
+    ASSERT_TRUE(sc != nullptr);
+    ASSERT_TRUE(sc->payload != nullptr);
+    EXPECT_EQ(sc->payload->payload_epoch, epoch_c);
+    EXPECT_TRUE(sc->texture_serial != serial_a);
+    EXPECT_TRUE(sc->has_new_texture);
+    EXPECT_TRUE(gui::ShouldUploadPayload(*sc, serial_a, /*display_epoch_floor=*/epoch_a));
+  }
+
+  local.Stop();
+  LUMICE_DestroyServer(server);
+}
+
+// 10b — the composite (raypath-color) half of 10a. Not a courtesy duplicate: PopulateCompositePayload
+// runs INSIDE the very same `if (quality_ok)` block that builds the XYZ payload, so whatever gates
+// one gates the other. This pins both directions of that coupling — the window must not publish a
+// composite built from the previous run's lanes, and the window ending must not leave the composite
+// path suppressed. It also checks the composite fire-gate's mode_changed OR-branch, which reads
+// snap.payload and could otherwise fire an upload on a carried-forward frame.
+TEST(GuiLifecycle, restart_window_does_not_republish_prior_run_composite) {
+  gui::g_server_poller.Stop();
+  gui::g_server = nullptr;
+
+  // Match-all red class over a finite single-prism scene, so the RenderConsumer's ColoredMask() is
+  // non-zero and DoSnapshot Phase-2 produces a composite for the generation (the img_buffer
+  // sentinel the poller keys on). Copied from test_composite_preview.cpp's kColorConfig rather than
+  // adapted from kFiniteConfig above: a class matching `layer: 0` needs rays that TERMINATE at
+  // layer 0, so kFiniteConfig's scattering prob of 1.0 yields an empty mask and a non-composite
+  // payload — which makes the case silently stop testing the composite path at all.
+  const char* kColorConfig = R"({
+    "crystal": [{
+      "id": 1, "type": "prism",
+      "shape": {"height": 1.5},
+      "axis": {"zenith": {"type": "gauss", "mean": 90.0, "std": 10.0},
+               "azimuth": {"type": "uniform", "mean": 0.0, "std": 180.0},
+               "roll": {"type": "uniform", "mean": 0.0, "std": 180.0}}
+    }],
+    "filter": [],
+    "scene": {
+      "light_source": {"type": "sun", "altitude": 20.0, "azimuth": 0.0,
+                       "diameter": 0.5, "spectrum": "D65"},
+      "ray_num": 200000,
+      "max_hits": 8,
+      "scattering": [{"prob": 0.0, "entries": [{"crystal": 1, "proportion": 1.0}]}]
+    },
+    "render": [{
+      "id": 1,
+      "lens": {"type": "dual_fisheye_equal_area", "fov": 180.0},
+      "resolution": [128, 64],
+      "view": {"elevation": 0, "azimuth": 0, "roll": 0},
+      "visible": "full", "background": [0, 0, 0],
+      "opacity": 1.0, "intensity_factor": 1.0
+    }],
+    "raypath_color": {
+      "mode": "dominant",
+      "classes": [
+        {"color": [1.0, 0.0, 0.0], "match": [{"layer": 0, "crystal": 1}]}
+      ]
+    }
+  })";
+
+  LUMICE_Server* server = LUMICE_CreateServer();
+  ASSERT_TRUE(server != nullptr);
+  ASSERT_EQ(CommitJsonConfig(server, kColorConfig), LUMICE_OK);
+  const bool completed = WaitForValidData(server);
+  EXPECT_TRUE(completed);
+  if (!completed) {
+    LUMICE_DestroyServer(server);
+    return;
+  }
+
+  gui::ServerPoller local;
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+
+  const unsigned long long epoch_a = CurrentEpoch(server);
+  unsigned long long serial_a = 0;
+  {
+    auto sa = local.LoadSnapshot();
+    ASSERT_TRUE(sa != nullptr);
+    ASSERT_TRUE(sa->payload != nullptr);
+    // If this fails the case is not exercising the composite path at all and the rest proves nothing.
+    ASSERT_TRUE(sa->payload->is_composite);
+    ASSERT_TRUE(!sa->payload->rgb_data.empty());
+    EXPECT_EQ(sa->payload->payload_epoch, epoch_a);
+    serial_a = sa->texture_serial;
+  }
+
+  ASSERT_EQ(CommitJsonConfig(server, kColorConfig), LUMICE_OK);
+  const unsigned long long epoch_b = CurrentEpoch(server);
+  ASSERT_TRUE(epoch_b > epoch_a);
+  LUMICE_StopServer(server);
+
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+  {
+    auto sb = local.LoadSnapshot();
+    ASSERT_TRUE(sb != nullptr);
+    ASSERT_TRUE(sb->payload != nullptr);
+    // Carried forward, so it stays composite and keeps run A's stamp — the window publishes no new
+    // composite rather than one rebuilt from the previous generation's lanes.
+    EXPECT_TRUE(sb->payload->is_composite);
+    EXPECT_EQ(sb->payload->payload_epoch, epoch_a);
+    EXPECT_EQ(sb->texture_serial, serial_a);
+    // The fire gate stays quiet: the serial-dedup branch is false (same serial, floor not cleared by
+    // the carried-forward stamp) and mode_changed is false because the carried-forward payload is
+    // composite exactly as the last upload was. A payload absent from this branch is what would
+    // make mode_changed misfire, so it is asserted here rather than assumed.
+    EXPECT_TRUE(!gui::ShouldFireCompositeUpload(*sb, serial_a, /*display_epoch_floor=*/epoch_a,
+                                                /*show_composite_preview=*/true,
+                                                /*last_uploaded_as_composite=*/true));
+  }
+
+  // Window ends: the composite path recovers, it is not suppressed past the window.
+  ASSERT_EQ(CommitJsonConfig(server, kColorConfig), LUMICE_OK);
+  const unsigned long long epoch_c = CurrentEpoch(server);
+  ASSERT_TRUE(WaitForValidData(server));
+  local.ResetGenerationForTest();
+  local.PollOnceForTest(server);
+  {
+    auto sc = local.LoadSnapshot();
+    ASSERT_TRUE(sc != nullptr);
+    ASSERT_TRUE(sc->payload != nullptr);
+    EXPECT_TRUE(sc->payload->is_composite);
+    EXPECT_TRUE(!sc->payload->rgb_data.empty());
+    EXPECT_EQ(sc->payload->payload_epoch, epoch_c);
+    EXPECT_TRUE(gui::ShouldFireCompositeUpload(*sc, serial_a, /*display_epoch_floor=*/epoch_a,
+                                               /*show_composite_preview=*/true,
+                                               /*last_uploaded_as_composite=*/true));
+  }
 
   local.Stop();
   LUMICE_DestroyServer(server);


### PR DESCRIPTION
## 背景

`task-421`（PR #244）修的是 **stats 侧**：服务端 `cached_stats_result_` 不随 `Stop()` 清除，重启后 `GetCachedStats` 会返回上一次运行的数字。它的 SUMMARY 把**纹理侧**同形态的疑虑有意搁置、交 owner 判断——纹理侧的 `payload->payload_epoch = xyz_results[0].epoch` 走的是同一个「活读 epoch」。

本 PR 是那条搁置项的定性 + 收口。任务以**定性优先**立项：先证明窗口是否可达，再决定要不要修。

## 定性结论：真缺陷

重启（新 epoch）后、新一代第一批数据落地前的窗口里，**上一代像素会被打上当前 epoch 戳并越过上屏闸**。三个条件同时成立：

1. **epoch 早熟** —— `committed_epoch_` 在 `CommitConfig` 内无条件 `fetch_add(1)`，而 `RawXyzResult::epoch_` 每次调用都无条件重读它，不依赖 `DoSnapshot()` 是否真做了事。
2. **像素滞后** —— `RenderConsumer::Reset()` 显式不清 `snapshot_xyz_`（"PrepareSnapshot will memcpy over it"），而 `PrepareSnapshot()` 只在 `snapshot_dirty_` 为真时跑，`Stop()` 刚把它清掉 ⇒ 缓冲区原封不动是上一代的完整图像。
3. **`has_new_snapshot` 错配触发** —— 服务端 `snapshot_generation_` 全仓无重置点，而 poller 的 `last_generation_` 被 `ResetPerResumeState()` 归零 ⇒ 重启后首个 poll 必判「有新快照」。

**`display_epoch_floor` 闸挡不住**：它只能按世代**编号**过滤（`payload_epoch > floor`，floor 被 `MarkStructHardDirty` 抬到旧 epoch），问不了「这份内容是不是真产自该编号」。被冒领戳的陈旧数据与真正的新一代数据，在该闸门前不可区分。

> ⚠️ `GetRawXyzAndCompositeResults` 处有一句注释说 "a new epoch with stale data tear cannot occur"。它讲的是**另一种失效**——同一次调用内两个读取在锁下序列化、不会读到半更新的配对。本缺陷里两边**各自都完整自洽**，错的是配对。**无 tear ≠ 无陈旧**。这一辨析已写进代码注释与 doc，避免下一个人据此认为已处理。

## 修法

`ServerPoller::PollOnce()` 在质量闸的两条 bypass **之后**新增一道内容世代闸：

```
has_valid_data || prev_published->payload->payload_epoch == xyz_results[0].epoch
```

不满足即 `quality_ok = false`，走既有 carry-forward 分支继续显示上一帧（携带**它自己的**旧 epoch）——这才是「本代尚未产出任何东西」的诚实呈现。

**为什么不是裸 `has_valid_data`**：实施时先按这个方案落地，既有用例 `resume_rearms_generation_tracker` 真红。`has_valid_data` 镜像 `has_ever_consumed_`，而 `Stop()` 会清它，于是它为两种语义相反的原因转 false：「新一代已 commit、尚未产出」（该抑制）与「用户按了 Stop，手上这帧仍属本代」（该允许重绘——`DoStop → 改色 → WakeForRefresh` 是生产活路径）。故改为比世代而非比「有没有消费过」。

- 无新增字段、无 C API 变化、`src/` 净增 54 行
- carry-forward 发布逻辑**一行未动**（防闪烁设计意图完好）
- I6 终帧上屏不受影响：`force_final_upload` 要求 `lifecycle == COMPLETED`，服务端由 `has_ever_consumed_` 派生 ⇒ 终帧必有 valid data，走第一个析取项

## 测试

两条**红态自证**钉子（`test/unit-correctness/gui/test_lifecycle.cpp`），覆盖 XYZ 与染色两条通道——二者共享同一个 `if (quality_ok)` 块，故同一处收紧同时作用于两者：

- `GuiLifecycle.restart_does_not_republish_prior_run_pixels`
- `GuiLifecycle.restart_window_does_not_republish_prior_run_composite`

复现是**确定性**的：零 sleep、零「至少命中一次」的概率论证——窗口由 `Stop()` 按构造钉开。红态实测值：`payload_epoch` 2≠1、`texture_serial` 2≠1、`has_new_texture` 为真、`ShouldUploadPayload` 与 `ShouldFireCompositeUpload` 双双放行，而像素指纹逐字节等于上一代。

红绿双态：修复前基线仅这两条红、其余全绿；修复后 `gui_unit_test` 270/270，`./scripts/test.sh pr` 六层全绿。

## 已知窄缺口（owner 已裁决接受）

若某一代产出数据后、在 poller 从未 poll 过的间隙里被 `Stop`，则无任何 payload 记录过该代 epoch ⇒ 其画面被抑制、屏幕停在上一帧。闭合它必须由**服务端**戳出「`snapshot_xyz_` 是在哪一代填的」（新 C API 字段），poller 侧任何状态都做不到。后果是保守的（多显示一帧旧图，而非显示错标世代的图），故 owner 裁决接受并另记待办。代码注释与 `doc/gui-preview-lifecycle-architecture.md` §9 均有记载。

## 文档

`doc/gui-preview-lifecycle-architecture.md` §9 新增「I1 的前提『世代号是诚实的』曾不成立」落地补丁段（与既有 I6 补丁并列）。I1 文本不变——这是实现对 I1 的一次合规回归，不是新增不变量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)