### PR TITLE
fix(gui-test): 序列化被唤醒的全局 poller，消除 display-time 编辑后的撕裂快照

### DIFF
--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -286,6 +286,35 @@ conservation double gate is a deliberate scrum-267.3 reinforcement and must not 
 This battery is also what lets a future CUDA backend distinguish "kernel is wrong" from "both
 backends agree and are both wrong".
 
+#### §4.2.1 A differential test is structurally blind to drift its two sides share
+
+The battery above guards against a *metric* that masks a bug. There is a second blind spot, and
+it belongs to the **differential shape itself** rather than to the metric: a test that compares
+two paths and asserts they agree can only see disagreement. When both paths derive from the same
+authority, a change to that authority moves both sides together and the test stays green — no
+matter how carefully the comparison is written.
+
+The worked example is `JsonParserParity`
+(`test/unit-correctness/server/test_json_parser_parity.cpp`): it runs a config corpus through
+core's parser directly, and through the C API (parse → re-encode → parse again with core), then
+asserts the two agree. Both sides read core's key table. Rename a key **in that table and in its
+consumers together** and the two sides remain perfectly self-consistent, so the differential test
+never reddens — while the JSON now emitted is silently incompatible with every config file
+already on disk. This is measured, not hypothetical: it is what a mutation did while the
+red-state criterion for PR #230 was being established.
+
+What does catch it is a pin whose expected value is a **bare string literal** and which **never
+calls the authority under test** — `CrystalSchemaKeyNames.*` in
+`test/unit-correctness/config/test_json.cpp` for the `shape` and `axis` objects, and the
+sync-group sub-map pins in `test/unit-correctness/config/test_crystal_sync_group.cpp`. Expressing
+those expectations through `ShapeScalarSyncKeyName(...)` would make the authority table and its
+own test drift together and pass forever.
+
+**Rule.** When a change gives some domain a single source of truth for names or wire format
+(the same single-source treatment is a plausible future for render, filter, and light-source
+config), a differential parity test **cannot** serve as its red-state criterion. At least one
+test must assert the literal wire format against something outside the code under test.
+
 ### §4.3 Config and reference ownership
 
 - Each reference image is **owned by exactly one layer**: `e2e-correctness` owns

--- a/doc/testing-architecture_zh.md
+++ b/doc/testing-architecture_zh.md
@@ -234,6 +234,28 @@ tag 如何编码取决于该层的物理形态（§6）：对有自然 subsystem
 相关性是*烟雾信号*，不是裁决。跨 seed 自洽 + 能量守恒双门是 scrum-267.3 的刻意补强，不可删除。
 这套全套也是未来 CUDA 后端区分"kernel 错"与"两后端一致但都错"的依据。
 
+#### §4.2.1 差分测试对「两侧共享的同步漂移」存在结构性盲区
+
+上面那套全套防的是**指标**掩盖缺陷；还有第二个盲区，它属于**差分这个形态本身**而非指标：
+一个「跑两条路径、断言两者一致」的测试，只能看见**不一致**。当两条路径同出一个权威时，
+改动该权威会让两侧**一起移动**，测试照绿——无论比较写得多仔细。
+
+样例是 `JsonParserParity`（`test/unit-correctness/server/test_json_parser_parity.cpp`）：
+它把一份 config 语料分别喂给 core 的解析器直读、以及 C API（解析 → 回编码 → 再用 core 解析），
+然后断言两侧一致。**两侧读的是 core 的同一张键名表**。若把某个键名**在权威表与其消费点一起改掉**，
+两侧仍完全自洽 ⇒ 差分测试**不会变红**，尽管此时产出的 JSON 已经与磁盘上所有既有配置文件不兼容。
+这是实测而非推演：PR #230 建立红态判据时，一次突变实际就是这个结果。
+
+真正能抓住它的，是**期望值写成裸字符串字面量、且完全不调用被测权威函数**的钉子测试——
+`test/unit-correctness/config/test_json.cpp` 里的 `CrystalSchemaKeyNames.*`（覆盖 `shape` 与
+`axis` 两个对象），以及 `test/unit-correctness/config/test_crystal_sync_group.cpp` 里的
+sync_group 子表钉子。若把这些期望改写成调用 `ShapeScalarSyncKeyName(...)`，权威表与它自己的
+测试就会一起漂移、永远通过。
+
+**规则**：当某个域被改造成「名称 / wire format 单一权威」时（render、filter、light source
+都可能做同款改造），差分 parity 测试**不能**充当它的红态判据。至少要有一个测试，
+拿被测代码**之外**的东西来断言字面的 wire format。
+
 ### §4.3 config 与 reference 的归属
 
 - 每张参考图**恰好属于一层**：`e2e-correctness` 拥有 `test/e2e/references/*.jpg`；`gui` 拥有

--- a/test/unit-correctness/gui/test_composite_preview.cpp
+++ b/test/unit-correctness/gui/test_composite_preview.cpp
@@ -383,6 +383,9 @@ TEST(CompositePreview, display_time_color_edit_repaints_without_restart) {
   ASSERT_TRUE(snap_before->payload != nullptr);
   EXPECT_TRUE(snap_before->payload->is_composite);
   std::vector<uint8_t> composite_before(snap_before->payload->rgb_data.begin(), snap_before->payload->rgb_data.end());
+  // Kept so the post-edit poll can be shown to have MATERIALIZED a payload rather than carried the
+  // previous one forward — see the serial assertion below.
+  const unsigned long long serial_before = snap_before->texture_serial;
 
   // Display-time edit: swap the class-0 color from red → blue. kColorConfig commits exactly
   // one raypath_color class, so class_count == 1 matches.
@@ -398,6 +401,36 @@ TEST(CompositePreview, display_time_color_edit_repaints_without_restart) {
   // "worker wakes up and runs one PollOnce, then self-pauses at COMPLETED".
   gui::g_server_poller.WakeForRefresh(server);
 
+  // The wake above starts a REAL background thread that polls this same server, so from here to
+  // the read below there are two consumers driving ServerImpl::DoSnapshot() concurrently — and
+  // that getter family is not safe for two. DoSnapshot's three segments are not jointly atomic:
+  // Phase 1 consumes snapshot_dirty_ and bumps snapshot_generation_ under consumer_mutex_,
+  // Phase 1.5 counts effective pixels under NO lock, and only Phase 2 rebuilds
+  // cached_composite_results_ under snapshot_mutex_ (server.cpp:702-799). A second caller arriving
+  // while the first is in Phase 1.5 finds snapshot_dirty_ already false, returns early WITHOUT
+  // waiting for that Phase 2, and then reports the already-bumped generation beside the PREVIOUS
+  // generation's pixels. That is exactly the failure this case hit on CI: the payload came back
+  // byte-identical to composite_before while a direct read a few lines later was already the new
+  // image. Worse, img_buffer is a borrowed pointer that Phase 2's cache swap frees, so the loser
+  // is also reading memory that may have been released.
+  //
+  // Stop() drains the worker synchronously (it returns only once the worker has left the poll
+  // loop), collapsing the two consumers back to one. That removes the window structurally rather
+  // than narrowing it — no sleep, no retry, no tolerance. It is the same serialization the sibling
+  // cases in this file and in test/gui/functional/test_gui_composite_preview.cpp already apply
+  // before every composite read; this case woke the poller without it.
+  //
+  // The yield is the nail rather than an incidental detail: without it the woken worker usually
+  // never gets scheduled before Stop() lands, so the two-consumer interleaving this case is
+  // supposed to survive is barely exercised and deleting the Stop() would mostly go unnoticed —
+  // that is precisely how the CI flake survived here. Measured on this case with --gtest_repeat,
+  // macOS ARM64 release: no yield + no Stop() (the shape that flaked) 1/200 red; yield + no Stop()
+  // 14/50 red; yield + Stop() 0/200 red. So the yield buys ~56x detection power against a missing
+  // Stop(), and it cannot produce a false red — it only hands the CPU to a worker that a correct
+  // sequence has already serialized away.
+  std::this_thread::yield();
+  gui::g_server_poller.Stop();
+
   // (a) MECHANISM: the poll after the edit must produce a composite reflecting the new colors —
   // i.e., not byte-identical to composite_before (the color changed, so the rendered image must
   // differ). And it must byte-match a same-tick direct C-API read.
@@ -407,6 +440,13 @@ TEST(CompositePreview, display_time_color_edit_repaints_without_restart) {
   EXPECT_TRUE(snap_after->valid);
   ASSERT_TRUE(snap_after->payload != nullptr);
   EXPECT_TRUE(snap_after->payload->is_composite);
+  // This poll must have materialized a payload of its own, not carried snap_before's forward. The
+  // two ways this case can go stale look identical at the byte level but differ here: a torn read
+  // publishes a NEW payload (serial advances) holding the old pixels, whereas a quality-gate or
+  // content-freshness rejection republishes the OLD payload pointer (serial unchanged). Asserting
+  // the serial separately keeps a future failure self-diagnosing instead of collapsing both into
+  // one "bytes are stale" symptom.
+  EXPECT_TRUE(snap_after->texture_serial != serial_before);
   EXPECT_EQ(snap_after->payload->rgb_data.size(), composite_before.size());
   EXPECT_TRUE(std::memcmp(snap_after->payload->rgb_data.data(), composite_before.data(), composite_before.size()) != 0);
 

--- a/test/unit-correctness/gui/test_composite_preview.cpp
+++ b/test/unit-correctness/gui/test_composite_preview.cpp
@@ -423,11 +423,12 @@ TEST(CompositePreview, display_time_color_edit_repaints_without_restart) {
   // The yield is the nail rather than an incidental detail: without it the woken worker usually
   // never gets scheduled before Stop() lands, so the two-consumer interleaving this case is
   // supposed to survive is barely exercised and deleting the Stop() would mostly go unnoticed —
-  // that is precisely how the CI flake survived here. Measured on this case with --gtest_repeat,
-  // macOS ARM64 release: no yield + no Stop() (the shape that flaked) 1/200 red; yield + no Stop()
-  // 14/50 red; yield + Stop() 0/200 red. So the yield buys ~56x detection power against a missing
-  // Stop(), and it cannot produce a false red — it only hands the CPU to a worker that a correct
-  // sequence has already serialized away.
+  // that is precisely how the CI flake survived here. A --gtest_repeat sweep measured the yield to
+  // raise detection of a missing Stop() by roughly two orders of magnitude (per-run rates and the
+  // exact arms are in commit e5cbb170; they are one machine's one-off sample, not an invariant, and
+  // will drift with hardware, pixel count and scheduler). What does NOT drift, and is the reason
+  // the yield stays: it cannot produce a false red — it only hands the CPU to a worker that a
+  // correct sequence has already serialized away, so a green run never depends on the sample above.
   std::this_thread::yield();
   gui::g_server_poller.Stop();
 


### PR DESCRIPTION
## 背景

`gui_unit_test` 的 `CompositePreview.display_time_color_edit_repaints_without_restart` 在 PR #245 的 CI 上于 macOS ARM64 红过一次、同 commit 重跑即绿（run `30815182169` / job `91691055517`）。两条断言的实际读数是：poller 发布的快照与编辑前**逐字节相同**，而同 tick 的直读**已是新图**。

## 根因（白盒定性，非表面收敛）

`ServerImpl::DoSnapshot()`（`server.cpp:702-799`）三段不联合原子：

- Phase 1 持 `consumer_mutex_`，消费 `snapshot_dirty_` 并递增 `snapshot_generation_`
- Phase 1.5 **不持任何锁**（`CountEffectivePixels()`，有实际耗时）
- Phase 2 才持 `snapshot_mutex_` 重建 `cached_composite_results_`

落后的调用者在 Phase 1 发现 dirty 已被抢先者消费，**立即返回、不等 Phase 2**，随后照常读出已递增的世代号 + 上一代的像素。该测试同时用全局 `g_server_poller`（`WakeForRefresh` 启动的真实后台线程）和 `local` 实例做同步 poll，制造了两个并发消费者。

## 修法

沿用本仓既有范式：读之前 `Stop()` 后台线程，把两个消费者结构性收敛回一个（`Stop()` 同步等待 worker 退出 poll 循环）。**不缩窗口、不加 sleep、不放宽容差**。兄弟文件 `test/gui/functional/test_gui_composite_preview.cpp` 已有 10 处同类用法。

另加：
- 一次 `std::this_thread::yield()` —— 它是钉子的检出力来源而非装饰。没有它，被唤醒的 worker 通常来不及被调度，`Stop()` 被删掉也基本发现不了。它**不可能造成误报**（单消费者对照臂 0 红），所以绿跑从不依赖这组采样。
- 一条 `texture_serial` 断言 —— 把「撕裂读」（发布新 payload、装旧像素）与「质量闸/内容闸沿用旧 payload」（原样重发旧 payload 指针）这两种字节层面同形的失效区分开，使后续失败可自诊断。

## 验证

- **本地首次复现了这条 CI 间歇红**（1/200），此前「本地未复现过」的前提已作废
- 红态探针四臂对照 300 轮：唤醒 2/300 撕裂 → 加 yield 297/300 → 不唤醒对照臂 0/300 → 加 `Stop()` 后 0/300；`carry` 恒 0，排除「沿用旧 payload」这一竞争解释
- 第二个探针（两线程直打 C API）**100/100 轮确定性复现**，不依赖调度运气
- `./scripts/test.sh full` 四层 PASS；三闸（policy / new-refs / new-gui-tests）exit 0

## 附带

首个 commit 是一条独立的 `doc/testing-architecture.md` 补充（差分测试对两侧共享漂移的结构性盲区），与本修复无关，随分支一并带入。

## 已上抛、未在本 PR 处理

1. ⭐ `doc/c_api.md:831` 声称 `LUMICE_GetRenderResults`/`GetStatsResults` 线程安全，被探针 100/100 证伪。后续讨论已定性：该行把**纯值返回**（`StatsResult` 无指针）与**借用指针返回**（`img_buffer`，"managed by Server"）并列，后者靠内部加锁不可达线程安全——危险发生在函数返回之后。
2. `RefreshCpuTextureForSave()`（`app.cpp:291-314`）生产侧无 `Stop()` 并发读。同一竞态第三次复发。
3. `wake_for_refresh_preserves_valid` 断言了一个本质瞬态（插 5ms sleep 后 30/30 全红）。

1 与 2 的根因已进一步定性为：借用指针原本依赖「快照 buffer 稳定、原地重写」这一前提，而 `cached_* = std::move(...)` 悄悄破坏了它，把「读到过期数据」升级成「读已释放内存」。修复方向另立任务。

🤖 Generated with [Claude Code](https://claude.com/claude-code)